### PR TITLE
Buff enums

### DIFF
--- a/src/base/enumoption.cpp
+++ b/src/base/enumoption.cpp
@@ -45,9 +45,6 @@ std::string_view EnumOption::keyword() const { return keyword_; }
 // Return option description
 std::string_view EnumOption::description() const { return description_; }
 
-// Return whether the option has any associated arguments
-bool EnumOption::hasArguments() const { return (minArgs_ != 0); }
-
 // Return minimum number of arguments the option takes
 int EnumOption::minArgs() const { return minArgs_; }
 

--- a/src/base/enumoption.cpp
+++ b/src/base/enumoption.cpp
@@ -8,29 +8,16 @@
 // Static Singleton
 UnrecognisedEnumOption EnumOptionsBase::unrecognisedOption_;
 
-EnumOption::EnumOption()
+EnumOption::EnumOption() : enumeration_(0) {}
+EnumOption::EnumOption(const int enumeration, std::string_view keyword) : enumeration_(enumeration), keyword_(keyword) {}
+EnumOption::EnumOption(const int enumeration, std::string_view keyword, int minArgs, std::optional<int> maxArgs)
+    : enumeration_(enumeration), keyword_(keyword), minArgs_(minArgs), maxArgs_(maxArgs)
 {
-    enumeration_ = 0;
-    keyword_ = "";
-    description_ = "";
-    minArgs_ = 0;
-    maxArgs_ = 0;
 }
-EnumOption::EnumOption(const int enumeration, std::string_view keyword, int minArgs, int maxArgs)
+EnumOption::EnumOption(const int enumeration, std::string_view keyword, std::string_view description,
+                       std::optional<int> minArgs, std::optional<int> maxArgs)
+    : enumeration_(enumeration), keyword_(keyword), description_(description), minArgs_(minArgs), maxArgs_(maxArgs)
 {
-    enumeration_ = enumeration;
-    keyword_ = keyword;
-    description_ = "";
-    minArgs_ = minArgs;
-    maxArgs_ = (maxArgs == 0 ? minArgs : maxArgs);
-}
-EnumOption::EnumOption(const int enumeration, std::string_view keyword, std::string_view description, int minArgs, int maxArgs)
-{
-    enumeration_ = enumeration;
-    keyword_ = keyword;
-    description_ = description;
-    minArgs_ = minArgs;
-    maxArgs_ = (maxArgs == 0 ? minArgs : maxArgs);
 }
 
 // Return if the option is valid (true except in derived classes)
@@ -46,7 +33,7 @@ std::string_view EnumOption::keyword() const { return keyword_; }
 std::string_view EnumOption::description() const { return description_; }
 
 // Return minimum number of arguments the option takes
-int EnumOption::minArgs() const { return minArgs_; }
+std::optional<int> EnumOption::minArgs() const { return minArgs_; }
 
 // Return maximum number of arguments the option takes
-int EnumOption::maxArgs() const { return maxArgs_; }
+std::optional<int> EnumOption::maxArgs() const { return maxArgs_; }

--- a/src/base/enumoption.cpp
+++ b/src/base/enumoption.cpp
@@ -9,8 +9,7 @@
 UnrecognisedEnumOption EnumOptionsBase::unrecognisedOption_;
 
 EnumOption::EnumOption() : enumeration_(0) {}
-EnumOption::EnumOption(const int enumeration, std::string_view keyword) : enumeration_(enumeration), keyword_(keyword) {}
-EnumOption::EnumOption(const int enumeration, std::string_view keyword, int minArgs, std::optional<int> maxArgs)
+EnumOption::EnumOption(const int enumeration, std::string_view keyword, std::optional<int> minArgs, std::optional<int> maxArgs)
     : enumeration_(enumeration), keyword_(keyword), minArgs_(minArgs), maxArgs_(maxArgs)
 {
 }

--- a/src/base/enumoption.h
+++ b/src/base/enumoption.h
@@ -33,8 +33,6 @@ class EnumOption
     std::string keyword_;
     // Option description / long text
     std::string description_;
-    // Whether the option has any associated arguments
-    bool hasArguments_;
     // Minimum number of arguments the option takes
     int minArgs_;
     // Maximum number of arguments the option takes
@@ -49,8 +47,6 @@ class EnumOption
     std::string_view keyword() const;
     // Return option description
     std::string_view description() const;
