### PR TITLE
Improve error calculation for system tests

### DIFF
--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -245,8 +245,8 @@ std::vector<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const st
 // Calculate and return Q-dependent average squared scattering (<b>**2) for supplied Q value
 double XRayWeights::boundCoherentSquareOfAverage(double Q) const
 {
-    auto result = std::inner_product(concentrations_.begin(), concentrations_.end(), formFactorData_.begin(), 0, std::plus<>(),
-                                     [Q](auto con, auto form) { return con * form.get().magnitude(Q); });
+    auto result = std::inner_product(concentrations_.begin(), concentrations_.end(), formFactorData_.begin(), 0.0,
+                                     std::plus<>(), [Q](auto con, auto form) { return con * form.get().magnitude(Q); });
     return result * result;
 }
 
@@ -273,7 +273,7 @@ std::vector<double> XRayWeights::boundCoherentSquareOfAverage(const std::vector<
 // Calculate and return Q-dependent squared average scattering (<b**2>) for supplied Q value
 double XRayWeights::boundCoherentAverageOfSquares(double Q) const
 {
-    return std::inner_product(concentrations_.begin(), concentrations_.end(), formFactorData_.begin(), 0, std::plus<>(),
+    return std::inner_product(concentrations_.begin(), concentrations_.end(), formFactorData_.begin(), 0.0, std::plus<>(),
                               [Q](auto con, auto form) { return con * form.get().magnitude(Q) * form.get().magnitude(Q); });
 }
 

--- a/src/math/error.cpp
+++ b/src/math/error.cpp
@@ -13,9 +13,10 @@ namespace Error
 // Return enum option info for AveragingScheme
 EnumOptions<ErrorType> errorTypes()
 {
-    static EnumOptionsList ErrorTypeOptions =
-        EnumOptionsList() << EnumOption(RMSEError, "RMSE") << EnumOption(MAAPEError, "MAAPE") << EnumOption(MAPEError, "MAPE")
-                          << EnumOption(PercentError, "Percent") << EnumOption(RFactorError, "RFactor");
+    static EnumOptionsList ErrorTypeOptions = EnumOptionsList()
+                                              << EnumOption(RMSEError, "RMSE") << EnumOption(MAAPEError, "MAAPE")
+                                              << EnumOption(MAPEError, "MAPE") << EnumOption(PercentError, "Percent")
+                                              << EnumOption(RFactorError, "RFactor") << EnumOption(EuclideanError, "Euclidean");
 
     static EnumOptions<ErrorType> options("ErrorType", ErrorTypeOptions, PercentError);
 
@@ -35,6 +36,8 @@ double error(ErrorType errorType, const Data1D &A, const Data1D &B, bool quiet)
         return percent(A, B, quiet);
     else if (errorType == RFactorError)
         return rFactor(A, B, quiet);
+    else if (errorType == EuclideanError)
+        return euclidean(A, B, quiet);
 
     Messenger::error("Error type {} is not accounted for! Take the developer's Kolkata privileges away...\n");
     return 0.0;
@@ -290,6 +293,55 @@ double rFactor(const Data1D &A, const Data1D &B, bool quiet)
                          lastX, nPointsConsidered);
 
     return rfac;
+}
+
+// Return Euclidean distance, normalised to mean of B, between supplied data
+double euclidean(const Data1D &A, const Data1D &B, bool quiet)
+{
+    // First, generate interpolation of data B
+    Interpolator interpolatedB(B);
+
+    // Grab x and y arrays from data A
+    const auto &aX = A.xAxis();
+    const auto &aY = A.values();
+
+    auto a2 = 0.0, a = 0.0, sos = 0.0, delta = 0.0;
+    double firstX = 0.0, lastX = 0.0, x = 0.0;
+    auto nPointsConsidered = 0;
+    for (auto n = 0; n < aX.size(); ++n)
+    {
+        // Grab x value
+        x = aX[n];
+
+        // Is our x value lower than the lowest x value of the reference data?
+        if (x < B.xAxis().front())
+            continue;
+
+        // Is our x value higher than the last x value of the reference data?
+        if (x > B.xAxis().back())
+            break;
+
+        // Is this the first point considered?
+        if (nPointsConsidered == 0)
+            firstX = x;
+
+        a = aY[n];
+
+        delta = a - interpolatedB.y(x);
+        sos += delta * delta;
+        a2 += a * a;
+
+        lastX = x;
+        ++nPointsConsidered;
+    }
+
+    // Calculate final error and summarise result
+    auto euc = sos / sqrt(a2);
+    if (!quiet)
+        Messenger::print("Euclidean between datasets is {:15.9e} over {:15.9e} < x < {:15.9e} ({} points).\n", euc, firstX,
+                         lastX, nPointsConsidered);
+
+    return euc;
 }
 
 } // namespace Error

--- a/src/math/error.h
+++ b/src/math/error.h
@@ -21,6 +21,7 @@ enum ErrorType
     MAPEError,
     PercentError,
     RFactorError,
+    EuclideanError,
     nErrorCalculationTypes
 };
 // Return enum options for ErrorType
