### PR TITLE
Bugfix 09-02-21 Species Editing

### DIFF
--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -32,6 +32,7 @@ void Species::removeAtom(SpeciesAtom *i)
 
     // Now remove the atom
     atoms_.remove(i);
+    selectedAtoms_.remove(i);
 
     ++version_;
 }

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -516,4 +516,7 @@ void Species::detachFromMasterTerms()
 
     for (auto &torsion : torsions_)
         torsion.detachFromMasterIntra();
+
+    for (auto &improper : impropers_)
+        improper.detachFromMasterIntra();
 }

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -113,6 +113,8 @@ SpeciesBond &Species::addBond(int i, int j) { return addBond(atoms_[i], atoms_[j
 void Species::removeBond(SpeciesAtom *i, SpeciesAtom *j)
 {
     auto it = std::remove_if(bonds_.begin(), bonds_.end(), [i, j](const auto &bond) { return bond.matches(i, j); });
+    if (it != bonds_.end())
+        ++version_;
     std::for_each(it, bonds_.end(), [](auto &bond) { bond.detach(); });
     bonds_.erase(it);
 }

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -110,12 +110,78 @@ SpeciesBond &Species::addBond(SpeciesAtom *i, SpeciesAtom *j)
 SpeciesBond &Species::addBond(int i, int j) { return addBond(atoms_[i], atoms_[j]); }
 
 // Remove bond between specified SpeciesAtoms
-void Species::removeBond(SpeciesAtom *i, SpeciesAtom *j)
+void Species::removeBond(SpeciesAtom *j, SpeciesAtom *k)
 {
-    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [i, j](const auto &bond) { return bond.matches(i, j); });
+    angles_.clear();
+    torsions_.clear();
+    impropers_.clear();
+    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [j, k](const auto &bond) { return bond.matches(j, k); });
     if (it != bonds_.end())
         ++version_;
-    std::for_each(it, bonds_.end(), [](auto &bond) { bond.detach(); });
+    std::for_each(it, bonds_.end(), [&, j, k](auto &jk) {
+        // Remove any higher-order terms that contain this bond
+
+        // Loop over bonds 'ij'
+        for (SpeciesBond &ij : j->bonds())
+        {
+            // Avoid 'ij' == 'jk'
+            if (&ij == &jk)
+                continue;
+
+            // Get atom 'i'
+            auto *i = ij.partner(j);
+
+            // Remove angle term 'ijk' if it exists
+            auto ijkIt =
+                std::remove_if(angles_.begin(), angles_.end(), [&, i, j, k](auto &angle) { return angle.matches(i, j, k); });
+            if (ijkIt != angles_.end())
+                angles_.erase(ijkIt);
+
+            // Loop over bonds 'kl'
+            for (SpeciesBond &kl : k->bonds())
+            {
+                // Avoid 'kl' == 'jk'
+                if (&kl == &jk)
+                    continue;
+
+                // Get atom 'l'
+                auto *l = kl.partner(k);
+
+                // Remove angle term 'jkl' if it exists
+                auto jklIt = std::remove_if(angles_.begin(), angles_.end(),
+                                            [&, j, k, l](auto &angle) { return angle.matches(j, k, l); });
+                if (jklIt != angles_.end())
+                    angles_.erase(jklIt);
+
+                // Remove torsion term 'ijkl' if it exists
+                auto torsionIt = std::remove_if(torsions_.begin(), torsions_.end(),
+                                                [&, i, j, k, l](auto &torsion) { return torsion.matches(i, j, k, l); });
+                if (torsionIt != torsions_.end())
+                    torsions_.erase(torsionIt);
+            }
+
+            // Loop over bonds 'jl'
+            for (SpeciesBond &jl : j->bonds())
+            {
+                // Avoid 'jl' == 'ij' and 'jl' == 'jk'
+                if (&jl == &ij || &jl == &jk)
+                    continue;
+
+                auto *l = jl.partner(j);
+
+                // Remove improper term 'ijkl' if it exists
+                auto improperIt = std::remove_if(impropers_.begin(), impropers_.end(),
+                                                 [&, i, j, k, l](auto &improper) { return improper.matches(i, j, k, l); });
+                if (improperIt != impropers_.end())
+                    impropers_.erase(improperIt);
+            }
+        }
+
+        // Finally, detach the bond from its atoms
+        jk.detach();
+    });
+
+    // Erase the now-redundant objects from the vector
     bonds_.erase(it);
 }
 

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -8,25 +8,119 @@
 #include "classes/speciestorsion.h"
 #include "templates/enumhelpers.h"
 
-SpeciesImproper::SpeciesImproper() : SpeciesIntra() { clear(); }
-
-SpeciesImproper::SpeciesImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l)
-    : SpeciesIntra(), i_(i), j_(j), k_(k), l_(l)
+SpeciesImproper::SpeciesImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l) : SpeciesIntra()
 {
+
+    parent_ = nullptr;
+    i_ = i;
+    j_ = j;
+    k_ = k;
+    l_ = l;
+    form_ = SpeciesImproper::NoForm;
+
+    // Add ourself to the list of impropers on each atom
+    if (i_ && j_ && k_ && l_)
+    {
+        i_->addImproper(*this);
+        j_->addImproper(*this);
+        k_->addImproper(*this);
+        l_->addImproper(*this);
+    }
 }
 
+SpeciesImproper::SpeciesImproper(SpeciesImproper &source) { this->operator=(source); }
+
 SpeciesImproper::SpeciesImproper(SpeciesImproper &&source) : SpeciesIntra(source)
+{
+    // Detach source torsion referred to by the species atoms
+    if (source.i_ && source.j_ && source.k_ && source.l_)
+    {
+        source.i_->removeImproper(source);
+        source.j_->removeImproper(source);
+        source.k_->removeImproper(source);
+        source.l_->removeImproper(source);
+    }
+
+    // Copy data
+    i_ = source.i_;
+    j_ = source.j_;
+    k_ = source.k_;
+    l_ = source.l_;
+    if (i_ && j_ && k_ && l_)
+    {
+        i_->addImproper(*this);
+        j_->addImproper(*this);
+        k_->addImproper(*this);
+        l_->addImproper(*this);
+    }
+    form_ = source.form_;
+
+    // Reset source data
+    source.i_ = nullptr;
+    source.j_ = nullptr;
+    source.k_ = nullptr;
+    source.l_ = nullptr;
+}
+
+SpeciesImproper::~SpeciesImproper() { detach(); }
+
+SpeciesImproper &SpeciesImproper::operator=(const SpeciesImproper &source)
 {
     i_ = source.i_;
     j_ = source.j_;
     k_ = source.k_;
     l_ = source.l_;
-    form_ = source.form_;
 
-    source.i_ = nullptr;
-    source.j_ = nullptr;
-    source.k_ = nullptr;
-    source.l_ = nullptr;
+    if (i_ && j_ && k_ && l_)
+    {
+        i_->addImproper(*this);
+        j_->addImproper(*this);
+        k_->addImproper(*this);
+        l_->addImproper(*this);
+    }
+    form_ = source.form_;
+    SpeciesIntra::operator=(source);
+
+    return *this;
+}
+
+SpeciesImproper &SpeciesImproper::operator=(SpeciesImproper &&source)
+{
+    if (i_ && j_ && k_ && l_)
+        detach();
+
+    i_ = source.i_;
+    j_ = source.j_;
+    k_ = source.k_;
+    l_ = source.l_;
+
+    if (i_ && j_ && k_ && l_)
+    {
+        i_->addImproper(*this);
+        j_->addImproper(*this);
+        k_->addImproper(*this);
+        l_->addImproper(*this);
+    }
+    form_ = source.form_;
+    SpeciesIntra::operator=(source);
+
+    return *this;
+}
+
+// Detach from current atoms
+void SpeciesImproper::detach()
+{
+    if (i_ && j_ && k_ && l_)
+    {
+        i_->removeImproper(*this);
+        j_->removeImproper(*this);
+        k_->removeImproper(*this);
+        l_->removeImproper(*this);
+    }
+    i_ = nullptr;
+    j_ = nullptr;
+    k_ = nullptr;
+    l_ = nullptr;
 }
 
 /*

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -124,21 +124,6 @@ void SpeciesImproper::detach()
 }
 
 /*
- * DynamicArrayObject Virtuals
- */
-
-// Clear object, ready for re-use
-void SpeciesImproper::clear()
-{
-    parent_ = nullptr;
-    i_ = nullptr;
-    j_ = nullptr;
-    k_ = nullptr;
-    l_ = nullptr;
-    form_ = SpeciesImproper::NoForm;
-}
-
-/*
  * Atom Information
  */
 

--- a/src/classes/speciesimproper.h
+++ b/src/classes/speciesimproper.h
@@ -15,10 +15,12 @@ class ProcessPool;
 class SpeciesImproper : public SpeciesIntra
 {
     public:
-    SpeciesImproper();
-    SpeciesImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l);
-    ~SpeciesImproper() = default;
+    SpeciesImproper(SpeciesImproper &source);
     SpeciesImproper(SpeciesImproper &&source);
