### PR TITLE
Use assertions

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -30,7 +30,7 @@ stages:
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-serial-gui.yml
             parameters:
-              extraflags: '-DBUILD_TESTS:bool=true'
+              extraflags: '-DBUILD_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug'
               ppa: 'beineri/opt-qt-5.13.2-bionic'
               qtver: 513
           - task: PublishBuildArtifacts@1
@@ -48,7 +48,7 @@ stages:
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-parallel.yml
             parameters:
-              extraflags: '-DBUILD_TESTS:bool=true'
+              extraflags: '-DBUILD_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug'
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "build/"

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -30,7 +30,7 @@ stages:
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-serial-gui.yml
             parameters:
-              extraflags: '-DCHECKS:bool=true -DBUILD_TESTS:bool=true'
+              extraflags: '-DBUILD_TESTS:bool=true'
               ppa: 'beineri/opt-qt-5.13.2-bionic'
               qtver: 513
           - task: PublishBuildArtifacts@1
@@ -48,7 +48,7 @@ stages:
           - template: templates/set-short-hash.yml
           - template: templates/build-linux-parallel.yml
             parameters:
-              extraflags: '-DCHECKS:bool=true -DBUILD_TESTS:bool=true'
+              extraflags: '-DBUILD_TESTS:bool=true'
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "build/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,6 @@ if(PARALLEL)
   set(EXTRA_LINK_LIBS ${EXTRA_LINK_LIBS} ${MPI_LIBRARIES})
 endif(PARALLEL)
 
-if(CHECKS)
-  add_definitions("-DCHECKS")
-endif(CHECKS)
-
 # Add local Modules dir to cmake search path
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")
 

--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -202,16 +202,7 @@ int ProcessPool::groupIndex() const { return groupIndex_; }
 // Return local group in which this process exists
 ProcessGroup &ProcessPool::myGroup()
 {
-#ifdef CHECKS
-    if ((groupIndex_ < 0) || (groupIndex_ >= processGroups_.nItems()))
-    {
-        static ProcessGroup dummyGroup;
-        Messenger::print("OUT_OF_RANGE - Local group index for this process ({}) is out of range in "
-                         "ProcessPool::localGroupSize() (nProcessGroups = {}).\n",
-                         groupIndex_, processGroups_.nItems());
-        return dummyGroup;
-    }
-#endif
+    assert(groupIndex_ >= 0 && groupIndex_ < processGroups_.nItems());
     return processGroups_[groupIndex_];
 }
 
@@ -472,46 +463,21 @@ int ProcessPool::nProcessGroups() const { return processGroups_.nItems(); }
 // Return nth process group
 ProcessGroup &ProcessPool::processGroup(int n)
 {
-#ifdef CHECKS
-    if ((n < 0) || (n >= processGroups_.nItems()))
-    {
-        static ProcessGroup dummyGroup;
-        Messenger::print("OUT_OF_RANGE - Specified groupId ({}) is out of range in ProcessPool::processGroup() "
-                         "(nProcessGroups = {}).\n",
-                         n, processGroups_.nItems());
-        return dummyGroup;
-    }
-#endif
+    assert(n >= 0 && n < processGroups_.nItems());
     return processGroups_[n];
 }
 
 // Return number of processes in specified group
 int ProcessPool::nProcessesInGroup(int groupId) const
 {
-#ifdef CHECKS
-    if ((groupId < 0) || (groupId >= processGroups_.nItems()))
-    {
-        Messenger::print("OUT_OF_RANGE - Specified groupId ({}) is out of range in ProcessPool::nProcessesInGroup() "
-                         "(nProcessGroups = {}).\n",
-                         groupId, processGroups_.nItems());
-        return 0;
-    }
-#endif
+    assert(groupId >= 0 && groupId < processGroups_.nItems());
     return processGroups_.at(groupId).nProcesses();
 }
 
 // Return array of pool ranks in specified group
 const Array<int> &ProcessPool::poolRanksInGroup(int groupId) const
 {
-#ifdef CHECKS
-    if ((groupId < 0) || (groupId >= processGroups_.nItems()))
-    {
-        Messenger::print("OUT_OF_RANGE - Specified groupId ({}) is out of range in ProcessPool::worldRanksInGroup() "
-                         "(nProcessGroups = {}).\n",
-                         groupId, processGroups_.nItems());
-        return 0;
-    }
-#endif
+    assert(groupId >= 0 && groupId < processGroups_.nItems());
     return processGroups_.at(groupId).poolRanks();
 }
 

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -55,22 +55,10 @@ void Atom::setLocalTypeIndex(int id) { localTypeIndex_ = id; }
 int Atom::localTypeIndex() const { return localTypeIndex_; }
 
 // Set master AtomType index
-void Atom::setMasterTypeIndex(int id)
-{
-    if (masterTypeIndex_ != -1)
-        Messenger::warn("Warning: Overwriting master AtomType index for atom...\n");
-    masterTypeIndex_ = id;
-}
+void Atom::setMasterTypeIndex(int id) { masterTypeIndex_ = id; }
 
 // Return master AtomType index