@@ -42,4 +43,7 @@ double mape(const Data1D &A, const Data1D &B, bool quiet = false);
 double percent(const Data1D &A, const Data1D &B, bool quiet = false);
 // Return R-Factor (average squared error per point) between supplied data
 double rFactor(const Data1D &A, const Data1D &B, bool quiet = false);
+// Return Euclidean distance, normalised to mean of B, between supplied data
+double euclidean(const Data1D &A, const Data1D &B, bool quiet = false);
+
 }; // namespace Error

--- a/src/modules/datatest/init.cpp
+++ b/src/modules/datatest/init.cpp
@@ -13,9 +13,9 @@ void DataTestModule::initialise()
                   "<target> <fileformat> <filename> [options...]");
     keywords_.add("Test", new Data2DStoreKeyword(test2DData_), "Data2D", "Specify two-dimensional test reference data",
                   "<target> <fileformat> <filename> [options...]");
-    keywords_.add("Test", new EnumOptionsKeyword<Error::ErrorType>(Error::errorTypes() = Error::PercentError), "ErrorType",
+    keywords_.add("Test", new EnumOptionsKeyword<Error::ErrorType>(Error::errorTypes() = Error::EuclideanError), "ErrorType",
                   "Type of error calculation to use");
     keywords_.add("Test", new ModuleRefListKeyword(targetModule_, 1), "Target", "Module containing target data", "<Module>");
-    keywords_.add("Test", new DoubleKeyword(0.1, 1.0e-5), "Threshold", "Test threshold (%error) above which test fails",
+    keywords_.add("Test", new DoubleKeyword(5.0e-3, 1.0e-5), "Threshold", "Threshold for error metric above which test fails",
                   "<threshold[0.1]>");
 }

--- a/src/modules/datatest/process.cpp
+++ b/src/modules/datatest/process.cpp
@@ -49,7 +49,7 @@ bool DataTestModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
         // Generate the error estimate and compare against the threshold value
         double error = Error::error(errorType, data, *testData1D, true);
-        Messenger::print("Target data '{}' has error of {:7.3f} with calculated data and is {} (threshold is {:6.3e})\n\n",
+        Messenger::print("Target data '{}' has error of {:7.3e} with calculated data and is {} (threshold is {:6.3e})\n\n",
                          testData1D->name(), error, error <= testThreshold ? "OK" : "NOT OK", testThreshold);
         if (error > testThreshold)
             return false;

--- a/src/modules/datatest/process.cpp
+++ b/src/modules/datatest/process.cpp
@@ -50,8 +50,8 @@ bool DataTestModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Generate the error estimate and compare against the threshold value
         double error = Error::error(errorType, data, *testData1D, true);
         Messenger::print("Target data '{}' has error of {:7.3e} with calculated data and is {} (threshold is {:6.3e})\n\n",
-                         testData1D->name(), error, error <= testThreshold ? "OK" : "NOT OK", testThreshold);
-        if (error > testThreshold)
+                         testData1D->name(), error, isnan(error) || error > testThreshold ? "NOT OK" : "OK", testThreshold);
+        if (isnan(error) || error > testThreshold)
             return false;
     }
 
@@ -77,8 +77,8 @@ bool DataTestModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Generate the error estimate and compare against the threshold value
         // 		double error = Error::error(errorType, data, *testData2D, true);
         // 		Messenger::print("Target data '{}' has error of {:7.3f} with calculated data and is {} (threshold
-        // is {:6.3e})\n\n", testData2D->name(), error, error <= testThreshold ? "OK" : "NOT OK", testThreshold); if
-        // (error > testThreshold) return false;
+        // is {:6.3e})\n\n", testData2D->name(), error, isnan(error) || error > testThreshold ? "NOT OK" : "OK", testThreshold);
+        // if (isnan(error) || error > testThreshold) return false;
 
         return Messenger::error("Error calculation between 2D datasets is not yet implemented.\n");
     }

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -228,7 +228,7 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                             dissolve.processingModuleData().version("UnweightedGR", rdfModule->uniqueName()),
                                             includeBragg ? dissolve.processingModuleData().version("BraggReflections") : -1));
     // Save data if requested
-    if (saveData && (!MPIRunMaster(procPool, unweightedsq.save())))
+    if (saveData && !MPIRunMaster(procPool, unweightedsq.save()))
         return false;
 
     return true;

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -228,7 +228,7 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                             dissolve.processingModuleData().version("UnweightedGR", rdfModule->uniqueName()),
                                             includeBragg ? dissolve.processingModuleData().version("BraggReflections") : -1));
     // Save data if requested
-    if (saveData && configurationLocal_ && (!MPIRunMaster(procPool, unweightedsq.save())))
+    if (saveData && (!MPIRunMaster(procPool, unweightedsq.save())))
         return false;
 
     return true;

--- a/tests/broadening/argon_dep0.1indep0.2.txt
+++ b/tests/broadening/argon_dep0.1indep0.2.txt
@@ -45,7 +45,6 @@ Module  NeutronSQ
 EndModule
 
 Module DataTest