+    SpeciesImproper(SpeciesAtom *i = nullptr, SpeciesAtom *j = nullptr, SpeciesAtom *k = nullptr, SpeciesAtom *l = nullptr);
+    ~SpeciesImproper();
+    SpeciesImproper &operator=(const SpeciesImproper &source);
+    SpeciesImproper &operator=(SpeciesImproper &&source);
 
     /*
      * DynamicArrayObject Virtuals
@@ -39,6 +41,8 @@ class SpeciesImproper : public SpeciesIntra
     SpeciesAtom *k_;
     // Fourth SpeciesAtom in interaction
     SpeciesAtom *l_;
+    // Detach from current atoms
+    void detach();
 
     public:
     // Set Atoms involved in Improper

--- a/src/classes/speciesimproper.h
+++ b/src/classes/speciesimproper.h
@@ -23,13 +23,6 @@ class SpeciesImproper : public SpeciesIntra
     SpeciesImproper &operator=(SpeciesImproper &&source);
 
     /*
-     * DynamicArrayObject Virtuals
-     */
-    public:
-    // Clear object, ready for re-use
-    void clear();
-
-    /*
      * Atom Information
      */
     private:

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -123,21 +123,6 @@ void SpeciesTorsion::detach()
 }
 
 /*
- * DynamicArrayObject Virtuals
- */
-
-// Clear object, ready for re-use
-void SpeciesTorsion::clear()
-{
-    parent_ = nullptr;
-    i_ = nullptr;
-    j_ = nullptr;
-    k_ = nullptr;
-    l_ = nullptr;
-    form_ = SpeciesTorsion::NoForm;
-}
-
-/*
  * Atom Information
  */
 

--- a/src/classes/speciestorsion.h
+++ b/src/classes/speciestorsion.h
@@ -24,13 +24,6 @@ class SpeciesTorsion : public SpeciesIntra
     SpeciesTorsion &operator=(SpeciesTorsion &&source);
 
     /*
-     * DynamicArrayObject Virtuals
-     */
-    public:
-    // Clear object, ready for re-use
-    void clear();
-
-    /*
      * Atom Information
      */
     private:

--- a/src/gui/configurationviewer.hui
+++ b/src/gui/configurationviewer.hui
@@ -42,13 +42,24 @@ class ConfigurationViewer : public BaseViewer
      */
     public:
     // Interaction Mode enum
-    enum InteractionMode
+    enum class InteractionMode
     {
-        DefaultInteraction,
-        TranslateViewInteraction,
-        RotateViewInteraction,
+        Default,
         nInteractionModes
     };
+    // Secondary Interaction Mode enum
+    enum class TransientInteractionMode
+    {
+        None,
+        TranslateView,
+        RotateView
+    };
+
+    private:
+    // Primary interaction mode (left mouse button)
+    InteractionMode interactionMode_;
+    // Transient interaction mode (i.e. one not invoked by primary button)
+    TransientInteractionMode transientInteractionMode_;
 
     private:
     // Return atom at specified coordinates
@@ -63,6 +74,10 @@ class ConfigurationViewer : public BaseViewer
     void cancelInteraction();
 
     public:
+    // Set current interaction mode
+    void setInteractionMode(InteractionMode mode);
+    // Return current interaction mode
+    InteractionMode interactionMode() const;
     // Return text describing current interaction mode
     const QString interactionModeText() const;
 

--- a/src/gui/configurationviewer_funcs.cpp
+++ b/src/gui/configurationviewer_funcs.cpp
@@ -12,7 +12,8 @@ ConfigurationViewer::ConfigurationViewer(QWidget *parent) : BaseViewer(parent)
     configuration_ = nullptr;
 
     // Interaction
-    setInteractionMode(ConfigurationViewer::DefaultInteraction);
+    setInteractionMode(ConfigurationViewer::InteractionMode::Default);
+    transientInteractionMode_ = TransientInteractionMode::None;
 
     // Set up the view
     view_.setViewType(View::NormalView);

--- a/src/gui/configurationviewer_input.cpp
+++ b/src/gui/configurationviewer_input.cpp
@@ -16,9 +16,22 @@ void ConfigurationViewer::mouseMoved(int dx, int dy)
     auto refresh = false;
 
     // What we do here depends on the current mode