-int Atom::masterTypeIndex() const
-{
-#ifdef CHECKS
-    if (masterTypeIndex_ == -1)
-        Messenger::warn("Global AtomType index has not yet been set for atom...\n");
-#endif
-    return masterTypeIndex_;
-}
+int Atom::masterTypeIndex() const { return masterTypeIndex_; }
 
 /*
  * Location
@@ -117,23 +105,9 @@ void Atom::translateCoordinates(double dx, double dy, double dz) { setCoordinate
 // Return scaling factor to employ with specified Atom
 double Atom::scaling(std::shared_ptr<Atom> j) const
 {
-#ifdef CHECKS
-    if (!speciesAtom_)
-    {
-        Messenger::error("Source SpeciesAtom pointer has not been set in Atom {}, so can't return scaling().\n", arrayIndex());
-        return 0.0;
-    }
-    if (!j)
-    {
-        Messenger::error("Partner Atom 'j' not passed, so can't return scaling().\n");
-        return 0.0;
-    }
-    if (!j->speciesAtom())
-    {
-        Messenger::error("SpeciesAtom pointer has not been set in partner Atom {}, so can't return scaling().\n",
-                         j->arrayIndex());
-        return 0.0;
-    }
-#endif
+    assert(speciesAtom_ != nullptr);
+    assert(j != nullptr);
+    assert(j->speciesAtom() != nullptr);
+
     return speciesAtom_->scaling(j->speciesAtom());
 }

--- a/src/classes/atomtypelist.cpp
+++ b/src/classes/atomtypelist.cpp
@@ -25,12 +25,8 @@ void AtomTypeList::operator=(const AtomTypeList &source) { types_ = source.types
 // Array access operator
 AtomTypeData &AtomTypeList::operator[](int n)
 {
-#ifdef CHECKS
-    if ((n < 0) || (n >= types_.size()))
-    {
-        Messenger::print("OUT_OF_RANGE - Specified index {} out of range in AtomTypeList::operator[].\n", n);
-    }
-#endif
+    assert(n >= 0 && n < types_.size());
+
     return types_[n];
 }
 
@@ -228,12 +224,8 @@ double AtomTypeList::totalPopulation() const
 // Return nth referenced AtomType
 const std::shared_ptr<AtomType> AtomTypeList::atomType(int n) const
 {
-#ifdef CHECKS
-    if ((n < 0) || (n >= types_.size()))
-    {
-        Messenger::print("OUT_OF_RANGE - Specified index {} out of range in AtomTypeList::atomType().\n");
-    }
-#endif
+    assert(n >= 0 && n < types_.size());
+
     return types_[n].atomType();
 }
 

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -92,13 +92,8 @@ Vec3<double> Box::axisLengths() const
 // Return axis length specified
 double Box::axisLength(int n) const
 {
-#ifdef CHECKS
-    if ((n < 0) || (n > 2))
-    {
-        Messenger::print("OUT_OF_RANGE - Requested length for a bad axis ({}) in Box::axisLength().\n", n);
-        return 0.0;
-    }
-#endif
+    assert(n >= 0 && n < 3);
+
     return axes_.columnMagnitude(n);
 }
 
@@ -108,13 +103,8 @@ Vec3<double> Box::axisAngles() const { return Vec3<double>(axisAngle(0), axisAng
 // Return axis angle specified
 double Box::axisAngle(int n) const
 {
-#ifdef CHECKS
-    if ((n < 0) || (n > 2))
-    {
-        Messenger::print("OUT_OF_RANGE - Requested angle for a bad axis ({}) in Box::axisAngle().\n", n);
-        return 0.0;
-    }
-#endif
+    assert(n >= 0 && n < 3);
+
     Vec3<double> u, v;
     u = axes_.columnAsVec3((n + 1) % 3);
     v = axes_.columnAsVec3((n + 2) % 3);

--- a/src/classes/braggreflection.cpp
+++ b/src/classes/braggreflection.cpp
@@ -82,18 +82,9 @@ void BraggReflection::scaleIntensities(double factor) { intensities_ *= factor; 
 // Scale intensity between all specific atom types by factor provided
 void BraggReflection::scaleIntensity(int typeI, int typeJ, double factor)
 {
-#ifdef CHECKS
-    if ((typeI < 0) || (typeI > intensities_.nRows()))
-    {
-        Messenger::error("Type index i of {} is out of range for BraggReflection intensities.\n", typeI);
-        return;
-    }
-    if ((typeJ < 0) || (typeJ > intensities_.nColumns()))
-    {
-        Messenger::error("Type index j of {} is out of range for BraggReflection intensities.\n", typeJ);
-        return;
-    }
-#endif
+    assert(typeI >= 0 && typeI < intensities_.nRows());
+    assert(typeJ >= 0 && typeJ < intensities_.nColumns());
+
     intensities_[{typeI, typeJ}] *= factor;
 }
 

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -322,13 +322,8 @@ Cell *CellArray::cell(int x, int y, int z) const
 // Retrieve Cell with id specified
 Cell *CellArray::cell(int id) const
 {
-#ifdef CHECKS
-    if ((id < 0) || (id >= nCells_))
-    {
-        Messenger::print("OUT_OF_RANGE - Cell ID {} is out of range (nCells = {})\n.", id, nCells_);
-        return 0;
-    }
-#endif
+    assert(id >= 0 && id < nCells_);
+
     return &cells_[id];
 }
 
@@ -350,19 +345,8 @@ Cell *CellArray::cell(const Vec3<double> r) const
 // Check if it is possible for any pair of Atoms in the supplied cells to be within the specified distance
 bool CellArray::withinRange(const Cell *a, const Cell *b, double distance)
 {
-#ifdef CHECKS
-    // Check for NULL cell pointers
-    if (a == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr 'a' given to CellArray::withinRange().\n");
-        return false;
-    }
-    if (b == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr 'b' given to CellArray::withinRange().\n");
-        return false;
-    }
-#endif
+    assert(a != nullptr);
+    assert(b != nullptr);
 
     // We need both the minimum image centroid-centroid distance, as well as the integer mim grid-reference delta
     Vec3<int> u = mimGridDelta(a, b);
@@ -386,19 +370,8 @@ bool CellArray::withinRange(const Cell *a, const Cell *b, double distance)
 // Check if minimum image calculation is necessary for any potential pair of atoms in the supplied cells
 bool CellArray::minimumImageRequired(const Cell *a, const Cell *b, double distance)
 {
-#ifdef CHECKS
-    // Check for NULL cell pointers
-    if (a == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr 'a' given to CellArray::minimumImageRequired().\n");
-        return false;
-    }
-    if (b == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr 'b' given to CellArray::minimumImageRequired().\n");
-        return false;
-    }
-#endif
+    assert(a != nullptr);
+    assert(b != nullptr);
 
     // Check every pair of corners between the Cell two grid references, and determine if minimum image calculation would be
     // required

--- a/src/classes/changedata.cpp
+++ b/src/classes/changedata.cpp
@@ -15,13 +15,8 @@ ChangeData::ChangeData() : atom_(nullptr), moved_(false), cell_(nullptr) {}
 // Set target atom
 void ChangeData::setAtom(std::shared_ptr<Atom> i)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::print("NULL_POINTER - nullptr passed to ChangeData::setAtom().\n");
-        return;
-    }
-#endif
+    assert(i != nullptr);
+
     atom_ = i;
     moved_ = false;
     r_ = atom_->r();

--- a/src/classes/changestore.cpp
+++ b/src/classes/changestore.cpp
@@ -57,14 +57,7 @@ void ChangeStore::updateAll()
 // Update single atom position
 void ChangeStore::updateAtom(int id)
 {
-#ifdef CHECKS
-    if ((id < 0) || (id >= targetAtoms_.size()))
-    {
-        Messenger::print("OUT_OF_RANGE - Specified index {} is out of range in ChangeStore::updateAtom() (nTargetAtoms = {})\n",
-                         id, targetAtoms_.size());
-        return;
-    }
-#endif
+    assert(id >= 0 && id < targetAtoms_.size());
     targetAtoms_[id].updatePosition();
 }
 
@@ -80,14 +73,7 @@ void ChangeStore::revertAll()
 // Revert specified index to stored position
 void ChangeStore::revert(int id)
 {
-#ifdef CHECKS
-    if ((id < 0) || (id >= targetAtoms_.size()))
-    {
-        Messenger::print("OUT_OF_RANGE - Index of Atom ({}) is out of range in ChangeStore::revert() (nAtoms = {}).\n", id,
-                         targetAtoms_.size());
-        return;
-    }
-#endif
+    assert(id >= 0 && id < targetAtoms_.size());
     targetAtoms_[id].revertPosition();
 }
 
@@ -161,16 +147,9 @@ bool ChangeStore::distributeAndApply(Configuration *cfg)
     std::vector<std::shared_ptr<Atom>> &atoms = cfg->atoms();
     for (auto n = 0; n < nTotalChanges; ++n)
     {
-#ifdef CHECKS
-        if ((indices_[n] < 0) || (indices_[n] >= cfg->nAtoms()))
-        {
-            Messenger::print("OUT_OF_RANGE - Index of Atom change ({}) is out of range in "
-                             "ChangeStore::distribute() (nAtoms = {}).\n",
-                             indices_[n], cfg->nAtoms());
-            continue;
-        }
-#endif
-        // Set new coordinates and check cell position
+        assert(indices_[n] >= 0 && indices_[n] < cfg->nAtoms());
+
+        // Set new coordinates and update cell position
         atoms[indices_[n]]->setCoordinates(x_[n], y_[n], z_[n]);
         cfg->updateCellLocation(atoms[indices_[n]]);
     }

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -175,14 +175,7 @@ const std::vector<std::shared_ptr<Atom>> &Configuration::atoms() const { return 
 // Return nth atom
 std::shared_ptr<Atom> Configuration::atom(int n)
 {
-#ifdef CHECKS
-    if ((n < 0) || (n >= atoms_.size()))
-    {
-        Messenger::print("OUT_OF_RANGE - Atom index {} passed to Configuration::atom() is out of range (nAtoms = {}).\n", n,
-                         atoms_.size());
-        return nullptr;
-    }
-#endif
+    assert(n >= 0 && n < atoms_.size());
     return atoms_[n];
 }
 

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -597,12 +597,6 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
 // Return SpeciesBond energy at Atoms specified
 double EnergyKernel::energy(const SpeciesBond &bond, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j)
 {
-#ifdef CHECKS
-    // Check for spurious bond distances
-    double distance = i->cell()->mimRequired(j->cell()) ? box_->minimumDistance(i, j) : (i->r() - j->r()).magnitude();
-    if (distance > 5.0)
-        Messenger::print("!!! Long bond: {}-{} = {} Angstroms\n", i->arrayIndex(), j->arrayIndex(), distance);
-#endif
     // Determine whether we need to apply minimum image to the distance calculation
     if (i->cell()->mimRequired(j->cell()))
         return bond.energy(box_->minimumDistance(i, j));

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -74,7 +74,7 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
 {
     assert(centralCell && otherCell);
 
-    double totalEnergy = 0.0;
+    auto totalEnergy = 0.0;
     auto &centralAtoms = centralCell->atoms();
     auto &otherAtoms = otherCell->atoms();
     std::shared_ptr<Atom> ii;
@@ -163,7 +163,7 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
 double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolecular, ProcessPool::DivisionStrategy strategy,
                             bool performSum)
 {
-    double totalEnergy = 0.0;
+    auto totalEnergy = 0.0;
     auto &centralAtoms = centralCell->atoms();
     std::shared_ptr<Atom> ii;
     Vec3<double> rJ;
@@ -261,13 +261,13 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
 {
     assert(i && cell);
 
-    double totalEnergy = 0.0;
+    auto totalEnergy = 0.0;
     std::shared_ptr<Atom> jj;
     double rSq, scale;
     auto &otherAtoms = cell->atoms();
 
     // Grab some information on the supplied Atom
-    std::shared_ptr<Molecule> moleculeI = i->molecule();
+    auto moleculeI = i->molecule();
     const auto rI = i->r();
 
     // Get start/stride for specified loop context
@@ -487,10 +487,10 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, ProcessPool::Division
 {
     assert(i);
 
-    Cell *cellI = i->cell();
+    auto *cellI = i->cell();
 
     // This Atom with its own Cell
-    double totalEnergy = energy(i, cellI, KernelFlags::ExcludeSelfFlag, strategy, false);
+    auto totalEnergy = energy(i, cellI, KernelFlags::ExcludeSelfFlag, strategy, false);
 
     // Cell neighbours not requiring minimum image
     for (auto *neighbour : cellI->cellNeighbours())
@@ -510,7 +510,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, ProcessPool::Division
 // Return PairPotential energy of Molecule with world
 double EnergyKernel::energy(std::shared_ptr<const Molecule> mol, ProcessPool::DivisionStrategy strategy, bool performSum)
 {
-    double totalEnergy = 0.0;
+    auto totalEnergy = 0.0;
 
     for (auto ii : mol->atoms())
     {
@@ -574,7 +574,7 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
     auto start = processPool_.interleavedLoopStart(strategy);
     auto stride = processPool_.interleavedLoopStride(strategy);
 
-    double totalEnergy = 0.0;
+    auto totalEnergy = 0.0;
     Cell *cell;
     for (auto cellId = start; cellId < cellArray.nCells(); cellId += stride)
     {
@@ -640,7 +640,7 @@ double EnergyKernel::energy(const SpeciesAngle &angle, const std::shared_ptr<Ato
 // Return SpeciesAngle energy
 double EnergyKernel::energy(const SpeciesAngle &angle)
 {
-    Vec3<double> vecji = angle.i()->r() - angle.j()->r(), vecjk = angle.k()->r() - angle.j()->r();
+    auto vecji = angle.i()->r() - angle.j()->r(), vecjk = angle.k()->r() - angle.j()->r();
 
     // Normalise vectors
     vecji.normalise();
@@ -716,7 +716,7 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, c
     assert(i);
 
     // Get the SpeciesAtom
-    const SpeciesAtom *spAtom = i->speciesAtom();
+    const auto *spAtom = i->speciesAtom();
     assert(spAtom);
 
     // If no terms are present, return zero

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -52,18 +52,8 @@ double EnergyKernel::energyWithMim(const std::shared_ptr<Atom> i, const std::sha
 // Return PairPotential energy between atoms (provided as pointers)
 double EnergyKernel::energy(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, bool applyMim, bool excludeIgeJ)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr (i) passed to EnergyKernel::energy(Atom,Atom,bool,bool).\n");
-        return 0.0;
-    }
-    if (j == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr (j) passed to EnergyKernel::energy(Atom,Atom,bool,bool).\n");
-        return 0.0;
-    }
-#endif
+    assert(i && j);
+
     // If Atoms are the same, we refuse to calculate
     if (i == j)
         return 0.0;
@@ -82,19 +72,8 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const std::shared_ptr
 double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, bool excludeIgeJ, bool interMolecular,
                             ProcessPool::DivisionStrategy strategy, bool performSum)
 {
-#ifdef CHECKS
-    if (centralCell == nullptr)
-    {
-        Messenger::error(
-            "NULL_POINTER - nullptr (central cell) pointer passed to EnergyKernel::energy(Cell,Cell,bool,bool).\n");
-        return 0.0;
-    }
-    if (otherCell == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr (other cell) pointer passed to EnergyKernel::energy(Cell,Cell,bool,bool).\n");
-        return 0.0;
-    }
-#endif
+    assert(centralCell && otherCell);
+
     double totalEnergy = 0.0;
     auto &centralAtoms = centralCell->atoms();
     auto &otherAtoms = otherCell->atoms();
@@ -280,18 +259,8 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
 double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int flags, ProcessPool::DivisionStrategy strategy,
                             bool performSum)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL atom pointer passed to EnergyKernel::energy(Atom,Cell).\n");
-        return 0.0;
-    }
-    if (cell == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr passed to EnergyKernel::energy(Atom,Cell).\n");
-        return 0.0;
-    }
-#endif
+    assert(i && cell);
+
     double totalEnergy = 0.0;
     std::shared_ptr<Atom> jj;
     double rSq, scale;
@@ -516,13 +485,8 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
 // Return PairPotential energy of Atom with world
 double EnergyKernel::energy(const std::shared_ptr<Atom> i, ProcessPool::DivisionStrategy strategy, bool performSum)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr passed to EnergyKernel::energy(Atom,ParallelStyle).\n");
-        return 0.0;
-    }
-#endif
+    assert(i);
+
     Cell *cellI = i->cell();
 
     // This Atom with its own Cell
@@ -749,20 +713,11 @@ double EnergyKernel::energy(const SpeciesImproper &imp)
 // Return intramolecular energy for the supplied Atom
 double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, const std::shared_ptr<Atom> i)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL Atom given to EnergyKernel::intraEnergy().\n");
-        return 0.0;
-    }
-    if (i->speciesAtom() == nullptr)
-    {
-        Messenger::error("NULL SpeciesAtom in Atom given to EnergyKernel::intraEnergy().\n");
-        return 0.0;
-    }
-#endif
+    assert(i);
+
     // Get the SpeciesAtom
     const SpeciesAtom *spAtom = i->speciesAtom();
+    assert(spAtom);
 
     // If no terms are present, return zero
     if ((spAtom->nBonds() == 0) && (spAtom->nAngles() == 0) && (spAtom->nTorsions() == 0))
@@ -802,13 +757,7 @@ double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol, c
 // Return intramolecular energy for the supplied Molecule
 double EnergyKernel::intramolecularEnergy(std::shared_ptr<const Molecule> mol)
 {
-#ifdef CHECKS
-    if (mol == nullptr)
-    {
-        Messenger::error("NULL Molecule pointer given to EnergyKernel::intramolecularEnergy.\n");
-        return 0.0;
-    }
-#endif
+    assert(mol);
 
     auto intraEnergy = 0.0;
 

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -401,11 +401,6 @@ void ForceKernel::forces(const SpeciesBond &bond, const std::shared_ptr<Atom> i,
     // Get distance and normalise vector ready for force calculation
     double distance = vecji.magAndNormalise();
 
-#ifdef CHECKS
-    if (distance > 5.0)
-        Messenger::print("!!! Long bond: {}-{} = {} Angstroms\n", i->arrayIndex(), j->arrayIndex(), distance);
-#endif
-
     // Determine final forces
     vecji *= bond.force(distance);
 
@@ -435,11 +430,6 @@ void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesBond
 
     // Get distance and normalise vector ready for force calculation
     double distance = vecji.magAndNormalise();
-
-#ifdef CHECKS
-    if (distance > 5.0)
-        Messenger::print("!!! Long bond: {}-{} = {} Angstroms\n", i->arrayIndex(), j->arrayIndex(), distance);
-#endif
 
     // Determine final forces
     vecji *= bond.force(distance);

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -72,18 +72,8 @@ void ForceKernel::forcesWithMim(const std::shared_ptr<Atom> i, const std::shared
 // Calculate forces between atoms
 void ForceKernel::forces(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, bool applyMim, bool excludeIgeJ)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr (i) passed to ForceKernel::forces(Atom,Atom,bool,bool).\n");
-        return;
-    }
-    if (j == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr (j) passed to ForceKernel::forces(Atom,Atom,bool,bool).\n");
-        return;
-    }
-#endif
+    assert(i && j);
+
     // If Atoms are the same, we refuse to calculate
     if (i == j)
         return;
@@ -102,20 +92,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, const std::shared_ptr<At
 void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool excludeIgeJ,
                          ProcessPool::DivisionStrategy strategy)
 {
-#ifdef CHECKS
-    if (centralCell == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL central Cell pointer passed to "
-                         "ForceKernel::forces(Cell,Cell,bool,bool,DivisionStrategy).\n");
-        return;
-    }
-    if (otherCell == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL other Cell pointer passed to "
-                         "ForceKernel::forces(Cell,Cell,bool,bool,DivisionStrategy).\n");
-        return;
-    }
-#endif
+    assert(centralCell && otherCell);
+
     auto &centralAtoms = centralCell->atoms();
     auto &otherAtoms = otherCell->atoms();
     std::shared_ptr<Atom> ii;
@@ -199,13 +177,8 @@ void ForceKernel::forces(Cell *cell, bool excludeIgeJ, ProcessPool::DivisionStra
 // Calculate forces between Atom and Cell
 void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, ProcessPool::DivisionStrategy strategy)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL atom pointer passed to ForceKernel::forces(Atom,Cell,int,DivisionStrategy).\n");
-        return;
-    }
-#endif
+    assert(i);
+
     std::shared_ptr<Atom> jj;
     double scale;
 
@@ -383,13 +356,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
 // Calculate forces between atom and world
 void ForceKernel::forces(const std::shared_ptr<Atom> i, ProcessPool::DivisionStrategy strategy)
 {
-#ifdef CHECKS
-    if (i == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr passed to ForceKernel::forces(Atom,DivisionStrategy).\n");
-        return;
-    }
-#endif
+    assert(i);
+
     Cell *cellI = i->cell();
 
     // This Atom with other Atoms in the same Cell
@@ -456,13 +424,7 @@ void ForceKernel::forces(const SpeciesBond &bond, const std::shared_ptr<Atom> i,
 void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesBond &bond, const std::shared_ptr<Atom> i,
                          const std::shared_ptr<Atom> j)
 {
-#ifdef CHECKS
-    if ((i != onlyThis) && (j != onlyThis))
-    {
-        Messenger::error("Forces requested for specific Atom in Bond, but neither Atom in the Bond is the one specified.\n");
-        return;
-    }
-#endif
+    assert((i != onlyThis) && (j != onlyThis));
 
     // Determine whether we need to apply minimum image to the vector calculation
     Vec3<double> vecji;
@@ -575,15 +537,9 @@ void ForceKernel::forces(const SpeciesAngle &angle, const std::shared_ptr<Atom> 
 void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesAngle &angle, const std::shared_ptr<Atom> i,
                          const std::shared_ptr<Atom> j, const std::shared_ptr<Atom> k)
 {
-    Vec3<double> vecji, vecjk;
+    assert((i != onlyThis) && (j != onlyThis) && (k != onlyThis));
 
-#ifdef CHECKS
-    if ((i != onlyThis) && (j != onlyThis) && (k != onlyThis))
-    {
-        Messenger::error("Forces requested for specific Atom in Angle, but no Atom in the Angle is the one specified.\n");
-        return;
-    }
-#endif
+    Vec3<double> vecji, vecjk;
 
     // Determine whether we need to apply minimum image between 'j-i' and 'j-k'
     if (j->cell()->mimRequired(i->cell()))

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -399,7 +399,7 @@ void ForceKernel::forces(const SpeciesBond &bond, const std::shared_ptr<Atom> i,
         vecji = j->r() - i->r();
 
     // Get distance and normalise vector ready for force calculation
-    double distance = vecji.magAndNormalise();
+    auto distance = vecji.magAndNormalise();
 
     // Determine final forces
     vecji *= bond.force(distance);
@@ -429,7 +429,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesBond
         vecji = j->r() - i->r();
 
     // Get distance and normalise vector ready for force calculation
-    double distance = vecji.magAndNormalise();
+    auto distance = vecji.magAndNormalise();
 
     // Determine final forces
     vecji *= bond.force(distance);

--- a/src/classes/kvector.cpp
+++ b/src/classes/kvector.cpp
@@ -69,43 +69,16 @@ void KVector::zeroCosSinTerms()
 }
 
 // Add value to cosTerm index specified
-void KVector::addCosTerm(int atomTypeIndex, double value)
-{
-#ifdef CHECKS
-    if (atomTypeIndex >= cosTerms_.nItems())
-    {
-        Messenger::print("BAD_USAGE - KVector::cosTerms_ index supplied ({}) is greated than the size of the array ({}).\n",
-                         atomTypeIndex, cosTerms_.nItems());
-        return;
-    }
-#endif
-    cosTerms_[atomTypeIndex] += value;
-}
+void KVector::addCosTerm(int atomTypeIndex, double value) { cosTerms_[atomTypeIndex] += value; }
 
 // Add value to sinTerm index specified
-void KVector::addSinTerm(int atomTypeIndex, double value)
-{
-#ifdef CHECKS
-    if (atomTypeIndex >= sinTerms_.nItems())
-    {
-        Messenger::print("BAD_USAGE - KVector::sinTerms_ index supplied ({}) is greated than the size of the array ({}).\n",
-                         atomTypeIndex, sinTerms_.nItems());
-        return;
-    }
-#endif
-    sinTerms_[atomTypeIndex] += value;
-}
+void KVector::addSinTerm(int atomTypeIndex, double value) { sinTerms_[atomTypeIndex] += value; }
 
 // Calculate intensities from stored cos and sin term arrays
 void KVector::calculateIntensities(BraggReflection *reflectionArray)
 {
-#ifdef CHECKS
-    if (reflectionArray == nullptr)
-    {
-        Messenger::print("NULL_POINTER - NULL BraggReflection array found in KVector::calculateIntensities().\n");
-        return;
-    }
-#endif
+    assert(reflectionArray);
+
     // Calculate final intensities from stored cos/sin terms
     // Take account of the half-sphere, doubling intensities of all k-vectors not on h == 0
     // Do *not* multiply cross-terms (i != j) by 2 - we want to generate the unmultiplied intensity for consistency with

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -50,17 +50,7 @@ std::vector<std::shared_ptr<Atom>> &Molecule::atoms() { return atoms_; }
 const std::vector<std::shared_ptr<Atom>> &Molecule::atoms() const { return atoms_; }
 
 // Return nth Atom pointer
-std::shared_ptr<Atom> Molecule::atom(int n) const
-{
-#ifdef CHECKS
-    if ((n < 0) || (n >= nAtoms()))
-    {
-        Messenger::print("OUT_OF_RANGE - Atom index {} is out of range in Molecule::atom().\n", n);
-        return nullptr;
-    }
-#endif
-    return atoms_[n];
-}
+std::shared_ptr<Atom> Molecule::atom(int n) const { return atoms_[n]; }
 
 /*
  * Manipulations

--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -99,16 +99,7 @@ PairPotential::CoulombTruncationScheme PairPotential::coulombTruncationScheme() 
 void PairPotential::setData1DNames()
 {
     // Check for NULL pointers
-    if (atomTypeI_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL AtomType pointer (atomTypeI_) found in PairPotential::setData1DNames().\n");
-        return;
-    }
-    if (atomTypeJ_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL AtomType pointer (atomTypeJ_) found in PairPotential::setData1DNames().\n");
-        return;
-    }
+    assert(atomTypeI_ && atomTypeJ_);
 
     uFull_.setName(fmt::format("{}-{}", atomTypeI_->name(), atomTypeJ_->name()));
     uFull_.setObjectTag(fmt::format("PairPotential//{}-{}//Full", atomTypeI_->name(), atomTypeJ_->name()));
@@ -200,24 +191,14 @@ bool PairPotential::setUp(std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomT
 // Return first AtomType name
 std::string_view PairPotential::atomTypeNameI() const
 {
-    // Check for NULL pointers
-    if (atomTypeI_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL AtomType pointer found in PairPotential::atomTypeNameI().\n");
-        return "NULL";
-    }
+    assert(atomTypeI_);
     return atomTypeI_->name();
 }
 
 // Return second AtomType name
 std::string_view PairPotential::atomTypeNameJ() const
 {
-    // Check for NULL pointers
-    if (atomTypeJ_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL AtomType pointer found in PairPotential::atomTypeNameJ().\n");
-        return "NULL";
-    }
+    assert(atomTypeJ_);
     return atomTypeJ_->name();
 }
 
@@ -481,16 +462,8 @@ void PairPotential::calculateUOriginal(bool recalculateUFull)
 // Return potential at specified r
 double PairPotential::energy(double r)
 {
-    // Perform some checks
-#ifdef CHECKS
-    if (int(r * rDelta_) < 0)
-    {
-        Messenger::print("BAD_VALUE - Bin value of r is negative ({}) in PairPotential::energy.\n", int(r * rDelta_));
-        return 0.0;
-    }
-#endif
+    assert(r >= 0);
 
-    // Return interpolated value
     return uFullInterpolation_.y(r, r * rDelta_);
 }
 
@@ -533,16 +506,8 @@ double PairPotential::analyticCoulombEnergy(double qiqj, double r, PairPotential
 // Return derivative at specified r
 double PairPotential::force(double r)
 {
-    // Perform some checks
-#ifdef CHECKS
-    if (int(r * rDelta_) < 0)
-    {
-        Messenger::print("BAD_VALUE - Bin value of r is negative ({}) in PairPotential::force.\n", int(r * rDelta_));
-        return 0.0;
-    }
-#endif
+    assert(r >= 0);
 
-    // Return interpolated value
     return dUFullInterpolation_.y(r, r * rDelta_);
 }
 

--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -246,10 +246,10 @@ double PairPotential::analyticShortRangeEnergy(double r, Forcefield::ShortRangeT
          * Parameter 0 = Epsilon
          * Parameter 1 = Sigma
          */