-  Threshold  0.07
   Data1D  'NeutronSQ01//WeightedSQ//Total'  xy  '../_data/epsr25/argon10000_dep0.1indep0.2/argon.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/broadening/argon_dep0.2indep0.1.txt
+++ b/tests/broadening/argon_dep0.2indep0.1.txt
@@ -45,7 +45,6 @@ Module  NeutronSQ
 EndModule
 
 Module DataTest
-  Threshold  0.25
   Data1D  'NeutronSQ01//WeightedSQ//Total'  xy  '../_data/epsr25/argon10000_dep0.2indep0.1/argon.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/broadening/argon_qdep0.1.txt
+++ b/tests/broadening/argon_qdep0.1.txt
@@ -45,7 +45,6 @@ Module  NeutronSQ
 EndModule
 
 Module DataTest
-  Threshold  0.35
   Data1D  'NeutronSQ01//WeightedSQ//Total'  xy  '../_data/epsr25/argon10000_qdep0.1/argon.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/broadening/argon_qdep0.2.txt
+++ b/tests/broadening/argon_qdep0.2.txt
@@ -45,7 +45,6 @@ Module  NeutronSQ
 EndModule
 
 Module DataTest
-  Threshold  0.38
   Data1D  'NeutronSQ01//WeightedSQ//Total'  xy  '../_data/epsr25/argon10000_qdep0.2/argon.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/broadening/argon_qindep0.1.txt
+++ b/tests/broadening/argon_qindep0.1.txt
@@ -45,7 +45,6 @@ Module  NeutronSQ
 EndModule
 
 Module DataTest
-  Threshold  0.5
   Data1D  'NeutronSQ01//WeightedSQ//Total'  xy  '../_data/epsr25/argon10000_qindep0.1/argon.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/broadening/argon_qindep0.2.txt
+++ b/tests/broadening/argon_qindep0.2.txt
@@ -45,7 +45,6 @@ Module  NeutronSQ
 EndModule
 
 Module DataTest
-  Threshold  0.25
   Data1D  'NeutronSQ01//WeightedSQ//Total'  xy  '../_data/epsr25/argon10000_qindep0.2/argon.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/calculate_cn/cn.txt
+++ b/tests/calculate_cn/cn.txt
@@ -156,18 +156,18 @@ EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  9.0e-3
   Target  'RDF(OW-OW)'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_02_02'
   EndData1D
-  Threshold  2.0
 EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  9.0e-3
   Target  'RDF(OW-OW)-Analyser'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_02_02'
   EndData1D
-  Threshold  2.0
 EndModule
 
 # Hydrogen-hydrogen (H1-H2, 1-3) radial distribution function, excluding intramolecular correlations
@@ -222,18 +222,18 @@ EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  6.0e-3
   Target  'RDF(H1-H2)'
   Data1D  RDF_Bulk  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_01_03'
   EndData1D
-  Threshold  1.5
 EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  6.0e-3
   Target  'RDF(H1-H2)-Analyser'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_01_03'
   EndData1D
-  Threshold  1.5
 EndModule
 
 # Center-of-mass radial distribution function
@@ -293,7 +293,7 @@ Module CalculateCN  'CN(COM-COM)'
   RangeBEnabled  True
   TestRangeA  4.32359551
   TestRangeB  19.413049
-  TestThreshold  0.2
+  Frequency  95
 EndModule
 
 Module DataTest
@@ -301,7 +301,6 @@ Module DataTest
   Target  'RDF(COM-COM)'
   Data1D  RDF_Bulk  xy  '../_data/dlpoly/water267-analysis/water-267-298K.rdf11'
   EndData1D
-  Threshold  0.75
 EndModule
 
 Module DataTest
@@ -309,7 +308,6 @@ Module DataTest
   Target  'RDF(COM-COM)-Analyser'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.rdf11'
   EndData1D
-  Threshold  0.75
 EndModule
 
 EndLayer

--- a/tests/calculate_dangle/dangle.txt
+++ b/tests/calculate_dangle/dangle.txt
@@ -236,7 +236,6 @@ Module DataTest
   Target  'DAngle(X-H...O)'
   Data1D  'DAngle(X-H...O)_RDF(BC)_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf_21_23_inter_sum'
   EndData1D
-  Threshold  1.03
 EndModule
 
 Module DataTest
@@ -244,7 +243,6 @@ Module DataTest
   Target  'DAngle(X-H...O)-Analyser'
   Data1D  'DAngle(X-H...O)-Analyser//Process1D//Bulk//RDF'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf_21_23_inter_sum'
   EndData1D
-  Threshold  1.03
 EndModule
 
 Module DataTest
@@ -252,7 +250,6 @@ Module DataTest
   Target  'DAngle(X-H...O)'
   Data1D  'DAngle(X-H...O)_ANGLE(ABC)_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.dahist1_02_1_01_02.angle.norm'
   EndData1D
-  Threshold  0.4
 EndModule
 
 Module DataTest
@@ -260,7 +257,6 @@ Module DataTest
   Target  'DAngle(X-H...O)-Analyser'
   Data1D  'DAngle(X-H...O)-Analyser//Process1D//Bulk//Angle'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.dahist1_02_1_01_02.angle.norm'
   EndData1D