-    switch (interactionMode())
+    switch (transientInteractionMode_)
     {
-        case (ConfigurationViewer::RotateViewInteraction):
+        case (TransientInteractionMode::None):
+            // End primary interaction
+            switch (interactionMode_)
+            {
+                case (ConfigurationViewer::InteractionMode::Default):
+                    // No action to take - the selection box will be drawn from the clicked and current positions (already
+                    // stored)
+                    refresh = true;
+                    break;
+                default:
+                    break;
+            }
+            break;
+        case (ConfigurationViewer::TransientInteractionMode::RotateView):
             // Rotate view
             if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
             {
@@ -32,7 +45,7 @@ void ConfigurationViewer::mouseMoved(int dx, int dy)
                 refresh = true;
             }
             break;
-        case (ConfigurationViewer::TranslateViewInteraction):
+        case (ConfigurationViewer::TransientInteractionMode::TranslateView):
             // If this is a flat view, shift the axis limits rather than translating the view
             if (view_.isFlatView())
                 view_.shiftFlatAxisLimits(dx, dy);

--- a/src/gui/dataviewer.hui
+++ b/src/gui/dataviewer.hui
@@ -54,15 +54,26 @@ class DataViewer : public BaseViewer
      */
     public:
     // Interaction Mode enum
-    enum InteractionMode
+    enum class InteractionMode
     {
-        DefaultInteraction,
-        ZoomToAreaInteraction,
-        TranslateViewInteraction,
-        RotateViewInteraction,
-        ZoomXRangeInteraction,
+        Default,
+        ZoomToArea,
+        ZoomXRange,
         nInteractionModes
     };
+    // Secondary Interaction Mode enum
+    enum class TransientInteractionMode
+    {
+        None,
+        TranslateView,
+        RotateView
+    };
+
+    private:
+    // Primary interaction mode (left mouse button)
+    InteractionMode interactionMode_;
+    // Transient interaction mode (i.e. one not invoked by primary button)
+    TransientInteractionMode transientInteractionMode_;
 
     protected:
     // Start interaction
@@ -73,6 +84,10 @@ class DataViewer : public BaseViewer
     void cancelInteraction();
 
     public:
+    // Set current interaction mode
+    void setInteractionMode(InteractionMode mode);
+    // Return current interaction mode
+    InteractionMode interactionMode() const;
     // Return text describing current interaction mode
     const QString interactionModeText() const;
     // Return clicked interaction coordinate on axis

--- a/src/gui/dataviewer_funcs.cpp
+++ b/src/gui/dataviewer_funcs.cpp
@@ -7,7 +7,8 @@
 DataViewer::DataViewer(QWidget *parent) : BaseViewer(parent)
 {
     // Interaction
-    setInteractionMode(DataViewer::DefaultInteraction);
+    setInteractionMode(DataViewer::InteractionMode::Default);
+    transientInteractionMode_ = TransientInteractionMode::None;
 
     // Set up the view
     view_.setViewType(View::FlatXYView);

--- a/src/gui/dataviewer_input.cpp
+++ b/src/gui/dataviewer_input.cpp
@@ -19,15 +19,26 @@ void DataViewer::mouseMoved(int dx, int dy)
     auto refresh = false;
 
     // What we do here depends on the current mode
-    switch (interactionMode())
+    switch (transientInteractionMode_)
     {
-        case (DataViewer::ZoomToAreaInteraction):
-            // No action to take - the selection box will be drawn from the clicked and current positions (already
-            // stored)
-            refresh = true;
+        // Perform primary interaction
+        case (TransientInteractionMode::None):
+            switch (interactionMode())
+            {
+                case (DataViewer::InteractionMode::ZoomToArea):
+                    // No action to take - the selection box will be drawn from the clicked and current positions (already
+                    // stored)
+                    refresh = true;
+                    break;
+                case (DataViewer::InteractionMode::ZoomXRange):
+                    // No action to take - the range will be drawn from the clicked and current positions (already stored)
+                    refresh = true;
+                    break;
+                default:
+                    break;
+            }
             break;
-        case (DataViewer::RotateViewInteraction):
-            // Rotate view
+        case (DataViewer::TransientInteractionMode::RotateView):
             if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
             {
             }
@@ -40,7 +51,7 @@ void DataViewer::mouseMoved(int dx, int dy)
                 refresh = true;
             }
             break;
-        case (DataViewer::TranslateViewInteraction):
+        case (DataViewer::TransientInteractionMode::TranslateView):
             // Turn off autofollow if it is currently on...
             if (view().autoFollowType() != View::NoAutoFollow)
             {
@@ -53,10 +64,6 @@ void DataViewer::mouseMoved(int dx, int dy)
                 view().shiftFlatAxisLimits(dx, dy);
             else
                 view().translateView(dx / 15.0, dy / 15.0, 0.0);
-            refresh = true;
-            break;
-        case (DataViewer::ZoomXRangeInteraction):
-            // No action to take - the range will be drawn from the clicked and current positions (already stored)
             refresh = true;
             break;
         default:

--- a/src/gui/dataviewer_render.cpp
+++ b/src/gui/dataviewer_render.cpp
@@ -116,7 +116,7 @@ void DataViewer::render2DOverlay()
     if (interacting())
         switch (interactionMode())
         {
-            case (DataViewer::ZoomToAreaInteraction):
+            case (DataViewer::InteractionMode::ZoomToArea):
                 // Draw dashed box indicating selection area, form clicked to current mouse coordinates
                 selectionBoxStyle.sendToGL();
                 glBegin(GL_LINE_LOOP);

--- a/src/gui/datawidget_funcs.cpp
+++ b/src/gui/datawidget_funcs.cpp
@@ -46,7 +46,7 @@ DataViewer *DataWidget::dataViewer() { return ui_.DataView; }
 // Interaction
 void DataWidget::on_InteractionViewButton_clicked(bool checked)
 {
-    dataViewer()->setInteractionMode(DataViewer::DefaultInteraction);
+    dataViewer()->setInteractionMode(DataViewer::InteractionMode::Default);
 }
 
 // Graph
@@ -280,12 +280,11 @@ void DataWidget::updateToolbar()
     // Set current interaction mode
     switch (dataViewer()->interactionMode())
     {
-        case (DataViewer::DefaultInteraction):
+        case (DataViewer::InteractionMode::Default):
             ui_.InteractionViewButton->setChecked(true);
             break;
-            // 		case (DataViewer::ZoomInteraction):
-            // 			ui_.InteractionZoomutton->setChecked(true);
-            // 			break;
+        default:
+            break;
     }
 
     // Controls reflecting the state of options in the underlying DataViewer

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -24,8 +24,8 @@ RenderableSpecies::RenderableSpecies(const Species *source, std::string_view obj
     selectedAtomPrimitive_->sphere(1.25, 8, 10);
     bondPrimitive_ = createPrimitive(GL_TRIANGLES, false);
     bondPrimitive_->cylinder(0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1, 8);
-    unitCellPrimitive_ = createPrimitive(GL_LINES, false);
-    // 	unitCellPrimitive_->wireCube(1.0, 4, 0, 0, 0);
+    crossBoxPrimitive_ = createPrimitive(GL_LINES, false);
+    crossBoxPrimitive_->wireOrthorhomboid(1.0, 1.0, 1.0, 0.0, 0.0);
     lineSpeciesPrimitive_ = createPrimitive(GL_LINES, true);
     lineSelectionPrimitive_ = createPrimitive(GL_LINES, true);
     lineSelectionPrimitive_->setNoInstances();
@@ -472,6 +472,48 @@ void RenderableSpecies::recreateDrawInteractionPrimitive(Vec3<double> fromPoint,
 
         // Draw the temporary bond between the atoms
         createCylinderBond(interactionAssembly_, &i, &j, spheresBondRadius_);
+    }
+}
+
+// Recreate interaction Primitive to display delete interaction (from existing atom to existing atom)
+void RenderableSpecies::recreateDeleteInteractionPrimitive(SpeciesAtom *fromAtom, SpeciesAtom *toAtom)
+{
+    // Clear existing data
+    clearInteractionPrimitive();
+
+    Matrix4 A;
+
+    A.setTranslation(fromAtom->r());
+
+    // Render based on the current drawing style
+    if (displayStyle_ == LinesStyle)
+    {
+        A.applyScaling(0.1);
+
+        // Set basic styling for assembly
+        interactionAssembly_.add(false, GL_LINE);
+        interactionAssembly_.add(crossBoxPrimitive_, A);
+
+        if (toAtom)
+        {
+            A.setTranslation(toAtom->r());
+            interactionAssembly_.add(crossBoxPrimitive_, A);
+        }
+    }
+    else if (displayStyle_ == SpheresStyle)
+    {
+        // Set basic styling for assembly
+        interactionAssembly_.add(true, GL_FILL);
+
+        // Draw the indicators
+        A.applyScaling(spheresAtomRadius_ * 2.2);
+        interactionAssembly_.add(crossBoxPrimitive_, A, 0.0, 0.0, 0.0, 1.0);
+
+        if (toAtom)
+        {
+            A.setTranslation(toAtom->r());
+            interactionAssembly_.add(crossBoxPrimitive_, A, 0.0, 0.0, 0.0, 1.0);
+        }
     }
 }
 

--- a/src/gui/render/renderablespecies.h
+++ b/src/gui/render/renderablespecies.h
@@ -45,7 +45,7 @@ class RenderableSpecies : public Renderable
      */
     private:
     // Basic primitives
-    Primitive *atomPrimitive_, *selectedAtomPrimitive_, *unitCellPrimitive_, *bondPrimitive_;
+    Primitive *atomPrimitive_, *selectedAtomPrimitive_, *crossBoxPrimitive_, *bondPrimitive_;
     // Main primitives
     Primitive *lineSpeciesPrimitive_, *lineSelectionPrimitive_, *lineInteractionPrimitive_;
     // Main assemblies
@@ -75,6 +75,8 @@ class RenderableSpecies : public Renderable
     // Recreate interaction Primitive to display drawing interaction (from point to point)
     void recreateDrawInteractionPrimitive(Vec3<double> fromPoint, Elements::Element fromElement, Vec3<double> toPoint,
                                           Elements::Element toElement);
+    // Recreate interaction Primitive to display delete interaction (from existing atom to existing atom)
+    void recreateDeleteInteractionPrimitive(SpeciesAtom *fromAtom, SpeciesAtom *toAtom = nullptr);
 
     /*
      * Style

--- a/src/gui/siteviewer.hui
+++ b/src/gui/siteviewer.hui
@@ -44,16 +44,25 @@ class SiteViewer : public BaseViewer
      */
     public:
     // Interaction Mode enum
-    enum InteractionMode
+    enum class InteractionMode
     {
-        DefaultInteraction,
-        SelectAreaInteraction,
-        TranslateViewInteraction,
-        RotateViewInteraction,
+        Select,
+        SelectArea,
         nInteractionModes
+    };
+    // Secondary Interaction Mode enum
+    enum class TransientInteractionMode
+    {
+        None,
+        TranslateView,
+        RotateView
     };
 
     private:
+    // Primary interaction mode (left mouse button)
+    InteractionMode interactionMode_;
+    // Transient interaction mode (i.e. one not invoked by primary button)
+    TransientInteractionMode transientInteractionMode_;
     // Clicked atom at the start of the interaction (if any)
     SpeciesAtom *clickedAtom_;
 
@@ -70,6 +79,10 @@ class SiteViewer : public BaseViewer
     void cancelInteraction();
 
     public:
+    // Set current interaction mode
+    void setInteractionMode(InteractionMode mode);
+    // Return current interaction mode
+    InteractionMode interactionMode() const;
     // Return text describing current interaction mode
     const QString interactionModeText() const;
 

--- a/src/gui/siteviewer.hui
+++ b/src/gui/siteviewer.hui
@@ -127,5 +127,5 @@ class SiteViewer : public BaseViewer
      */
     signals:
     // Atom selection changed
-    void atomSelectionChanged();
+    void atomsChanged();
 };

--- a/src/gui/siteviewer_funcs.cpp
+++ b/src/gui/siteviewer_funcs.cpp
@@ -15,7 +15,8 @@ SiteViewer::SiteViewer(QWidget *parent) : BaseViewer(parent)
     siteRenderable_ = nullptr;
 
     // Interaction
-    setInteractionMode(SiteViewer::DefaultInteraction);
+    setInteractionMode(SiteViewer::InteractionMode::Select);
+    transientInteractionMode_ = TransientInteractionMode::None;
     clickedAtom_ = nullptr;
 
     // Set up the view

--- a/src/gui/siteviewer_funcs.cpp
+++ b/src/gui/siteviewer_funcs.cpp
@@ -55,7 +55,7 @@ void SiteViewer::setSpecies(Species *sp)
     }
 
     // Send relevant signals
-    emit(atomSelectionChanged());
+    emit(atomsChanged());
 }
 
 // Return target Species

--- a/src/gui/siteviewer_input.cpp
+++ b/src/gui/siteviewer_input.cpp
@@ -16,14 +16,22 @@ void SiteViewer::mouseMoved(int dx, int dy)
     auto refresh = false;
 
     // What we do here depends on the current mode
-    switch (interactionMode())
+    switch (transientInteractionMode_)
     {
-        case (SiteViewer::SelectAreaInteraction):
-            // No action to take - the selection box will be drawn from the clicked and current positions (already
-            // stored)
-            refresh = true;
+        case (TransientInteractionMode::None):
+            // End primary interaction
+            switch (interactionMode_)
+            {
+                case (SiteViewer::InteractionMode::SelectArea):
+                    // No action to take - the selection box will be drawn from the clicked and current positions (already
+                    // stored)
+                    refresh = true;
+                    break;
+                default:
+                    break;
+            }
             break;
-        case (SiteViewer::RotateViewInteraction):
+        case (SiteViewer::TransientInteractionMode::RotateView):
             // Rotate view
             if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
             {
@@ -37,7 +45,7 @@ void SiteViewer::mouseMoved(int dx, int dy)
                 refresh = true;
             }
             break;
-        case (SiteViewer::TranslateViewInteraction):
+        case (SiteViewer::TransientInteractionMode::TranslateView):
             // If this is a flat view, shift the axis limits rather than translating the view
             if (view_.isFlatView())
                 view_.shiftFlatAxisLimits(dx, dy);

--- a/src/gui/siteviewer_interaction.cpp
+++ b/src/gui/siteviewer_interaction.cpp
@@ -46,94 +46,105 @@ SpeciesAtom *SiteViewer::atomAt(int x, int y)
 // Start interaction at the specified screen coordinates
 void SiteViewer::startInteraction()
 {
-    switch (interactionMode())
+    // Check the button that started the interaction
+    if (buttonState_.testFlag(Qt::LeftButton))
     {
-        // Default Interaction Mode
-        case (SiteViewer::DefaultInteraction):
-            // This is the standard mode, giving access to view manipulation
-            if (buttonState_.testFlag(Qt::LeftButton))
-                setInteractionMode(SiteViewer::SelectAreaInteraction);
-            else if (buttonState_.testFlag(Qt::RightButton))
-                setInteractionMode(SiteViewer::RotateViewInteraction);
-            else if (buttonState_.testFlag(Qt::MiddleButton))
-                setInteractionMode(SiteViewer::TranslateViewInteraction);
-            break;
-        default:
-            break;
+        switch (interactionMode_)
+        {
+            // Default Interaction Mode
+            case (SiteViewer::InteractionMode::Select):
+                setInteractionMode(SiteViewer::InteractionMode::SelectArea);
+                break;
+            default:
+                fmt::print("Unhandled primary mode {} in SiteViewer::startInteraction().\n", interactionMode_);
+                break;
+        }
     }
+    else if (buttonState_.testFlag(Qt::RightButton))
+        transientInteractionMode_ = SiteViewer::TransientInteractionMode::RotateView;
+    else if (buttonState_.testFlag(Qt::MiddleButton))
+        transientInteractionMode_ = SiteViewer::TransientInteractionMode::TranslateView;
 }
 
 // End interaction at the specified screen coordinates
 void SiteViewer::endInteraction()
 {
     // Finalise interaction type
-    switch (interactionMode())
+    switch (transientInteractionMode_)
     {
-        case (SiteViewer::DefaultInteraction):
-            break;
-        case (SiteViewer::SelectAreaInteraction):
-            // Check the pixel area of the clicked region and determine whether this was actually a targeted click
-            // rather than an area select
-            if ((rMouseDown_ - rMouseLast_).magnitude() < 9.0)
+        case (TransientInteractionMode::None):
+            // End primary interaction
+            switch (interactionMode_)
             {
-                // Single, targetted click - atom under mouse?
-                SpeciesAtom *i = atomAt(rMouseLast_.x, rMouseLast_.y);
+                case (SiteViewer::InteractionMode::Select):
+                    break;
+                case (SiteViewer::InteractionMode::SelectArea):
+                    // Check the pixel area of the clicked region and determine whether this was actually a targeted click
+                    // rather than an area select
+                    if ((rMouseDown_ - rMouseLast_).magnitude() < 9.0)
+                    {
+                        // Single, targetted click - atom under mouse?
+                        SpeciesAtom *i = atomAt(rMouseLast_.x, rMouseLast_.y);
 
-                // If there is an atom at the current position, (de)select it, maintaining the current selection
-                // if Shift was pressed
-                if (i)
-                {
-                    if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
-                        species_->toggleAtomSelection(i);
+                        // If there is an atom at the current position, (de)select it, maintaining the current selection
+                        // if Shift was pressed
+                        if (i)
+                        {
+                            if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
+                                species_->toggleAtomSelection(i);
+                            else
+                            {
+                                species_->clearAtomSelection();
+                                species_->selectAtom(i);
+                            }
+                        }
+                        else
+                        {
+                            // No atom at the current position - if Shift was not pressed, deselect everything
+                            if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
+                                species_->clearAtomSelection();
+                        }
+                    }
                     else
                     {
-                        species_->clearAtomSelection();
-                        species_->selectAtom(i);
+                        // Click-drag - area select
+                        // If Shift was not pressed, clear the current selection first
+                        if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
+                            species_->clearAtomSelection();
+                        Vec3<double> rScreen;
+                        QRect selectionRect(QPoint(rMouseDown_.x, rMouseDown_.y), QPoint(rMouseLast_.x, rMouseLast_.y));
+                        ListIterator<SpeciesAtom> atomIterator(species_->atoms());
+                        while (SpeciesAtom *i = atomIterator.iterate())
+                        {
+                            rScreen = view_.dataToScreen(i->r());
+                            if (selectionRect.contains(rScreen.x, rScreen.y))
+                                species_->selectAtom(i);
+                        }
                     }
-                }
-                else
-                {
-                    // No atom at the current position - if Shift was not pressed, deselect everything
-                    if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
-                        species_->clearAtomSelection();
-                }
-            }
-            else
-            {
-                // Click-drag - area select
-                // If Shift was not pressed, clear the current selection first
-                if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
-                    species_->clearAtomSelection();
-                Vec3<double> rScreen;
-                QRect selectionRect(QPoint(rMouseDown_.x, rMouseDown_.y), QPoint(rMouseLast_.x, rMouseLast_.y));
-                ListIterator<SpeciesAtom> atomIterator(species_->atoms());
-                while (SpeciesAtom *i = atomIterator.iterate())
-                {
-                    rScreen = view_.dataToScreen(i->r());
-                    if (selectionRect.contains(rScreen.x, rScreen.y))
-                        species_->selectAtom(i);
-                }
-            }
 
-            // Update the selection
-            speciesRenderable_->recreateSelectionPrimitive();
-            emit(atomSelectionChanged());
+                    // Update the selection
+                    speciesRenderable_->recreateSelectionPrimitive();
+                    emit(atomSelectionChanged());
 
-            // Revert to default interaction mode
-            setInteractionMode(SiteViewer::DefaultInteraction);
+                    // Revert to default interaction mode
+                    setInteractionMode(SiteViewer::InteractionMode::Select);
+                    break;
+                default:
+                    fmt::print("Unhandled primary mode {} in SiteViewer::endInteraction().\n", interactionMode_);
+                    break;
+            }
             break;
-        case (SiteViewer::RotateViewInteraction):
-            // Rotation matrix has already been modified. Revert to default interaction mode
-            setInteractionMode(SiteViewer::DefaultInteraction);
-            break;
-        case (SiteViewer::TranslateViewInteraction):
-            // Translation has already been applied. Revert to default interaction mode
-            setInteractionMode(SiteViewer::DefaultInteraction);
+        case (SiteViewer::TransientInteractionMode::RotateView):
+        case (SiteViewer::TransientInteractionMode::TranslateView):
+            // Rotation / translation has already been modified, so nothing more to do
             break;
         default:
-            Messenger::error("Don't know how to complete interaction mode {}\n", interactionMode());
+            fmt::print("Unhandled secondary mode {} in SiteViewer::endInteraction().\n", transientInteractionMode_);
             break;
     }
+
+    // Reset any transient interaction
+    transientInteractionMode_ = TransientInteractionMode::None;
 }
 
 // Cancel current interaction
@@ -154,20 +165,30 @@ void SiteViewer::cancelInteraction()
  * Public Functions
  */
 
+// Set current interaction mode
+void SiteViewer::setInteractionMode(SiteViewer::InteractionMode mode)
+{
+    // Cancel any current interaction
+    cancelInteraction();
+
+    interactionMode_ = mode;
+
+    emit(interactionModeChanged());
+}
+
+// Return current interaction mode
+SiteViewer::InteractionMode SiteViewer::interactionMode() const { return interactionMode_; }
+
 // Return text describing current interaction mode
 const QString SiteViewer::interactionModeText() const
 {
     switch (interactionMode())
     {
-        case (SiteViewer::DefaultInteraction):
+        case (SiteViewer::InteractionMode::Select):
             return "View: <b>Left</b> Select; <b>Right</b> Rotate; <b>Middle</b> Translate; <b>Wheel</b> Zoom";
-        case (SiteViewer::SelectAreaInteraction):
+        case (SiteViewer::InteractionMode::SelectArea):
             return "Select atoms: <b>Left-Click</b> Select individual atoms; <b>Left-Click-Drag</b> Area select; "
                    "<i>+Shift</i> Toggle";
-        case (SiteViewer::RotateViewInteraction):
-            return "Rotate view";
-        case (SiteViewer::TranslateViewInteraction):
-            return "Translate";
         default:
             return "Unknown SiteViewerInteraction";
     }

--- a/src/gui/siteviewer_interaction.cpp
+++ b/src/gui/siteviewer_interaction.cpp
@@ -124,7 +124,7 @@ void SiteViewer::endInteraction()
 
                     // Update the selection
                     speciesRenderable_->recreateSelectionPrimitive();
-                    emit(atomSelectionChanged());
+                    emit(atomsChanged());
 
                     // Revert to default interaction mode
                     setInteractionMode(SiteViewer::InteractionMode::Select);

--- a/src/gui/siteviewer_render.cpp
+++ b/src/gui/siteviewer_render.cpp
@@ -22,7 +22,7 @@ void SiteViewer::render2DOverlay()
     if (interacting())
         switch (interactionMode())
         {
-            case (SiteViewer::SelectAreaInteraction):
+            case (SiteViewer::InteractionMode::SelectArea):
                 // Draw dashed box indicating selection area, form clicked to current mouse coordinates
                 selectionBoxStyle.sendToGL();
                 glBegin(GL_LINE_LOOP);

--- a/src/gui/sitewidget_funcs.cpp
+++ b/src/gui/sitewidget_funcs.cpp
@@ -57,8 +57,11 @@ void SiteWidget::updateToolbar()
     // Set current interaction mode
     switch (siteViewer()->interactionMode())
     {
-        case (SiteViewer::DefaultInteraction):
+        case (SiteViewer::InteractionMode::Select):
+        case (SiteViewer::InteractionMode::SelectArea):
             ui_.InteractionViewButton->setChecked(true);
+            break;
+        default:
             break;
     }
 
@@ -119,7 +122,7 @@ SiteViewer *SiteWidget::siteViewer() { return ui_.SiteView; }
 void SiteWidget::on_InteractionViewButton_clicked(bool checked)
 {
     if (checked)
-        siteViewer()->setInteractionMode(SiteViewer::DefaultInteraction);
+        siteViewer()->setInteractionMode(SiteViewer::InteractionMode::Select);
 }
 
 void SiteWidget::on_ViewResetButton_clicked(bool checked)

--- a/src/gui/sitewidget_funcs.cpp
+++ b/src/gui/sitewidget_funcs.cpp
@@ -24,8 +24,8 @@ SiteWidget::SiteWidget(QWidget *parent) : QWidget(parent)
     // Connect signals / slots
     connect(ui_.SiteView, SIGNAL(dataModified()), this, SLOT(notifyDataModified()));
     connect(ui_.SiteView, SIGNAL(styleModified()), this, SLOT(notifyStyleModified()));
-    connect(ui_.SiteView, SIGNAL(atomSelectionChanged()), this, SLOT(updateStatusBar()));
-    connect(ui_.SiteView, SIGNAL(atomSelectionChanged()), this, SLOT(updateToolbar()));
+    connect(ui_.SiteView, SIGNAL(atomsChanged()), this, SLOT(updateStatusBar()));
+    connect(ui_.SiteView, SIGNAL(atomsChanged()), this, SLOT(updateToolbar()));
     connect(ui_.SiteView, SIGNAL(interactionModeChanged()), this, SLOT(updateStatusBar()));
 
     // Make sure our controls are consistent with the underlying viewer / data

--- a/src/gui/specieseditor_funcs.cpp
+++ b/src/gui/specieseditor_funcs.cpp
@@ -28,7 +28,7 @@ SpeciesEditor::SpeciesEditor(QWidget *parent) : QWidget(parent)
     // Connect signals / slots
     connect(ui_.SpeciesView, SIGNAL(dataModified()), this, SLOT(notifyDataModified()));
     connect(ui_.SpeciesView, SIGNAL(styleModified()), this, SLOT(notifyStyleModified()));
-    connect(ui_.SpeciesView, SIGNAL(atomSelectionChanged()), this, SLOT(updateStatusBar()));
+    connect(ui_.SpeciesView, SIGNAL(atomsChanged()), this, SLOT(updateStatusBar()));
     connect(ui_.SpeciesView, SIGNAL(interactionModeChanged()), this, SLOT(updateStatusBar()));
 
     // Make sure our controls are consistent with the underlying viewer / data

--- a/src/gui/specieseditor_funcs.cpp
+++ b/src/gui/specieseditor_funcs.cpp
@@ -60,11 +60,17 @@ void SpeciesEditor::updateToolbar()
     // Set current interaction mode
     switch (speciesViewer()->interactionMode())
     {
-        case (SpeciesViewer::DefaultInteraction):
+        case (SpeciesViewer::InteractionMode::Select):
+        case (SpeciesViewer::InteractionMode::SelectArea):
             ui_.InteractionViewButton->setChecked(true);
             break;
-        case (SpeciesViewer::DrawInteraction):
+        case (SpeciesViewer::InteractionMode::Draw):
             ui_.InteractionDrawButton->setChecked(true);
+            break;
+        case (SpeciesViewer::InteractionMode::Delete):
+            ui_.InteractionDeleteButton->setChecked(true);
+            break;
+        default:
             break;
     }
 
@@ -115,13 +121,13 @@ SpeciesViewer *SpeciesEditor::speciesViewer() { return ui_.SpeciesView; }
 void SpeciesEditor::on_InteractionViewButton_clicked(bool checked)
 {
     if (checked)
-        speciesViewer()->setInteractionMode(SpeciesViewer::DefaultInteraction);
+        speciesViewer()->setInteractionMode(SpeciesViewer::InteractionMode::Select);
 }
 
 void SpeciesEditor::on_InteractionDrawButton_clicked(bool checked)
 {
     if (checked)
-        speciesViewer()->setInteractionMode(SpeciesViewer::DrawInteraction);
+        speciesViewer()->setInteractionMode(SpeciesViewer::InteractionMode::Draw);
 }
 
 void SpeciesEditor::on_InteractionDrawElementButton_clicked(bool checked)
@@ -141,7 +147,7 @@ void SpeciesEditor::on_InteractionDrawElementButton_clicked(bool checked)
 void SpeciesEditor::on_InteractionDeleteButton_clicked(bool checked)
 {
     if (checked)
-        speciesViewer()->setInteractionMode(SpeciesViewer::DeleteInteraction);
+        speciesViewer()->setInteractionMode(SpeciesViewer::InteractionMode::Delete);
 }
 
 void SpeciesEditor::on_ViewResetButton_clicked(bool checked)

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -75,7 +75,7 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
     // Connect signals / slots
     connect(ui_.ViewerWidget, SIGNAL(dataModified()), this, SLOT(updateControls()));
     connect(ui_.ViewerWidget, SIGNAL(dataModified()), dissolveWindow_, SLOT(setModified()));
-    connect(ui_.ViewerWidget->speciesViewer(), SIGNAL(atomSelectionChanged()), this, SLOT(updateAtomTableSelection()));
+    connect(ui_.ViewerWidget->speciesViewer(), SIGNAL(atomsChanged()), this, SLOT(updateAtomTableSelection()));
     connect(ui_.SiteViewerWidget, SIGNAL(dataModified()), this, SLOT(updateSitesTab()));
     connect(ui_.SiteViewerWidget, SIGNAL(siteCreatedAndShown()), this, SLOT(setCurrentSiteFromViewer()));
     connect(ui_.SiteViewerWidget, SIGNAL(dataModified()), dissolveWindow_, SLOT(setModified()));

--- a/src/gui/speciesviewer.hui
+++ b/src/gui/speciesviewer.hui
@@ -43,18 +43,27 @@ class SpeciesViewer : public BaseViewer
      */
     public:
     // Interaction Mode enum
-    enum InteractionMode
+    enum class InteractionMode
     {
-        DefaultInteraction,
-        SelectAreaInteraction,
-        TranslateViewInteraction,
-        RotateViewInteraction,
-        DrawInteraction,
-        DeleteInteraction,
+        Select,
+        SelectArea,
+        Draw,
+        Delete,
         nInteractionModes
+    };
+    // Secondary Interaction Mode enum
+    enum class TransientInteractionMode
+    {
+        None,
+        TranslateView,
+        RotateView
     };
 
     private:
+    // Primary interaction mode (left mouse button)
+    InteractionMode interactionMode_;
+    // Transient interaction mode (i.e. one not invoked by primary button)
+    TransientInteractionMode transientInteractionMode_;
     // Clicked atom at the start of the interaction (if any)
     SpeciesAtom *clickedAtom_;
     // Element for created atoms in DrawInteraction
@@ -77,6 +86,10 @@ class SpeciesViewer : public BaseViewer
     void cancelInteraction();
 
     public:
+    // Set current interaction mode
+    void setInteractionMode(InteractionMode mode);
+    // Return current interaction mode
+    InteractionMode interactionMode() const;
     // Return text describing current interaction mode
     const QString interactionModeText() const;
     // Set current Element for DrawInteraction

--- a/src/gui/speciesviewer.hui
+++ b/src/gui/speciesviewer.hui
@@ -130,5 +130,5 @@ class SpeciesViewer : public BaseViewer
      */
     signals:
     // Atom selection changed
-    void atomSelectionChanged();
+    void atomsChanged();
 };

--- a/src/gui/speciesviewer_funcs.cpp
+++ b/src/gui/speciesviewer_funcs.cpp
@@ -52,7 +52,7 @@ void SpeciesViewer::setSpecies(Species *sp)
     }
 
     // Send relevant signals
-    emit(atomSelectionChanged());
+    emit(atomsChanged());
 }
 
 // Return target Species

