### PR TITLE
Buxfix 11/01/21 Various issues

### DIFF
--- a/src/modules/epsr/gui/modulewidget_funcs.cpp
+++ b/src/modules/epsr/gui/modulewidget_funcs.cpp
@@ -141,7 +141,7 @@ EPSRModuleWidget::EPSRModuleWidget(QWidget *parent, EPSRModule *module, Dissolve
     numberFormat.setType(NumberFormat::IntegerFormat);
     phiMagGraph_->view().axes().setNumberFormat(0, numberFormat);
     phiMagGraph_->view().axes().setMax(0, 10.0);
-    phiMagGraph_->view().axes().setTitle(1, "\\sym{Delta}\\sym{phi}(\\it{r}), kJ mol\\sup{-1} \\sum{angstrom}\\sup{-1}");
+    phiMagGraph_->view().axes().setTitle(1, "\\sym{Delta}\\sym{phi}(\\it{r}), kJ mol\\sup{-1} \\sym{angstrom}\\sup{-1}");
     phiMagGraph_->view().axes().setMin(1, 0.0);
     phiMagGraph_->view().axes().setMax(1, 1.0);
     phiMagGraph_->view().setAutoFollowType(View::XAutoFollow);

--- a/tests/restart/CMakeLists.txt
+++ b/tests/restart/CMakeLists.txt
@@ -1,1 +1,1 @@
-dissolve_system_test(restart benzene 1 --restart benzene.txt.restart.test)
+dissolve_system_test(restart benzene 0 --restart benzene.txt.restart.test)


### PR DESCRIPTION
Small bugfix PR to address a trio of small issues:

1. Parallel broadcast and equality checks in the `std::vector<double>` `GenericItem` container were broken.
2. Removed unnecessary iteration from `restart` system test.
3. Fixed symbol escape in GUI.
