### PR TITLE
Namespace math-related classes

### DIFF
--- a/src/math/averaging.cpp
+++ b/src/math/averaging.cpp
@@ -3,8 +3,11 @@
 
 #include "math/averaging.h"
 
+namespace Averaging
+{
+
 // Return enum option info for AveragingScheme
-EnumOptions<Averaging::AveragingScheme> &Averaging::averagingSchemes()
+EnumOptions<Averaging::AveragingScheme> averagingSchemes()
 {
     static EnumOptionsList AveragingSchemeOptions = EnumOptionsList()
                                                     << EnumOption(Averaging::LinearAveraging, "Linear")
@@ -15,3 +18,42 @@ EnumOptions<Averaging::AveragingScheme> &Averaging::averagingSchemes()
 
     return options;
 }
+
+// Establish the number of stored datasets, shift indices down, and lose oldest dataset if necessary
+int pruneOldData(GenericList &moduleData, std::string_view name, std::string_view prefix, int nSetsInAverage)
+{
+    // Establish how many stored datasets we have
+    int nStored = 0;
+    for (nStored = 0; nStored < nSetsInAverage; ++nStored)
+        if (!moduleData.contains(fmt::format("{}_{}", name, nStored + 1), prefix))
+            break;
+    Messenger::print("Average requested over {} datsets - {} available in module data ({} max).\n", nSetsInAverage, nStored,
+                     nSetsInAverage - 1);
+
+    // Remove the oldest dataset if it exists, and shuffle the others down
+    if (nStored == nSetsInAverage)
+    {
+        moduleData.remove(fmt::format("{}_{}", name, nStored), prefix);
+        --nStored;
+    }
+    for (auto n = nStored; n > 0; --n)
+        moduleData.rename(fmt::format("{}_{}", name, n), prefix, fmt::format("{}_{}", name, n + 1), prefix);
+
+    return nStored;
+}
+
+// Return exponential decay factor
+double expDecay() { return 0.7; }
+
+// Return the normalisation factor for the supplied scheme and number of data
+double normalisationFactor(Averaging::AveragingScheme scheme, int nData)
+{
+    if (scheme == Averaging::LinearAveraging)
+        return nData;
+    else if (scheme == Averaging::ExponentialAveraging)
+        return (1.0 - pow(expDecay(), nData)) / (1.0 - expDecay());
+
+    return 1.0;
+}
+
+} // namespace Averaging

--- a/src/math/error.cpp
+++ b/src/math/error.cpp
@@ -7,33 +7,33 @@
 #include "math/interpolator.h"
 #include <algorithm>
 