--- a/src/gui/speciesviewer_funcs.cpp
+++ b/src/gui/speciesviewer_funcs.cpp
@@ -13,7 +13,8 @@ SpeciesViewer::SpeciesViewer(QWidget *parent) : BaseViewer(parent)
     speciesRenderable_ = nullptr;
 
     // Interaction
-    setInteractionMode(SpeciesViewer::DefaultInteraction);
+    setInteractionMode(SpeciesViewer::InteractionMode::Select);
+    transientInteractionMode_ = SpeciesViewer::TransientInteractionMode::None;
     clickedAtom_ = nullptr;
     drawElement_ = Elements::H;
 

--- a/src/gui/speciesviewer_input.cpp
+++ b/src/gui/speciesviewer_input.cpp
@@ -17,14 +17,50 @@ void SpeciesViewer::mouseMoved(int dx, int dy)
     SpeciesAtom *currentAtom = nullptr;
 
     // What we do here depends on the current mode
-    switch (interactionMode())
+    switch (transientInteractionMode_)
     {
-        case (SpeciesViewer::SelectAreaInteraction):
-            // No action to take - the selection box will be drawn from the clicked and current positions (already
-            // stored)
-            refresh = true;
+        case (TransientInteractionMode::None):
+            // End primary interaction
+            switch (interactionMode_)
+            {
+                case (SpeciesViewer::InteractionMode::SelectArea):
+                    // No action to take - the selection box will be drawn from the clicked and current positions (already
+                    // stored)
+                    refresh = true;
+                    break;
+                case (SpeciesViewer::InteractionMode::Draw):
+                    if (buttonState_.testFlag(Qt::LeftButton))
+                    {
+                        // Get atom at the current position (if any)
+                        currentAtom = atomAt(rMouseLast_.x, rMouseLast_.y);
+
+                        // Set the current drawing coordinates in data-space
+                        drawCoordinateCurrent_ =
+                            currentAtom ? currentAtom->r() : view().screenToData(rMouseLast_.x, rMouseLast_.y, 0.0);
+
+                        // Update the interaction Primitive
+                        if (clickedAtom_)
+                        {
+                            if (currentAtom)
+                                speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, currentAtom);
+                            else
+                                speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_,
+                                                                                     drawElement_);
+                        }
+                        else
+                            speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
+                                                                                 drawCoordinateCurrent_, drawElement_);
+                    }
+                    else if (buttonState_.testFlag(Qt::RightButton))
+                        view_.rotateView(-dy / 2.0, dx / 2.0);
+
+                    refresh = true;
+                    break;
+                default:
+                    break;
+            }
             break;