-        double sigmar = parameters_[1] / r;
-        double sigmar6 = pow(sigmar, 6.0);
-        double sigmar12 = sigmar6 * sigmar6;
-        double energy = 4.0 * parameters_[0] * (sigmar12 - sigmar6);
+        auto sigmar = parameters_[1] / r;
+        auto sigmar6 = pow(sigmar, 6.0);
+        auto sigmar12 = sigmar6 * sigmar6;
+        auto energy = 4.0 * parameters_[0] * (sigmar12 - sigmar6);
 
         // Apply the selected truncation scheme
         if (truncation == PairPotential::ShiftedShortRangeTruncation)
@@ -259,7 +259,7 @@ double PairPotential::analyticShortRangeEnergy(double r, Forcefield::ShortRangeT
         else if (truncation == PairPotential::CosineShortRangeTruncation)
         {
             // Are we into the truncation strip?
-            double truncr = r - (range_ - shortRangeTruncationWidth_);
+            auto truncr = r - (range_ - shortRangeTruncationWidth_);
             if (truncr >= 0)
             {
                 // Simple truncation scheme - (cos(x)+1)*0.5, mapping the truncation region to {0,Pi}
@@ -293,9 +293,9 @@ double PairPotential::analyticShortRangeForce(double r, Forcefield::ShortRangeTy
 
         // f = -48*epsilon*((sigma**12/x**13)-0.5*(sigma**6/x**7))
 
-        double sigmar = parameters_[1] / r;
-        double sigmar6 = pow(sigmar, 6.0);
-        double sigmar12 = sigmar6 * sigmar6;
+        auto sigmar = parameters_[1] / r;
+        auto sigmar6 = pow(sigmar, 6.0);
+        auto sigmar12 = sigmar6 * sigmar6;
 
         // Apply the selected truncation scheme
         if (truncation == PairPotential::NoShortRangeTruncation)
@@ -474,7 +474,7 @@ double PairPotential::analyticEnergy(double r)
         return 0.0;
 
     // Short-range potential
-    double energy = analyticShortRangeEnergy(r, shortRangeType_);
+    auto energy = analyticShortRangeEnergy(r, shortRangeType_);
 
     // Coulomb contribution
     energy += analyticCoulombEnergy(chargeI_ * chargeJ_, r);

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -83,7 +83,7 @@ double PotentialMap::energy(const std::shared_ptr<Atom> i, const std::shared_ptr
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
     return pp->energy(r) +
            (pp->includeCoulomb() ? 0 : pp->analyticCoulombEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r));
 }
@@ -108,7 +108,7 @@ double PotentialMap::analyticEnergy(const std::shared_ptr<Atom> i, const std::sh
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
     return pp->includeCoulomb() ? pp->analyticEnergy(r)
                                 : pp->analyticEnergy(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
 }
@@ -122,7 +122,7 @@ double PotentialMap::force(const std::shared_ptr<Atom> i, const std::shared_ptr<
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
     return pp->includeCoulomb()
                ? pp->force(r)
                : pp->force(r) + pp->analyticCoulombForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
@@ -136,7 +136,7 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r)
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    PairPotential *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
+    auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return pp->includeCoulomb() ? pp->force(r) : pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r);
 }
 
@@ -149,7 +149,7 @@ double PotentialMap::analyticForce(const std::shared_ptr<Atom> i, const std::sha
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
     return pp->includeCoulomb() ? pp->analyticForce(r)
                                 : pp->analyticForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
 }

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -78,33 +78,9 @@ double PotentialMap::range() const { return range_; }
 // Return energy between Atoms at distance specified
 double PotentialMap::energy(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const
 {
-#ifdef CHECKS
-    if ((i->masterTypeIndex() < 0) || (i->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom i ({}) passed to PotentialMap::energy() is out of range "
-                         "(nTypes_ = {}).\n",
-                         i->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if ((j->masterTypeIndex() < 0) || (j->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom j ({}) passed to PotentialMap::energy() is out of range "
-                         "(nTypes_ = {}).\n",
-                         j->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if (r < 0.0)
-    {
-        Messenger::print("OUT_OF_RANGE - Distance passed to PotentialMap::energy() is negative ({}).\n", r);
-        return 0.0;
-    }
-    if ((!i->speciesAtom()) || (!j->speciesAtom()))
-    {
-        Messenger::print("NULL_POINTER - One or both SpeciesAtoms in the Atoms passed to PotentialMap::energy() are "
-                         "NULL.\n");
-        return 0.0;
-    }
-#endif
+    assert(r >= 0.0);
+    assert(i->speciesAtom() && j->speciesAtom());
+
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
@@ -115,36 +91,21 @@ double PotentialMap::energy(const std::shared_ptr<Atom> i, const std::shared_ptr
 // Return energy between SpeciesAtoms at distance specified
 double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r) const
 {
+    assert(r >= 0.0);
+    assert(i && j);
+
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    PairPotential *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
+    auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return pp->energy(r) + (pp->includeCoulomb() ? 0 : pp->analyticCoulombEnergy(i->charge() * j->charge(), r));
 }
 
 // Return analytic energy between Atom types at distance specified
 double PotentialMap::analyticEnergy(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const
 {
-#ifdef CHECKS
-    if ((i->masterTypeIndex() < 0) || (i->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom i ({}) passed to PotentialMap::analyticEnergy() is out of "
-                         "range (nTypes_ = {}).\n",
-                         i->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if ((j->masterTypeIndex() < 0) || (j->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom j ({}) passed to PotentialMap::analyticEnergy() is out of "
-                         "range (nTypes_ = {}).\n",
-                         j->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if (r < 0.0)
-    {
-        Messenger::print("OUT_OF_RANGE - Distance passed to PotentialMap::analyticEnergy() is negative ({}).\n", r);
-        return 0.0;
-    }
-#endif
+    assert(r >= 0.0);
+    assert(i && j);
+
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
     PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
@@ -155,33 +116,10 @@ double PotentialMap::analyticEnergy(const std::shared_ptr<Atom> i, const std::sh
 // Return force between Atoms at distance specified
 double PotentialMap::force(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const
 {
-#ifdef CHECKS
-    if ((i->masterTypeIndex() < 0) || (i->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom i ({}) passed to PotentialMap::force() is out of range "
-                         "(nTypes_ = {}).\n",
-                         i->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if ((j->masterTypeIndex() < 0) || (j->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom j ({}) passed to PotentialMap::force() is out of range "
-                         "(nTypes_ = {}).\n",
-                         j->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if (r < 0.0)
-    {
-        Messenger::print("OUT_OF_RANGE - Distance passed to PotentialMap::force() is negative ({}).\n", r);
-        return 0.0;
-    }
-    if ((!i->speciesAtom()) || (!j->speciesAtom()))
-    {
-        Messenger::print("NULL_POINTER - One or both SpeciesAtoms in the Atoms passed to PotentialMap::force() are "
-                         "NULL.\n");
-        return 0.0;
-    }
-#endif
+    assert(r >= 0.0);
+    assert(i && j);
+    assert(i->speciesAtom() && j->speciesAtom());
+
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
@@ -193,6 +131,9 @@ double PotentialMap::force(const std::shared_ptr<Atom> i, const std::shared_ptr<
 // Return force between SpeciesAtoms at distance specified
 double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r) const
 {
+    assert(r >= 0.0);
+    assert(i && j);
+
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
@@ -202,27 +143,10 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r)
 // Return analytic force between Atom types at distance specified
 double PotentialMap::analyticForce(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const
 {
-#ifdef CHECKS
-    if ((i->masterTypeIndex() < 0) || (i->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom i ({}) passed to PotentialMap::analyticForce() is out of "
-                         "range (nTypes_ = {}).\n",
-                         i->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if ((j->masterTypeIndex() < 0) || (j->masterTypeIndex() >= nTypes_))
-    {
-        Messenger::print("OUT_OF_RANGE - Type index of atom j ({}) passed to PotentialMap::analyticForce() is out of "
-                         "range (nTypes_ = {}).\n",
-                         j->masterTypeIndex(), nTypes_);
-        return 0.0;
-    }
-    if (r < 0.0)
-    {
-        Messenger::print("OUT_OF_RANGE - Distance passed to PotentialMap::analyticForce() is negative ({}).\n", r);
-        return 0.0;
-    }
-#endif
+    assert(r >= 0.0);
+    assert(i && j);
+    assert(i->speciesAtom() && j->speciesAtom());
+
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     PairPotential *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -66,13 +66,7 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
         if (molecule->species() != targetSpecies)
             continue;
 
-            // Calculate origin
-#ifdef CHECKS
-        for (auto i = 0; i < originAtomIndices.nItems(); ++i)
-            if ((originAtomIndices[i] < 0) || (originAtomIndices[i] >= molecule->nAtoms()))
-                return Messenger::error("Origin atom index {} is out of range for molecule (contains {} atoms).\n",
-                                        originAtomIndices[i], molecule->nAtoms());
-#endif
+        // Calculate origin
         if (speciesSite->originMassWeighted())
         {
             double mass = AtomicMass::mass(molecule->atom(originAtomIndices.firstValue())->speciesAtom()->Z());
@@ -100,16 +94,6 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
         // Calculate axes and store data
         if (sitesHaveOrientation_)
         {
-#ifdef CHECKS
-            for (auto i = 0; i < xAxisAtomIndices.nItems(); ++i)
-                if ((xAxisAtomIndices[i] < 0) || (xAxisAtomIndices[i] >= molecule->nAtoms()))
-                    return Messenger::error("X-axis atom index {} is out of range for molecule (contains {} atoms).\n",
-                                            xAxisAtomIndices[i], molecule->nAtoms());
-            for (auto i = 0; i < yAxisAtomIndices.nItems(); ++i)
-                if ((yAxisAtomIndices[i] < 0) || (yAxisAtomIndices[i] >= molecule->nAtoms()))
-                    return Messenger::error("Y-axis atom index {} is out of range for molecule (contains {} atoms).\n",
-                                            yAxisAtomIndices[i], molecule->nAtoms());
-#endif
             // Get average position of supplied x-axis atoms
             v = molecule->atom(xAxisAtomIndices.firstValue())->r();
             for (auto m = 1; m < xAxisAtomIndices.nItems(); ++m)

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -38,10 +38,10 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
     sitesHaveOrientation_ = speciesSite->hasAxes();
 
     // Get origin atom indices from site, and grab the Configuration's Box
-    Array<int> originAtomIndices = speciesSite->originAtomIndices();
+    auto originAtomIndices = speciesSite->originAtomIndices();
     if (originAtomIndices.nItems() == 0)
         return Messenger::error("No origin atoms defined in SpeciesSite '{}'.\n", speciesSite->name());
-    const Box *box = configuration_->box();
+    const auto *box = configuration_->box();
 
     // If the site has axes, grab the atom indices involved
     Array<int> xAxisAtomIndices, yAxisAtomIndices;
@@ -58,10 +58,10 @@ bool SiteStack::create(Configuration *cfg, SpeciesSite *speciesSite)
 
     // Get Molecule array from Configuration and search for the target Species
     std::deque<std::shared_ptr<Molecule>> &molecules = cfg->molecules();
-    Species *targetSpecies = speciesSite->parent();
+    auto *targetSpecies = speciesSite->parent();
     Vec3<double> origin, v, x, y, z;
     Matrix3 axes;
-    for (auto molecule : molecules)
+    for (const auto &molecule : molecules)
     {
         if (molecule->species() != targetSpecies)
             continue;

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -60,24 +60,12 @@ void Species::setAtomCoordinates(SpeciesAtom *i, Vec3<double> r)
 }
 
 // Set coordinates of specified atom (by index and individual coordinates)
-void Species::setAtomCoordinates(int id, double x, double y, double z)
-{
-#ifdef CHECKS
-    if ((id < 0) || (id >= atoms_.nItems()))
-    {
-        Messenger::error("Atom index {} is out of range - nAtoms = {}\n", id, atoms_.nItems());
-        return;
-    }
-#endif
-
-    atoms_[id]->setCoordinates(x, y, z);
-}
+void Species::setAtomCoordinates(int id, double x, double y, double z) { atoms_[id]->setCoordinates(x, y, z); }
 
 // Transmute specified SpeciesAtom
 void Species::transmuteAtom(SpeciesAtom *i, Elements::Element newZ)
 {
-    if (!i)
-        return;
+    assert(i);
 
     // Nothing to do if current element matches that supplied
     if (i->Z() == newZ)

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -112,39 +112,21 @@ SpeciesAtom *SpeciesAngle::k() const { return k_; }
 // Return index (in parent Species) of first SpeciesAtom
 int SpeciesAngle::indexI() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'i' found in SpeciesAngle::indexI(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(i_);
     return i_->index();
 }
 
 // Return index (in parent Species) of second (central) SpeciesAtom
 int SpeciesAngle::indexJ() const
 {
-#ifdef CHECKS
-    if (j_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'j' found in SpeciesAngle::indexJ(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(j_);
     return j_->index();
 }
 
 // Return index (in parent Species) of third SpeciesAtom
 int SpeciesAngle::indexK() const
 {
-#ifdef CHECKS
-    if (k_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'k' found in SpeciesAngle::indexK(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(k_);
     return k_->index();
 }
 
@@ -177,13 +159,7 @@ bool SpeciesAngle::matches(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k) const
 // Return whether all atoms in the interaction are currently selected
 bool SpeciesAngle::isSelected() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr || j_ == nullptr || k_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer found in SpeciesAngle::isSelected(). Returning false...\n");
-        return false;
-    }
-#endif
+    assert(i_ && j_ && k_);
     return (i_->isSelected() && j_->isSelected() && k_->isSelected());
 }
 

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -100,26 +100,14 @@ SpeciesAtom *SpeciesBond::partner(const SpeciesAtom *i) const { return (i == i_ 
 // Return index (in parent Species) of first SpeciesAtom
 int SpeciesBond::indexI() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'i' found in SpeciesBond::indexI(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(i_);
     return i_->index();
 }
 
 // Return index (in parent Species) of second SpeciesAtom
 int SpeciesBond::indexJ() const
 {
-#ifdef CHECKS
-    if (j_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'j' found in SpeciesBond::indexJ(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(j_);
     return j_->index();
 }
 
@@ -148,13 +136,7 @@ bool SpeciesBond::matches(const SpeciesAtom *i, const SpeciesAtom *j) const
 // Return whether all atoms in the interaction are currently selected
 bool SpeciesBond::isSelected() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr || j_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer found in SpeciesBond::isSelected(). Returning false...\n");
-        return false;
-    }
-#endif
+    assert(i_ && j_);
     return (i_->isSelected() && j_->isSelected());
 }
 

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -55,16 +55,8 @@ void SpeciesImproper::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, Spe
     j_ = j;
     k_ = k;
     l_ = l;
-#ifdef CHECKS
-    if (i_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* i in SpeciesImproper::set().\n");
-    if (j_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* j in SpeciesImproper::set().\n");
-    if (k_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* k in SpeciesImproper::set().\n");
-    if (l_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* l in SpeciesImproper::set().\n");
-#endif
+
+    assert(i_ && j_ && k_ && l_);
 
     if (i_)
         i_->addImproper(*this);
@@ -97,52 +89,28 @@ bool SpeciesImproper::uses(SpeciesAtom *spAtom) const
 // Return index (in parent Species) of first SpeciesAtom
 int SpeciesImproper::indexI() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'i' found in SpeciesImproper::indexI(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(i_);
     return i_->index();
 }
 
 // Return index (in parent Species) of second (central) SpeciesAtom
 int SpeciesImproper::indexJ() const
 {
-#ifdef CHECKS
-    if (j_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'j' found in SpeciesImproper::indexJ(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(j_);
     return j_->index();
 }
 
 // Return index (in parent Species) of third SpeciesAtom
 int SpeciesImproper::indexK() const
 {
-#ifdef CHECKS
-    if (k_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'k' found in SpeciesImproper::indexK(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(k_);
     return k_->index();
 }
 
 // Return index (in parent Species) of fourth SpeciesAtom
 int SpeciesImproper::indexL() const
 {
-#ifdef CHECKS
-    if (l_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'l' found in SpeciesImproper::indexL(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(l_);
     return l_->index();
 }
 
@@ -190,14 +158,7 @@ bool SpeciesImproper::matches(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, Sp
 // Return whether all atoms in the interaction are currently selected
 bool SpeciesImproper::isSelected() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr || j_ == nullptr || k_ == nullptr || l_ == nullptr)
-    {
-        Messenger::error(
-            "NULL_POINTER - NULL SpeciesAtom pointer found in SpeciesImproper::isSelected(). Returning false...\n");
-        return false;
-    }
-#endif
+    assert(i_ && j_ && k_ && l_);
     return (i_->isSelected() && j_->isSelected() && k_->isSelected() && l_->isSelected());
 }
 

--- a/src/classes/speciesintra.cpp
+++ b/src/classes/speciesintra.cpp
@@ -90,15 +90,6 @@ void SpeciesIntra::addParameter(double param)
 // Set existing parameter
 void SpeciesIntra::setParameter(int id, double value)
 {
-#ifdef CHECKS
-    if ((id < 0) || (id >= parameters_.size()))
-    {
-        Messenger::error("Tried to set a parameter in a SpeciesIntra definition, but the index is out of range ({} vs "
-                         "{} parameters current).\n",
-                         id, parameters_.size());
-        return;
-    }
-#endif
     // Does this intramolecular interaction reference a set of master parameters?
     if (masterParameters_)
     {

--- a/src/classes/speciessite.cpp
+++ b/src/classes/speciessite.cpp
@@ -71,10 +71,7 @@ void SpeciesSite::removeOriginAtom(SpeciesAtom *originAtom)
 // Add origin atom from index
 bool SpeciesSite::addOriginAtom(int atomIndex)
 {
-#ifdef CHECKS
-    if (!parent_)
-        return Messenger::error("Tried to add an origin atom by index to a SpeciesSite, but no parent Species is set.\n");
-#endif
+    assert(parent_);
     return addOriginAtom(parent_->atom(atomIndex));
 }
 
@@ -139,10 +136,7 @@ bool SpeciesSite::addXAxisAtom(SpeciesAtom *xAxisAtom)
 // Add x-axis atom from index
 bool SpeciesSite::addXAxisAtom(int atomIndex)
 {
-#ifdef CHECKS
-    if (!parent_)
-        return Messenger::error("Tried to add an x-axis atom by index to a SpeciesSite, but no parent Species is set.\n");
-#endif
+    assert(parent_);
     return addXAxisAtom(parent_->atom(atomIndex));
 }
 
@@ -209,10 +203,7 @@ bool SpeciesSite::addYAxisAtom(SpeciesAtom *yAxisAtom)
 // Add y-axis atom from index
 bool SpeciesSite::addYAxisAtom(int atomIndex)
 {
-#ifdef CHECKS
-    if (!parent_)
-        return Messenger::error("Tried to add a y-axis atom by index to a SpeciesSite, but no parent Species is set.\n");
-#endif
+    assert(parent_);
     return addYAxisAtom(parent_->atom(atomIndex));
 }
 

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -148,16 +148,8 @@ void SpeciesTorsion::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, Spec
     j_ = j;
     k_ = k;
     l_ = l;
-#ifdef CHECKS
-    if (i_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* i in SpeciesTorsion::set().\n");
-    if (j_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* j in SpeciesTorsion::set().\n");
-    if (k_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* k in SpeciesTorsion::set().\n");
-    if (l_ == nullptr)
-        Messenger::error("NULL_POINTER - NULL pointer passed for SpeciesAtom* l in SpeciesTorsion::set().\n");
-#endif
+    assert(i_ && j_ && k_ && l_);
+
     if (i_)
         i_->addTorsion(*this, 0.5);
     if (j_)
@@ -183,52 +175,28 @@ SpeciesAtom *SpeciesTorsion::l() const { return l_; }
 // Return index (in parent Species) of first SpeciesAtom
 int SpeciesTorsion::indexI() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'i' found in SpeciesTorsion::indexI(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(i_);
     return i_->index();
 }
 
 // Return index (in parent Species) of second (central) SpeciesAtom
 int SpeciesTorsion::indexJ() const
 {
-#ifdef CHECKS
-    if (j_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'j' found in SpeciesTorsion::indexJ(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(j_);
     return j_->index();
 }
 
 // Return index (in parent Species) of third SpeciesAtom
 int SpeciesTorsion::indexK() const
 {
-#ifdef CHECKS
-    if (k_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'k' found in SpeciesTorsion::indexK(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(k_);
     return k_->index();
 }
 
 // Return index (in parent Species) of fourth SpeciesAtom
 int SpeciesTorsion::indexL() const
 {
-#ifdef CHECKS
-    if (l_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer 'l' found in SpeciesTorsion::indexL(). Returning 0...\n");
-        return 0;
-    }
-#endif
+    assert(l_);
     return l_->index();
 }
 
@@ -276,13 +244,7 @@ bool SpeciesTorsion::matches(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, Spe
 // Return whether all atoms in the interaction are currently selected
 bool SpeciesTorsion::isSelected() const
 {
-#ifdef CHECKS
-    if (i_ == nullptr || j_ == nullptr || k_ == nullptr || l_ == nullptr)
-    {
-        Messenger::error("NULL_POINTER - NULL SpeciesAtom pointer found in SpeciesTorsion::isSelected(). Returning false...\n");
-        return false;
-    }
-#endif
+    assert(i_ && j_ && k_ && l_);
     return (i_->isSelected() && j_->isSelected() && k_->isSelected() && l_->isSelected());
 }
 

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -172,14 +172,6 @@ std::vector<double> XRayWeights::formFactor(int typeIndexI, const std::vector<do
     // Initialise results array
     std::vector<double> fiq(Q.size());
 
-#ifdef CHECKS
-    if ((typeIndexI < 0) || (typeIndexI >= formFactorData_.size()))
-    {
-        Messenger::error("XRayWeights::formFactorProduct() - Type i index {} is out of range.\n", typeIndexI);
-        return fiq;
-    }
-#endif
-
     auto &fi = formFactorData_[typeIndexI].get();
 
     for (auto n = 0; n < Q.size(); ++n)
@@ -191,18 +183,6 @@ std::vector<double> XRayWeights::formFactor(int typeIndexI, const std::vector<do
 // Return form factor product for types i and j at specified Q value
 double XRayWeights::formFactorProduct(int typeIndexI, int typeIndexJ, double Q) const
 {
-#ifdef CHECKS
-    if ((typeIndexI < 0) || (typeIndexI >= formFactorData_.size()))
-    {
-        Messenger::error("XRayWeights::formFactorProduct() - Type i index {} is out of range.\n", typeIndexI);
-        return 0.0;
-    }
-    if ((typeIndexJ < 0) || (typeIndexJ >= formFactorData_.size()))
-    {
-        Messenger::error("XRayWeights::formFactorProduct() - Type j index {} is out of range.\n", typeIndexJ);
-        return 0.0;
-    }
-#endif
     return formFactorData_[typeIndexI].get().magnitude(Q) * formFactorData_[typeIndexJ].get().magnitude(Q);
 }
 
@@ -217,20 +197,6 @@ std::vector<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const st
 {
     // Initialise results array
     std::vector<double> fijq(Q.size());
-
-    // Get form factor data for involved types
-#ifdef CHECKS
-    if ((typeIndexI < 0) || (typeIndexI >= formFactorData_.size()))
-    {
-        Messenger::error("XRayWeights::weight() - Type i index {} is out of range.\n", typeIndexI);
-        return fijq;
-    }
-    if ((typeIndexJ < 0) || (typeIndexJ >= formFactorData_.size()))
-    {
-        Messenger::error("XRayWeights::weight() - Type j index {} is out of range.\n", typeIndexJ);
-        return fijq;
-    }
-#endif
 
     auto &fi = formFactorData_[typeIndexI].get();
     auto &fj = formFactorData_[typeIndexJ].get();

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -131,7 +131,7 @@ void ConfigurationTab::updateControls()
     ui_.TemperatureSpin->setValue(configuration_->temperature());
 
     // Current Box
-    const Box *box = configuration_->box();
+    const auto *box = configuration_->box();
     ui_.CurrentBoxTypeLabel->setText(QString::fromStdString(std::string(Box::boxTypes().keyword(box->type()))));
     ui_.CurrentBoxALabel->setText(QString::number(box->axisLengths().x));
     ui_.CurrentBoxBLabel->setText(QString::number(box->axisLengths().y));

--- a/src/gui/render/renderableconfiguration.cpp
+++ b/src/gui/render/renderableconfiguration.cpp
@@ -153,7 +153,7 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
     unitCellAssembly_.clear();
 
     // Grab the Configuration's Box and CellArray
-    const Box *box = source_->box();
+    const auto *box = source_->box();
 
     // Render according to the current displayStyle
     if (displayStyle_ == LinesStyle)

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -162,30 +162,12 @@ void Data1D::removeLastPoint()
 // Return x value specified
 double &Data1D::xAxis(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data1D::xAxis().\n", index);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return x_[index];
 }
 
-const double &Data1D::xAxis(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= x_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data1D::xAxis().\n", index);
-        return 0.0;
-    }
-#endif
-    return x_[index];
-}
+const double &Data1D::xAxis(int index) const { return x_[index]; }
 
 // Return x Array
 std::vector<double> &Data1D::xAxis()
@@ -200,30 +182,12 @@ const std::vector<double> &Data1D::xAxis() const { return x_; }
 // Return y value specified
 double &Data1D::value(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= values_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for values_ array in Data1D::value().\n", index);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return values_[index];
 }
 
-const double &Data1D::value(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= values_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for values_ array in Data1D::value().\n", index);
-        return 0.0;
-    }
-#endif
-    return values_[index];
-}
+const double &Data1D::value(int index) const { return values_[index]; }
 
 // Return values Array
 std::vector<double> &Data1D::values()
@@ -277,7 +241,7 @@ double &Data1D::error(int index)
 {
     if (!hasError_)
     {
-        static double dummy;
+        static double dummy = 0.0;
         Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
                         objectTag());
         return dummy;
@@ -355,19 +319,6 @@ void Data1D::operator+=(const Data1D &source)
 
     ++version_;
 
-#ifdef CHECKS
-    for (auto n = 0; n < x_.size(); ++n)
-    {
-        // Check x values for consistency
-        if (fabs(x_[n] - source.x_[n]) > 1.0e-6)
-        {
-            Messenger::error("Failed to += these Data1D together since the x arrays are different (at point {}, x "
-                             "are {:e} and {:e}).\n",
-                             n, x_[n], source.xAxis(n));
-            return;
-        }
-    }
-#endif
     // Loop over points, summing them into our array
     std::transform(source.values().begin(), source.values().end(), values_.begin(), values_.begin(), std::plus<>());
 }
@@ -382,7 +333,7 @@ void Data1D::operator+=(const double delta)
 void Data1D::operator-=(const Data1D &source)
 {
     // If no data is present, simply copy the other arrays and negate the y array
-    if (x_.size() == 0)
+    if (x_.empty())
     {
         copyArrays(source);
         std::transform(values_.begin(), values_.end(), values_.begin(), std::negate<>());
@@ -398,19 +349,6 @@ void Data1D::operator-=(const Data1D &source)
 
     ++version_;
 
-#ifdef CHECKS
-    for (auto n = 0; n < x_.size(); ++n)
-    {
-        // Check x values for consistency
-        if (fabs(x_[n] - source.x_[n]) > 1.0e-6)
-        {
-            Messenger::error("Failed to -= these Data1D together since the x arrays are different (at point {}, x "
-                             "are {:e} and {:e}).\n",
-                             n, x_[n], source.xAxis(n));
-            return;
-        }
-    }
-#endif
     // Loop over points, summing them into our array
     std::transform(values_.begin(), values_.end(), source.values().begin(), values_.begin(), std::minus<>());
 }

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -144,31 +144,12 @@ int Data2D::version() const { return version_; }
 // Return x value specified
 double &Data2D::xAxis(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data2D::xAxis().\n", index);
-        return dummy;
-    }
-#endif
-
     ++version_;
 
     return x_[index];
 }
 
-const double &Data2D::xAxis(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= x_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data2D::xAxis().\n", index);
-        return 0.0;
-    }
-#endif
-    return x_[index];
-}
+const double &Data2D::xAxis(int index) const { return x_[index]; }
 
 // Return x axis Array
 std::vector<double> &Data2D::xAxis()
@@ -183,30 +164,12 @@ const std::vector<double> &Data2D::xAxis() const { return x_; }
 // Return y value specified
 double &Data2D::yAxis(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y_ array in Data2D::yAxis().\n", index);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return y_[index];
 }
 
-const double &Data2D::yAxis(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= y_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y_ array in Data2D::yAxis().\n", index);
-        return 0.0;
-    }
-#endif
-    return y_[index];
-}
+const double &Data2D::yAxis(int index) const { return y_[index]; }
 
 // Return y Array
 std::vector<double> &Data2D::yAxis()
@@ -221,41 +184,12 @@ const std::vector<double> &Data2D::yAxis() const { return y_; }
 // Return value specified
 double &Data2D::value(int xIndex, int yIndex)
 {
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::value().\n", xIndex);
-        return dummy;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::value().\n", yIndex);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return values_[{xIndex, yIndex}];
 }
 
-const double &Data2D::value(int xIndex, int yIndex) const
-{
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::value().\n", xIndex);
-        return 0.0;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::value().\n", yIndex);
-        return 0.0;
-    }
-#endif
-    return values_[{xIndex, yIndex}];
-}
+const double &Data2D::value(int xIndex, int yIndex) const { return values_[{xIndex, yIndex}]; }
 
 // Return two-dimensional values Array
 Array2D<double> &Data2D::values2D()
@@ -312,25 +246,11 @@ double &Data2D::error(int xIndex, int yIndex)
 {
     if (!hasError_)
     {
-        static double dummy;
+        static double dummy = 0.0;
         Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
                         objectTag());
         return dummy;
     }
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::error().\n", xIndex);
-        return dummy;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::error().\n", yIndex);
-        return dummy;
-    }
-#endif
 
     ++version_;
 
@@ -341,25 +261,11 @@ const double &Data2D::error(int xIndex, int yIndex) const
 {
     if (!hasError_)
     {
-        static double dummy;
+        static double dummy = 0.0;
         Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but error(int,int) was requested.\n",
                         name(), objectTag());
         return dummy;
     }
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data2D::error().\n", xIndex);
-        return dummy;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data2D::error().\n", yIndex);
-        return dummy;
-    }
-#endif
 
     return errors_[{xIndex, yIndex}];
 }

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -106,31 +106,12 @@ int Data3D::version() const { return version_; }
 // Return x value specified
 double &Data3D::xAxis(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::xAxis().\n", index);
-        return dummy;
-    }
-#endif
-
     ++version_;
 
     return x_[index];
 }
 
-const double &Data3D::xAxis(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= x_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::xAxis().\n", index);
-        return 0.0;
-    }
-#endif
-    return x_[index];
-}
+const double &Data3D::xAxis(int index) const { return x_[index]; }
 
 // Return x axis Array
 std::vector<double> &Data3D::xAxis()
@@ -145,30 +126,12 @@ const std::vector<double> &Data3D::xAxis() const { return x_; }
 // Return y value specified
 double &Data3D::yAxis(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::yAxis().\n", index);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return y_[index];
 }
 
-const double &Data3D::yAxis(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= y_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x_ array in Data3D::yAxis().\n", index);
-        return 0.0;
-    }
-#endif
-    return y_[index];
-}
+const double &Data3D::yAxis(int index) const { return y_[index]; }
 
 // Return y Array
 std::vector<double> &Data3D::yAxis()
@@ -183,30 +146,12 @@ const std::vector<double> &Data3D::yAxis() const { return y_; }
 // Return z value specified
 double &Data3D::zAxis(int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= z_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z_ array in Data3D::zAxis().\n", index);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return z_[index];
 }
 
-const double &Data3D::zAxis(int index) const
-{
-#ifdef CHECKS
-    if ((index < 0) || (index >= z_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z_ array in Data3D::zAxis().\n", index);
-        return 0.0;
-    }
-#endif
-    return z_[index];
-}
+const double &Data3D::zAxis(int index) const { return z_[index]; }
 
 // Return z Array
 std::vector<double> &Data3D::zAxis()
@@ -221,52 +166,12 @@ const std::vector<double> &Data3D::zAxis() const { return z_; }
 // Return value specified
 double &Data3D::value(int xIndex, int yIndex, int zIndex)
 {
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::value().\n", xIndex);
-        return dummy;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::value().\n", yIndex);
-        return dummy;
-    }
-    if ((zIndex < 0) || (zIndex >= z_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::value().\n", zIndex);
-        return dummy;
-    }
-#endif
     ++version_;
 
     return values_[{xIndex, yIndex, zIndex}];
 }
 
-const double &Data3D::value(int xIndex, int yIndex, int zIndex) const
-{
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::value().\n", xIndex);
-        return 0.0;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::value().\n", yIndex);
-        return 0.0;
-    }
-    if ((zIndex < 0) || (zIndex >= z_.size()))
-    {
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::value().\n", zIndex);
-        return 0.0;
-    }
-#endif
-    return values_[{xIndex, yIndex, zIndex}];
-}
+const double &Data3D::value(int xIndex, int yIndex, int zIndex) const { return values_[{xIndex, yIndex, zIndex}]; }
 
 // Return three-dimensional values Array
 Array3D<double> &Data3D::values3D()
@@ -325,26 +230,7 @@ double &Data3D::error(int xIndex, int yIndex, int zIndex)
                         objectTag());
         return dummy;
     }
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::error().\n", xIndex);
-        return dummy;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::error().\n", yIndex);
-        return dummy;
-    }
-    if ((zIndex < 0) || (zIndex >= z_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::error().\n", zIndex);
-        return dummy;
-    }
-#endif
+
     ++version_;
 
     return errors_[{xIndex, yIndex, zIndex}];
@@ -359,26 +245,6 @@ const double &Data3D::error(int xIndex, int yIndex, int zIndex) const
                         name(), objectTag());
         return dummy;
     }
-#ifdef CHECKS
-    if ((xIndex < 0) || (xIndex >= x_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for x axis in Data3D::error().\n", xIndex);
-        return dummy;
-    }
-    if ((yIndex < 0) || (yIndex >= y_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for y axis in Data3D::error().\n", yIndex);
-        return dummy;
-    }
-    if ((zIndex < 0) || (zIndex >= z_.size()))
-    {
-        static double dummy;
-        Messenger::error("OUT_OF_RANGE - Index {} is out of range for z axis in Data3D::error().\n", zIndex);
-        return dummy;
-    }
-#endif
 
     return errors_[{xIndex, yIndex, zIndex}];
 }

--- a/src/math/windowfunction.cpp
+++ b/src/math/windowfunction.cpp
@@ -200,11 +200,7 @@ double WindowFunction::y(double x, double omega) const
 {
     // Determine current fractional x value (from our stored xMax_)
     const auto chi = x / xMax_;
-
-#ifdef CHECKS
-    if ((chi < 0.0) || (chi > 1.0))
-        Messenger::warn("Position for window function is out of range ({}).\n", chi);
-#endif
+    assert(chi >= 0.0 && chi <= 1.0);
 
     switch (function_)
     {

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -48,7 +48,7 @@ bool BraggModule::calculateBraggTerms(ProcessPool &procPool, Configuration *cfg,
     auto &braggMaximumHKL = GenericListHelper<Vec3<int>>::realise(cfg->moduleData(), "BraggMaximumHKL");
 
     // Grab some useful values
-    const Box *box = cfg->box();
+    const auto *box = cfg->box();
     auto nTypes = cfg->nUsedAtomTypes();
     auto nAtoms = cfg->nAtoms();
     auto &atoms = cfg->atoms();

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -103,13 +103,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
     for (auto n = 0; n < stack->nSites(); ++n)
     {
         const Site &s = stack->site(n);
-#ifdef CHECKS
-        if (s.molecule()->species() != targetSpecies_)
-        {
-            Messenger::error("Site species doesn't match target species.\n");
-            continue;
-        }
-#endif
+        assert(s.molecule()->species() == targetSpecies_);
 
         // Get axes and take inverse
         Matrix3 inverseAxes = s.axes();

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -69,7 +69,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
     // Grab Configuration and Box pointers
     auto *cfg = targetConfigurations_.firstItem();
-    const Box *box = cfg->box();
+    const auto *box = cfg->box();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());
@@ -80,7 +80,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
         return Messenger::error("No target site defined.\n");
 
     // Get site parent species
-    Species *sp = site->parent();
+    auto *sp = site->parent();
     if (sp != targetSpecies_)
         return Messenger::error("Internal error - target site parent is not the same as the target species.\n");
 
@@ -88,7 +88,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
     updateArrays(dissolve);
 
     // Get the site stack
-    const SiteStack *stack = cfg->siteStack(site);
+    const auto *stack = cfg->siteStack(site);
 
     // Retrieve data arrays
     Array<SampledDouble> &x =
@@ -102,11 +102,11 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
     Vec3<double> r;
     for (auto n = 0; n < stack->nSites(); ++n)
     {
-        const Site &s = stack->site(n);
+        const auto &s = stack->site(n);
         assert(s.molecule()->species() == targetSpecies_);
 
         // Get axes and take inverse
-        Matrix3 inverseAxes = s.axes();
+        auto inverseAxes = s.axes();
         inverseAxes.invert();
 
         // Loop over atoms, taking delta position with origin, and rotating into local axes

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -26,7 +26,7 @@ double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Configuration *cfg
     ProcessPool::DivisionStrategy strategy = ProcessPool::PoolStrategy;
 
     // Grab the Cell array and calculate total energy
-    const CellArray &cellArray = cfg->cells();
+    const auto &cellArray = cfg->cells();
     double totalEnergy = kernel.energy(cellArray, false, strategy, false);
 
     // Print process-local energy
@@ -96,7 +96,7 @@ double EnergyModule::interMolecularEnergy(ProcessPool &procPool, Configuration *
     ProcessPool::DivisionStrategy strategy = ProcessPool::PoolStrategy;
 
     // Grab the Cell array and calculate total energy
-    const CellArray &cellArray = cfg->cells();
+    const auto &cellArray = cfg->cells();
     double totalEnergy = kernel.energy(cellArray, true, strategy, false);
 
     // Print process-local energy

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -20,7 +20,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
      */
 
     // Grab the Cell array
-    const CellArray &cellArray = cfg->cells();
+    const auto &cellArray = cfg->cells();
 
     // Create a ForceKernel
     ForceKernel kernel(procPool, cfg->box(), potentialMap, fx, fy, fz);

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -116,7 +116,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
         double ppEnergy, newPPEnergy, intraEnergy, newIntraEnergy, delta, totalDelta = 0.0;
         Vec3<double> vji, vjk, v;
         Matrix3 transform;
-        const Box *box = cfg->box();
+        const auto *box = cfg->box();
         std::shared_ptr<Atom> i, j, k, l;
 
         Timer timer;

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -80,7 +80,7 @@ bool MolShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
         double currentEnergy, newEnergy, delta, totalDelta = 0.0;
         Matrix3 transform;
         Vec3<double> rDelta;
-        const Box *box = cfg->box();
+        const auto *box = cfg->box();
 
         /*
          * In order to be able to adjust translation and rotational steps independently, we will perform 80% of moves

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -27,7 +27,7 @@
 bool RDFModule::calculateGRTestSerial(Configuration *cfg, PartialSet &partialSet)
 {
     // Calculate radial distribution functions with a simple double loop, in serial
-    const Box *box = cfg->box();
+    const auto *box = cfg->box();
 
     for_each_pair(cfg->atoms().begin(), cfg->atoms().end(), [box, &partialSet](auto i, auto ii, auto j, auto jj) {
         if (ii != jj)
@@ -46,7 +46,7 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
     // Construct local arrays of atom type positions
     nTypes = partialSet.nAtomTypes();
     Messenger::printVerbose("Constructing local partial working arrays for {} types.\n", nTypes);
-    const Box *box = cfg->box();
+    const auto *box = cfg->box();
     std::vector<Vec3<double> *> r(nTypes);
     std::vector<int> maxr(nTypes), nr(nTypes);
     std::vector<int *> binss(nTypes);
@@ -153,8 +153,8 @@ bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, Part
     Vec3<double> rI;
 
     // Grab the Box pointer and Cell array
-    const Box *box = cfg->box();
-    CellArray &cellArray = cfg->cells();
+    const auto *box = cfg->box();
+    auto &cellArray = cfg->cells();
 
     // Loop context is to use all processes in Pool as one group
     auto start = procPool.interleavedLoopStart(ProcessPool::PoolStrategy);
@@ -316,7 +316,7 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
      */
 
     double distance;
-    const Box *box = cfg->box();
+    const auto *box = cfg->box();
 
     // Set start/stride for parallel loop (pool solo)
     auto start = (method == RDFModule::TestMethod ? 0 : procPool.interleavedLoopStart(ProcessPool::PoolStrategy));

--- a/src/procedure/nodes/addspecies.cpp
+++ b/src/procedure/nodes/addspecies.cpp
@@ -197,7 +197,7 @@ ProcedureNode::NodeExecutionResult AddSpeciesProcedureNode::execute(ProcessPool 
     Vec3<double> r, cog, newCentre, fr;
     CoordinateSet *coordSet = sp->coordinateSets().first();
     Matrix3 transform;
-    const Box *box = cfg->box();
+    const auto *box = cfg->box();
     for (auto n = 0; n < requestedPopulation; ++n)
     {
         // Add the Molecule

--- a/src/procedure/nodes/calculateangle.cpp
+++ b/src/procedure/nodes/calculateangle.cpp
@@ -42,16 +42,10 @@ int CalculateAngleProcedureNode::dimensionality() const { return 1; }
 ProcedureNode::NodeExecutionResult CalculateAngleProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                         std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    for (auto n = 0; n < nSitesRequired(); ++n)
-    {
-        if (sites_[n]->currentSite() == nullptr)
-        {
-            Messenger::error("Observable {} has no current site.\n", n);
-            return ProcedureNode::Failure;
-        }
-    }
-#endif
+    assert(sites_[0] && sites_[0]->currentSite());
+    assert(sites_[1] && sites_[1]->currentSite());
+    assert(sites_[2] && sites_[2]->currentSite());
+
     // Determine the value of the observable
     value_.x = cfg->box()->angleInDegrees(sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin(),
                                           sites_[2]->currentSite()->origin());

--- a/src/procedure/nodes/calculateaxisangle.cpp
+++ b/src/procedure/nodes/calculateaxisangle.cpp
@@ -60,16 +60,9 @@ bool CalculateAxisAngleProcedureNode::prepare(Configuration *cfg, std::string_vi
 ProcedureNode::NodeExecutionResult CalculateAxisAngleProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                             std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    for (auto n = 0; n < nSitesRequired(); ++n)
-    {
-        if (sites_[n]->currentSite() == nullptr)
-        {
-            Messenger::error("Observable {} has no current site.\n", n);
-            return ProcedureNode::Failure;
-        }
-    }
-#endif
+    assert(sites_[0] && sites_[0]->currentSite());
+    assert(sites_[1] && sites_[1]->currentSite());
+
     value_ = Box::angleInDegrees(sites_[0]->currentSite()->axes().columnAsVec3(axisI_),
                                  sites_[1]->currentSite()->axes().columnAsVec3(axisJ_));
 

--- a/src/procedure/nodes/calculatebase.cpp
+++ b/src/procedure/nodes/calculatebase.cpp
@@ -39,18 +39,7 @@ bool CalculateProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext co
  */
 
 // Return last calculated value of observable
-double CalculateProcedureNodeBase::value(int id) const
-{
-#ifdef CHECKS
-    if ((id < 0) || (id >= dimensionality()))
-    {
-        Messenger::error("Observable value index {} is out of range for this observable which has a dimensionality of {}.\n",
-                         id, dimensionality());
-        return 0.0;
-    }
-#endif
-    return value_.get(id);
-}
+double CalculateProcedureNodeBase::value(int id) const { return value_.get(id); }
 
 // Return last calculated value of observable
 Vec3<double> CalculateProcedureNodeBase::values() const { return value_; }

--- a/src/procedure/nodes/calculatedistance.cpp
+++ b/src/procedure/nodes/calculatedistance.cpp
@@ -39,16 +39,10 @@ int CalculateDistanceProcedureNode::dimensionality() const { return 1; }
 ProcedureNode::NodeExecutionResult CalculateDistanceProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                            std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    for (auto n = 0; n < nSitesRequired(); ++n)
-    {
-        if (sites_[n]->currentSite() == nullptr)
-        {
-            Messenger::error("Observable {} has no current site.\n", n);
-            return ProcedureNode::Failure;
-        }
-    }
-#endif
+
+    assert(sites_[0] && sites_[0]->currentSite());
+    assert(sites_[1] && sites_[1]->currentSite());
+
     // Determine the value of the observable
     value_.x = cfg->box()->minimumDistance(sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin());
 

--- a/src/procedure/nodes/calculatevector.cpp
+++ b/src/procedure/nodes/calculatevector.cpp
@@ -56,16 +56,9 @@ bool CalculateVectorProcedureNode::prepare(Configuration *cfg, std::string_view 
 ProcedureNode::NodeExecutionResult CalculateVectorProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                          std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    for (auto n = 0; n < nSitesRequired(); ++n)
-    {
-        if (sites_[n]->currentSite() == nullptr)
-        {
-            Messenger::error("Observable {} has no current site.\n", n);
-            return ProcedureNode::Failure;
-        }
-    }
-#endif
+    assert(sites_[0] && sites_[0]->currentSite());
+    assert(sites_[1] && sites_[1]->currentSite());
+
     // Determine the value of the observable
     value_ = cfg->box()->minimumVector(sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin());
 

--- a/src/procedure/nodes/collect1d.cpp
+++ b/src/procedure/nodes/collect1d.cpp
@@ -129,13 +129,8 @@ bool Collect1DProcedureNode::prepare(Configuration *cfg, std::string_view prefix
 ProcedureNode::NodeExecutionResult Collect1DProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                    std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    if (!xObservable_)
-    {
-        Messenger::error("No CalculateProcedureNodeBase pointer set in Collect1DProcedureNode '{}'.\n", name());
-        return ProcedureNode::Failure;
-    }
-#endif
+    assert(xObservable_);
+
     // Bin the current value of the observable, and execute sub-collection branch on success
     if (histogram_->bin(xObservable_->value(xObservableIndex_)) && subCollectBranch_)
         return subCollectBranch_->execute(procPool, cfg, prefix, targetList);
@@ -147,13 +142,8 @@ ProcedureNode::NodeExecutionResult Collect1DProcedureNode::execute(ProcessPool &
 bool Collect1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
                                       GenericList &targetList)
 {
-#ifdef CHECKS
-    if (!histogram_)
-    {
-        Messenger::error("No Data1D pointer set in Collect1DProcedureNode '{}'.\n", name());
-        return ProcedureNode::Failure;
-    }
-#endif
+    assert(histogram_);
+
     // Accumulate the current binned data
     histogram_->accumulate();
 

--- a/src/procedure/nodes/collect2d.cpp
+++ b/src/procedure/nodes/collect2d.cpp
@@ -149,20 +149,9 @@ bool Collect2DProcedureNode::prepare(Configuration *cfg, std::string_view prefix
 ProcedureNode::NodeExecutionResult Collect2DProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                    std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    if (!xObservable_)
-    {
-        Messenger::error("No CalculateProcedureNodeBase pointer set for X observable in Collect2DProcedureNode '{}'.\n",
-                         name());
-        return ProcedureNode::Failure;
-    }
-    if (!yObservable_)
-    {
-        Messenger::error("No CalculateProcedureNodeBase pointer set for Y observable in Collect2DProcedureNode '{}'.\n",
-                         name());
-        return ProcedureNode::Failure;
-    }
-#endif
+    assert(xObservable_);
+    assert(yObservable_);
+
     // Bin the current value of the observable
     if (histogram_->bin(xObservable_->value(xObservableIndex_), yObservable_->value(yObservableIndex_)) && subCollectBranch_)
         return subCollectBranch_->execute(procPool, cfg, prefix, targetList);
@@ -174,13 +163,8 @@ ProcedureNode::NodeExecutionResult Collect2DProcedureNode::execute(ProcessPool &
 bool Collect2DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
                                       GenericList &targetList)
 {
-#ifdef CHECKS
-    if (!histogram_)
-    {
-        Messenger::error("No Data2D pointer set in Collect2DProcedureNode '{}'.\n", name());
-        return ProcedureNode::Failure;
-    }
-#endif
+    assert(histogram_);
+
     // Accumulate the current binned data
     histogram_->accumulate();
 

--- a/src/procedure/nodes/collect3d.cpp
+++ b/src/procedure/nodes/collect3d.cpp
@@ -206,26 +206,10 @@ bool Collect3DProcedureNode::prepare(Configuration *cfg, std::string_view prefix
 ProcedureNode::NodeExecutionResult Collect3DProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
                                                                    std::string_view prefix, GenericList &targetList)
 {
-#ifdef CHECKS
-    if (!xObservable_)
-    {
-        Messenger::error("No CalculateProcedureNodeBase pointer set for X observable in Collect3DProcedureNode '{}'.\n",
-                         name());
-        return ProcedureNode::Failure;
-    }
-    if (!yObservable_)
-    {
-        Messenger::error("No CalculateProcedureNodeBase pointer set for Y observable in Collect3DProcedureNode '{}'.\n",
-                         name());
-        return ProcedureNode::Failure;
-    }
-    if (!zObservable_)
-    {
-        Messenger::error("No CalculateProcedureNodeBase pointer set for Z observable in Collect3DProcedureNode '{}'.\n",
-                         name());
-        return ProcedureNode::Failure;
-    }
-#endif
+    assert(xObservable_);
+    assert(yObservable_);
+    assert(zObservable_);
+
     // Bin the current value of the observable
     if (histogram_->bin(xObservable_->value(xObservableIndex_), yObservable_->value(yObservableIndex_),
                         zObservable_->value(zObservableIndex_)) &&
@@ -239,13 +223,8 @@ ProcedureNode::NodeExecutionResult Collect3DProcedureNode::execute(ProcessPool &
 bool Collect3DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
                                       GenericList &targetList)
 {
-#ifdef CHECKS
-    if (!histogram_)
-    {
-        Messenger::error("No Data3D pointer set in Collect3DProcedureNode '{}'.\n", name());
-        return ProcedureNode::Failure;
-    }
-#endif
+    assert(histogram_);
+
     // Accumulate the current binned data
     histogram_->accumulate();
 

--- a/src/templates/array.h
+++ b/src/templates/array.h
@@ -171,14 +171,7 @@ template <class A> class Array : public ListItem<Array<A>>
     // Insert new element in array
     void insert(A data, const int position)
     {
-#ifdef CHECKS
-        if ((position < 0) || (position >= nItems_))
-        {
-            Messenger::print("OUT_OF_RANGE - Position index {} is out of range in Array::insert() (nItems = {}).\n", position,
-                             nItems_);
-            return;
-        }
-#endif
+        assert(position >= 0 && position < nItems_);
 
         // Is current array large enough?
         if (nItems_ == size_)
@@ -229,14 +222,8 @@ template <class A> class Array : public ListItem<Array<A>>
     // Remove the specified index
     void remove(const int position)
     {
-#ifdef CHECKS
-        if ((position < 0) || (position >= nItems_))
-        {
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::remove() (nItems = {}).\n", position,
-                             nItems_);
-            return;
-        }
-#endif
+        assert(position >= 0 && position < nItems_);
+
         for (auto n = position; n < nItems_ - 1; ++n)
             array_[n] = array_[n + 1];
 
@@ -250,82 +237,50 @@ template <class A> class Array : public ListItem<Array<A>>
     // Return reference to nth item in array
     A &operator[](int n)
     {
-#ifdef CHECKS
-        if ((n < 0) || (n >= nItems_))
-        {
-            static A dummy;
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::operator[] (nItems = {}).\n", n, nItems_);
-            return dummy;
-        }
-#endif
+        assert(n >= 0 && n < nItems_);
+
         return array_[n];
     }
     // Return single value
     A &at(int n)
     {
-#ifdef CHECKS
-        if ((n < 0) || (n >= nItems_))
-        {
-            static A dummy;
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::at() (nItems = {}).\n", n, nItems_);
-            return dummy;
-        }
-#endif
+        assert(n >= 0 && n < nItems_);
+
         return array_[n];
     }
     // Return nth item as const reference
     const A &at(int n) const
     {
-#ifdef CHECKS
-        if ((n < 0) || (n >= nItems_))
-        {
-            static A dummy;
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::at() (nItems = {}).\n", n, nItems_);
-            return dummy;
-        }
-#endif
+        assert(n >= 0 && n < nItems_);
+
         return array_[n];
     }
     // Return first value in array
     A firstValue() const
     {
-        if (nItems_ == 0)
-        {
-            Messenger::print("OUT_OF_RANGE - No first item to return in Array.\n");
-            return A();
-        }
+        assert(nItems_ > 0);
+
         return array_[0];
     }
     // Return last value in array
     A lastValue() const
     {
-        if (nItems_ == 0)
-        {
-            Messenger::print("OUT_OF_RANGE - No last item to return in Array.\n");
-            return A();
-        }
+        assert(nItems_ > 0);
+
         return array_[nItems_ - 1];
     }
     // Return first item in array
     A &first()
     {
-        if (nItems_ == 0)
-        {
-            static A dummy;
-            Messenger::print("OUT_OF_RANGE - No first item to return in Array.\n");
-            return dummy;
-        }
+        assert(nItems_ > 0);
+
         return array_[0];
     }
     // Return last item in array
     A &last()
     {
-        if (nItems_ == 0)
-        {
-            static A dummy;
-            Messenger::print("OUT_OF_RANGE - No last item to return in Array.\n");
-            return dummy;
-        }
+        assert(nItems_ > 0);
+
         return array_[nItems_ - 1];
     }
 
@@ -336,14 +291,8 @@ template <class A> class Array : public ListItem<Array<A>>
     // Shift item up in the array (towards higher indices)
     void shiftUp(int position)
     {
-#ifdef CHECKS
-        if ((position < 0) || (position >= nItems_))
-        {
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::shiftUp() (nItems = {}).\n", position,
-                             nItems_);
-            return;
-        }
-#endif
+        assert(position >= 0 && position < nItems_);
+
         // If this item is already last in the list, return now
         if (position == (nItems_ - 1))
             return;
@@ -355,14 +304,8 @@ template <class A> class Array : public ListItem<Array<A>>
     // Shift item down in the array (towards lower indices)
     void shiftDown(int position)
     {
-#ifdef CHECKS
-        if ((position < 0) || (position >= nItems_))
-        {
-            Messenger::print("OUT_OF_RANGE - Array index {} is out of range in Array::shiftDown() (nItems = {}).\n", position,
-                             nItems_);
-            return;
-        }
-#endif
+        assert(position >= 0 && position < nItems_);
+
         // If this item is already first in the list, return now
         if (position == 0)
             return;

--- a/src/templates/array2d.h
+++ b/src/templates/array2d.h
@@ -142,20 +142,9 @@ template <class A> class Array2D
     A &operator[](const std::tuple<int, int> index)
     {
         auto [row, column] = index;
-#ifdef CHECKS
-        static A dummy;
-        if ((row < 0) || (row >= nRows_))
-        {
-            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::at() (nRows = {}).\n", row, nRows_);
-            return dummy;
-        }
-        if ((column < 0) || (column >= nColumns_))
-        {
-            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::at() (nColumns = {}).\n", column,
-                             nColumns_);
-            return dummy;
-        }
-#endif
+        assert(row >= 0 && row < nRows_);
+        assert(column >= 0 && column < nColumns_);
+
         if (half_)
         {
             if (row > column)
@@ -170,20 +159,9 @@ template <class A> class Array2D
     const A &operator[](const std::tuple<int, int> index) const
     {
         auto [row, column] = index;
-#ifdef CHECKS
-        static A dummy;
-        if ((row < 0) || (row >= nRows_))
-        {
-            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::at() (nRows = {}).\n", row, nRows_);
-            return dummy;
-        }
-        if ((column < 0) || (column >= nColumns_))
-        {
-            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::at() (nColumns = {}).\n", column,
-                             nColumns_);
-            return dummy;
-        }
-#endif
+        assert(row >= 0 && row < nRows_);
+        assert(column >= 0 && column < nColumns_);
+
         if (half_)
         {
             if (row > column)
@@ -197,21 +175,9 @@ template <class A> class Array2D
     // Return address of specified element
     A *pointerAt(int row, int column)
     {
-#ifdef CHECKS
-        static A dummy;
-        if ((row < 0) || (row >= nRows_))
-        {
-            Messenger::print("OUT_OF_RANGE - Row number ({}) is out of range in Array2D::pointerAt() (nRows = {}).\n", row,
-                             nRows_);
-            return &dummy;
-        }
-        if ((column < 0) || (column >= nColumns_))
-        {
-            Messenger::print("OUT_OF_RANGE - Column number ({}) is out of range in Array2D::pointerAt() (nColumns = {}).\n",
-                             column, nColumns_);
-            return &dummy;
-        }
-#endif
+        assert(row >= 0 && row < nRows_);
+        assert(column >= 0 && column < nColumns_);
+
         if (half_)
         {
             if (row > column)

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -88,71 +88,29 @@ template <class A> class Array3D
     A &operator[](std::tuple<int, int, int> index)
     {
         auto [x, y, z] = index;
-#ifdef CHECKS
-        static A dummy;
-        if ((x < 0) || (x >= nX_))
-        {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in Array3D::at() (nX_ = {}).\n", x, nX_);
-            return dummy;
-        }
-        if ((y < 0) || (y >= nY_))
-        {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in Array3D::at() (nY_ = {}).\n", y, nY_);
-            return dummy;
-        }
-        if ((z < 0) || (z >= nZ_))
-        {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in Array3D::at() (nZ_ = {}).\n", z, nZ_);
-            return dummy;
-        }
-#endif
+        assert(x >= 0 && x < nX_);
+        assert(y >= 0 && y < nY_);
+        assert(z >= 0 && z < nZ_);
+
         return array_[sliceOffsets_[z] + y * nX_ + x];
     }
     // Return specified element as const-reference
     const A &operator[](std::tuple<int, int, int> index) const
     {
         auto [x, y, z] = index;
-#ifdef CHECKS
-        static A dummy;
-        if ((x < 0) || (x >= nX_))
-        {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in Array3D::at() (nX_ = {}).\n", x, nX_);
-            return dummy;
-        }
-        if ((y < 0) || (y >= nY_))
-        {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in Array3D::at() (nY_ = {}).\n", y, nY_);
-            return dummy;
-        }
-        if ((z < 0) || (z >= nZ_))
-        {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in Array3D::at() (nZ_ = {}).\n", z, nZ_);
-            return dummy;
-        }
-#endif
+        assert(x >= 0 && x < nX_);
+        assert(y >= 0 && y < nY_);
+        assert(z >= 0 && z < nZ_);
+
         return array_[sliceOffsets_[z] + y * nX_ + x];
     }
     // Return address of specified element
     A *ptr(int x, int y, int z)
     {
-#ifdef CHECKS
-        static A dummy;
-        if ((x < 0) || (x >= nX_))
-        {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in Array3D::ptr() (nX_ = {}).\n", x, nX_);
-            return dummy;
-        }
-        if ((y < 0) || (y >= nY_))
-        {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in Array3D::ptr() (nY_ = {}).\n", y, nY_);
-            return dummy;
-        }
-        if ((z < 0) || (z >= nZ_))
-        {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in Array3D::ptr() (nZ_ = {}).\n", z, nZ_);
-            return dummy;
-        }
-#endif
+        assert(x >= 0 && x < nX_);
+        assert(y >= 0 && y < nY_);
+        assert(z >= 0 && z < nZ_);
+
         return &array_[sliceOffsets_[z] + y * nX_ + x];
     }
     // Return array size in x
@@ -177,32 +135,8 @@ template <class A> class Array3D
     typename std::vector<A>::const_iterator cend() const { return array_.cend(); }
     bool empty() const { return array_.empty(); }
     // Return linear value
-    A &linearValue(int index)
-    {
-#ifdef CHECKS
-        static A dummy;
-        if ((index < 0) || (index >= array_.size()))
-        {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in Array3D::linearValue() (linearSize = {}).\n", index,
-                             array_.size());
-            return dummy;
-        }
-#endif
-        return array_[index];
-    }
-    const A &linearValue(int index) const
-    {
-#ifdef CHECKS
-        static A dummy;
-        if ((index < 0) || (index >= array_.size()))
-        {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in Array3D::linearValue() (linearSize = {}).\n", index,
-                             array_.size());
-            return dummy;
-        }
-#endif
-        return array_[index];
-    }
+    A &linearValue(int index) { return array_[index]; }
+    const A &linearValue(int index) const { return array_[index]; }
 
     /*
      * Operators
@@ -325,89 +259,29 @@ template <class A> class OffsetArray3D
     A &operator[](std::tuple<int, int, int> index)
     {
         auto [x, y, z] = index;
-#ifdef CHECKS
-        static A dummy;
-        if ((x < xMin_) || (x > xMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in OffsetArray3D::ref() (xMin_ = {}, "
-                             "xMax_ = {}).\n",
-                             x, xMin_, xMax_);
-            return dummy;
-        }
-        if ((y < yMin_) || (y > yMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in OffsetArray3D::ref() (yMin_ = {}, "
-                             "yMay_ = {}).\n",
-                             y, yMin_, yMax_);
-            return dummy;
-        }
-        if ((z < zMin_) || (z > zMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in OffsetArray3D::ref() (zMin_ = {}, "
-                             "zMaz_ = {}).\n",
-                             z, zMin_, zMax_);
-            return dummy;
-        }
-#endif
+        assert(x >= xMin_ && x <= xMax_);
+        assert(y >= yMin_ && y <= yMax_);
+        assert(z >= zMin_ && z <= zMax_);
+
         return array_[sliceOffsets_[z - zMin_] + (y - yMin_) * nX_ + (x - xMin_)];
     }
     // Return specified element as const reference
     const A &operator[](std::tuple<int, int, int> index) const
     {
         auto [x, y, z] = index;
-#ifdef CHECKS
-        static A dummy;
-        if ((x < xMin_) || (x > xMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in OffsetArray3D::value() (xMin_ = {}, "
-                             "xMax_ = {}).\n",
-                             x, xMin_, xMax_);
-            return dummy;
-        }
-        if ((y < yMin_) || (y > yMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in OffsetArray3D::value() (yMin_ = {}, "
-                             "yMay_ = {}).\n",
-                             y, yMin_, yMax_);
-            return dummy;
-        }
-        if ((z < zMin_) || (z > zMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in OffsetArray3D::value() (zMin_ = {}, "
-                             "zMaz_ = {}).\n",
-                             z, zMin_, zMax_);
-            return dummy;
-        }
-#endif
+        assert(x >= xMin_ && x <= xMax_);
+        assert(y >= yMin_ && y <= yMax_);
+        assert(z >= zMin_ && z <= zMax_);
+
         return array_[sliceOffsets_[z - zMin_] + (y - yMin_) * nX_ + (x - xMin_)];
     }
     // Return address of specified element
     A *pointerAt(int x, int y, int z)
     {
-#ifdef CHECKS
-        static A dummy;
-        if ((x < xMin_) || (x > xMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - X index ({}) is out of range in OffsetArray3D::ptr() (xMin_ = {}, "
-                             "xMax_ = {}).\n",
-                             x, xMin_, xMax_);
-            return dummy;
-        }
-        if ((y < yMin_) || (y > yMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - Y index ({}) is out of range in OffsetArray3D::ptr() (yMin_ = {}, "
-                             "yMay_ = {}).\n",
-                             y, yMin_, yMax_);
-            return dummy;
-        }
-        if ((z < zMin_) || (z > zMax_))
-        {
-            Messenger::print("OUT_OF_RANGE - Z index ({}) is out of range in OffsetArray3D::ptr() (zMin_ = {}, "
-                             "zMaz_ = {}).\n",
-                             z, zMin_, zMax_);
-            return dummy;
-        }
-#endif
+        assert(x >= xMin_ && x <= xMax_);
+        assert(y >= yMin_ && y <= yMax_);
+        assert(z >= zMin_ && z <= zMax_);
+
         return &array_[sliceOffsets_[z - zMin_] + (y - yMin_) * nX_ + (x - xMin_)];
     }
     // Return array size in x
@@ -425,34 +299,8 @@ template <class A> class OffsetArray3D
     // End iterator
     typename std::vector<A>::iterator end() { return array_.end(); }
     // Return linear value
-    A &linearValue(int index)
-    {
-#ifdef CHECKS
-        static A dummy;
-        if ((index < 0) || (index >= array_.size()))
-        {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in OffsetArray3D::linearValue() "
-                             "(linearSize = {}).\n",
-                             index, array_.size());
-            return dummy;
-        }
-#endif
-        return array_[index];
-    }
-    const A &linearValue(int index) const
-    {
-#ifdef CHECKS
-        static A dummy;
-        if ((index < 0) || (index >= array_.size()))
-        {
-            Messenger::print("OUT_OF_RANGE - Index ({}) is out of range in OffsetArray3D::linearValue() "
-                             "(linearSize = {}).\n",
-                             index, array_.size());
-            return dummy;
-        }
-#endif
-        return array_[index];
-    }
+    A &linearValue(int index) { return array_[index]; }
+    const A &linearValue(int index) const { return array_[index]; }
 
     /*
      * Operators

--- a/src/templates/objectstore.h
+++ b/src/templates/objectstore.h
@@ -160,7 +160,6 @@ template <class T> class ObjectStore
         if (ObjectInfo::autoSuffixing())
             objectTag = fmt::format("{}@{}", objectTag, ObjectInfo::autoSuffix());
 
-#ifdef CHECKS
         // Check for duplicate value already in list
         if (!objectTag.empty())
         {
@@ -175,7 +174,7 @@ template <class T> class ObjectStore
                                 objectTypeName_, objectTypeName_, objectTag);
             }
         }
-#endif
+
         objectInfo_.setTag(fmt::format("{}%{}", objectTypeName_, objectTag));
     }
     // Return object tag

--- a/src/templates/orderedlist.h
+++ b/src/templates/orderedlist.h
@@ -366,13 +366,7 @@ template <class T> void OrderedList<T>::remove(int objectIndex)
 {
     // Get item for specified objectIndex
     OrderedListItem<T> *item = contains(objectIndex);
-#ifdef CHECKS
-    if (item == nullptr)
-    {
-        Messenger::error("Specified objectIndex ({}) does not exist in this OrderedList.\n", objectIndex);
-        return;
-    }
-#endif
+    assert(item);
     remove(item);
 }
 
@@ -392,13 +386,8 @@ template <class T> void OrderedList<T>::move(int objectIndex, OrderedList<T> &ta
 {
     // Get item for specified objectIndex
     OrderedListItem<T> *item = contains(objectIndex);
-#ifdef CHECKS
-    if (item == nullptr)
-    {
-        Messenger::error("Specified objectIndex ({}) does not exist in this OrderedList.\n", objectIndex);
-        return;
-    }
-#endif
+    assert(item);
+
     // Add to target list, then delete from this list
     targetList.add(item->object());
     remove(item);
@@ -549,12 +538,7 @@ template <class T> void OrderedList<T>::operator=(const OrderedList<T> &other)
 
 template <class T> OrderedListItem<T> *OrderedList<T>::operator[](int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= nItems_))
-    {
-        Messenger::error("LIST_OPERATOR[] - Array index ({}) out of bounds ({} items in List) >>>>\n", index, nItems_);
-        return nullptr;
-    }
-#endif
+    assert(index >= 0 && index < nItems_);
+
     return items()[index];
 }

--- a/src/templates/orderedpointerdataarray.h
+++ b/src/templates/orderedpointerdataarray.h
@@ -7,9 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// Forward Declarations
-/* none */
-
 /*
  * Simple Ordered Pointer Array Class
  * A contiguous pointer array class designed to be as lightweight as possible.
@@ -50,15 +47,8 @@ template <class T, class D> class OrderedPointerDataArray
     }
     T *operator[](int index)
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            Messenger::error("OrderedPointerDataArray<T,D>::operator[]({}) - Array index out of bounds ({} items "
-                             "in array).\n",
-                             index, nItems_);
-            return nullptr;
-        }
-#endif
+        assert(index >= 0 && index < nItems_);
+
         return items_[index];
     }
 
@@ -117,28 +107,14 @@ template <class T, class D> class OrderedPointerDataArray
     // Const pointer access
     T *pointer(int index) const
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            Messenger::error("OrderedPointerDataArray<T,D>::value({}) - Array index out of bounds ({} items in array).\n",
-                             index, nItems_);
-            return nullptr;
-        }
-#endif
+        assert(index >= 0 && index < nItems_);
 
         return items_[index];
     }
     // Const-data access
     D data(int index) const
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            Messenger::error("OrderedPointerDataArray<T,D>::data({}) - Array index out of bounds ({} items in array).\n", index,
-                             nItems_);
-            return D();
-        }
-#endif
+        assert(index >= 0 && index < nItems_);
 
         return data_[index];
     }
@@ -223,14 +199,7 @@ template <class T, class D> class OrderedPointerDataArray
     // Set data for the nth item
     void setData(int index, D value)
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            Messenger::error("OrderedPointerDataArray<T,D>::setData({}) - Array index out of bounds ({} items in array).\n",
-                             index, nItems_);
-            return;
-        }
-#endif
+        assert(index >= 0 && index < nItems_);
 
         data_[index] = value;
     }

--- a/src/templates/orderedpointerdatalist.h
+++ b/src/templates/orderedpointerdatalist.h
@@ -284,13 +284,8 @@ template <class T, class D> class OrderedPointerDataList
     // Add a new item reference to the list
     void add(T *object, D data = D())
     {
-#ifdef CHECKS
-        if (object == nullptr)
-        {
-            Messenger::error("NULL_POINTER - nullptr passed to OrderedPointerDataList<T,D>::add().\n");
-            return;
-        }
-#endif
+        assert(object);
+
         // Add it in the correct place in the list
         OrderedPointerDataListItem<T, D> *nextLargest = nextHighest(object);
         insertBefore(object, nextLargest)->setData(data);
@@ -298,13 +293,8 @@ template <class T, class D> class OrderedPointerDataList
     // Add a new item reference to the list, unless it is already there
     void addExclusive(T *object, D data = D())
     {
-#ifdef CHECKS
-        if (object == nullptr)
-        {
-            Messenger::error("NULL_POINTER - nullptr passed to OrderedPointerDataList<T,D>::add().\n");
-            return;
-        }
-#endif
+        assert(object);
+
         // Seek the next highest object, checking to see if we find the specified index
         // TODO This can be made much faster - binary chop?
         OrderedPointerDataListItem<T, D> *nextLargest = listHead_;
@@ -322,13 +312,8 @@ template <class T, class D> class OrderedPointerDataList
     // Add a new item reference to the end of the list (with checks)
     void addAtEnd(T *object, D data = D())
     {
-#ifdef CHECKS
-        if (object == nullptr)
-        {
-            Messenger::error("NULL_POINTER - nullptr passed to OrderedPointerDataList<T,D>::addAtEnd().\n");
-            return;
-        }
-#endif
+        assert(object);
+
         // Add it directly to the end of the list, provided this adheres to the current order
         // Check object index of last item in list
         if (listTail_ == nullptr)
@@ -502,13 +487,8 @@ template <class T, class D> class OrderedPointerDataList
     }
     OrderedPointerDataListItem<T, D> *operator[](int index)
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            Messenger::error("LIST_OPERATOR[] - Array index ({}) out of bounds ({} items in List) >>>>\n", index, nItems_);
-            return nullptr;
-        }
-#endif
+        assert(index >= 0 && index < nItems_);
+
         return items()[index];
     }
 };

--- a/src/templates/orderedpointerlist.h
+++ b/src/templates/orderedpointerlist.h
@@ -351,13 +351,8 @@ template <class T> int OrderedPointerList<T>::nItems() const { return nItems_; }
 // Add item to list
 template <class T> void OrderedPointerList<T>::add(T *object)
 {
-#ifdef CHECKS
-    if (object == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr passed to OrderedPointerList<T>::add().\n");
-        return;
-    }
-#endif
+    assert(object);
+
     // Add it in the correct place in the list
     OrderedPointerListItem<T> *nextLargest = nextHighest(object);
     insertBefore(object, nextLargest);
@@ -366,13 +361,8 @@ template <class T> void OrderedPointerList<T>::add(T *object)
 // Add a new item reference to the list, unless it is already there
 template <class T> void OrderedPointerList<T>::addExclusive(T *object)
 {
-#ifdef CHECKS
-    if (object == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr passed to OrderedPointerList<T>::add().\n");
-        return;
-    }
-#endif
+    assert(object);
+
     // Seek the next highest index, checking to see if we find the specified index
     // TODO This can be made much faster - binary chop?
     OrderedPointerListItem<T> *nextLargest = listHead_;
@@ -391,13 +381,8 @@ template <class T> void OrderedPointerList<T>::addExclusive(T *object)
 // Add a new item reference to the end of the list
 template <class T> void OrderedPointerList<T>::addAtEnd(T *object)
 {
-#ifdef CHECKS
-    if (object == nullptr)
-    {
-        Messenger::error("NULL_POINTER - nullptr passed to OrderedPointerList<T>::addAtEnd().\n");
-        return;
-    }
-#endif
+    assert(object);
+
     // Add it directly to the end of the list, provided this adheres to the current order
     // Check object index of last item in list
     if (listTail_ == nullptr)
@@ -525,13 +510,8 @@ template <class T> void OrderedPointerList<T>::operator=(const OrderedPointerLis
 
 template <class T> OrderedPointerListItem<T> *OrderedPointerList<T>::operator[](int index)
 {
-#ifdef CHECKS
-    if ((index < 0) || (index >= nItems_))
-    {
-        Messenger::error("LIST_OPERATOR[] - Array index ({}) out of bounds ({} items in List) >>>>\n", index, nItems_);
-        return nullptr;
-    }
-#endif
+    assert(index >= 0 && index < nItems_);
+
     return items()[index];
 }
 

--- a/src/templates/refdatalist.h
+++ b/src/templates/refdatalist.h
@@ -92,14 +92,8 @@ template <class T, class D> class RefDataList
     }
     RefDataItem<T, D> *operator[](int index)
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            fmt::print("Array index ({}) out of bounds ({} items in RefDataList)\n", index, nItems_);
-            return nullptr;
-        }
-#endif
-        // Use array() function to return item
+        assert(index >= 0 && index < nItems_);
+
         return array()[index];
     }
 
@@ -425,13 +419,8 @@ template <class T, class D> class RefDataList
     // Return nth item in list
     T *item(int n)
     {
-#ifdef CHECKS
-        if ((n < 0) || (n >= nItems_))
-        {
-            fmt::print("Array index ({}) out of bounds ({} items in RefDataList)\n", n, nItems_);
-            return nullptr;
-        }
-#endif
+        assert(n >= 0 && n < nItems_);
+
         // Use array() function to return item
         return array()[n]->item();
     }

--- a/src/templates/reflist.h
+++ b/src/templates/reflist.h
@@ -120,22 +120,15 @@ template <class T> class RefList
     }
     RefListItem<T> *operator[](int index)
     {
-#ifdef CHECKS
-        if ((index < 0) || (index >= nItems_))
-        {
-            Messenger::error("Array index ({}) out of bounds ({} items in RefList)\n", index, nItems_);
-            return nullptr;
-        }
-#endif
-        // Use array() function to return item
+        assert(index >= 0 && index < nItems_);
+
         return array()[index];
     }
     RefListItem<T> begin() const
     {
         if (listHead_ == nullptr)
-        {
             return end();
-        }
+
         return *listHead_;
     }
     const RefListItem<T> end() const

--- a/web/content/docs/startingout/compilation.md
+++ b/web/content/docs/startingout/compilation.md
@@ -176,7 +176,7 @@ Default: `not set`
 
 #### `BUILD_TESTS`
 
-In addition to the main build, also build unit tests.
+In addition to the main build, also build unit/system tests.
 
 Example: `-DBUILD_TESTS:bool=true`
 


### PR DESCRIPTION
This PR removes the custom error-checking from the code (activated with the `-DCHECKS` build define) which basically fulfilled the role of assertions. Now that STL classes are more widespread in the code, many of these checks are redundant and covered by the STL classes themselves. Where the STL is not yet implemented, code enclosed in an `#ifdef CHECKS` block has been replaced with suitable calls to `assert()`.

Closes #275.