-    // Return whether the option has any associated arguments
-    bool hasArguments() const;
     // Return minimum number of arguments the option takes
     int minArgs() const;
     // Return maximum number of arguments the option takes

--- a/src/base/enumoption.h
+++ b/src/base/enumoption.h
@@ -11,8 +11,8 @@ class EnumOption
 {
     public:
     EnumOption();
-    EnumOption(const int enumeration, std::string_view keyword);
-    EnumOption(const int enumeration, std::string_view keyword, int minArgs, std::optional<int> maxArgs = std::nullopt);
+    EnumOption(const int enumeration, std::string_view keyword, std::optional<int> minArgs = std::nullopt,
+               std::optional<int> maxArgs = std::nullopt);
     EnumOption(const int enumeration, std::string_view keyword, std::string_view description,
                std::optional<int> minArgs = std::nullopt, std::optional<int> maxArgs = std::nullopt);
     virtual ~EnumOption() = default;

--- a/src/base/enumoption.h
+++ b/src/base/enumoption.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 // Enum Option
@@ -10,8 +11,10 @@ class EnumOption
 {
     public:
     EnumOption();
-    EnumOption(const int enumeration, std::string_view keyword, int minArgs = 0, int maxArgs = 0);
-    EnumOption(const int enumeration, std::string_view keyword, std::string_view description, int minArgs = 0, int maxArgs = 0);
+    EnumOption(const int enumeration, std::string_view keyword);
+    EnumOption(const int enumeration, std::string_view keyword, int minArgs, std::optional<int> maxArgs = std::nullopt);
+    EnumOption(const int enumeration, std::string_view keyword, std::string_view description,
+               std::optional<int> minArgs = std::nullopt, std::optional<int> maxArgs = std::nullopt);
     virtual ~EnumOption() = default;
 
     /*
@@ -21,9 +24,9 @@ class EnumOption
     // Argument Numbers
     enum ArgumentNumber
     {
-        NoArguments = 0,
         OneOrMoreArguments = -1,
-        OptionalSecondArgument = -2
+        OptionalSecondArgument = -2,
+        AnyNumberOfArguments = -3
     };
 
     private:
@@ -34,9 +37,9 @@ class EnumOption
     // Option description / long text
     std::string description_;
     // Minimum number of arguments the option takes
-    int minArgs_;
+    std::optional<int> minArgs_;
     // Maximum number of arguments the option takes
-    int maxArgs_;
+    std::optional<int> maxArgs_;
 
     public:
     // Return if the option is valid (true except in derived classes)
@@ -48,9 +51,9 @@ class EnumOption
     // Return option description
     std::string_view description() const;
     // Return minimum number of arguments the option takes
-    int minArgs() const;
+    std::optional<int> minArgs() const;
     // Return maximum number of arguments the option takes
-    int maxArgs() const;
+    std::optional<int> maxArgs() const;
 };
 
 // Unrecognised Enum Option

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -76,17 +76,18 @@ bool Species::loadFromXYZ(std::string_view filename)
 EnumOptions<Species::SpeciesKeyword> Species::keywords()
 {
     static EnumOptionsList SpeciesKeywords =
-        EnumOptionsList() << EnumOption(Species::AngleKeyword, "Angle", 3, 6) << EnumOption(Species::AtomKeyword, "Atom", 6, 7)
-                          << EnumOption(Species::BondKeyword, "Bond", 2, 5)
+        EnumOptionsList() << EnumOption(Species::AngleKeyword, "Angle", 3, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(Species::AtomKeyword, "Atom", 6, 7)
+                          << EnumOption(Species::BondKeyword, "Bond", 2, EnumOption::AnyNumberOfArguments)
                           << EnumOption(Species::BondTypeKeyword, "BondType", 3)
                           << EnumOption(Species::ChargeKeyword, "Charge", 2)
-                          << EnumOption(Species::CoordinateSetsKeyword, "CoordinateSets", 2, 99)
+                          << EnumOption(Species::CoordinateSetsKeyword, "CoordinateSets", 2, EnumOption::AnyNumberOfArguments)
                           << EnumOption(Species::EndSpeciesKeyword, "EndSpecies")
                           << EnumOption(Species::ForcefieldKeyword, "Forcefield", 1)
-                          << EnumOption(Species::ImproperKeyword, "Improper", 5, 9)
+                          << EnumOption(Species::ImproperKeyword, "Improper", 5, EnumOption::AnyNumberOfArguments)
                           << EnumOption(Species::IsotopologueKeyword, "Isotopologue", EnumOption::OneOrMoreArguments)
                           << EnumOption(Species::SiteKeyword, "Site", 1)
-                          << EnumOption(Species::TorsionKeyword, "Torsion", 4, 9);
+                          << EnumOption(Species::TorsionKeyword, "Torsion", 4, EnumOption::AnyNumberOfArguments);
 
     static EnumOptions<Species::SpeciesKeyword> options("SpeciesKeyword", SpeciesKeywords);
 

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -184,10 +184,9 @@ void SpeciesAngle::detach()
 // Return enum options for AngleFunction
 EnumOptions<SpeciesAngle::AngleFunction> SpeciesAngle::angleFunctions()
 {
-    static EnumOptionsList AngleFunctionOptions = EnumOptionsList() << EnumOption(SpeciesAngle::NoForm, "None", 0, 0)
-                                                                    << EnumOption(SpeciesAngle::HarmonicForm, "Harmonic", 2, 2)
-                                                                    << EnumOption(SpeciesAngle::CosineForm, "Cos", 4, 4)
-                                                                    << EnumOption(SpeciesAngle::Cos2Form, "Cos2", 4, 4);
+    static EnumOptionsList AngleFunctionOptions =
+        EnumOptionsList() << EnumOption(SpeciesAngle::NoForm, "None") << EnumOption(SpeciesAngle::HarmonicForm, "Harmonic", 2)
+                          << EnumOption(SpeciesAngle::CosineForm, "Cos", 4) << EnumOption(SpeciesAngle::Cos2Form, "Cos2", 4);
 
     static EnumOptions<SpeciesAngle::AngleFunction> options("AngleFunction", AngleFunctionOptions);
 

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -191,9 +191,9 @@ double SpeciesBond::bondOrder() const { return SpeciesBond::bondOrder(bondType_)
 // Return enum options for BondFunction
 EnumOptions<SpeciesBond::BondFunction> SpeciesBond::bondFunctions()
 {
-    static EnumOptionsList BondFunctionOptions = EnumOptionsList() << EnumOption(SpeciesBond::NoForm, "None", 0, 0)
-                                                                   << EnumOption(SpeciesBond::HarmonicForm, "Harmonic", 2, 2)
-                                                                   << EnumOption(SpeciesBond::EPSRForm, "EPSR", 2, 2);
+    static EnumOptionsList BondFunctionOptions = EnumOptionsList() << EnumOption(SpeciesBond::NoForm, "None")
+                                                                   << EnumOption(SpeciesBond::HarmonicForm, "Harmonic", 2)
+                                                                   << EnumOption(SpeciesBond::EPSRForm, "EPSR", 2);
 
     static EnumOptions<SpeciesBond::BondFunction> options("BondFunction", BondFunctionOptions);
 

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -169,15 +169,14 @@ bool SpeciesImproper::isSelected() const
 // Return enum options for ImproperFunction
 EnumOptions<SpeciesImproper::ImproperFunction> SpeciesImproper::improperFunctions()
 {
-    static EnumOptionsList ImproperFunctionOptions = EnumOptionsList()
-                                                     << EnumOption(SpeciesTorsion::NoForm, "None", 0, 0)
-                                                     << EnumOption(SpeciesTorsion::CosineForm, "Cos", 4, 4)
-                                                     << EnumOption(SpeciesTorsion::Cos3Form, "Cos3", 3, 3)
-                                                     << EnumOption(SpeciesTorsion::Cos3CForm, "Cos3C", 4, 4)
-                                                     << EnumOption(SpeciesTorsion::Cos4Form, "Cos4", 4, 4)
-                                                     << EnumOption(SpeciesTorsion::CosNForm, "CosN", 1, 10)
-                                                     << EnumOption(SpeciesTorsion::CosNCForm, "CosNC", 1, 11)
-                                                     << EnumOption(SpeciesTorsion::UFFCosineForm, "UFFCosine", 3, 3);
+    static EnumOptionsList ImproperFunctionOptions =
+        EnumOptionsList() << EnumOption(SpeciesTorsion::NoForm, "None") << EnumOption(SpeciesTorsion::CosineForm, "Cos", 4)
+                          << EnumOption(SpeciesTorsion::Cos3Form, "Cos3", 3)
+                          << EnumOption(SpeciesTorsion::Cos3CForm, "Cos3C", 4)
+                          << EnumOption(SpeciesTorsion::Cos4Form, "Cos4", 4)
+                          << EnumOption(SpeciesTorsion::CosNForm, "CosN", 1, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(SpeciesTorsion::CosNCForm, "CosNC", 1, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(SpeciesTorsion::UFFCosineForm, "UFFCosine", 3);
 
     static EnumOptions<SpeciesImproper::ImproperFunction> options("ImproperFunction", ImproperFunctionOptions);
 

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -255,15 +255,14 @@ bool SpeciesTorsion::isSelected() const
 // Return enum options for TorsionFunction
 EnumOptions<SpeciesTorsion::TorsionFunction> SpeciesTorsion::torsionFunctions()
 {
-    static EnumOptionsList TorsionFunctionOptions = EnumOptionsList()
-                                                    << EnumOption(SpeciesTorsion::NoForm, "None", 0, 0)
-                                                    << EnumOption(SpeciesTorsion::CosineForm, "Cos", 4, 4)
-                                                    << EnumOption(SpeciesTorsion::Cos3Form, "Cos3", 3, 3)
-                                                    << EnumOption(SpeciesTorsion::Cos3CForm, "Cos3C", 4, 4)
-                                                    << EnumOption(SpeciesTorsion::Cos4Form, "Cos4", 4, 4)
-                                                    << EnumOption(SpeciesTorsion::CosNForm, "CosN", 1, 10)
-                                                    << EnumOption(SpeciesTorsion::CosNCForm, "CosNC", 1, 11)
-                                                    << EnumOption(SpeciesTorsion::UFFCosineForm, "UFFCosine", 3, 3);
+    static EnumOptionsList TorsionFunctionOptions =
+        EnumOptionsList() << EnumOption(SpeciesTorsion::NoForm, "None") << EnumOption(SpeciesTorsion::CosineForm, "Cos", 4)
+                          << EnumOption(SpeciesTorsion::Cos3Form, "Cos3", 3)
+                          << EnumOption(SpeciesTorsion::Cos3CForm, "Cos3C", 4)
+                          << EnumOption(SpeciesTorsion::Cos4Form, "Cos4", 4)
+                          << EnumOption(SpeciesTorsion::CosNForm, "CosN", 1, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(SpeciesTorsion::CosNCForm, "CosNC", 1, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(SpeciesTorsion::UFFCosineForm, "UFFCosine", 3);
 
     static EnumOptions<SpeciesTorsion::TorsionFunction> options("TorsionFunction", TorsionFunctionOptions);
 

--- a/src/expression/ExpressionVisitor.cpp
+++ b/src/expression/ExpressionVisitor.cpp
@@ -140,18 +140,15 @@ antlrcpp::Any ExpressionVisitor::visitFunction(ExpressionParser::FunctionContext
     contextStack_.pop_back();
 
     // Check number of args that were given...
-    const auto nArgs = ExpressionFunctionNode::internalFunctions().minArgs(func);
-    if (node->nChildren() != nArgs)
+    if (!ExpressionFunctionNode::internalFunctions().validNArgs(func, node->nChildren()))
         throw(ExpressionExceptions::ExpressionSyntaxException(
-            fmt::format("Internal function '{}' expects exactly {} {} but {} {} given.", ctx->Name()->getText(), nArgs,
-                        nArgs == 1 ? "argument" : "arguments", node->nChildren(), node->nChildren() == 1 ? "was" : "were")));
+            fmt::format("Internal function '{}' was given the wrong number of arguments.", ctx->Name()->getText())));
 
     return result;
 }
 
 antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext *ctx)
 {
-
     // Do we have any external variables available?
     if (!externalVariables_)
         throw(ExpressionExceptions::ExpressionSyntaxException(fmt::format(

--- a/src/expression/function.cpp
+++ b/src/expression/function.cpp
@@ -7,13 +7,13 @@
 // Return enum options for NodeTypes
 EnumOptions<ExpressionFunctionNode::InternalFunction> ExpressionFunctionNode::internalFunctions()
 {
-    static EnumOptionsList InternalFunctions =
-        EnumOptionsList() << EnumOption(AbsFunction, "abs", 1, 1) << EnumOption(ACosFunction, "acos", 1, 1)
-                          << EnumOption(ASinFunction, "asin", 1, 1) << EnumOption(ATanFunction, "atan", 1, 1)
-                          << EnumOption(CosFunction, "cos", 1, 1) << EnumOption(ExpFunction, "exp", 1, 1)
-                          << EnumOption(LnFunction, "ln", 1, 1) << EnumOption(LogFunction, "log", 1, 1)
-                          << EnumOption(SinFunction, "sin", 1, 1) << EnumOption(SqrtFunction, "sqrt", 1, 1)
-                          << EnumOption(TanFunction, "tan", 1, 1);
+    static EnumOptionsList InternalFunctions = EnumOptionsList()
+                                               << EnumOption(AbsFunction, "abs", 1) << EnumOption(ACosFunction, "acos", 1)
+                                               << EnumOption(ASinFunction, "asin", 1) << EnumOption(ATanFunction, "atan", 1)
+                                               << EnumOption(CosFunction, "cos", 1) << EnumOption(ExpFunction, "exp", 1)
+                                               << EnumOption(LnFunction, "ln", 1) << EnumOption(LogFunction, "log", 1)
+                                               << EnumOption(SinFunction, "sin", 1) << EnumOption(SqrtFunction, "sqrt", 1)
+                                               << EnumOption(TanFunction, "tan", 1);
 
     static EnumOptions<ExpressionFunctionNode::InternalFunction> options("InternalFunction", InternalFunctions);
 

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -10,11 +10,12 @@
 // Return enum option info for MasterKeyword
 EnumOptions<MasterBlock::MasterKeyword> MasterBlock::keywords()
 {
-    static EnumOptionsList MasterKeywords = EnumOptionsList() << EnumOption(MasterBlock::AngleKeyword, "Angle", 2, 11)
-                                                              << EnumOption(MasterBlock::BondKeyword, "Bond", 2, 11)
-                                                              << EnumOption(MasterBlock::EndMasterKeyword, "EndMaster")
-                                                              << EnumOption(MasterBlock::ImproperKeyword, "Improper", 2, 11)
-                                                              << EnumOption(MasterBlock::TorsionKeyword, "Torsion", 2, 11);
+    static EnumOptionsList MasterKeywords =
+        EnumOptionsList() << EnumOption(MasterBlock::AngleKeyword, "Angle", 2, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(MasterBlock::BondKeyword, "Bond", 2, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(MasterBlock::EndMasterKeyword, "EndMaster")
+                          << EnumOption(MasterBlock::ImproperKeyword, "Improper", 2, EnumOption::AnyNumberOfArguments)
+                          << EnumOption(MasterBlock::TorsionKeyword, "Torsion", 2, EnumOption::AnyNumberOfArguments);
 
     static EnumOptions<MasterBlock::MasterKeyword> options("MasterKeyword", MasterKeywords);
 

--- a/src/main/keywords_pairpotentials.cpp
+++ b/src/main/keywords_pairpotentials.cpp
@@ -17,8 +17,8 @@ EnumOptions<PairPotentialsBlock::PairPotentialsKeyword> PairPotentialsBlock::key
         // 		EnumOption(PairPotentialsBlock::GenerateKeyword, 			"Generate",
         // 3,9)
         // <<
-        EnumOption(PairPotentialsBlock::IncludeCoulombKeyword, "IncludeCoulomb", 1)
-                          << EnumOption(PairPotentialsBlock::ParametersKeyword, "Parameters", 3, 8)
+        EnumOption(PairPotentialsBlock::IncludeCoulombKeyword, "IncludeCoulomb",
+                   1) << EnumOption(PairPotentialsBlock::ParametersKeyword, "Parameters", 3, EnumOption::AnyNumberOfArguments)
                           << EnumOption(PairPotentialsBlock::RangeKeyword, "Range", 1)
                           << EnumOption(PairPotentialsBlock::ShortRangeTruncationKeyword, "ShortRangeTruncation", 1)
                           << EnumOption(PairPotentialsBlock::ShortRangeTruncationWidthKeyword, "ShortRangeTruncationWidth", 1);

--- a/unit/test_enumoptions.cpp
+++ b/unit/test_enumoptions.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "base/enumoption.h"
+#include "base/enumoptions.h"
+#include "base/enumoptionslist.h"
+#include <gtest/gtest.h>
+
+TEST(EnumOptionsTest, EnumOptions)
+{
+    // Create some enumerated options to test
+    enum Condition
+    {
+        Red,
+        Mauve,
+        Magenta,
+        Taupe,
+        Marigold,
+        Heliotrope,
+        Tangerine
+    };
+    EnumOptionsList testOptions =
+        EnumOptionsList() << EnumOption(Condition::Red, "Red")
+                          << EnumOption(Condition::Mauve, "Mauve", EnumOption::OneOrMoreArguments)
+                          << EnumOption(Condition::Magenta, "Magenta", EnumOption::OptionalSecondArgument)
+                          << EnumOption(Condition::Taupe, "Taupe", 3, 6) << EnumOption(Condition::Marigold, "Marigold", 4)
+                          << EnumOption(Condition::Heliotrope, "Heliotrope", 3, 3)
+                          << EnumOption(Condition::Tangerine, "Tangerine", 2, EnumOption::AnyNumberOfArguments);
+    EnumOptions<Condition> options("TestOptions", testOptions);
+
+    // Test options
+    // Red - no arguments accepted
+    ASSERT_TRUE(options.validNArgs(Condition::Red, 0));
+    ASSERT_FALSE(options.validNArgs(Condition::Red, 1));
+    // Mauve - One or more arguments
+    ASSERT_TRUE(options.validNArgs(Condition::Mauve, 1));
+    ASSERT_TRUE(options.validNArgs(Condition::Mauve, 99));
+    ASSERT_FALSE(options.validNArgs(Condition::Mauve, 0));
+    // Magenta - One or two arguments
+    ASSERT_TRUE(options.validNArgs(Condition::Magenta, 1));
+    ASSERT_TRUE(options.validNArgs(Condition::Magenta, 2));
+    ASSERT_FALSE(options.validNArgs(Condition::Magenta, 0));
+    ASSERT_FALSE(options.validNArgs(Condition::Magenta, 10));
+    // Taupe - Three to six arguments
+    ASSERT_TRUE(options.validNArgs(Condition::Taupe, 3));
+    ASSERT_TRUE(options.validNArgs(Condition::Taupe, 4));
+    ASSERT_TRUE(options.validNArgs(Condition::Taupe, 5));
+    ASSERT_TRUE(options.validNArgs(Condition::Taupe, 6));
+    ASSERT_FALSE(options.validNArgs(Condition::Taupe, 2));
+    ASSERT_FALSE(options.validNArgs(Condition::Taupe, 7));
+    // Marigold - Exactly four arguments
+    ASSERT_TRUE(options.validNArgs(Condition::Marigold, 4));
+    ASSERT_FALSE(options.validNArgs(Condition::Marigold, 0));
+    ASSERT_FALSE(options.validNArgs(Condition::Marigold, 2));
+    ASSERT_FALSE(options.validNArgs(Condition::Marigold, 5));
+    // Heliotrope - Exactly three arguments (min and max specified)
+    ASSERT_TRUE(options.validNArgs(Condition::Heliotrope, 3));
+    ASSERT_FALSE(options.validNArgs(Condition::Heliotrope, 2));
+    ASSERT_FALSE(options.validNArgs(Condition::Heliotrope, 4));
+    // Tangerine - At least two arguments
+    ASSERT_TRUE(options.validNArgs(Condition::Tangerine, 2));
+    ASSERT_FALSE(options.validNArgs(Condition::Tangerine, 0));
+    ASSERT_FALSE(options.validNArgs(Condition::Tangerine, 1));
+    ASSERT_TRUE(options.validNArgs(Condition::Tangerine, 10));
+    ASSERT_TRUE(options.validNArgs(Condition::Tangerine, 99));
+}


### PR DESCRIPTION
This PR addresses an issue encountered where intramolecular parameters could not correctly be supplied for all the different functional forms as the number of arguments expected by the relevant keywords was limited to the wrong number.

Here, the `EnumOption` class is overhauled to make supplying argument limits a little more transparent, and various uses of it throughout the code are adjusted. A new enumeration for maximum arguments is added.
