### PR TITLE
Bugfix 23-12-20 Binary path for unit tests

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -31,9 +31,6 @@ stages:
               extraflags: '-DCHECKS:bool=true'
               ppa: 'beineri/opt-qt-5.13.2-bionic'
               qtver: 513
-          - bash: |
-              cp build/bin/dissolve tests/
-            displayName: 'Copy Executable'
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "."
@@ -48,9 +45,6 @@ stages:
             fetchDepth: 1
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-parallel.yml
-          - bash: |
-              cp build/bin/dissolve-mpi tests/
-            displayName: 'Copy Executable'
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "."

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -33,7 +33,7 @@ stages:
               qtver: 513
           - task: PublishBuildArtifacts@1
             inputs:
-              PathtoPublish: "."
+              PathtoPublish: "build/"
               ArtifactName: 'linux-tests-serial'
             displayName: 'Publish Serial Test Artifacts'
       - job: 'linux_parallel'
@@ -49,7 +49,7 @@ stages:
               extraflags: '-DCHECKS:bool=true -DBUILD_TESTS:bool=true'
           - task: PublishBuildArtifacts@1
             inputs:
-              PathtoPublish: "."
+              PathtoPublish: "build/"
               ArtifactName: 'linux-tests-parallel'
             displayName: 'Publish Parallel Test Artifacts'
       - job: 'osx_serialgui'

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -28,7 +28,7 @@ stages:
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-serial-gui.yml
             parameters:
-              extraflags: '-DCHECKS:bool=true'
+              extraflags: '-DCHECKS:bool=true -DBUILD_TESTS:bool=true'
               ppa: 'beineri/opt-qt-5.13.2-bionic'
               qtver: 513
           - task: PublishBuildArtifacts@1
@@ -45,6 +45,8 @@ stages:
             fetchDepth: 1
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-parallel.yml
+            parameters:
+              extraflags: '-DCHECKS:bool=true -DBUILD_TESTS:bool=true'
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "."

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -18,6 +18,7 @@ jobs:
           artifactName: 'linux-tests-serial'
         displayName: 'Download Serial Test Artifacts'
       - bash: |
+          set -ex
           cd $(System.ArtifactsDirectory)/linux-tests-serial/build
           chmod +x bin/dissolve
           ctest -j2 --output-on-failure
@@ -41,7 +42,8 @@ jobs:
           artifactName: 'linux-tests-parallel'
         displayName: 'Download Parallel Test Artifacts'
       - bash: |
-          cd $(System.ArtifactsDirectory)/linux-tests-parallel/build-parallel
+          set -ex
+          cd $(System.ArtifactsDirectory)/linux-tests-parallel/build
           chmod +x bin/dissolve-mpi
           ctest --output-on-failure
         displayName: 'Run Parallel System Tests'

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -22,7 +22,7 @@ jobs:
           set -ex
           mkdir build && cd build
           mv $(System.ArtifactsDirectory)/linux-tests-serial/* ./
-          chmod +x bin/dissolve
+          chmod +x bin/*
           ctest -j2 --output-on-failure
         displayName: 'Run Serial System Tests'
   - job:
@@ -48,6 +48,6 @@ jobs:
           set -ex
           mkdir build && cd build
           mv $(System.ArtifactsDirectory)/linux-tests-parallel/* ./
-          chmod +x bin/dissolve-mpi
+          chmod +x bin/*
           ctest --output-on-failure
         displayName: 'Run Parallel System Tests'

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -9,7 +9,8 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     steps:
-      - checkout: none
+      - checkout: self
+        fetchDepth: 1
       - task: DownloadBuildArtifacts@0
         inputs:
           buildType: 'current'
@@ -19,7 +20,8 @@ jobs:
         displayName: 'Download Serial Test Artifacts'
       - bash: |
           set -ex
-          cd $(System.ArtifactsDirectory)/linux-tests-serial/build
+          mkdir build && cd build
+          mv $(System.ArtifactsDirectory)/linux-tests-serial/* ./
           chmod +x bin/dissolve
           ctest -j2 --output-on-failure
         displayName: 'Run Serial System Tests'
@@ -29,7 +31,8 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     steps:
-      - checkout: none
+      - checkout: self
+        fetchDepth: 1
       - bash: |
           set -ex
           sudo apt-get install libopenmpi-dev openmpi-bin openmpi-common
@@ -43,7 +46,8 @@ jobs:
         displayName: 'Download Parallel Test Artifacts'
       - bash: |
           set -ex
-          cd $(System.ArtifactsDirectory)/linux-tests-parallel/build
+          mkdir build && cd build
+          mv $(System.ArtifactsDirectory)/linux-tests-parallel/* ./
           chmod +x bin/dissolve-mpi
           ctest --output-on-failure
         displayName: 'Run Parallel System Tests'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ enable_testing()
 function(dissolve_system_test directory file_name count)
   if(PARALLEL)
     foreach(nproc 1 2 3 4)
-      set(test_target_executable ../../build/bin/${target_name})
+      set(test_target_executable ${CMAKE_BINARY_DIR}/bin/${target_name})
       add_test(
         NAME ${directory}-${file_name}-${nproc}
         COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${nproc} ${test_target_executable} -n ${count} -x -i ${file_name}.txt ${ARGN}
@@ -22,7 +22,7 @@ function(dissolve_system_test directory file_name count)
       )
     endforeach()
   else()
-    set(test_target_executable ../../build/bin/${target_name})
+    set(test_target_executable ${CMAKE_BINARY_DIR}/bin/${target_name})
     add_test(
       NAME ${directory}-${file_name}
       COMMAND ${test_target_executable} -n ${count} -x -i ${file_name}.txt ${ARGN}


### PR DESCRIPTION
Started as a quick bugfix to more reliably set paths to the generated binaries using `CMAKE_BINARY_DIR` rather than a relative path. Works for CI paths (`build/bin`) as well as more exotic paths used by IDEs (e.g. `cmake-build-debug/bin`).

Also addresses tests not being built in the CI, and adds better failure to parts of the system-tests pipeline.

**NOTE - Not all parallel system tests pass in this PR:**
 - energyforce2-full-2 (fixed in pending PR #504)
 - energyforce2-full-4 (fixed in pending PR #504)
 - exchangeable-watermeth-1 (fails - to be addressed)
 - exchangeable-watermeth-2 (fails - to be addressed)
 - exchangeable-watermeth-3 (fails - to be addressed)
 - exchangeable-watermeth-4 (fails - to be addressed)
 - md-benzene-1 (fixed in pending PR #501)
 - md-benzene-2 (fixed in pending PR #501)
 - md-benzene-3 (fixed in pending PR #501)
 - md-benzene-4 (fixed in pending PR #501)

