### PR TITLE
Bugfix 11-02-21 Parameter Editing

### DIFF
--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -28,8 +28,6 @@ ExpressionValue::ExpressionValue(double value, bool fixedType)
     typeFixed_ = fixedType;
 }
 
-ExpressionValue::~ExpressionValue() {}
-
 ExpressionValue::ExpressionValue(const ExpressionValue &source)
 {
     valueI_ = source.valueI_;
@@ -38,7 +36,7 @@ ExpressionValue::ExpressionValue(const ExpressionValue &source)
     typeFixed_ = source.typeFixed_;
 }
 
-void ExpressionValue::operator=(const ExpressionValue &source)
+ExpressionValue &ExpressionValue::operator=(const ExpressionValue &source)
 {
     if (typeFixed_)
     {
@@ -64,6 +62,28 @@ void ExpressionValue::operator=(const ExpressionValue &source)
         valueD_ = source.valueD_;
         type_ = source.type_;
     }
+
+    return *this;
+}
+
+ExpressionValue &ExpressionValue::operator=(int i)
+{
+    valueI_ = i;
+    valueD_ = i;
+    if (!typeFixed_)
+        type_ = IntegerType;
+
+    return *this;
+}
+
+ExpressionValue &ExpressionValue::operator=(double d)
+{
+    valueI_ = int(d);
+    valueD_ = d;
+    if (!typeFixed_)
+        type_ = DoubleType;
+
+    return *this;
 }
 
 /*
@@ -72,22 +92,6 @@ void ExpressionValue::operator=(const ExpressionValue &source)
 
 // Return the current result type
 ExpressionValue::ValueType ExpressionValue::type() const { return type_; }
-
-void ExpressionValue::operator=(int i)
-{
-    valueI_ = i;
-    valueD_ = i;
-    if (!typeFixed_)
-        type_ = IntegerType;
-}
-
-void ExpressionValue::operator=(double d)
-{
-    valueI_ = int(d);
-    valueD_ = d;
-    if (!typeFixed_)
-        type_ = DoubleType;
-}
 
 // Return result as integer (regardless of current type)
 int ExpressionValue::asInteger() const { return (type_ == IntegerType ? valueI_ : int(valueD_)); }

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -8,7 +8,7 @@ ExpressionValue::ExpressionValue()
 {
     valueI_ = 0;
     valueD_ = 0.0;
-    type_ = IntegerType;
+    type_ = ValueType::Integer;
     typeFixed_ = false;
 }
 
@@ -16,7 +16,7 @@ ExpressionValue::ExpressionValue(int value, bool fixedType)
 {
     valueI_ = value;
     valueD_ = 0.0;
-    type_ = IntegerType;
+    type_ = ValueType::Integer;
     typeFixed_ = fixedType;
 }
 
@@ -24,7 +24,7 @@ ExpressionValue::ExpressionValue(double value, bool fixedType)
 {
     valueI_ = 0;
     valueD_ = value;
-    type_ = DoubleType;
+    type_ = ValueType::Double;
     typeFixed_ = fixedType;
 }
 
@@ -40,16 +40,16 @@ ExpressionValue &ExpressionValue::operator=(const ExpressionValue &source)
 {
     if (typeFixed_)
     {
-        if (type_ == IntegerType)
+        if (type_ == ValueType::Integer)
         {
-            if (source.type_ == IntegerType)
+            if (source.type_ == ValueType::Integer)
                 valueI_ = source.valueI_;
             else
                 valueI_ = int(source.valueD_);
         }
         else
         {
-            if (source.type_ == IntegerType)
+            if (source.type_ == ValueType::Integer)
                 valueD_ = source.valueI_;
             else
                 valueD_ = source.valueD_;
@@ -71,7 +71,7 @@ ExpressionValue &ExpressionValue::operator=(int i)
     valueI_ = i;
     valueD_ = i;
     if (!typeFixed_)
-        type_ = IntegerType;
+        type_ = ValueType::Integer;
 
     return *this;
 }
@@ -81,7 +81,7 @@ ExpressionValue &ExpressionValue::operator=(double d)
     valueI_ = int(d);
     valueD_ = d;
     if (!typeFixed_)
-        type_ = DoubleType;
+        type_ = ValueType::Double;
 
     return *this;
 }
@@ -94,15 +94,15 @@ ExpressionValue &ExpressionValue::operator=(double d)
 ExpressionValue::ValueType ExpressionValue::type() const { return type_; }
 
 // Return result as integer (regardless of current type)
-int ExpressionValue::asInteger() const { return (type_ == IntegerType ? valueI_ : int(valueD_)); }
+int ExpressionValue::asInteger() const { return (type_ == ValueType::Integer ? valueI_ : int(valueD_)); }
 
 // Return result as double (regardless of current type)
-double ExpressionValue::asDouble() const { return (type_ == IntegerType ? double(valueI_) : valueD_); }
+double ExpressionValue::asDouble() const { return (type_ == ValueType::Integer ? double(valueI_) : valueD_); }
 
 // Return result as a string
 std::string ExpressionValue::asString() const
 {
-    return (type_ == IntegerType ? fmt::format("{}", valueI_) : fmt::format("{:12.6e}", valueD_));
+    return (type_ == ValueType::Integer ? fmt::format("{}", valueI_) : fmt::format("{:12.6e}", valueD_));
 }
 
 // Return pointer to integer value
@@ -116,19 +116,19 @@ double *ExpressionValue::doublePointer() { return &valueD_; }
  */
 
 // Return whether the contained type is an integer