-using namespace std;
+namespace Error
+{
 
 // Return enum option info for AveragingScheme
-EnumOptions<Error::ErrorType> Error::errorTypes()
+EnumOptions<ErrorType> errorTypes()
 {
     static EnumOptionsList ErrorTypeOptions =
-        EnumOptionsList() << EnumOption(Error::RMSEError, "RMSE") << EnumOption(Error::MAAPEError, "MAAPE")
-                          << EnumOption(Error::MAPEError, "MAPE") << EnumOption(Error::PercentError, "Percent")
-                          << EnumOption(Error::RFactorError, "RFactor");
+        EnumOptionsList() << EnumOption(RMSEError, "RMSE") << EnumOption(MAAPEError, "MAAPE") << EnumOption(MAPEError, "MAPE")
+                          << EnumOption(PercentError, "Percent") << EnumOption(RFactorError, "RFactor");
 
-    static EnumOptions<Error::ErrorType> options("ErrorType", ErrorTypeOptions, Error::PercentError);
+    static EnumOptions<ErrorType> options("ErrorType", ErrorTypeOptions, PercentError);
 
     return options;
 }
 
-// Return erorr of specified type between supplied data
-double Error::error(ErrorType errorType, const Data1D &A, const Data1D &B, bool quiet)
+// Return error of specified type between supplied data
+double error(ErrorType errorType, const Data1D &A, const Data1D &B, bool quiet)
 {
-    if (errorType == Error::RMSEError)
+    if (errorType == RMSEError)
         return rmse(A, B, quiet);
-    else if (errorType == Error::MAAPEError)
+    else if (errorType == MAAPEError)
         return maape(A, B, quiet);
-    else if (errorType == Error::MAPEError)
+    else if (errorType == MAPEError)
         return mape(A, B, quiet);
-    else if (errorType == Error::PercentError)
+    else if (errorType == PercentError)
         return percent(A, B, quiet);
-    else if (errorType == Error::RFactorError)
+    else if (errorType == RFactorError)
         return rFactor(A, B, quiet);
 
     Messenger::error("Error type {} is not accounted for! Take the developer's Kolkata privileges away...\n");
@@ -45,7 +45,7 @@ double Error::error(ErrorType errorType, const Data1D &A, const Data1D &B, bool 
  */
 
 // Return RMSE between supplied data
-double Error::rmse(const Data1D &A, const Data1D &B, bool quiet)
+double rmse(const Data1D &A, const Data1D &B, bool quiet)
 {
     // First, generate interpolation of data B
     Interpolator interpolatedB(B);
@@ -92,7 +92,7 @@ double Error::rmse(const Data1D &A, const Data1D &B, bool quiet)
 }
 
 // Return MAPE between supplied data
-double Error::mape(const Data1D &A, const Data1D &B, bool quiet)
+double mape(const Data1D &A, const Data1D &B, bool quiet)
 {
     // First, generate interpolation of data B
     Interpolator interpolatedB(B);
@@ -142,7 +142,7 @@ double Error::mape(const Data1D &A, const Data1D &B, bool quiet)
 }
 
 // Return MAAPE between supplied data
-double Error::maape(const Data1D &A, const Data1D &B, bool quiet)
+double maape(const Data1D &A, const Data1D &B, bool quiet)
 {
     // First, generate interpolation of data B
     Interpolator interpolatedB(B);
@@ -190,7 +190,7 @@ double Error::maape(const Data1D &A, const Data1D &B, bool quiet)
 }
 
 // Return percentage error between supplied data
-double Error::percent(const Data1D &A, const Data1D &B, bool quiet)
+double percent(const Data1D &A, const Data1D &B, bool quiet)
 {
     // First, generate interpolation of data B
     Interpolator interpolatedB(B);
@@ -246,7 +246,7 @@ double Error::percent(const Data1D &A, const Data1D &B, bool quiet)
 }
 
 // Return R-Factor (average squared error per point) between supplied data
-double Error::rFactor(const Data1D &A, const Data1D &B, bool quiet)
+double rFactor(const Data1D &A, const Data1D &B, bool quiet)
 {
     // First, generate interpolation of data B
     Interpolator interpolatedB(B);
@@ -291,3 +291,5 @@ double Error::rFactor(const Data1D &A, const Data1D &B, bool quiet)
 
     return rfac;
 }
+
+} // namespace Error

--- a/src/math/error.h
+++ b/src/math/error.h
@@ -10,39 +10,36 @@ class Data1D;
 class Data2D;
 
 // Error Calculation
-class Error
+namespace Error
 {
-    /*
-     * Error Type
-     */
-    public:
-    // Error Types
-    enum ErrorType
-    {
-        RMSEError,
-        MAAPEError,
-        MAPEError,
-        PercentError,
-        RFactorError,
-        nErrorCalculationTypes
-    };
-    // Return enum options for ErrorType
-    static EnumOptions<Error::ErrorType> errorTypes();
 
-    /*
-     * Data1D
-     */
-    public:
-    // Return erorr of specified type between supplied data
-    static double error(ErrorType errorType, const Data1D &A, const Data1D &B, bool quiet = false);
-    // Return RMSE between supplied data
-    static double rmse(const Data1D &A, const Data1D &B, bool quiet = false);
-    // Return MAAPE between supplied data
-    static double maape(const Data1D &A, const Data1D &B, bool quiet = false);
-    // Return MAPE between supplied data
-    static double mape(const Data1D &A, const Data1D &B, bool quiet = false);
-    // Return percentage error between supplied data
-    static double percent(const Data1D &A, const Data1D &B, bool quiet = false);
-    // Return R-Factor (average squared error per point) between supplied data
-    static double rFactor(const Data1D &A, const Data1D &B, bool quiet = false);
+// Error Types
+enum ErrorType
+{
+    RMSEError,
+    MAAPEError,
+    MAPEError,
+    PercentError,
+    RFactorError,
+    nErrorCalculationTypes
 };
+// Return enum options for ErrorType
+EnumOptions<Error::ErrorType> errorTypes();
+
+/*
+ * Data1D
+ */
+
+// Return error of specified type between supplied data
+double error(ErrorType errorType, const Data1D &A, const Data1D &B, bool quiet = false);
+// Return RMSE between supplied data
+double rmse(const Data1D &A, const Data1D &B, bool quiet = false);
+// Return MAAPE between supplied data
+double maape(const Data1D &A, const Data1D &B, bool quiet = false);
+// Return MAPE between supplied data
+double mape(const Data1D &A, const Data1D &B, bool quiet = false);
+// Return percentage error between supplied data
+double percent(const Data1D &A, const Data1D &B, bool quiet = false);
+// Return R-Factor (average squared error per point) between supplied data
+double rFactor(const Data1D &A, const Data1D &B, bool quiet = false);
+}; // namespace Error

--- a/src/math/extrema.cpp
+++ b/src/math/extrema.cpp
@@ -5,8 +5,10 @@
 #include "templates/array.h"
 #include "templates/array2d.h"
 
+namespace Extrema
+{
 // Return minimum from 1D array provided
-double Extrema::min(const Array<double> &A)
+double min(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
@@ -23,7 +25,7 @@ double Extrema::min(const Array<double> &A)
 }
 
 // Return maximum from 1D array provided
-double Extrema::max(const Array<double> &A)
+double max(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
@@ -40,7 +42,7 @@ double Extrema::max(const Array<double> &A)
 }
 
 // Return minimum from 2D array provided
-double Extrema::min(const Array2D<double> &A)
+double min(const Array2D<double> &A)
 {
     if (A.empty())
         return 0;
@@ -48,7 +50,7 @@ double Extrema::min(const Array2D<double> &A)
 }
 
 // Return maximum from 2D array provided
-double Extrema::max(const Array2D<double> &A)
+double max(const Array2D<double> &A)
 {
     if (A.empty())
         return 0;
@@ -56,7 +58,7 @@ double Extrema::max(const Array2D<double> &A)
 }
 
 // Return absolute minimum from array provided
-double Extrema::absMin(const Array<double> &A)
+double absMin(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
@@ -73,7 +75,7 @@ double Extrema::absMin(const Array<double> &A)
 }
 
 // Return absolute maximum from array provided
-double Extrema::absMax(const Array<double> &A)
+double absMax(const Array<double> &A)
 {
     if (A.nItems() > 0)
     {
@@ -90,7 +92,7 @@ double Extrema::absMax(const Array<double> &A)
 }
 
 // Return absolute minimum from 2D array provided
-double Extrema::absMin(const Array2D<double> &A)
+double absMin(const Array2D<double> &A)
 {
     if (A.empty())
         return 0;
@@ -98,9 +100,10 @@ double Extrema::absMin(const Array2D<double> &A)
 }
 
 // Return absolute maximum from 2D array provided
-double Extrema::absMax(const Array2D<double> &A)
+double absMax(const Array2D<double> &A)
 {
     if (A.empty())
         return 0;
     return *std::max_element(A.begin(), A.end(), [](auto a, auto b) { return fabs(a) < fabs(b); });
 }
+} // namespace Extrema

--- a/src/math/extrema.h
+++ b/src/math/extrema.h
@@ -9,23 +9,22 @@ template <class T> class Array2D;
 template <class T> class Array3D;
 
 // Extrema
-class Extrema
+namespace Extrema
 {
-    public:
-    // Return minimum from array provided
-    static double min(const Array<double> &A);
-    // Return maximum from array provided
-    static double max(const Array<double> &A);
-    // Return minimum from 2D array provided
-    static double min(const Array2D<double> &A);
-    // Return maximum from 2D array provided
-    static double max(const Array2D<double> &A);
-    // Return absolute minimum from array provided
-    static double absMin(const Array<double> &A);
-    // Return absolute maximum from array provided
-    static double absMax(const Array<double> &A);
-    // Return absolute minimum from 2D array provided
-    static double absMin(const Array2D<double> &A);
-    // Return absolute maximum from 2D array provided
-    static double absMax(const Array2D<double> &A);
-};
+// Return minimum from array provided
+double min(const Array<double> &A);
+// Return maximum from array provided
+double max(const Array<double> &A);
+// Return minimum from 2D array provided
+double min(const Array2D<double> &A);
+// Return maximum from 2D array provided
+double max(const Array2D<double> &A);
+// Return absolute minimum from array provided
+double absMin(const Array<double> &A);
+// Return absolute maximum from array provided
+double absMax(const Array<double> &A);
+// Return absolute minimum from 2D array provided
+double absMin(const Array2D<double> &A);
+// Return absolute maximum from 2D array provided
+double absMax(const Array2D<double> &A);
+}; // namespace Extrema

--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -6,8 +6,10 @@
 #include "math/integrator.h"
 #include "templates/array.h"
 
+namespace Filters
+{
 // Perform point-wise convolution of data with the supplied BroadeningFunction
-void Filters::convolve(Data1D &data, const BroadeningFunction &function, bool variableOmega, bool normalise)
+void convolve(Data1D &data, const BroadeningFunction &function, bool variableOmega, bool normalise)
 {
     // Check for no broadening function specified
     if (function.function() == BroadeningFunction::NoFunction)
@@ -60,7 +62,7 @@ void Filters::convolve(Data1D &data, const BroadeningFunction &function, bool va
 }
 
 // Perform convolution of the supplied delta function into the supplied data
-void Filters::convolve(double xCentre, double value, const BroadeningFunction &function, Data1D &dest)
+void convolve(double xCentre, double value, const BroadeningFunction &function, Data1D &dest)
 {
     // Check for no broadening function specified
     if (function.function() == BroadeningFunction::NoFunction)
@@ -77,14 +79,14 @@ void Filters::convolve(double xCentre, double value, const BroadeningFunction &f
 }
 
 // Apply Kolmogorov–Zurbenko filter
-void Filters::kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised)
+void kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised)
 {
     for (auto iteration = 0; iteration < k; ++iteration)
         normalised ? normalisedMovingAverage(data, m) : movingAverage(data, m);
 }
 
 // Apply median filter to data
-void Filters::median(Data1D &data, int length)
+void median(Data1D &data, int length)
 {
     // Grab y array
     auto &y = data.values();
@@ -140,7 +142,7 @@ void Filters::median(Data1D &data, int length)
 }
 
 // Perform moving average smoothing
-void Filters::movingAverage(Data1D &data, int avgSize)
+void movingAverage(Data1D &data, int avgSize)
 {
     // Grab y array
     auto &y = data.values();
@@ -181,7 +183,7 @@ void Filters::movingAverage(Data1D &data, int avgSize)
 }
 
 // Perform moving average smoothing, normalising area after smooth
-void Filters::normalisedMovingAverage(Data1D &data, int avgSize)
+void normalisedMovingAverage(Data1D &data, int avgSize)
 {
     // Calculate the original integral
     double originalIntegral = Integrator::absTrapezoid(data);
@@ -196,7 +198,7 @@ void Filters::normalisedMovingAverage(Data1D &data, int avgSize)
 }
 
 // Subtract average level from data, forming average from supplied x value
-double Filters::subtractAverage(Data1D &data, double xStart)
+double subtractAverage(Data1D &data, double xStart)
 {
     // Grab x and y arrays
     const auto &x = data.xAxis();
@@ -219,7 +221,7 @@ double Filters::subtractAverage(Data1D &data, double xStart)
 }
 
 // Trim supplied data to specified range
-void Filters::trim(Data1D &data, double xMin, double xMax, bool interpolateEnds, double interpolationThreshold)
+void trim(Data1D &data, double xMin, double xMax, bool interpolateEnds, double interpolationThreshold)
 {
     std::vector<double> newX, newY;
     const auto &x = data.xAxis();
@@ -271,13 +273,13 @@ void Filters::trim(Data1D &data, double xMin, double xMax, bool interpolateEnds,
 }
 
 // Trim supplied data to be the same range as the reference data
-void Filters::trim(Data1D &data, const Data1D &ref, bool interpolateEnds, double interpolationThreshold)
+void trim(Data1D &data, const Data1D &ref, bool interpolateEnds, double interpolationThreshold)
 {
     trim(data, ref.xAxis().front(), ref.xAxis().back(), interpolateEnds, interpolationThreshold);
 }
 
 // Convert bin boundaries to centre-bin values
-void Filters::convertBinBoundaries(Data1D &data)
+void convertBinBoundaries(Data1D &data)
 {
     // Assume that input x values are histogram bin left-boundaries, so x(n) = 0.5[x(n)+x(n_1)]
     auto &x = data.xAxis();
@@ -292,3 +294,4 @@ void Filters::convertBinBoundaries(Data1D &data)
     // Remove last point
     data.removeLastPoint();
 }
+} // namespace Filters

--- a/src/math/filters.h
+++ b/src/math/filters.h
@@ -9,28 +9,26 @@
 class Data1D;
 
 // Filters
-class Filters
+namespace Filters
 {
-    public:
-    // Perform point-wise convolution of data with the supplied BroadeningFunction
-    static void convolve(Data1D &data, const BroadeningFunction &function, bool variableOmega = false, bool normalise = true);
-    // Perform convolution of the supplied delta function into the supplied data
-    static void convolve(double xCentre, double value, const BroadeningFunction &function, Data1D &dest);
-    // Apply Kolmogorov–Zurbenko filter to data
-    static void kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised = false);
-    // Apply median filter to data
-    static void median(Data1D &data, int length);
-    // Perform moving average smoothing on data
-    static void movingAverage(Data1D &data, int avgSize);
-    // Perform moving average smoothing on data, normalising area after smooth
-    static void normalisedMovingAverage(Data1D &data, int avgSize);
-    // Subtract average level (starting at supplied x value) from data
-    static double subtractAverage(Data1D &data, double xStart);
-    // Trim supplied data to specified range
-    static void trim(Data1D &data, double xMin, double xMax, bool interpolateEnds = false,
-                     double interpolationThreshold = 0.01);
-    // Trim supplied data to be the same range as the reference data
-    static void trim(Data1D &data, const Data1D &ref, bool interpolateEnds = false, double interpolationThreshold = 0.01);
-    // Convert bin boundaries to centre-bin values
-    static void convertBinBoundaries(Data1D &data);
-};
+// Perform point-wise convolution of data with the supplied BroadeningFunction
+void convolve(Data1D &data, const BroadeningFunction &function, bool variableOmega = false, bool normalise = true);
+// Perform convolution of the supplied delta function into the supplied data
+void convolve(double xCentre, double value, const BroadeningFunction &function, Data1D &dest);
+// Apply Kolmogorov–Zurbenko filter to data
+void kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised = false);
+// Apply median filter to data
+void median(Data1D &data, int length);
+// Perform moving average smoothing on data
+void movingAverage(Data1D &data, int avgSize);
+// Perform moving average smoothing on data, normalising area after smooth
+void normalisedMovingAverage(Data1D &data, int avgSize);
+// Subtract average level (starting at supplied x value) from data
+double subtractAverage(Data1D &data, double xStart);
+// Trim supplied data to specified range
+void trim(Data1D &data, double xMin, double xMax, bool interpolateEnds = false, double interpolationThreshold = 0.01);
+// Trim supplied data to be the same range as the reference data
+void trim(Data1D &data, const Data1D &ref, bool interpolateEnds = false, double interpolationThreshold = 0.01);
+// Convert bin boundaries to centre-bin values
+void convertBinBoundaries(Data1D &data);
+}; // namespace Filters

