### PR TITLE
Bugfix 07-02-21 Fix EPSR

### DIFF
--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -299,7 +299,6 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Copy the original difference data and trim to the allowed range
         deltaFQ = differenceData;
         Filters::trim(deltaFQ, qMin, qMax);
-        Interpolator::addInterpolated(deltaFQ, weightedSQ.total(), -1.0);
         deltaFQ *= -1.0;
 
         // Fit a function expansion to the deltaFQ - if the coefficient arrays already exist then re-fit starting from those.


### PR DESCRIPTION
This one-liner bugfix PR fixes a dumb error introduced in 2101843d4313ffdae016ceb1ce0c1017fb73ce77, where the total structure factor was subtracted twice from the delta function.

**Requires rebase after #529 is merged.**