-  Threshold  0.4
 EndModule
 
 Module DataTest
@@ -270,7 +266,6 @@ Module DataTest
 #    XRange  0.0  5.0  0.01
 #    YRange  0.0  180  1.0
   #EndData2D
-  Threshold  0.3
 EndModule
 
 EndLayer

--- a/tests/calculate_rdf/rdf.txt
+++ b/tests/calculate_rdf/rdf.txt
@@ -156,18 +156,18 @@ EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  9.0e-3
   Target  'RDF(OW-OW)'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_02_02'
   EndData1D
-  Threshold  1.4
 EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  9.0e-3
   Target  'RDF(OW-OW)-Analyser'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_02_02'
   EndData1D
-  Threshold  1.4
 EndModule
 
 # Hydrogen-hydrogen (H1-H2, 1-3) radial distribution function, excluding intramolecular correlations
@@ -222,18 +222,18 @@ EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  6.0e-3
   Target  'RDF(H1-H2)'
   Data1D  RDF_Bulk  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_01_03'
   EndData1D
-  Threshold  1.1
 EndModule
 
 Module DataTest
   Frequency  95
+  Threshold  6.0e-3
   Target  'RDF(H1-H2)-Analyser'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.aardf1_01_03'
   EndData1D
-  Threshold  1.1
 EndModule
 
 # Center-of-mass radial distribution function
@@ -291,7 +291,6 @@ Module DataTest
   Target  'RDF(COM-COM)'
   Data1D  RDF_Bulk  xy  '../_data/dlpoly/water267-analysis/water-267-298K.rdf11'
   EndData1D
-  Threshold  0.6
 EndModule
 
 Module DataTest
@@ -299,7 +298,6 @@ Module DataTest
   Target  'RDF(COM-COM)-Analyser'
   Data1D  'RDF_Bulk'  xy  '../_data/dlpoly/water267-analysis/water-267-298K.rdf11'
   EndData1D
-  Threshold  0.6
 EndModule
 
 EndLayer

--- a/tests/correlations/sq.txt
+++ b/tests/correlations/sq.txt
@@ -42,7 +42,6 @@ Layer  'Processing'
 # -- Partial g(r) (unbound terms)
 Module  DataTest  'Partial g(r) (unbound)'
 Threshold  0.06
-ErrorType  RMSE
 Data1D  'Bulk//RDF01//OriginalGR//OW-OW//Unbound'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.g01'
     Y  2
 EndData1D
@@ -56,7 +55,6 @@ EndModule
 
 # -- Partial g(r) (intramolecular terms)
 Module  DataTest  'Partial g(r) (bound)'
-ErrorType  RMSE
 Threshold  0.1
 Data1D  'Bulk//RDF01//OriginalGR//OW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.y01'
     Y  4
@@ -68,7 +66,8 @@ EndModule
 
 # -- Partial g(r) (intramolecular terms)
 Module  DataTest  'Partial g(r) (zeroed bound)'
-Threshold  0.001
+ErrorType  RMSE
+Threshold  1.0e-5
 Data1D  'Bulk//RDF01//OriginalGR//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.y01'
     Y  2
 EndData1D
@@ -79,19 +78,18 @@ QMin 0.05
 QBroadening  OmegaDependentGaussian  0.02    # For SLS
 WindowFunction  None
 SourceRDFs  'RDF01'
+# Save  On
 EndModule
 
 Module  NeutronSQ  'D2O'
 SourceSQs  'SQ01'
 Isotopologue  'Water'  'Deuteriated'  1.0
-# SaveUnweighted  On
+# SaveSQ  On
 Frequency  1
 EndModule
 
 # -- Partial S(Q) (unbound terms)
 Module  DataTest  'Partial S(Q) (unbound)'
-ErrorType  RMSE
-Threshold  0.01
 Data1D  'SQ01//UnweightedSQ//OW-OW//Unbound'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.f01'
     Y  2
 EndData1D
@@ -105,8 +103,6 @@ EndModule
 
 # -- Partial S(Q) (bound terms)
 Module  DataTest  'Partial S(Q) (bound)'
-ErrorType  RMSE
-Threshold  0.002
 Data1D  'SQ01//UnweightedSQ//OW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.s01'
     Y  4
 EndData1D
@@ -118,7 +114,7 @@ EndModule
 # -- Partial S(Q) (bound terms)
 Module  DataTest  'Partial S(Q) (zeroed bound)'
 ErrorType  RMSE
-Threshold  0.001
+Threshold  1.0e-5
 Data1D  'SQ01//UnweightedSQ//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.s01'
     Y  2
 EndData1D
@@ -126,8 +122,6 @@ EndModule
 
 # -- Total neutron-weighted F(Q)
 Module  DataTest  'F(Q) D2O'
-ErrorType  RMSE
-Threshold  2.0e-3
 Data1D  'D2O//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.u01'
     Y  2
 EndData1D
@@ -136,14 +130,12 @@ EndModule
 Module  NeutronSQ  'H2O'
 SourceSQs  'SQ01'
 Isotopologue  'Water'  'Protiated'  1.0