-        case (SpeciesViewer::RotateViewInteraction):
+        case (SpeciesViewer::TransientInteractionMode::RotateView):
             // Rotate view
             if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
             {
@@ -38,43 +74,13 @@ void SpeciesViewer::mouseMoved(int dx, int dy)
                 refresh = true;
             }
             break;
-        case (SpeciesViewer::TranslateViewInteraction):
+        case (SpeciesViewer::TransientInteractionMode::TranslateView):
             // If this is a flat view, shift the axis limits rather than translating the view
             if (view_.isFlatView())
                 view_.shiftFlatAxisLimits(dx, dy);
             else
                 view_.translateView(dx / 15.0, dy / 15.0, 0.0);
             refresh = true;
-            break;
-        case (SpeciesViewer::DrawInteraction):
-            if (buttonState_.testFlag(Qt::LeftButton))
-            {
-                // Get atom at the current position (if any)
-                currentAtom = atomAt(rMouseLast_.x, rMouseLast_.y);
-
-                // Set the current drawing coordinates in data-space
-                drawCoordinateCurrent_ =
-                    currentAtom ? currentAtom->r() : view().screenToData(rMouseLast_.x, rMouseLast_.y, 0.0);
-
-                // Update the interaction Primitive
-                if (clickedAtom_)
-                {
-                    if (currentAtom)
-                        speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, currentAtom);
-                    else
-                        speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_,
-                                                                             drawElement_);
-                }
-                else
-                    speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
-                                                                         drawCoordinateCurrent_, drawElement_);
-            }
-            else if (buttonState_.testFlag(Qt::RightButton))
-                view_.rotateView(-dy / 2.0, dx / 2.0);
-
-            refresh = true;
-            break;
-        default:
             break;
     }
 