--- a/src/math/ft.cpp
+++ b/src/math/ft.cpp
@@ -2,13 +2,14 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "math/ft.h"
-#include "base/sysfunc.h"
 #include "math/data1d.h"
 
+namespace Fourier
+{
 // Perform Fourier sine transform of current distribution function, over range specified, and with specified broadening
 // function, modification function, and window applied (if requested)
-bool Fourier::sineFT(Data1D &data, double normFactor, double wMin, double wStep, double wMax, WindowFunction windowFunction,
-                     BroadeningFunction broadening)
+bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double wMax, WindowFunction windowFunction,
+            BroadeningFunction broadening)
 {
     /*
      * Perform sine Fourier transform of current data. Function has no notion of forward or backwards transforms -
@@ -99,72 +100,4 @@ bool Fourier::sineFT(Data1D &data, double normFactor, double wMin, double wStep,
 
     return true;
 }
-
-// // Fourier transform current data, applying line-width broadening in real-space using the modified Lorch function
-// bool Data1D::transformLorch(double atomicDensity, double step, double rMax, double beta, double delta0, bool qToR)
-// {
-// 	/*
-// 	 * Fourier transforms from Q to r-space, or r to Q-space, employing the modified Lorch function as described by Soper in
-// 	 * XXX TODO.
-// 	 * XXX TODO Only valid when input x_[] values are bin boundaries, not centre-bin values.
-// 	 */
-//
-// 	// Okay to continue with transform?
-// 	if (!checkBeforeTransform()) return false;
-//
-// 	double deltaIn = x_[1] - x_[0];
-// 	double deltar, width, r, factor, norm, ftx, qr, j1qr, j2qr;
-// 	int n, m, nPts = x_.size();
-//
-// 	// Create working arrays
-// 	Array<double> result;
-// 	r = step * 0.5;
-//
-// 	// Set up correct factor, depending on whether we are going from Q -> r or r -> Q
-// 	if (qToR) factor = 1.0 / (2.0 * PI * PI * atomicDensity);
-// 	else factor = 4.0 * PI * atomicDensity;
-//
-// 	// Perform Fourier sine transform
-// 	while (r <= rMax)
-// 	{
-// 		// Reset sum, and calculate r-dependent values
-// 		ftx = 0.0;
-// 		norm = factor / (r*r*r);
-// 		deltar = delta0 * (1.0 + pow(r, beta));
-//
-// 		// Calculate first argument at left-hand bin boundary
-// 		qr = r * x_[0];
-// 		j1qr = sin(qr) - qr * cos(qr);
-//
-// 		for (m=0; m<nPts-1; ++m)
-// 		{
-// 			// Calculate second argument at right-hand bin boundary
-// 			qr = r * x_[m+1];
-// 			j2qr = sin(qr) - qr * cos(qr);
-//
-// 			// Calculate 'width' at centre of bin
-// 			width = 0.5 * (x_[m]+x_[m+1]) * deltar;
-//
-// 			// Form integral of (Q sin Qr)/r from r1 to r2 (as detailed in equation 3.86 in reference above)
-// 			// Modified Lorch function is constructed and applied if the width is non-zero and positive
-// 			if (width < 0.0) ftx += y_[m] * (j2qr - j1qr);
-// 			else ftx += y_[m] * (j2qr - j1qr) * (3.0/(width*width*width)) * (sin(width) - width*cos(width));
-//
-// 			// Overwrite first Lorch argument
-// 			j1qr = j2qr;
-// 		}
-//
-// 		// Sum
-// 		result.add(ftx * norm);
-//
-// 		r += step;
-// 	}
-//
-// 	// Copy transform data over initial data
-// 	y_ = result;
-// 	x_.forgetData();
-// 	for (n=0; n<y_.size(); ++n) x_.add((n+0.5)*step);
-// 	interpolationInterval_ = -1;
-//
-// 	return true;
-// }
+} // namespace Fourier