-# Save  On
+# SaveSQ  On
 Frequency  1
 EndModule
 
 # -- Total neutron-weighted F(Q)
 Module  DataTest  'F(Q) H2O'
-ErrorType  RMSE
-Threshold  0.09
 Data1D  'H2O//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.u01'
     Y  4
 EndData1D
@@ -154,14 +146,12 @@ SourceSQs  'SQ01'
 Isotopologue  'Water'  'Protiated'  0.5
 Isotopologue  'Water'  'Deuteriated'  0.5
 Exchangeable  HW
-# Save  On
+# SaveSQ  On
 Frequency  1
 EndModule
 
 # -- Total neutron-weighted F(Q)
 Module  DataTest  'F(Q) HDO'
-ErrorType  RMSE
-Threshold  0.06
 Data1D  'HDO//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron/water.EPSR.u01'
     Y  6
 EndData1D

--- a/tests/epsr/benzene.txt
+++ b/tests/epsr/benzene.txt
@@ -133,11 +133,11 @@ Module  RDF  'RDFs'
   IntraBroadening  None
   BinWidth  0.03
   Frequency  1
+  #Save  On
 EndModule
 
 # Test partial g(r) (unbound terms)
 Module  DataTest  'Partial g(r) (unbound)'
-  ErrorType  RMSE
   Threshold  0.05
   Data1D  'Liquid//RDFs//OriginalGR//CA-CA//Unbound'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.g01'
     Y  2
@@ -152,8 +152,7 @@ EndModule
 
 # Test partial g(r) (intramolecular terms)
 Module  DataTest  'Partial g(r) (bound)'
-  ErrorType  RMSE
-  Threshold  0.08
+  Threshold  0.15
   Data1D  'Liquid//RDFs//OriginalGR//CA-CA//Bound'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.y01'
     Y  2
   EndData1D
@@ -170,6 +169,7 @@ Module SQ  'SQs'
   SourceRDFs  'RDFs'
   QBroadening  OmegaDependentGaussian  0.02
   WindowFunction  Lorch0
+  #Save  On
 EndModule
 
 # Calculate S(Q) for the C6H6 sample
@@ -179,12 +179,13 @@ Module  NeutronSQ  'C6H6'
   Reference  mint  '../_data/epsr25/benzene200-neutron/C6H6.mint01'
   EndReference
   Frequency  1
+  #SaveSQ  On
+  #SaveGR  On
 EndModule
 
 # Test partial S(Q) (unbound terms)
 Module  DataTest  'Partial S(Q) (unbound)'
-  ErrorType  RMSE
-  Threshold  0.04
+  Threshold  8.0e-3
   Data1D  'SQs//UnweightedSQ//CA-CA//Unbound'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.f01'
     Y  2
   EndData1D
@@ -198,8 +199,7 @@ EndModule
 
 # Test partial S(Q) (bound terms)
 Module  DataTest  'Partial S(Q) (bound)'
-  ErrorType  RMSE
-  Threshold  0.04
+  Threshold  0.01
   Data1D  'SQs//UnweightedSQ//CA-CA//Bound'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.s01'
     Y  2
   EndData1D
@@ -213,8 +213,6 @@ EndModule
 
 # Test total neutron-weighted F(Q)
 Module  DataTest  'F(Q) C6H6'
-  ErrorType  RMSE
-  Threshold  0.003
   Data1D  'C6H6//WeightedSQ//Total'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.u01'
     Y  2
   EndData1D
@@ -227,12 +225,12 @@ Module  NeutronSQ  'C6D6'
   Reference  mint  '../_data/epsr25/benzene200-neutron/C6D6.mint01'
   EndReference
   Frequency  1
+  #SaveSQ  On
+  #SaveGR  On
 EndModule
 
 # Test total neutron-weighted F(Q)
 Module  DataTest  'F(Q) C6D6'
-  ErrorType  RMSE
-  Threshold  0.003
   Data1D  'C6D6//WeightedSQ//Total'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.u01'
     Y  4
   EndData1D
@@ -246,12 +244,12 @@ Module  NeutronSQ  '5050'
   Reference  mint  '../_data/epsr25/benzene200-neutron/5050.mint01'
   EndReference
   Frequency  1
+  #SaveSQ  On
+  #SaveGR  On
 EndModule
 
 # Test total neutron-weighted F(Q)
 Module  DataTest  'F(Q) 5050'
-  ErrorType  RMSE
-  Threshold  0.003
   Data1D  '5050//WeightedSQ//Total'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.u01'
     Y  6
   EndData1D
@@ -271,12 +269,13 @@ Module  EPSR
   Frequency  1
   NPitss  10
   Feedback  0.9
+  #SaveSimulatedFR  On
+  #SaveEstimatedPartials  On
 EndModule
 
 # Test total neutron-weighted F(r)
 Module DataTest
-  ErrorType  RMSE
-  Threshold  0.02
+  Threshold  1.7e-2
   Data1D  'EPSR01//SimulatedFR//C6H6'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.x01'
     Y  2
   EndData1D