--- a/src/gui/speciesviewer_input.cpp
+++ b/src/gui/speciesviewer_input.cpp
@@ -29,30 +29,42 @@ void SpeciesViewer::mouseMoved(int dx, int dy)
                     refresh = true;
                     break;
                 case (SpeciesViewer::InteractionMode::Draw):
-                    if (buttonState_.testFlag(Qt::LeftButton))
+                    // If the left button is pressed, need to update our interaction primitives
+                    if (!buttonState_.testFlag(Qt::LeftButton))
+                        break;
+
+                    // Get atom at the current position (if any)
+                    currentAtom = atomAt(rMouseLast_.x, rMouseLast_.y);
+
+                    // Set the current drawing coordinates in data-space
+                    drawCoordinateCurrent_ =
+                        currentAtom ? currentAtom->r() : view().screenToData(rMouseLast_.x, rMouseLast_.y, 0.0);
+
+                    // Update the interaction Primitive
+                    if (clickedAtom_)
                     {
-                        // Get atom at the current position (if any)
-                        currentAtom = atomAt(rMouseLast_.x, rMouseLast_.y);
-
-                        // Set the current drawing coordinates in data-space
-                        drawCoordinateCurrent_ =
-                            currentAtom ? currentAtom->r() : view().screenToData(rMouseLast_.x, rMouseLast_.y, 0.0);
-
-                        // Update the interaction Primitive
-                        if (clickedAtom_)
-                        {
-                            if (currentAtom)
-                                speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, currentAtom);
-                            else
-                                speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_,
-                                                                                     drawElement_);
-                        }
+                        if (currentAtom)
+                            speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, currentAtom);
                         else
-                            speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
-                                                                                 drawCoordinateCurrent_, drawElement_);
+                            speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_,
+                                                                                 drawElement_);
                     }
-                    else if (buttonState_.testFlag(Qt::RightButton))
-                        view_.rotateView(-dy / 2.0, dx / 2.0);
+                    else
+                        speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
+                                                                             drawCoordinateCurrent_, drawElement_);
+                    refresh = true;
+                    break;
+                case (SpeciesViewer::InteractionMode::Delete):
+                    // If the left button is pressed, need to update our interaction primitives
+                    if (!buttonState_.testFlag(Qt::LeftButton))
+                        break;
+
+                    // Update the interaction Primitive
+                    if (clickedAtom_)
+                        speciesRenderable_->recreateDeleteInteractionPrimitive(clickedAtom_,
+                                                                               atomAt(rMouseLast_.x, rMouseLast_.y));
+                    else
+                        speciesRenderable_->clearInteractionPrimitive();
 
                     refresh = true;
                     break;

--- a/src/gui/speciesviewer_interaction.cpp
+++ b/src/gui/speciesviewer_interaction.cpp
@@ -46,65 +46,62 @@ SpeciesAtom *SpeciesViewer::atomAt(int x, int y)
 // Start interaction at the specified screen coordinates
 void SpeciesViewer::startInteraction()
 {
-    switch (interactionMode())
+    // Check the button that started the interaction
+    if (buttonState_.testFlag(Qt::LeftButton))
     {
-        // Default Interaction Mode
-        case (SpeciesViewer::DefaultInteraction):
-            // This is the standard mode, giving access to view manipulation
-            if (buttonState_.testFlag(Qt::LeftButton))
-                setInteractionMode(SpeciesViewer::SelectAreaInteraction);
-            else if (buttonState_.testFlag(Qt::RightButton))
-                setInteractionMode(SpeciesViewer::RotateViewInteraction);
-            else if (buttonState_.testFlag(Qt::MiddleButton))
-                setInteractionMode(SpeciesViewer::TranslateViewInteraction);
-            break;
-        // Draw
-        case (SpeciesViewer::DrawInteraction):
-            // If the left mouse button is not flagged, do nothing
-            if (!buttonState_.testFlag(Qt::LeftButton))
+        switch (interactionMode_)
+        {
+            // Selection
+            case (SpeciesViewer::InteractionMode::Select):
+                setInteractionMode(SpeciesViewer::InteractionMode::SelectArea);
                 break;
+            // Draw
+            case (SpeciesViewer::InteractionMode::Draw):
+                // Set starting atom (if there is one at the current position)
+                clickedAtom_ = atomAt(rMouseDown_.x, rMouseDown_.y);
 
-            // Set starting atom (if there is one at the current position)
-            clickedAtom_ = atomAt(rMouseDown_.x, rMouseDown_.y);
+                // Get the clicked position in the coordinate space of the Species
+                drawCoordinateStart_ =
+                    clickedAtom_ ? clickedAtom_->r() : view().screenToData(rMouseDown_.x, rMouseDown_.y, 0.0);
+                drawCoordinateCurrent_ = drawCoordinateStart_;
 
-            // Get the clicked position in the coordinate space of the Species
-            drawCoordinateStart_ = clickedAtom_ ? clickedAtom_->r() : view().screenToData(rMouseDown_.x, rMouseDown_.y, 0.0);
-            drawCoordinateCurrent_ = drawCoordinateStart_;
+                // If Ctrl is pressed, we transmute the atom under the mouse, but don't allow drawing of anything else
+                if (clickedAtom_ && mouseDownModifiers_.testFlag(Qt::ControlModifier))
+                    break;
 
-            // If Ctrl is pressed, we transmute the atom under the mouse, but don't allow drawing of anything else
-            if (clickedAtom_ && mouseDownModifiers_.testFlag(Qt::ControlModifier))
+                // Update the interaction Primitive
+                if (clickedAtom_)
+                    speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_, drawElement_);
+                else
+                    speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
+                                                                         drawCoordinateCurrent_, drawElement_);
                 break;
+            // Delete
+            case (SpeciesViewer::InteractionMode::Delete):
+                // Set starting atom (if there is one at the current position)
+                clickedAtom_ = atomAt(rMouseDown_.x, rMouseDown_.y);
 
-            // Update the interaction Primitive
-            if (clickedAtom_)
-                speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_, drawElement_);
-            else
-                speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_, drawCoordinateCurrent_,
-                                                                     drawElement_);
-            break;
-        // Delete
-        case (SpeciesViewer::DeleteInteraction):
-            // If the left mouse button is not flagged, do nothing
-            if (!buttonState_.testFlag(Qt::LeftButton))
+                // Get the clicked position in the coordinate space of the Species
+                drawCoordinateStart_ =
+                    clickedAtom_ ? clickedAtom_->r() : view().screenToData(rMouseDown_.x, rMouseDown_.y, 0.0);
+                drawCoordinateCurrent_ = drawCoordinateStart_;
+
+                // Update the interaction Primitive
+                if (clickedAtom_)
+                    speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_, drawElement_);
+                else
+                    speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
+                                                                         drawCoordinateCurrent_, drawElement_);
                 break;
-
-            // Set starting atom (if there is one at the current position)
-            clickedAtom_ = atomAt(rMouseDown_.x, rMouseDown_.y);
-
-            // Get the clicked position in the coordinate space of the Species
-            drawCoordinateStart_ = clickedAtom_ ? clickedAtom_->r() : view().screenToData(rMouseDown_.x, rMouseDown_.y, 0.0);
-            drawCoordinateCurrent_ = drawCoordinateStart_;
-
-            // Update the interaction Primitive
-            if (clickedAtom_)
-                speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_, drawElement_);
-            else
-                speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_, drawCoordinateCurrent_,
-                                                                     drawElement_);
-            break;
-        default:
-            break;
+            default:
+                fmt::print("Unhandled primary mode {} in SpeciesViewer::startInteraction().\n", interactionMode_);
+                break;
+        }
     }