-bool ExpressionValue::isInteger() const { return (type_ == IntegerType); }
+bool ExpressionValue::isInteger() const { return (type_ == ValueType::Integer); }
 
 // Return whether the contained type is an double
-bool ExpressionValue::isDouble() const { return (type_ == DoubleType); }
+bool ExpressionValue::isDouble() const { return (type_ == ValueType::Double); }
 
 // Return the supplied ExpressionValues both contain integer types
 bool ExpressionValue::bothIntegers(const ExpressionValue &a, const ExpressionValue &b)
 {
-    return ((a.type_ == IntegerType) && (b.type_ == IntegerType));
+    return ((a.type_ == ValueType::Integer) && (b.type_ == ValueType::Integer));
 }
 
 // Return the supplied ExpressionValues both contain double types
 bool ExpressionValue::bothDoubles(const ExpressionValue &a, const ExpressionValue &b)
 {
-    return ((a.type_ == DoubleType) && (b.type_ == DoubleType));
+    return ((a.type_ == ValueType::Double) && (b.type_ == ValueType::Double));
 }

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -12,20 +12,20 @@ ExpressionValue::ExpressionValue()
     typeFixed_ = false;
 }
 
-ExpressionValue::ExpressionValue(int value, bool fixedType)
+ExpressionValue::ExpressionValue(int value)
 {
     valueI_ = value;
     valueD_ = 0.0;
     type_ = ValueType::Integer;
-    typeFixed_ = fixedType;
+    typeFixed_ = false;
 }
 
-ExpressionValue::ExpressionValue(double value, bool fixedType)
+ExpressionValue::ExpressionValue(double value)
 {
     valueI_ = 0;
     valueD_ = value;
     type_ = ValueType::Double;
-    typeFixed_ = fixedType;
+    typeFixed_ = false;
 }
 
 ExpressionValue::ExpressionValue(const ExpressionValue &source)

--- a/src/expression/value.h
+++ b/src/expression/value.h
@@ -26,10 +26,10 @@ class ExpressionValue
      */
     public:
     // Value Type
-    enum ValueType
+    enum class ValueType
     {
-        IntegerType,
-        DoubleType
+        Integer,
+        Double
     };
 
     private:

--- a/src/expression/value.h
+++ b/src/expression/value.h
@@ -13,11 +13,13 @@ class ExpressionValue
 {
     public:
     ExpressionValue();
-    ExpressionValue(int value, bool fixedType = true);
-    ExpressionValue(double value, bool fixedType = true);
-    ~ExpressionValue();
+    explicit ExpressionValue(int value, bool fixedType = true);
+    explicit ExpressionValue(double value, bool fixedType = true);
+    ~ExpressionValue() = default;
     ExpressionValue(const ExpressionValue &source);
-    void operator=(const ExpressionValue &source);
+    ExpressionValue &operator=(const ExpressionValue &source);
+    ExpressionValue &operator=(int i);
+    ExpressionValue &operator=(double d);
 
     /*
      * Data
@@ -43,8 +45,6 @@ class ExpressionValue
     public:
     // Return the current result type
     ValueType type() const;
-    void operator=(int i);
-    void operator=(double d);
     // Return as integer (regardless of current type)
     int asInteger() const;
     // Return as double (regardless of current type)

--- a/src/expression/value.h
+++ b/src/expression/value.h
@@ -13,8 +13,8 @@ class ExpressionValue
 {
     public:
     ExpressionValue();
-    explicit ExpressionValue(int value, bool fixedType = true);
-    explicit ExpressionValue(double value, bool fixedType = true);
+    ExpressionValue(int value);
+    ExpressionValue(double value);
     ~ExpressionValue() = default;
     ExpressionValue(const ExpressionValue &source);
     ExpressionValue &operator=(const ExpressionValue &source);

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -67,7 +67,7 @@ void ExpressionVariableVectorKeywordWidget::updateVariableTableRow(int row, std:
     }
     else
         item = ui_.VariablesTable->item(row, 1);
-    item->setText(variable->value().type() == ExpressionValue::IntegerType ? "int" : "double");
+    item->setText(variable->value().type() == ExpressionValue::ValueType::Integer ? "int" : "double");
 
     // Value
     if (createItem)
@@ -110,7 +110,8 @@ void ExpressionVariableVectorKeywordWidget::on_VariablesTable_itemChanged(QTable
         // Variable value
         case (2):
             // Determine the type of the new value so we can convert and set accordingly
-            bool isFloatingPoint = false, originalFloatingPoint = variable->value().type() == ExpressionValue::DoubleType;
+            bool isFloatingPoint = false,
+                 originalFloatingPoint = variable->value().type() == ExpressionValue::ValueType::Double;
             if (DissolveSys::isNumber(qPrintable(w->text()), isFloatingPoint))
             {
                 if (isFloatingPoint)

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -115,9 +115,9 @@ void ExpressionVariableVectorKeywordWidget::on_VariablesTable_itemChanged(QTable
             if (DissolveSys::isNumber(qPrintable(w->text()), isFloatingPoint))
             {
                 if (isFloatingPoint)
-                    variable->setValue(ExpressionValue(w->text().toDouble(), false));
+                    variable->setValue(w->text().toDouble());
                 else
-                    variable->setValue(ExpressionValue(w->text().toInt(), false));
+                    variable->setValue(w->text().toInt());
 
                 // Update the type?
                 if (isFloatingPoint != originalFloatingPoint)

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -14,7 +14,7 @@
 
 void DissolveWindow::on_ConfigurationCreateEmptyAction_triggered(bool checked)
 {
-    Configuration *newConfiguration = dissolve_.addConfiguration();
+    auto *newConfiguration = dissolve_.addConfiguration();
 
     setModified();
     fullUpdate();
@@ -26,14 +26,14 @@ void DissolveWindow::on_ConfigurationCreateSimpleRandomMixAction_triggered(bool 
     // Create a SpeciesSelectDialog and use it to get the Species to add to the mix
     SelectSpeciesDialog speciesSelectDialog(this, dissolve_.coreData(), "Select species to mix");
 
-    RefList<Species> mixSpecies = speciesSelectDialog.selectSpecies(1, -1);
+    auto mixSpecies = speciesSelectDialog.selectSpecies(1, -1);
     if (mixSpecies.nItems() == 0)
         return;
 
     // Create the Configuration and a suitable generator
-    Configuration *newConfiguration = dissolve_.addConfiguration();
-    Procedure &generator = newConfiguration->generator();
-    ParametersProcedureNode *paramsNode = new ParametersProcedureNode;
+    auto *newConfiguration = dissolve_.addConfiguration();
+    auto &generator = newConfiguration->generator();
+    auto *paramsNode = new ParametersProcedureNode;
     paramsNode->addParameter("rho", 0.1);
     generator.addRootSequenceNode(paramsNode);
     generator.addRootSequenceNode(new BoxProcedureNode);
@@ -60,15 +60,15 @@ void DissolveWindow::on_ConfigurationCreateRelativeRandomMixAction_triggered(boo
         return;
 
     // Create the Configuration and a suitable generator
-    Configuration *newConfiguration = dissolve_.addConfiguration();
-    Procedure &generator = newConfiguration->generator();
-    ParametersProcedureNode *paramsNode = new ParametersProcedureNode;
+    auto *newConfiguration = dissolve_.addConfiguration();
+    auto &generator = newConfiguration->generator();
+    auto *paramsNode = new ParametersProcedureNode;
     paramsNode->addParameter("populationA", 100);
     paramsNode->addParameter("rho", 0.1);
     generator.addRootSequenceNode(paramsNode);
     generator.addRootSequenceNode(new BoxProcedureNode);
     auto count = 0;
-    for (Species *sp : mixSpecies)
+    for (auto *sp : mixSpecies)
     {
         // Add a parameter for the ratio of this species to the first (or the population of the first)
         if (count == 0)
@@ -76,7 +76,7 @@ void DissolveWindow::on_ConfigurationCreateRelativeRandomMixAction_triggered(boo
                                                                       NodeValue("rho", paramsNode->parameters())));
         else
         {
-            std::string parameterName = fmt::format("ratio{}", char(65 + count));
+            auto parameterName = fmt::format("ratio{}", char(65 + count));
             paramsNode->addParameter(parameterName, 1);
 
             generator.addRootSequenceNode(new AddSpeciesProcedureNode(
@@ -98,7 +98,7 @@ void DissolveWindow::on_ConfigurationCreateRelativeRandomMixAction_triggered(boo
 void DissolveWindow::on_ConfigurationRenameAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a ConfigurationTab, then call its rename() function
-    MainTab *tab = ui_.MainTabs->currentTab();
+    auto *tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::ConfigurationTabType))
         return;
     tab->rename();
@@ -107,12 +107,12 @@ void DissolveWindow::on_ConfigurationRenameAction_triggered(bool checked)
 void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a ConfigurationTab
-    MainTab *tab = ui_.MainTabs->currentTab();
+    auto *tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::ConfigurationTabType))
         return;
 
     // Cast up the tab to a ConfigurationTab so we can get the ModuleLayer pointer
-    ConfigurationTab *cfgTab = dynamic_cast<ConfigurationTab *>(tab);
+    auto *cfgTab = dynamic_cast<ConfigurationTab *>(tab);
     if (!cfgTab)
         return;
 
@@ -129,7 +129,7 @@ void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
 void DissolveWindow::on_ConfigurationExportToXYZAction_triggered(bool checked)
 {
     // Get the currently-displayed Configuration
-    Configuration *cfg = ui_.MainTabs->currentConfiguration();
+    auto *cfg = ui_.MainTabs->currentConfiguration();
     if (!cfg)
         return;
 

--- a/unit/test_expression.cpp
+++ b/unit/test_expression.cpp
@@ -36,10 +36,10 @@ class ExpressionTest : public ::testing::Test
         ASSERT_EQ(result.type(), val.type());
         switch (val.type())
         {
-            case val.DoubleType:
+            case (ExpressionValue::ValueType::Double):
                 EXPECT_DOUBLE_EQ(result.asDouble(), val.asDouble());
                 break;
-            case val.IntegerType:
+            case (ExpressionValue::ValueType::Integer):
                 EXPECT_EQ(result.asInteger(), val.asInteger());
                 break;
         }


### PR DESCRIPTION
A bugfix PR to address an issue noticed by a user where the type of several parameters in a `ParameterNode` could be edited to reflect new values, but those values always reverted to the original type (typically an `int`) thereby losing any floating-point values.

The problem stemmed from `ExpressionValue` ctors which had a default argument which fixed the type of the value to that of the passed value. This has been disabled, since there are currently no use-cases in the code where it is necessary for the type to be maintained.