--- a/src/math/ft.h
+++ b/src/math/ft.h
@@ -10,11 +10,10 @@
 class Data1D;
 
 // Fourier Transforms
-class Fourier
+namespace Fourier
 {
-    public:
-    // Perform Fourier sine transform of supplied data, over range specified, and with specified window and broadening
-    // functions applied
-    static bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double wMax,
-                       WindowFunction windowFunction = WindowFunction(), BroadeningFunction broadening = BroadeningFunction());
-};
+// Perform Fourier sine transform of supplied data, over range specified, and with specified window and broadening
+// functions applied
+bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double wMax,
+            WindowFunction windowFunction = WindowFunction(), BroadeningFunction broadening = BroadeningFunction());
+}; // namespace Fourier

--- a/src/math/gj.cpp
+++ b/src/math/gj.cpp
@@ -4,8 +4,10 @@
 #include "math/gj.h"
 #include "templates/array2d.h"
 
+namespace GaussJordan
+{
 // Perform Gauss-Jordan inversion of the supplied Array2D<double>
-bool GaussJordan::invert(Array2D<double> &A)
+bool invert(Array2D<double> &A)
 {
     // Matrix must be square, and not stored as a half-matrix
     if (A.nRows() != A.nColumns())
@@ -106,3 +108,4 @@ bool GaussJordan::invert(Array2D<double> &A)
 
     return true;
 }
+} // namespace GaussJordan