+    else if (buttonState_.testFlag(Qt::RightButton))
+        transientInteractionMode_ = SpeciesViewer::TransientInteractionMode::RotateView;
+    else if (buttonState_.testFlag(Qt::MiddleButton))
+        transientInteractionMode_ = SpeciesViewer::TransientInteractionMode::TranslateView;
 }
 
 // End interaction at the specified screen coordinates
@@ -113,147 +110,155 @@ void SpeciesViewer::endInteraction()
     SpeciesAtom *i, *j;
 
     // Finalise interaction type
-    switch (interactionMode())
+    switch (transientInteractionMode_)
     {
-        case (SpeciesViewer::DefaultInteraction):
-            break;
-        case (SpeciesViewer::SelectAreaInteraction):
-            // Check the pixel area of the clicked region and determine whether this was actually a targeted click
-            // rather than an area select
-            if ((rMouseDown_ - rMouseLast_).magnitude() < 9.0)
+        case (TransientInteractionMode::None):
+            // End primary interaction
+            switch (interactionMode_)
             {
-                // Single, targetted click - atom under mouse?
-                SpeciesAtom *i = atomAt(rMouseLast_.x, rMouseLast_.y);
+                case (SpeciesViewer::InteractionMode::Select):
+                    break;
+                case (SpeciesViewer::InteractionMode::SelectArea):
+                    // Check the pixel area of the clicked region and determine whether this was actually a targeted click
+                    // rather than an area select
+                    if ((rMouseDown_ - rMouseLast_).magnitude() < 9.0)
+                    {
+                        // Single, targetted click - atom under mouse?
+                        SpeciesAtom *i = atomAt(rMouseLast_.x, rMouseLast_.y);
 
-                // If there is an atom at the current position, (de)select it, maintaining the current selection
-                // if Shift was pressed
-                if (i)
-                {
-                    if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
-                        species_->toggleAtomSelection(i);
+                        // If there is an atom at the current position, (de)select it, maintaining the current selection
+                        // if Shift was pressed
+                        if (i)
+                        {
+                            if (mouseDownModifiers_.testFlag(Qt::ShiftModifier))
+                                species_->toggleAtomSelection(i);
+                            else
+                            {
+                                species_->clearAtomSelection();
+                                species_->selectAtom(i);
+                            }
+                        }
+                        else
+                        {
+                            // No atom at the current position - if Shift was not pressed, deselect everything
+                            if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
+                                species_->clearAtomSelection();
+                        }
+                    }
                     else
                     {
-                        species_->clearAtomSelection();
-                        species_->selectAtom(i);
+                        // Click-drag - area select
+                        // If Shift was not pressed, clear the current selection first
+                        if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
+                            species_->clearAtomSelection();
+                        Vec3<double> rScreen;
+                        QRect selectionRect(QPoint(rMouseDown_.x, rMouseDown_.y), QPoint(rMouseLast_.x, rMouseLast_.y));
+                        ListIterator<SpeciesAtom> atomIterator(species_->atoms());
+                        while (SpeciesAtom *i = atomIterator.iterate())
+                        {
+                            rScreen = view_.dataToScreen(i->r());
+                            if (selectionRect.contains(rScreen.x, rScreen.y))
+                                species_->selectAtom(i);
+                        }
                     }
-                }
-                else
-                {
-                    // No atom at the current position - if Shift was not pressed, deselect everything
-                    if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
-                        species_->clearAtomSelection();
-                }
-            }
-            else
-            {
-                // Click-drag - area select
-                // If Shift was not pressed, clear the current selection first
-                if (!mouseDownModifiers_.testFlag(Qt::ShiftModifier))
-                    species_->clearAtomSelection();
-                Vec3<double> rScreen;
-                QRect selectionRect(QPoint(rMouseDown_.x, rMouseDown_.y), QPoint(rMouseLast_.x, rMouseLast_.y));
-                ListIterator<SpeciesAtom> atomIterator(species_->atoms());
-                while (SpeciesAtom *i = atomIterator.iterate())
-                {
-                    rScreen = view_.dataToScreen(i->r());
-                    if (selectionRect.contains(rScreen.x, rScreen.y))
-                        species_->selectAtom(i);
-                }
-            }
 
-            // Update the selection
-            speciesRenderable_->recreateSelectionPrimitive();
-            emit(atomSelectionChanged());
+                    // Update the selection
+                    speciesRenderable_->recreateSelectionPrimitive();
+                    emit(atomSelectionChanged());
 
-            // Revert to default interaction mode
-            setInteractionMode(SpeciesViewer::DefaultInteraction);
-            break;
-        case (SpeciesViewer::RotateViewInteraction):
-            // Rotation matrix has already been modified. Revert to default interaction mode
-            setInteractionMode(SpeciesViewer::DefaultInteraction);
-            break;
-        case (SpeciesViewer::TranslateViewInteraction):
-            // Translation has already been applied. Revert to default interaction mode
-            setInteractionMode(SpeciesViewer::DefaultInteraction);
-            break;
-        case (SpeciesViewer::DrawInteraction):
-            // If the left mouse button is not flagged, do nothing
-            if (!buttonState_.testFlag(Qt::LeftButton))
-                break;
+                    // Revert to default interaction mode
+                    setInteractionMode(SpeciesViewer::InteractionMode::Select);
+                    break;
+                case (SpeciesViewer::InteractionMode::Draw):
+                    // If the left mouse button is not flagged, do nothing
+                    if (!buttonState_.testFlag(Qt::LeftButton))
+                        break;
 
-            // If Ctrl was pressed, and an atom was clicked, transmute it to the current element
-            if (mouseDownModifiers_.testFlag(Qt::ControlModifier))
-            {
-                if (clickedAtom_)
-                {
-                    species_->transmuteAtom(clickedAtom_, drawElement_);
+                    // If Ctrl was pressed, and an atom was clicked, transmute it to the current element
+                    if (mouseDownModifiers_.testFlag(Qt::ControlModifier))
+                    {
+                        if (clickedAtom_)
+                        {
+                            species_->transmuteAtom(clickedAtom_, drawElement_);
+
+                            // Notify that the data has changed
+                            emit(dataModified());
+
+                            // Update display
+                            postRedisplay();
+                        }
+
+                        // We're done - nothing more to add
+                        break;
+                    }
+
+                    // If an atom was not clicked at the start of the interaction, create a new one now
+                    i = clickedAtom_ ? clickedAtom_ : species_->addAtom(drawElement_, drawCoordinateStart_);
+
+                    // Get atom at current coordinates - if there isn't one, create one now
+                    j = atomAt(rMouseLast_.x, rMouseLast_.y);
+                    if (!j)
+                        j = species_->addAtom(drawElement_, drawCoordinateCurrent_);
+
+                    // Create a bond between the two atoms, if one doesn't currently exist
+                    if ((i != j) && (!species_->hasBond(i, j)))
+                        species_->addBond(i, j);
+
+                    // Clear the interaction Primitive
+                    speciesRenderable_->clearInteractionPrimitive();
 
                     // Notify that the data has changed
                     emit(dataModified());
 
                     // Update display
                     postRedisplay();
-                }
+                    break;
+                case (SpeciesViewer::InteractionMode::Delete):
+                    // If the left mouse button is not flagged, do nothing
+                    if (!buttonState_.testFlag(Qt::LeftButton))
+                        break;
 
-                // We're done - nothing more to add
-                break;
+                    // If an atom was not clicked at the start of the interaction, break now
+                    if (!clickedAtom_)
+                        break;
+
+                    // Get atom at current coordinates - if its the same as the clicked atom, nullify the pointer so we
+                    // don't try to remove a bond
+                    j = atomAt(rMouseLast_.x, rMouseLast_.y);
+                    if (j == clickedAtom_)
+                        j = nullptr;
+
+                    // If there is an atom 'j', search for the bond to delete. Otherwise, delete clickedAtom_
+                    if (!j)
+                        species_->removeAtom(clickedAtom_);
+                    else if (species_->hasBond(clickedAtom_, j))
+                        species_->removeBond(clickedAtom_, j);
+
+                    // Clear the interaction Primitive
+                    speciesRenderable_->clearInteractionPrimitive();
+
+                    // Notify that the data has changed
+                    emit(dataModified());
+
+                    // Update display
+                    postRedisplay();
+                    break;
+                default:
+                    fmt::print("Unhandled primary mode {} in SpeciesViewer::endInteraction().\n", interactionMode_);
+                    break;
             }
-
-            // If an atom was not clicked at the start of the interaction, create a new one now
-            i = clickedAtom_ ? clickedAtom_ : species_->addAtom(drawElement_, drawCoordinateStart_);
-
-            // Get atom at current coordinates - if there isn't one, create one now
-            j = atomAt(rMouseLast_.x, rMouseLast_.y);
-            if (!j)
-                j = species_->addAtom(drawElement_, drawCoordinateCurrent_);
-
-            // Create a bond between the two atoms, if one doesn't currently exist
-            if ((i != j) && (!species_->hasBond(i, j)))
-                species_->addBond(i, j);
-
-            // Clear the interaction Primitive
-            speciesRenderable_->clearInteractionPrimitive();
-
-            // Notify that the data has changed
-            emit(dataModified());
-
-            // Update display
-            postRedisplay();
             break;
-        case (SpeciesViewer::DeleteInteraction):
-            // If the left mouse button is not flagged, do nothing
-            if (!buttonState_.testFlag(Qt::LeftButton))
-                break;
-
-            // If an atom was not clicked at the start of the interaction, break now
-            if (!clickedAtom_)
-                break;
-
-            // Get atom at current coordinates - if its the same as the clicked atom, nullify the pointer so we
-            // don't try to remove a bonv
-            j = atomAt(rMouseLast_.x, rMouseLast_.y);
-            if (j == clickedAtom_)
-                j = nullptr;
-
-            // If there is an atom 'j', search for the bond to delete. Otherwise, delete clickedAtom_
-            if (!j)
-                species_->removeAtom(clickedAtom_);
-            else if (species_->hasBond(clickedAtom_, j))
-                species_->removeBond(clickedAtom_, j);
-
-            // Clear the interaction Primitive
-            speciesRenderable_->clearInteractionPrimitive();
-
-            // Notify that the data has changed
-            emit(dataModified());
-
-            // Update display
-            postRedisplay();
+        case (SpeciesViewer::TransientInteractionMode::RotateView):
+        case (SpeciesViewer::TransientInteractionMode::TranslateView):
+            // Rotation / translation has already been modified, so nothing more to do
             break;
         default:
-            Messenger::error("Don't know how to complete interaction mode {}\n", interactionMode());
+            fmt::print("Unhandled secondary mode {} in SpeciesViewer::endInteraction().\n", transientInteractionMode_);
             break;
     }
