### PR TITLE
AppImage Naming

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -106,11 +106,13 @@ stages:
               artifactName: 'windows-artifacts'
             displayName: 'Download Windows Artifacts'
           - bash: |
+              set -ex
               VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
               cd ./examples
               ./package-examples -v ${VERSION}
             displayName: 'Create Example Data Archives'
           - bash: |
+              set -ex
               VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
               # Linux AppImages
               cd $(System.ArtifactsDirectory)/linux-artifacts

--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -9,6 +9,7 @@ trigger:
     - cmake/*
     - icon/*
     - tests/*
+    - unit/*
     - CMakeLists.txt
     - conanfile.txt
     - .azure-pipelines/*

--- a/.azure-pipelines/templates/package-linux-serial-gui.yml
+++ b/.azure-pipelines/templates/package-linux-serial-gui.yml
@@ -22,6 +22,8 @@ steps:
       QT_BASE_DIR="/opt/qt${{ parameters.qtver }}"
       export QTDIR=$QT_BASE_DIR
       export PATH=$QT_BASE_DIR/bin:$PATH
+      # Extract the version from the source
+      export VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
       # Run on the targets
       ./linuxdeploy.AppImage --appdir Dissolve-continuous.AppDir --output appimage
       ./linuxdeploy.AppImage --appdir Dissolve-GUI-continuous.AppDir --plugin qt --output appimage

--- a/.azure-pipelines/templates/package-linux-serial-gui.yml
+++ b/.azure-pipelines/templates/package-linux-serial-gui.yml
@@ -9,6 +9,7 @@ steps:
       ci/scripts/prep-appimage -a Dissolve-GUI -v continuous -b build/bin/dissolve-gui
     displayName: 'Prepare AppDirs'
   - bash: |
+      set -ex
       echo -e "\nRetrieving linuxdeploy...\n"
       wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -O linuxdeploy.AppImage
       echo -e "\nRetrieving qt plugin for linuxdeploy...\n"
@@ -16,6 +17,7 @@ steps:
       chmod u+x ./linuxdeploy*.AppImage
     displayName: 'Download linuxdeploy Tools'
   - bash: |
+      set -ex
       # Set environment vars to locate Qt
       QT_BASE_DIR="/opt/qt${{ parameters.qtver }}"
       export QTDIR=$QT_BASE_DIR
@@ -25,6 +27,7 @@ steps:
       ./linuxdeploy.AppImage --appdir Dissolve-GUI-continuous.AppDir --plugin qt --output appimage
     displayName: 'Create AppImages'
   - bash: |
+      set -ex
       mkdir packages
       mv Dissolve-*-x86_64.AppImage packages
     displayName: 'Move Artifacts'


### PR DESCRIPTION
Tweak the continuous build pipeline, and correctly name AppImage artifacts.

- Add unit/ to inclusive targets.
- Better erroring in bash scripts.
- Set version in generated AppImage names.