@@ -290,8 +289,7 @@ EndModule
 
 # Test partial S(Q) derived from experiment via matrix inversion
 Module DataTest
-  ErrorType  RMSE
-  Threshold  0.04
+  Threshold  2.0e-2
   Data1D  'EPSR01//EstimatedSQ//Default//CA-CA'  xy  '../_data/epsr25/benzene200-neutron/benzene.EPSR.q01'
     Y  2
   EndData1D

--- a/tests/epsr/water-neutron-xray.txt
+++ b/tests/epsr/water-neutron-xray.txt
@@ -104,11 +104,11 @@ Layer  'RDF / Neutron / XRay'
 
     Configuration  'Bulk'
     IntraBroadening  None
+    #Save  On
   EndModule
 
   # Test partial g(r) (unbound terms)
   Module  DataTest  'Partial g(r) (unbound)'
-    ErrorType  RMSE
     Threshold  0.05
     Data1D  'Bulk//RDFs//OriginalGR//OW-OW//Unbound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.g01'
         Y  2
@@ -123,11 +123,7 @@ Layer  'RDF / Neutron / XRay'
 
   # Test partial g(r) (intramolecular terms)
   Module  DataTest  'Partial g(r) (bound)'
-    ErrorType  RMSE
-    Threshold  0.11
-    Data1D  'Bulk//RDFs//OriginalGR//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.y01'
-        Y  2
-    EndData1D
+    Threshold  0.2
     Data1D  'Bulk//RDFs//OriginalGR//OW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.y01'
         Y  4
     EndData1D
@@ -136,17 +132,25 @@ Layer  'RDF / Neutron / XRay'
     EndData1D
   EndModule
 
+  # Test partial g(r) (zeroed intramolecular terms)
+  Module  DataTest  'Partial g(r) (zeroed bound)'
+    ErrorType  RMSE
+    Threshold  1.0e-5
+    Data1D  'Bulk//RDFs//OriginalGR//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.y01'
+        Y  2
+    EndData1D
+  EndModule
+
   Module  SQ  'SQs'
     Frequency  1
 
     SourceRDFs  'RDFs'
     QBroadening  'OmegaDependentGaussian'  0.020000
+    #Save  On
   EndModule
 
   # Test partial S(Q) (unbound terms)
   Module  DataTest  'Partial S(Q) (unbound)'
-    ErrorType  RMSE
-    Threshold  0.04
     Data1D  'SQs//UnweightedSQ//OW-OW//Unbound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.f01'
       Y  2
     EndData1D
@@ -160,16 +164,20 @@ Layer  'RDF / Neutron / XRay'
 
   # Test partial S(Q) (bound terms)
   Module  DataTest  'Partial S(Q) (bound)'
-    ErrorType  RMSE
-    Threshold  0.04
-    Data1D  'SQs//UnweightedSQ//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.s01'
-      Y  2
-    EndData1D
     Data1D  'SQs//UnweightedSQ//OW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.s01'
       Y  4
     EndData1D
     Data1D  'SQs//UnweightedSQ//HW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.s01'
       Y  6
+    EndData1D
+  EndModule
+
+  # Test partial S(Q) (zeroes bound terms)
+  Module  DataTest  'Partial S(Q) (zeroed bound)'
+    ErrorType  RMSE
+    Threshold  1.0e-5
+    Data1D  'SQs//UnweightedSQ//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.s01'
+      Y  2
     EndData1D
   EndModule
 
@@ -180,12 +188,11 @@ Layer  'RDF / Neutron / XRay'
     Isotopologue  'Water'  'Natural'  1.000000
     Reference  mint  '../_data/epsr25/water1000-neutron-xray/H2O.mint01'
     EndReference
+    #SaveSQ  On
   EndModule
   
   # Test total neutron-weighted F(Q)
   Module  DataTest  'F(Q) H2O'
-    ErrorType  RMSE
-    Threshold  0.0035
     Data1D  'H2O//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.u01'
       Y  4
     EndData1D
@@ -198,11 +205,10 @@ Layer  'RDF / Neutron / XRay'
     Isotopologue  'Water'  'Deuterated'  1.000000
     Reference  mint  '../_data/epsr25/water1000-neutron-xray/D2O.mint01'
     EndReference
+    #SaveSQ  On
   EndModule
 
   Module  DataTest  'F(Q) D2O'
-    ErrorType  RMSE
-    Threshold  0.0035
     Data1D  'D2O//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.u01'
       Y  2
     EndData1D
@@ -217,11 +223,10 @@ Layer  'RDF / Neutron / XRay'
     Isotopologue  'Water'  'Deuterated'  1.000000
     Reference  mint  '../_data/epsr25/water1000-neutron-xray/HDO.mint01'
     EndReference
+    #SaveSQ  On
   EndModule
 
   Module  DataTest  'F(Q) HDO'
-    ErrorType  RMSE
-    Threshold  0.0035
     Data1D  'HDO//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.u01'
       Y  6
     EndData1D
@@ -234,12 +239,10 @@ Layer  'RDF / Neutron / XRay'
     Normalisation  AverageOfSquares
     Reference  xy  '../_data/epsr25/water1000-neutron-xray/PCCPfofq.txt'
     EndReference
