### PR TITLE
Bugfix 04/01/21 Keep ordering of species

### DIFF
--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -234,9 +234,9 @@ double RDFModule::effectiveDensity() const
 }
 
 // Calculate and return used species populations based on target Configurations
-std::map<const Species *, double> RDFModule::speciesPopulations() const
+std::vector<std::pair<const Species *, double>> RDFModule::speciesPopulations() const
 {
-    std::map<const Species *, double> populations;
+    std::vector<std::pair<const Species *, double>> populations;
 
     for (auto *cfg : targetConfigurations())
     {
@@ -246,8 +246,12 @@ std::map<const Species *, double> RDFModule::speciesPopulations() const
         ListIterator<SpeciesInfo> spInfoIterator(cfg->usedSpecies());
         while (auto *spInfo = spInfoIterator.iterate())
         {
-            populations.try_emplace(spInfo->species(), 0.0);
-            populations[spInfo->species()] += spInfo->population() * weight;
+            auto it = std::find_if(populations.begin(), populations.end(),
+                                   [&spInfo](auto &data) { return data.first == spInfo->species(); });
+            if (it != populations.end())
+                it->second += spInfo->population() * weight;
+            else
+                populations.emplace_back(spInfo->species(), spInfo->population() * weight);
         }
     }
 

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -86,7 +86,7 @@ class RDFModule : public Module
     // Calculate and return effective density for based on the target Configurations
     double effectiveDensity() const;
     // Calculate and return used species populations based on target Configurations
-    std::map<const Species *, double> speciesPopulations() const;
+    std::vector<std::pair<const Species *, double>> speciesPopulations() const;
     // (Re)calculate partial g(r) for the specified Configuration
     bool calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method, const double rdfRange,
                      const double rdfBinWidth, bool &alreadyUpToDate);


### PR DESCRIPTION
Bugfix PR to address an issue introduced by #481 which implemented `RDFModule::speciesPopulations()`. The function returns a `std::map` of species and their populations, but the sorted nature of the container means that the ordering of the species, and of `AtomType`s in a subsequently-constructed `AtomTypeList`, is not guaranteed to be consistent with similar lists constructed elsewhere in the code.

This PR replaces the `std::map` with a `std::vector` of `std::pair` in order to guarantee the required ordering.

To mitigate the issue completely, more substantial work is required (#508).