--- a/src/math/gj.h
+++ b/src/math/gj.h
@@ -7,9 +7,8 @@
 template <class A> class Array2D;
 
 // Gauss-Jordan Inversion
-class GaussJordan
+namespace GaussJordan
 {
-    public:
-    // Perform Gauss-Jordan inversion of the supplied Array2D<double>
-    static bool invert(Array2D<double> &A);
-};
+// Perform Gauss-Jordan inversion of the supplied Array2D<double>
+bool invert(Array2D<double> &A);
+}; // namespace GaussJordan

--- a/src/math/mathfunc.cpp
+++ b/src/math/mathfunc.cpp
@@ -6,12 +6,15 @@
 #include <cstdlib>
 #include <math.h>
 
+namespace DissolveMath
+{
+
 /*
  * Error Functions
  */
 
 // Error Function
-double DissolveMath::erfc(double x)
+double erfc(double x)
 {
     // Approximation to the complementary error function.
     // Ref: Abramowitz and Stegun, Handbook of Mathematical Functions,
@@ -25,14 +28,14 @@ double DissolveMath::erfc(double x)
 }
 
 // Complementary error function
-double DissolveMath::erf(double x) { return (1.0 - erfc(x)); }
+double erf(double x) { return (1.0 - erfc(x)); }
 
 /*
  * Random Number Generation
  */
 
 // Random Number Generator (0 - 1)
-double DissolveMath::random()
+double random()
 {
     // Simple random number generator from C++ stdlib.
     // Returns numbers from 0.0 to 1.0 inclusive.
@@ -41,17 +44,17 @@ double DissolveMath::random()
 }
 
 // Return random value between -1 and 1.0 inclusive
-double DissolveMath::randomPlusMinusOne() { return (random() - 0.5) * 2.0; }
+double randomPlusMinusOne() { return (random() - 0.5) * 2.0; }
 
 // Random number generator (0 - RAND_MAX)
-int DissolveMath::randomimax()
+int randomimax()
 {
     // Returns a random number from 0->(RAND_MAX-1) inclusive.
     return rand();
 }
 
 // Random number generator (0 - range-1)
-int DissolveMath::randomi(int range)
+int randomi(int range)
 {
     // Returns a random number from 0->(range-1) inclusive.
     return int(range * (double(rand() - 1) / RAND_MAX));
@@ -62,7 +65,7 @@ int DissolveMath::randomi(int range)
  */
 
 // Integer power function
-int DissolveMath::power(int i, int p)
+int power(int i, int p)
 {
     static int result, n;
     result = i;
@@ -75,13 +78,15 @@ int DissolveMath::power(int i, int p)
 }
 
 // Sign function
-int DissolveMath::sgn(int x) { return (x < 0 ? -1 : (x == 0 ? 0 : 1)); }
+int sgn(int x) { return (x < 0 ? -1 : (x == 0 ? 0 : 1)); }
 
 // Sign function
-int DissolveMath::sgn(double x) { return (x < 0.0 ? -1 : x > 0.0); }
+int sgn(double x) { return (x < 0.0 ? -1 : x > 0.0); }
 
 // Apply sign of second argument to first
-double DissolveMath::sgn(double a, double signOf) { return signOf >= 0.0 ? fabs(a) : -fabs(a); }
+double sgn(double a, double signOf) { return signOf >= 0.0 ? fabs(a) : -fabs(a); }
 
 // Return the cyclic permutation of the integer 'i', span 3
-int DissolveMath::cp3(int i) { return (i % 3); }
+int cp3(int i) { return (i % 3); }
+
+} // namespace DissolveMath

--- a/src/math/mathfunc.h
+++ b/src/math/mathfunc.h
@@ -7,36 +7,33 @@
 template <class A> class Array2D;
 
 // Mathematical functions
-class DissolveMath
+namespace DissolveMath
 {
-    /*
-     * Error Functions
-     */
-    public:
-    static double erfc(double);
-    static double erf(double);
+/*
+ * Error Functions
+ */
+double erfc(double);
+double erf(double);
 
-    /*
-     * Random Number Generation
-     */
-    public:
-    static double random();
-    static double randomPlusMinusOne();
-    static int randomimax();
-    static int randomi(int range);
+/*
+ * Random Number Generation
+ */
+double random();
+double randomPlusMinusOne();
+int randomimax();
+int randomi(int range);
 
-    /*
-     * Integer Functions
-     */
-    public:
-    // Raise the integer 'i' to the power 'p'
-    static int power(int i, int p);
-    // Sign function
-    static int sgn(int x);
-    // Sign function
-    static int sgn(double x);
-    // Apply sign of second argument to first
-    static double sgn(double a, double signOf);
-    // Return the cyclic permutation of the integer 'i', span 3
-    static int cp3(int i);
-};
+/*
+ * Integer Functions
+ */
+// Raise the integer 'i' to the power 'p'
+int power(int i, int p);
+// Sign function
+int sgn(int x);
+// Sign function
+int sgn(double x);
+// Apply sign of second argument to first
+double sgn(double a, double signOf);
+// Return the cyclic permutation of the integer 'i', span 3
+int cp3(int i);
+}; // namespace DissolveMath