-    SaveReference  On
+    #SaveSQ  On
   EndModule
 
   Module  DataTest  'F(Q) H2Ox'
-    ErrorType  RMSE
-    Threshold  0.0035
     Data1D  'H2Ox//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.u01'
       Y  8
     EndData1D
@@ -260,13 +263,13 @@ Layer  'Refine (EPSR)'
     Target  'H2Ox'
     QMin  0.5
     QMax  30.0
+    NPitss  10
     OnlyWhenEnergyStable  False
-    SaveSimulatedFR  On
-    SaveEstimatedPartials  On
+    #SaveSimulatedFR  On
+    #SaveEstimatedPartials  On
   EndModule
 
   Module DataTest  'SimulatedFR'
-    ErrorType  RMSE
     Threshold  0.02
     Data1D  'EPSR01//SimulatedFR//H2O'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.x01'
       Y  4
@@ -283,8 +286,7 @@ Layer  'Refine (EPSR)'
   EndModule
 
   Module DataTest  'Estimated Partials'
-    ErrorType  RMSE
-    Threshold  0.04
+    Threshold  0.02
     Data1D  'EPSR01//EstimatedSQ//Default//OW-OW'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.q01'
       Y  2
     EndData1D

--- a/tests/exchangeable/watermeth.txt
+++ b/tests/exchangeable/watermeth.txt
@@ -70,7 +70,7 @@ Layer  'Correlations'
   # Calculate and test g(r)
   Module  RDF  RDFs
     Configuration  'Mix'
-    # Save  On
+    #Save  On
     Frequency  1
     BinWidth 0.03
   EndModule
@@ -79,7 +79,8 @@ Layer  'Correlations'
     SourceRDFs  'RDFs'
     QMin 0.05
     QBroadening  OmegaDependentGaussian  0.02    # For SLS
-    WindowFunction  None
+    WindowFunction  Lorch0
+    #Save  On
   EndModule
 
   # Sample Structure Factor Calculations
@@ -97,7 +98,9 @@ Layer  'Correlations'
     Isotopologue  'Methanol'  'Protiated'  0.5
     Isotopologue  'Methanol'  'OD-MethylH'  0.5
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
   
@@ -106,7 +109,9 @@ Layer  'Correlations'
     Isotopologue  'Water'  'Deuteriated'  1.0
     Isotopologue  'Methanol'  'Protiated'  1.0
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
   
@@ -115,7 +120,9 @@ Layer  'Correlations'
     Isotopologue  'Water'  'Protiated'  1.0
     Isotopologue  'Methanol'  'OD-MethylH'  1.0
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
   
@@ -124,7 +131,9 @@ Layer  'Correlations'
     Isotopologue  'Water'  'Protiated'  1.0
     Isotopologue  'Methanol'  'MethylD-OH'  1.0
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
   
@@ -133,7 +142,9 @@ Layer  'Correlations'
     Isotopologue  'Water'  'Deuteriated'  1.0
     Isotopologue  'Methanol'  'OD-MethylH'  1.0
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
   
@@ -142,7 +153,9 @@ Layer  'Correlations'
     Isotopologue  'Water'  'Protiated'  1.0
     Isotopologue  'Methanol'  'Deuteriated'  1.0
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
   
@@ -151,7 +164,9 @@ Layer  'Correlations'
     Isotopologue  'Water'  'Deuteriated'  1.0
     Isotopologue  'Methanol'  'Deuteriated'  1.0
     Exchangeable  HW  HO
-    #  Save  On
+    #SaveGR  On
+    #SaveSQ  On
+    #SaveReference  On
     Frequency  1
   EndModule
 EndLayer
@@ -169,8 +184,7 @@ Layer  'Processing'
 
 # -- Partial g(r) (unbound terms)
 Module DataTest  'Unbound g(r)'
-  ErrorType  RMSE
-  Threshold  0.3
+  Threshold 1.0 
   Data1D  'Mix//RDFs//OriginalGR//OW-OW//Unbound'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.g01'
     Y  2
   EndData1D
@@ -238,8 +252,7 @@ EndModule
 
 # -- Partial g(r) (intramolecular terms)
 Module DataTest  'Bound g(r)'
-  ErrorType  RMSE
-  Threshold  0.5
+  Threshold  1.0
   Data1D  'Mix//RDFs//OriginalGR//OW-HW//Bound'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.y01'
     Y  4
   EndData1D
@@ -271,8 +284,8 @@ EndModule
 
 # -- Partial g(r) (intramolecular terms, zero)
 Module DataTest  'Zeroed bound g(r)
+  Threshold  1.0e-5
   ErrorType  RMSE
-  Threshold  0.00001
   Data1D  'Mix//RDFs//OriginalGR//OW-OW//Bound'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.y01'
     Y  2
   EndData1D
@@ -313,7 +326,6 @@ EndModule
 
 # -- Partial S(Q) (unbound terms), unweighted
 Module DataTest  'Partial unweighted unbound S(Q)'