+
+    // Reset any transient interaction
+    transientInteractionMode_ = TransientInteractionMode::None;
 }
 
 // Cancel current interaction
@@ -274,23 +279,33 @@ void SpeciesViewer::cancelInteraction()
  * Public Functions
  */
 
+// Set current interaction mode
+void SpeciesViewer::setInteractionMode(SpeciesViewer::InteractionMode mode)
+{
+    // Cancel any current interaction
+    cancelInteraction();
+
+    interactionMode_ = mode;
+
+    emit(interactionModeChanged());
+}
+
+// Return current interaction mode
+SpeciesViewer::InteractionMode SpeciesViewer::interactionMode() const { return interactionMode_; }
+
 // Return text describing current interaction mode
 const QString SpeciesViewer::interactionModeText() const
 {
     switch (interactionMode())
     {
-        case (SpeciesViewer::DefaultInteraction):
+        case (SpeciesViewer::InteractionMode::Select):
             return "View: <b>Left</b> Select; <b>Right</b> Rotate; <b>Middle</b> Translate; <b>Wheel</b> Zoom";
-        case (SpeciesViewer::SelectAreaInteraction):
+        case (SpeciesViewer::InteractionMode::SelectArea):
             return "Select atoms: <b>Left-Click</b> Select individual atoms; <b>Left-Click-Drag</b> Area select; "
                    "<i>+Shift</i> Toggle";
-        case (SpeciesViewer::RotateViewInteraction):
-            return "Rotate view";
-        case (SpeciesViewer::TranslateViewInteraction):
-            return "Translate";
-        case (SpeciesViewer::DrawInteraction):
+        case (SpeciesViewer::InteractionMode::Draw):
             return "Draw: <b>Left</b> Draw [+<i>Ctrl</i>: Transmute]; <b>Right</b> Rotate view";
-        case (SpeciesViewer::DeleteInteraction):
+        case (SpeciesViewer::InteractionMode::Delete):
             return "Delete: <b>Left-Click</b> Delete Atom; <b>Left-Click-Drag</b> Delete Bond";
         default:
             return "Unknown SpeciesViewerInteraction";

--- a/src/gui/speciesviewer_interaction.cpp
+++ b/src/gui/speciesviewer_interaction.cpp
@@ -88,10 +88,9 @@ void SpeciesViewer::startInteraction()
 
                 // Update the interaction Primitive
                 if (clickedAtom_)
-                    speciesRenderable_->recreateDrawInteractionPrimitive(clickedAtom_, drawCoordinateCurrent_, drawElement_);
+                    speciesRenderable_->recreateDeleteInteractionPrimitive(clickedAtom_);
                 else
-                    speciesRenderable_->recreateDrawInteractionPrimitive(drawCoordinateStart_, drawElement_,
-                                                                         drawCoordinateCurrent_, drawElement_);
+                    speciesRenderable_->clearInteractionPrimitive();
                 break;
             default:
                 fmt::print("Unhandled primary mode {} in SpeciesViewer::startInteraction().\n", interactionMode_);

--- a/src/gui/speciesviewer_interaction.cpp
+++ b/src/gui/speciesviewer_interaction.cpp
@@ -163,7 +163,7 @@ void SpeciesViewer::endInteraction()
 
                     // Update the selection
                     speciesRenderable_->recreateSelectionPrimitive();
-                    emit(atomSelectionChanged());
+                    emit(atomsChanged());
 
                     // Revert to default interaction mode
                     setInteractionMode(SpeciesViewer::InteractionMode::Select);
@@ -208,6 +208,7 @@ void SpeciesViewer::endInteraction()
 
                     // Notify that the data has changed
                     emit(dataModified());
+                    emit(atomsChanged());
 
                     // Update display
                     postRedisplay();
@@ -238,6 +239,7 @@ void SpeciesViewer::endInteraction()
 
                     // Notify that the data has changed
                     emit(dataModified());
+                    emit(atomsChanged());
 
                     // Update display
                     postRedisplay();

--- a/src/gui/speciesviewer_render.cpp
+++ b/src/gui/speciesviewer_render.cpp
@@ -22,7 +22,7 @@ void SpeciesViewer::render2DOverlay()
     if (interacting())
         switch (interactionMode())
         {
-            case (SpeciesViewer::SelectAreaInteraction):
+            case (SpeciesViewer::InteractionMode::SelectArea):
                 // Draw dashed box indicating selection area, form clicked to current mouse coordinates
                 selectionBoxStyle.sendToGL();
                 glBegin(GL_LINE_LOOP);

--- a/src/gui/specieswidget_funcs.cpp
+++ b/src/gui/specieswidget_funcs.cpp
@@ -22,7 +22,7 @@ SpeciesWidget::SpeciesWidget(QWidget *parent) : QWidget(parent)
     // Connect signals / slots
     connect(ui_.SpeciesView, SIGNAL(dataModified()), this, SLOT(notifyDataModified()));
     connect(ui_.SpeciesView, SIGNAL(styleModified()), this, SLOT(notifyStyleModified()));
-    connect(ui_.SpeciesView, SIGNAL(atomSelectionChanged()), this, SLOT(updateStatusBar()));
+    connect(ui_.SpeciesView, SIGNAL(atomsChanged()), this, SLOT(updateStatusBar()));
 
     // Make sure our controls are consistent with the underlying viewer / data
     updateToolbar();

--- a/src/gui/viewer.hui
+++ b/src/gui/viewer.hui
@@ -263,8 +263,6 @@ class BaseViewer : public QOpenGLWidget, protected QOpenGLFunctions
     Vec3<double> current2DAxesCoordinates_;
     // Whether the viewer is currently being interacted with
     bool interacting_;
-    // Current interaction mode
-    int interactionMode_;
 
     protected:
     // Start interaction
@@ -275,10 +273,6 @@ class BaseViewer : public QOpenGLWidget, protected QOpenGLFunctions
     virtual void cancelInteraction();
 
     public:
-    // Set current interaction mode
-    void setInteractionMode(int mode);
-    // Return current interaction mode
-    int interactionMode() const;
     // Return whether the viewer is currently being interacted with
     bool interacting() const;
     // Return text describing current interaction mode

--- a/src/gui/viewer_funcs.cpp
+++ b/src/gui/viewer_funcs.cpp
@@ -24,7 +24,6 @@ BaseViewer::BaseViewer(QWidget *parent) : QOpenGLWidget(parent), view_(renderabl
 
     // Interaction
     interacting_ = false;
-    interactionMode_ = -1;
     mouseReleaseTimer_.setSingleShot(true);
     mouseReleaseTimer_.setInterval(400);
 

--- a/src/gui/viewer_input.cpp
+++ b/src/gui/viewer_input.cpp
@@ -37,7 +37,7 @@ void BaseViewer::mouseReleaseEvent(QMouseEvent *event)
         (((rMouseLast_ - rMouseDown_).magnitude() <= 1) || mouseReleaseTimer_.isActive()))
     {
         // Reset to default interaction
-        setInteractionMode(0);
+        // resetInteraction(0);
 
         contextMenuRequested(event->pos());
     }

--- a/src/gui/viewer_interaction.cpp
+++ b/src/gui/viewer_interaction.cpp
@@ -23,20 +23,6 @@ void BaseViewer::cancelInteraction() {}
  * Public Functions
  */
 
-// Set current interaction mode
-void BaseViewer::setInteractionMode(int mode)
-{
-    // Cancel any current interaction
-    cancelInteraction();
-
-    interactionMode_ = mode;
-
-    emit(interactionModeChanged());
-}
-
-// Return current interaction mode
-int BaseViewer::interactionMode() const { return interactionMode_; }
-
 // Return whether the viewer is currently being interacted with
 bool BaseViewer::interacting() const { return interacting_; }
 


### PR DESCRIPTION
This PR addresses several issues with species editing within the GUI, stemming from a crash reported by a user. The bug report of that crash suggested that memory corruption was occurring via the deletion of intramolecular terms that were not valid.

Summary of changes:

- Adds missing standard, copy, and move ctors for `SpeciesImproper`, bringing it in line with the other related classes.
- Fix management and update (in widget statusbars) of atom selection.
- Disconnect higher-order intramolecular terms when removing bonds.

Closes #316.