--- a/src/math/regression.cpp
+++ b/src/math/regression.cpp
@@ -5,15 +5,17 @@
 #include "math/data1d.h"
 #include "templates/array.h"
 
+namespace Regression
+{
 // Return gradient of last n points
-double Regression::linear(const Data1D &data, int nSamples)
+double linear(const Data1D &data, int nSamples)
 {
     double yMean;
     return linear(data, nSamples, yMean);
 }
 
 // Return gradient of last n points, along with average y value
-double Regression::linear(const Data1D &data, int nSamples, double &yBar)
+double linear(const Data1D &data, int nSamples, double &yBar)
 {
     // Grab data arrays
     const auto &x = data.xAxis();
@@ -46,3 +48,4 @@ double Regression::linear(const Data1D &data, int nSamples, double &yBar)
     // Return the gradient
     return Sxy / Sxx;
 }
+} // namespace Regression

--- a/src/math/regression.h
+++ b/src/math/regression.h
@@ -7,11 +7,10 @@
 class Data1D;
 
 // Regression
-class Regression
+namespace Regression
 {
-    public:
-    // Return gradient of last n points
-    static double linear(const Data1D &data, int nSamples);
-    // Return gradient of last n points, along with average y value
-    static double linear(const Data1D &data, int nSamples, double &yBar);
-};
+// Return gradient of last n points
+double linear(const Data1D &data, int nSamples);
+// Return gradient of last n points, along with average y value
+double linear(const Data1D &data, int nSamples, double &yBar);
+}; // namespace Regression


### PR DESCRIPTION
Quick PR to move math-related static functions encapsulated within classes into namespaces.

Closes #274.

**Requires rebase - do not merge until rebased after #501 and #500 are merged.**