### PR TITLE
Unit Test - Derivatives

### DIFF
--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -640,17 +640,17 @@ void ForceKernel::forces(const SpeciesTorsion &torsion, const std::shared_ptr<At
     // Calculate vectors, ensuring we account for minimum image
     Vec3<double> vecji, vecjk, veckl;
     if (j->cell()->mimRequired(i->cell()))
-        vecji = box_->minimumVector(j, i);
+        vecji = box_->minimumVector(i, j);
     else
-        vecji = i->r() - j->r();
+        vecji = j->r() - i->r();
     if (j->cell()->mimRequired(k->cell()))
-        vecjk = box_->minimumVector(j, k);
+        vecjk = box_->minimumVector(k, j);
     else
-        vecjk = k->r() - j->r();
+        vecjk = j->r() - k->r();
     if (k->cell()->mimRequired(l->cell()))
-        veckl = box_->minimumVector(k, l);
+        veckl = box_->minimumVector(l, k);
     else
-        veckl = l->r() - k->r();
+        veckl = k->r() - l->r();
 
     calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = torsion.force(phi_ * DEGRAD);
@@ -690,17 +690,17 @@ void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesTors
     // Calculate vectors, ensuring we account for minimum image
     Vec3<double> vecji, vecjk, veckl;
     if (j->cell()->mimRequired(i->cell()))
-        vecji = box_->minimumVector(j, i);
+        vecji = box_->minimumVector(i, j);
     else
-        vecji = i->r() - j->r();
+        vecji = j->r() - i->r();
     if (j->cell()->mimRequired(k->cell()))
-        vecjk = box_->minimumVector(j, k);
+        vecjk = box_->minimumVector(k, j);
     else
-        vecjk = k->r() - j->r();
+        vecjk = j->r() - k->r();
     if (k->cell()->mimRequired(l->cell()))
-        veckl = box_->minimumVector(k, l);
+        veckl = box_->minimumVector(l, k);
     else
-        veckl = l->r() - k->r();
+        veckl = k->r() - l->r();
 
     calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = torsion.force(phi_ * DEGRAD);
@@ -743,8 +743,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesTors
 void ForceKernel::forces(const SpeciesTorsion &torsion)
 {
     // Calculate vectors, ensuring we account for minimum image
-    const Vec3<double> vecji = torsion.i()->r() - torsion.j()->r(), vecjk = torsion.k()->r() - torsion.j()->r(),
-                       veckl = torsion.l()->r() - torsion.k()->r();
+    const Vec3<double> vecji = torsion.j()->r() - torsion.i()->r(), vecjk = torsion.j()->r() - torsion.k()->r(),
+                       veckl = torsion.k()->r() - torsion.l()->r();
 
     calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = torsion.force(phi_ * DEGRAD);
@@ -784,17 +784,17 @@ void ForceKernel::forces(const SpeciesImproper &improper, const std::shared_ptr<
     // Calculate vectors, ensuring we account for minimum image
     Vec3<double> vecji, vecjk, veckl;
     if (j->cell()->mimRequired(i->cell()))
-        vecji = box_->minimumVector(j, i);
+        vecji = box_->minimumVector(i, j);
     else
-        vecji = i->r() - j->r();
+        vecji = j->r() - i->r();
     if (j->cell()->mimRequired(k->cell()))
-        vecjk = box_->minimumVector(j, k);
+        vecjk = box_->minimumVector(k, j);
     else
-        vecjk = k->r() - j->r();
+        vecjk = j->r() - k->r();
     if (k->cell()->mimRequired(l->cell()))
-        veckl = box_->minimumVector(k, l);
+        veckl = box_->minimumVector(l, k);
     else
-        veckl = l->r() - k->r();
+        veckl = k->r() - l->r();
 
     calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = improper.force(phi_ * DEGRAD);
@@ -834,17 +834,17 @@ void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesImpr
     // Calculate vectors, ensuring we account for minimum image
     Vec3<double> vecji, vecjk, veckl;
     if (j->cell()->mimRequired(i->cell()))
-        vecji = box_->minimumVector(j, i);
+        vecji = box_->minimumVector(i, j);
     else
-        vecji = i->r() - j->r();
+        vecji = j->r() - i->r();
     if (j->cell()->mimRequired(k->cell()))
-        vecjk = box_->minimumVector(j, k);
+        vecjk = box_->minimumVector(k, j);
     else
-        vecjk = k->r() - j->r();
+        vecjk = j->r() - k->r();
     if (k->cell()->mimRequired(l->cell()))
-        veckl = box_->minimumVector(k, l);
+        veckl = box_->minimumVector(l, k);
     else
-        veckl = l->r() - k->r();
+        veckl = k->r() - l->r();
 
     calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = imp.force(phi_ * DEGRAD);
@@ -887,8 +887,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> onlyThis, const SpeciesImpr
 void ForceKernel::forces(const SpeciesImproper &imp)
 {
     // Calculate vectors, ensuring we account for minimum image
-    const Vec3<double> vecji = imp.i()->r() - imp.j()->r(), vecjk = imp.k()->r() - imp.j()->r(),
-                       veckl = imp.l()->r() - imp.k()->r();
+    const Vec3<double> vecji = imp.j()->r() - imp.i()->r(), vecjk = imp.j()->r() - imp.k()->r(),
+                       veckl = imp.k()->r() - imp.l()->r();
 
     calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = imp.force(phi_ * DEGRAD);

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -611,7 +611,7 @@ void ForceKernel::calculateTorsionParameters(const Vec3<double> vecji, const Vec
      *	------------- = rij[cp(n+2)] * U[cp(n+1)] - rij[cp(n+1)] * U[cp(n+2)]
      *	d rkj[n]
      *
-     * where cp is a cylic permutation spanning {0,1,2} == {x,y,z}, and U[n] is a unit vector in the n direction.
+     * where cp is a cyclic permutation spanning {0,1,2} == {x,y,z}, and U[n] is a unit vector in the n direction.
      * So,
      *	d (rij x rkj)
      *	------------- = rij[2] * U[1] - rij[1] * U[2]

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -602,11 +602,7 @@ void ForceKernel::calculateTorsionParameters(const Vec3<double> vecji, const Vec
     const auto magxpj = xpj.magAndNormalise();
     const auto magxpk = xpk.magAndNormalise();
     auto dp = xpj.dp(xpk);
-    if (dp < -1.0)
-        dp = -1.0;
-    else if (dp > 1.0)
-        dp = 1.0;
-    phi = acos(dp);
+    phi = atan2(vecjk.dp(xpj * xpk) / vecjk.magnitude(), dp);
 
     /*
      * Construct derivatives of perpendicular axis (cross product) w.r.t. component vectors.

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -258,7 +258,7 @@ double SpeciesAngle::energy(double angleInDegrees) const
          * 2 : Equilibrium angle, eq (degrees)
          * 3 : Sign, s
          */
-        return params[0] * (1.0 + params[3] * cos(params[1] * angleInDegrees / DEGRAD - params[2]));
+        return params[0] * (1.0 + params[3] * cos(params[1] * angleInDegrees / DEGRAD - params[2] / DEGRAD));
     }
     else if (form() == SpeciesAngle::Cos2Form)
     {

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -244,7 +244,7 @@ double SpeciesAngle::energy(double angleInDegrees) const
          * 0 : Force constant, k
          * 1 : Equilibrium angle, eq (degrees)
          */
-        double delta = (angleInDegrees - params[1]) / DEGRAD;
+        const auto delta = (angleInDegrees - params[1]) / DEGRAD;
         return 0.5 * params[0] * delta * delta;
     }
     else if (form() == SpeciesAngle::CosineForm)

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -282,34 +282,42 @@ double SpeciesAngle::energy(double angleInDegrees) const
 // Return force multiplier for specified angle
 double SpeciesAngle::force(double angleInDegrees) const
 {
+    /*
+     * Force of any angle form is given via the chain rule:
+     *
+     *                    dU     dTheta
+     *     F(theta) = - ------ ----------
+     *                  dTheta cos(theta)
+     *
+     *                  dU       1
+     *              = ------ ---------
+     *                dTheta sin(theta)
+     */
+
     // Get pointer to relevant parameters array
     const auto &params = parameters();
 
     // Convert angle to radians
     const auto angleInRadians = angleInDegrees / DEGRAD;
 
-    // Set initial derivative of angle w.r.t. cos(angle) for chain rule
-    const auto dTheta_dCosTheta = -1.0 / sin(angleInDegrees / DEGRAD);
-
     if (form() == SpeciesAngle::NoForm)
         return 0.0;
     else if (form() == SpeciesAngle::HarmonicForm)
     {
         /*
-         * dU/d(theta) = k * (theta - eq)
+         * dU/dTheta = k * (theta - eq)
          *
          * Parameters:
          * 0 : Force constant, k
          * 1 : Equilibrium angle, eq (degrees)
          */
 
-        // Chain rule - multiply by derivative of energy w.r.t. angle (harmonic form)
-        return dTheta_dCosTheta * -params[0] * ((angleInDegrees - params[1]) / DEGRAD);
+        return params[0] * ((angleInDegrees - params[1]) / DEGRAD) / sin(angleInRadians);
     }
     else if (form() == SpeciesAngle::CosineForm)
     {
         /*
-         * dU/d(theta) = -forcek * n * s * sin(n*theta - eq)
+         * dU/dTheta = -k * n * s * sin(n*theta - eq)
          *
          * Parameters:
          * 0 : Force constant, k
@@ -317,12 +325,13 @@ double SpeciesAngle::force(double angleInDegrees) const
          * 2 : Equilibrium angle, eq (degrees)
          * 3 : Sign, s
          */
-        return dTheta_dCosTheta * -params[0] * params[1] * params[3] * sin(params[1] * angleInRadians - params[2] / DEGRAD);
+
+        return -params[0] * params[1] * params[3] * sin(params[1] * angleInRadians - params[2] / DEGRAD) / sin(angleInRadians);
     }
     else if (form() == SpeciesAngle::Cos2Form)
     {
         /*
-         * dU/d(theta) = -forcek * (c1 * sin(theta) + 2 * c2 * sin(2*theta))
+         * dU/dTheta = -k * (c1 * sin(theta) + 2 * c2 * sin(2*theta))
          *
          * Parameters:
          * 0 : Force constant, k
@@ -330,7 +339,9 @@ double SpeciesAngle::force(double angleInDegrees) const
          * 2 : Constant C1
          * 3 : Constant C2
          */
-        return dTheta_dCosTheta * -params[0] * (params[2] * sin(angleInRadians) + 2.0 * params[3] * sin(2.0 * angleInRadians));
+
+        return -params[0] * (params[2] * sin(angleInRadians) + 2.0 * params[3] * sin(2.0 * angleInRadians)) /
+               sin(angleInRadians);
     }
 
     Messenger::error("Functional form of SpeciesAngle term not accounted for, so can't calculate force.\n");

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -301,6 +301,8 @@ double SpeciesBond::force(double distance) const
     else if (form() == SpeciesBond::HarmonicForm)
     {
         /*
+         * V = -k * (r - eq)
+         *
          * Parameters:
          * 0 : force constant
          * 1 : equilibrium distance
@@ -317,7 +319,7 @@ double SpeciesBond::force(double distance) const
          * 1 : equilibrium distance
          * 2 : omega squared (LOCAL parameter)
          */
-        return -2.0 * params[0] * (distance - params[1]);
+        return -2.0 * params[0] * (distance - params[1]) / params[2];
     }
 
     Messenger::error("Functional form of SpeciesBond term not accounted for, so can't calculate force.\n");

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -369,10 +369,10 @@ double SpeciesTorsion::energy(double angleInDegrees, int form, const std::vector
     else if (form == SpeciesTorsion::UFFCosineForm)
     {
         /*
-         * U(phi) = 0.5 * V * (1 - cos(n*eq) * cos(n*phi))
+         * U(phi) = 0.5 * k * (1 - cos(n*eq) * cos(n*phi))
          *
          * Parameters:
-         * 0 : Force constant, V
+         * 0 : Force constant, k
          * 1 : Periodicity, n
          * 2 : Equilibrium angle, eq (degrees)
          */
@@ -392,16 +392,31 @@ double SpeciesTorsion::energy(double angleInDegrees) const
 // Return force multiplier for specified angle and functional form, given supplied parameters
 double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<double> &params)
 {
-    // Convert torsion angle from degrees to radians, and calculate derivative w.r.t. change in torsion angle
+    /*
+     * Force of any angle form is given via the chain rule:
+     *
+     *                 dU    dPhi
+     *     F(phi) = - ---- --------
+     *                dPhi cos(phi)
+     *
+     *               dU     1
+     *            = ---- --------
+     *              dPhi sin(phi)
+     */
+
+    // Convert torsion angle from degrees to radians, and calculate derivative w.r.t. change in torsion angle, avoiding step in
+    // 1/sin(phi)
     double phi = angleInDegrees / DEGRAD;
-    double dphi_dcosphi = (phi < 1E-8 ? 0.0 : -1.0 / sin(phi));
+    auto sinPhi = sin(phi);
+    // TODO Avoid singularities (#542)
+    double dphi_dcosphi = -1.0 / DissolveMath::sgn(std::max(1.0e-8, fabs(sinPhi)), sinPhi);
 
     if (form == SpeciesTorsion::NoForm)
         return 0.0;
     else if (form == SpeciesTorsion::CosineForm)
     {
         /*
-         * dU/dphi = k * n * s * -sin(n*phi - eq)
+         * dU/dphi = -k * n * s * sin(n*phi - eq)
          *
          * Parameters:
          * 0 : Force constant 'k'
@@ -409,7 +424,8 @@ double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<
          * 2 : Equilibrium angle (degrees)
          * 3 : Sign 's'
          */
-        return dphi_dcosphi * params[1] * params[0] * params[3] * -sin(params[1] * phi - (params[2] / DEGRAD));
+
+        return params[0] * params[1] * params[3] * sin(params[1] * phi - (params[2] / DEGRAD)) * dphi_dcosphi;
     }
     else if (form == SpeciesTorsion::Cos3Form)
     {
@@ -421,8 +437,8 @@ double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<
          * 1 : force constant k2
          * 2 : force constant k3
          */
-        return dphi_dcosphi * 0.5 *
-               (-params[0] * sin(phi) + 2.0 * params[1] * sin(2.0 * phi) - 3.0 * params[2] * sin(3.0 * phi));
+        return -0.5 * (-params[0] * sin(phi) + 2.0 * params[1] * sin(2.0 * phi) - 3.0 * params[2] * sin(3.0 * phi)) *
+               dphi_dcosphi;
     }
     else if (form == SpeciesTorsion::Cos3CForm)
     {
@@ -435,8 +451,8 @@ double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<
          * 2 : force constant k2
          * 3 : force constant k3
          */
-        return dphi_dcosphi * 0.5 *
-               (-params[1] * sin(phi) + 2.0 * params[2] * sin(2.0 * phi) - 3.0 * params[3] * sin(3.0 * phi));
+        return -0.5 * (-params[1] * sin(phi) + 2.0 * params[2] * sin(2.0 * phi) - 3.0 * params[3] * sin(3.0 * phi)) *
+               dphi_dcosphi;
     }
     else if (form == SpeciesTorsion::Cos4Form)
     {
@@ -449,16 +465,17 @@ double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<
          * 2 : force constant k3
          * 3 : force constant k4
          */
-        return dphi_dcosphi * 0.5 *
+        return -0.5 *
                (-params[0] * sin(phi) + 2.0 * params[1] * sin(2.0 * phi) - 3.0 * params[2] * sin(3.0 * phi) +
-                4.0 * params[3] * sin(4.0 * phi));
+                4.0 * params[3] * sin(4.0 * phi)) *
+               dphi_dcosphi;
     }
     else if (form == SpeciesTorsion::CosNForm)
     {
         /*
-         *           1
-         * U(phi) = SUM  -k(n) * ( n * sin( n * phi ) )
-         *           n
+         *            1
+         * dU/dphi = SUM  -k(n) * n * sin( n * phi )
+         *            n
          *
          * Parameters:
          * 0 : force constant k1
@@ -466,21 +483,21 @@ double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<
          * 2 : ...
          * n-1 : force constant kn
          */
-        auto result = 0.0;
+        auto dU_dphi = 0.0;
         auto c = 1;
         for (auto n = 0; n < params.size(); ++n)
         {
-            result -= params[n] * (c * sin(c * phi));
+            dU_dphi -= params[n] * (c * sin(c * phi));
             ++c;
         }
-        return dphi_dcosphi * result;
+        return -dU_dphi * dphi_dcosphi;
     }
     else if (form == SpeciesTorsion::CosNCForm)
     {
         /*
-         *           0
-         * U(phi) = SUM  -k(n) * ( n + sin( n * phi ) )
-         *           n
+         *            0
+         * dU/dphi = SUM  -k(n) * n * sin( n * phi )
+         *            n
          *
          * Parameters:
          * 0 : force constant k0
@@ -488,23 +505,24 @@ double SpeciesTorsion::force(double angleInDegrees, int form, const std::vector<
          * 2 : ...
          * n : force constant kn
          */
-        auto result = 0.0;
+        auto dU_dphi = 0.0;
         for (auto n = 1; n < params.size(); ++n)
-            result -= params[n] * (n * sin(n * phi));
+            dU_dphi -= params[n] * (n * sin(n * phi));
 
-        return dphi_dcosphi * result;
+        return -dU_dphi * dphi_dcosphi;
     }
     else if (form == SpeciesTorsion::UFFCosineForm)
     {
         /*
-         * dU/d(phi) = 0.5 * V * cos(n*eq) * n * sin(n*phi)
+         * dU/d(phi) = 0.5 * k * cos(n*eq) * n * sin(n*phi)
          *
          * Parameters:
-         * 0 : Force constant, V
+         * 0 : Force constant, k
          * 1 : Periodicity, n
          * 2 : Equilibrium angle, eq (degrees)
          */
-        return 0.5 * params[0] * cos(params[1] * params[2] / DEGRAD) * params[1] * sin(params[1] * phi);
+
+        return -0.5 * params[0] * params[1] * cos(params[1] * params[2] / DEGRAD) * sin(params[1] * phi) * dphi_dcosphi;
     }
 
     Messenger::error("Functional form of torsion / improper term not accounted for, so can't calculate force.\n");

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -258,9 +258,9 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                         l = molN->atom(torsion.indexL());
 
                         // Calculate vectors, ensuring we account for minimum image
-                        vecji = box->minimumVector(j, i);
-                        vecjk = box->minimumVector(j, k);
-                        veckl = box->minimumVector(k, l);
+                        vecji = box->minimumVector(i, j);
+                        vecjk = box->minimumVector(k, j);
+                        veckl = box->minimumVector(l, k);
 
                         // Calculate torsion force parameters
                         ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl, phi, dxpj_dij, dxpj_dkj, dxpk_dkj,
@@ -305,9 +305,9 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                         l = molN->atom(imp.indexL());
 
                         // Calculate vectors, ensuring we account for minimum image
-                        vecji = box->minimumVector(j, i);
-                        vecjk = box->minimumVector(j, k);
-                        veckl = box->minimumVector(k, l);
+                        vecji = box->minimumVector(i, j);
+                        vecjk = box->minimumVector(k, j);
+                        veckl = box->minimumVector(l, k);
 
                         // Calculate improper force parameters
                         ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl, phi, dxpj_dij, dxpj_dkj, dxpk_dkj,

--- a/tests/energyforce2/full.txt
+++ b/tests/energyforce2/full.txt
@@ -161,7 +161,7 @@ Module Forces
   Configuration  'Liquid'
   TestReference  dlpoly  '../_data/dlpoly/hexane200/REVCON'
   EndTestReference
-  TestThreshold  4.0
+  TestThreshold  0.4
 EndModule
 
 Module SanityCheck

--- a/tests/energyforce2/one.txt
+++ b/tests/energyforce2/one.txt
@@ -160,7 +160,7 @@ Module Forces
   Configuration  'Liquid'
   TestReference  dlpoly  '../_data/dlpoly/hexane1/REVCON'
   EndTestReference
-  TestThreshold  0.50
+  TestThreshold  0.4
 EndModule
 
 Module SanityCheck

--- a/tests/energyforce2/torsions.txt
+++ b/tests/energyforce2/torsions.txt
@@ -159,7 +159,7 @@ Module Forces
   Configuration  'Liquid'
   TestReference  dlpoly  '../_data/dlpoly/hexane200_torsions/REVCON'
   EndTestReference
-  TestThreshold  0.12
+  TestThreshold  1.0e-6
 EndModule
 
 Module SanityCheck

--- a/tests/energyforce2/two.txt
+++ b/tests/energyforce2/two.txt
@@ -161,7 +161,7 @@ Module Forces
   Configuration  'Liquid'
   TestReference  dlpoly  '../_data/dlpoly/hexane2/REVCON'
   EndTestReference
-  TestThreshold  0.37
+  TestThreshold  0.4
 EndModule
 
 Module SanityCheck

--- a/unit/test_derivatives.cpp
+++ b/unit/test_derivatives.cpp
@@ -33,7 +33,8 @@ class DerivativesTest : public ::testing::Test
     double tolerance_;
 
     protected:
-    // Test supplied intramolecular function over the supplied range, comparing numerical and analytical derivatives at each point
+    // Test supplied intramolecular function over the supplied range, comparing numerical and analytical derivatives at each
+    // point
     template <class T>
     void intraTest(T &intraTerm, int form, const std::vector<double> &params, double xMin, double xMax, double xDelta,
                    bool angular = false)

--- a/unit/test_derivatives.cpp
+++ b/unit/test_derivatives.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "classes/speciesangle.h"
+#include "classes/speciesatom.h"
+#include "classes/speciesbond.h"
+#include "classes/speciesimproper.h"
+#include "classes/speciestorsion.h"
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+class DerivativesTest : public ::testing::Test
+{
+    public:
+    DerivativesTest() : bond_(&i_, &j_), angle_(&i_, &j_, &k_), torsion_(&i_, &j_, &k_, &l_), tolerance_(1.0e-6)
+    {
+        i_.set(Elements::H, Vec3<double>(-1.0, 1.0, 0.0));
+        j_.set(Elements::C, Vec3<double>(-1.0, 0.0, 0.0));
+        k_.set(Elements::C, Vec3<double>(1.0, 0.0, 0.0));
+        l_.set(Elements::O, Vec3<double>(1.0, 1.0, 0.0));
+    }
+
+    protected:
+    // Atoms for use in intramolecular terms
+    SpeciesAtom i_, j_, k_, l_;
+    // Intramolecular objects
+    SpeciesBond bond_;
+    SpeciesAngle angle_;
+    SpeciesTorsion torsion_;
+    // Tolerance for value comparison
+    double tolerance_;
+
+    protected:
+    // Test supplied bond function over the supplied range, comparing numerical and analytical derivatives at each point
+    template <class T>
+    void intraTest(T &intraTerm, int form, const std::vector<double> &params, double xMin, double xMax, double xDelta,
+                   bool angular = false)
+    {
+        intraTerm.setForm(form);
+        intraTerm.setParameters(params);
+        intraTerm.setUp();
+
+        auto x = xMin;
+        const auto dx = xDelta / 100.0;
+        while (x <= xMax)
+        {
+            // Calculate derivative
+            auto E0 = intraTerm.energy(x - dx);
+            auto E1 = intraTerm.energy(x + dx);
+            auto grad = (E1 - E0) / (2.0 * dx);
+
+            // Compare analytic value - for angle terms, convert gradient to radians and remove factor of -1.0/sin(x) from force
+            if (angular)
+                ASSERT_NEAR(-grad * DEGRAD, intraTerm.force(x) * -sin(x / DEGRAD), tolerance_);
+            else
+                ASSERT_NEAR(-grad, intraTerm.force(x), tolerance_);
+
+            x += xDelta;
+        }
+    }
+};
+
+TEST_F(DerivativesTest, BondFunctions)
+{
+    tolerance_ = 1.0e-8;
+
+    // Harmonic form (parameters = k, eq)
+    intraTest<SpeciesBond>(bond_, SpeciesBond::HarmonicForm, {4184.0, 1.5}, 1.0, 2.0, 0.01);
+
+    // EPSR form (parameters = C/2, eq)
+    intraTest<SpeciesBond>(bond_, SpeciesBond::EPSRForm, {65.0, 1.1}, 0.6, 1.6, 0.01);
+}
+
+TEST_F(DerivativesTest, AngleFunctions)
+{
+    tolerance_ = 5.0e-7;
+
+    // Harmonic form (parameters = k, eq)
+    intraTest<SpeciesAngle>(angle_, SpeciesAngle::HarmonicForm, {418.4, 109.5}, 80.0, 120.0, 0.1, true);
+
+    // Cosine form (parameters = k, n, eq, s)
+    intraTest<SpeciesAngle>(angle_, SpeciesAngle::CosineForm, {418.4, 2.0, 95.0, -1}, 70.0, 120.0, 0.1, true);
+
+    // Cos2 form (parameters = k, C0, C1, C2)
+    intraTest<SpeciesAngle>(angle_, SpeciesAngle::Cos2Form, {418.4, 0.5, 2.0 / 3.0, 0.7}, 70.0, 120.0, 0.1, true);
+}
+
+TEST_F(DerivativesTest, TorsionFunctions)
+{
+    tolerance_ = 1.0e-5;
+    // TODO Increase range once #542 is addressed
+    auto thetaMin = 1.0, thetaMax = 179.0;
+
+    // Cosine form (parameters = k, n, eq, s)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosineForm, {41.84, 3.0, 120.0, 1.0}, thetaMin, thetaMax, 1.0, true);
+
+    // Cos3 form (parameters = k1, k2, k3)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::Cos3Form, {0.0, 11.4, 0.0}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::Cos3Form, {19.0, 1.2, 5.6}, thetaMin, thetaMax, 1.0, true);
+
+    // Cos3C form (parameters = k0, k1, k2, k3)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::Cos3CForm, {4.0, 0.0, 11.4, 0.0}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::Cos3CForm, {2.2, 19.0, 1.2, 5.6}, thetaMin, thetaMax, 1.0, true);
+
+    // Cos4 form (parameters = k1, k2, k3, k4)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::Cos4Form, {4.0, 0.0, 11.4, 0.0}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::Cos4Form, {2.2, 19.0, 1.2, 5.6}, thetaMin, thetaMax, 1.0, true);
+
+    // CosN form (parameters = k1, ..., kn)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosNForm, {4.0}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosNForm, {1.8, 15.9}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosNForm, {1.8, 15.9, 0.4, 5.7, 7.8}, thetaMin, thetaMax, 1.0, true);
+
+    // CosNC form (parameters = k0, ..., kn)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosNCForm, {1.04, 4.0}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosNCForm, {2.89, 1.8, 15.9}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::CosNCForm, {98.0, 1.8, 15.9, 0.4, 5.7, 7.8}, thetaMin, thetaMax, 1.0,
+                              true);
+
+    // UFF Cosine form (parameters = k, n, eq)
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::UFFCosineForm, {10.7, 3, 109.5}, thetaMin, thetaMax, 1.0, true);
+    intraTest<SpeciesTorsion>(torsion_, SpeciesTorsion::UFFCosineForm, {19.0, 4, 90.0}, thetaMin, thetaMax, 1.0, true);
+}
+
+} // namespace UnitTest

--- a/unit/test_derivatives.cpp
+++ b/unit/test_derivatives.cpp
@@ -33,7 +33,7 @@ class DerivativesTest : public ::testing::Test
     double tolerance_;
 
     protected:
-    // Test supplied bond function over the supplied range, comparing numerical and analytical derivatives at each point
+    // Test supplied intramolecular function over the supplied range, comparing numerical and analytical derivatives at each point
     template <class T>
     void intraTest(T &intraTerm, int form, const std::vector<double> &params, double xMin, double xMax, double xDelta,
                    bool angular = false)


### PR DESCRIPTION
This PR implements a unit test ensuring consistency between calculated intramolecular energies and the associated forces. Each functional form available is used to calculate numerical gradients over a certain discrete set of points, and these gradients are compared with those from the implemented analytic forms.

Once implemented, the unit test revealed a couple of errors in some analytic derivatives, which have been corrected. In particular, calculation of torsional (dihedral) forces typically returned values of the wrong sign, however the actual calculated forces agree with those in the system tests owing to the change of sign being reversed in the torsional and improper `ForceKernel` routines. This in turn has been corrected by reversing the vectors between the involved atoms, making it more consistent with, for instance, DL_POLY.

A similar unit test should be implemented for pair potentials, but this will be left for a separate PR.