-  ErrorType  RMSE
   Threshold  0.4
   Data1D  'SQs//UnweightedSQ//OW-OW//Unbound'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.f01'
     Y  2
@@ -382,8 +394,6 @@ EndModule
 
 # -- Partial S(Q) (bound terms)
 Module DataTest  'Partial unweighted bound S(Q)'
-  ErrorType  RMSE
-  Threshold  0.05
   Data1D  'SQs//UnweightedSQ//OW-HW//Bound'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.s01'
     Y  4
   EndData1D
@@ -416,7 +426,7 @@ EndModule
 # -- Partial S(Q) (bound terms, zero)
 Module DataTest  'Partial unweighted zeroed bound S(Q)'
   ErrorType  RMSE
-  Threshold  0.00001
+  Threshold  1.0e-5
   Data1D  'SQs//UnweightedSQ//OW-OW//Bound'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.s01'
     Y  2
   EndData1D
@@ -459,8 +469,6 @@ EndModule
 # u01 file: 1  2   4   6   8   10  12  14  16
 #           Q HHH H5H DHH HDH HHD DDH HDD DDD 
 Module DataTest  'Total weighted S(Q)'
-  ErrorType  RMSE
-  Threshold  0.02
   Data1D  'HHH//WeightedSQ//Total'  xy  '../_data/epsr25/water300methanol600/watermeth.EPSR.u01'
     Y  2
   EndData1D

--- a/tests/xray/water.txt
+++ b/tests/xray/water.txt
@@ -85,12 +85,12 @@ Layer  'Processing'
     Frequency  1
     SourceRDFs  'RDF01'
     QBroadening  GaussianC2  0.0  0.02
+    #Save  On
   EndModule
 
   # -- Partial g(r) (unbound terms)
   Module  DataTest  'Partial g(r) (unbound)'
-    Threshold  0.07
-    ErrorType  RMSE
+    Threshold  0.05
     Data1D  'Bulk//RDF01//OriginalGR//OW-OW//Unbound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.g01'
       Y  2
     EndData1D
@@ -104,7 +104,6 @@ Layer  'Processing'
 
   # -- Partial g(r) (intramolecular terms)
   Module  DataTest  'Partial g(r) (bound)'
-    ErrorType  RMSE
     Threshold  0.08
     Data1D  'Bulk//RDF01//OriginalGR//OW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.y01'
       Y  4
@@ -116,7 +115,8 @@ Layer  'Processing'
 
   # -- Partial g(r) (intramolecular terms)
   Module  DataTest  'Partial g(r) (zeroed bound)'
-    Threshold  0.001
+    ErrorType  RMSE
+    Threshold  1.0e-5
     Data1D  'Bulk//RDF01//OriginalGR//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.y01'
       Y  2
     EndData1D
@@ -125,14 +125,13 @@ Layer  'Processing'
   Module  XRaySQ  H2Oxray
     SourceSQs  'SQ01'
     # SaveFormFactors  On
-    SaveSQ  On
+    # SaveSQ  On
     Normalisation  AverageOfSquares
   EndModule
 
   # -- Partial S(Q) (unbound terms)
   Module  DataTest  'Partial S(Q) (unbound)'
-    ErrorType  RMSE
-    Threshold  0.02
+    Threshold  1.6e-2
     Data1D  'SQ01//UnweightedSQ//OW-OW//Unbound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.f01'
       Y  2
     EndData1D
@@ -146,8 +145,6 @@ Layer  'Processing'
 
   # -- Partial S(Q) (bound terms)
   Module  DataTest  'Partial S(Q) (bound)'
-    ErrorType  RMSE
-    Threshold  0.004
     Data1D  'SQ01//UnweightedSQ//OW-HW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.s01'
       Y  4
     EndData1D
@@ -159,7 +156,7 @@ Layer  'Processing'
   # -- Partial S(Q) (bound terms)
   Module  DataTest  'Partial S(Q) (zeroed bound)'
     ErrorType  RMSE
-    Threshold  0.001
+    Threshold  1.0e-5
     Data1D  'SQ01//UnweightedSQ//OW-OW//Bound'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.s01'
       Y  2
     EndData1D
@@ -167,7 +164,6 @@ Layer  'Processing'
 
   # -- Total xray-weighted F(Q)
   Module  DataTest  'F(Q) H2Oxray'
-    ErrorType  RMSE
     Threshold  5.0e-3
     Data1D  'H2Oxray//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.u01'
       Y  8


### PR DESCRIPTION
This PR focuses on implementing a more robust error metric for use in the `DataTest` module, with the intention to more reliably catch failures in the system tests. The new error metric is more sensitive to variations on data of the type frequently tested herein.

During implementation, all test thresholds were tightened as necessary, and all data checked visually for consistency with the reference sets.

Other bugfixes / improvements:
- Formatting of error output has been improved.
- Checks are now made for the calculated error (by any method) returning `nan` (and failing if so).
- Several instances of data saving from modules have been fixed.
- CRITICAL The summation var in the `std::inner_product` calls in `XRayWeights` were initialised to `int (`0`) rather than `double`, resulting in incorrect values.

**Requires rebase - do not merge until rebased after #502 is merged.**