### PR TITLE
Tidy Modules

### DIFF
--- a/src/modules/analyse/analyse.h
+++ b/src/modules/analyse/analyse.h
@@ -14,7 +14,7 @@ class AnalyseModule : public Module
 {
     public:
     AnalyseModule();
-    ~AnalyseModule();
+    ~AnalyseModule() = default;
 
     /*
      * Instances

--- a/src/modules/analyse/analyse.h
+++ b/src/modules/analyse/analyse.h
@@ -14,41 +14,41 @@ class AnalyseModule : public Module
 {
     public:
     AnalyseModule();
-    ~AnalyseModule() = default;
+    ~AnalyseModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Function Data
@@ -66,5 +66,5 @@ class AnalyseModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/analyse/core.cpp
+++ b/src/modules/analyse/core.cpp
@@ -9,8 +9,6 @@ AnalyseModule::AnalyseModule() : Module(nRequiredTargets()), analyser_(Procedure
     initialise();
 }
 
-AnalyseModule::~AnalyseModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/atomshake/atomshake.h
+++ b/src/modules/atomshake/atomshake.h
@@ -17,46 +17,46 @@ class AtomShakeModule : public Module
 
     public:
     AtomShakeModule();
-    ~AtomShakeModule() = default;
+    ~AtomShakeModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * GUI Widget
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/atomshake/atomshake.h
+++ b/src/modules/atomshake/atomshake.h
@@ -17,7 +17,7 @@ class AtomShakeModule : public Module
 
     public:
     AtomShakeModule();
-    ~AtomShakeModule();
+    ~AtomShakeModule() = default;
 
     /*
      * Instances

--- a/src/modules/atomshake/core.cpp
+++ b/src/modules/atomshake/core.cpp
@@ -9,8 +9,6 @@ AtomShakeModule::AtomShakeModule() : Module(nRequiredTargets())
     initialise();
 }
 
-AtomShakeModule::~AtomShakeModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -13,7 +13,7 @@ class BenchmarkModule : public Module
 {
     public:
     BenchmarkModule();
-    ~BenchmarkModule();
+    ~BenchmarkModule() = default;
 
     /*
      * Instances

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -13,41 +13,41 @@ class BenchmarkModule : public Module
 {
     public:
     BenchmarkModule();
-    ~BenchmarkModule() = default;
+    ~BenchmarkModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions
@@ -62,5 +62,5 @@ class BenchmarkModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/benchmark/core.cpp
+++ b/src/modules/benchmark/core.cpp
@@ -13,8 +13,6 @@ BenchmarkModule::BenchmarkModule() : Module(nRequiredTargets())
     initialise();
 }
 
-BenchmarkModule::~BenchmarkModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -16,7 +16,7 @@ class BraggModule : public Module
 {
     public:
     BraggModule();
-    ~BraggModule();
+    ~BraggModule() = default;
 
     /*
      * Instances

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -16,41 +16,41 @@ class BraggModule : public Module
 {
     public:
     BraggModule();
-    ~BraggModule() = default;
+    ~BraggModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Members / Functions
@@ -70,5 +70,5 @@ class BraggModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/bragg/core.cpp
+++ b/src/modules/bragg/core.cpp
@@ -9,8 +9,6 @@ BraggModule::BraggModule() : Module(nRequiredTargets())
     initialise();
 }
 
-BraggModule::~BraggModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_angle/angle.h
+++ b/src/modules/calculate_angle/angle.h
@@ -21,7 +21,7 @@ class CalculateAngleModule : public Module
 {
     public:
     CalculateAngleModule();
-    ~CalculateAngleModule();
+    ~CalculateAngleModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_angle/angle.h
+++ b/src/modules/calculate_angle/angle.h
@@ -21,43 +21,43 @@ class CalculateAngleModule : public Module
 {
     public:
     CalculateAngleModule();
-    ~CalculateAngleModule() = default;
+    ~CalculateAngleModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -101,5 +101,5 @@ class CalculateAngleModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calculate_angle/core.cpp
+++ b/src/modules/calculate_angle/core.cpp
@@ -13,8 +13,6 @@ CalculateAngleModule::CalculateAngleModule() : Module(nRequiredTargets()), analy
     initialise();
 }
 
-CalculateAngleModule::~CalculateAngleModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_avgmol/avgmol.h
+++ b/src/modules/calculate_avgmol/avgmol.h
@@ -14,7 +14,7 @@ class CalculateAvgMolModule : public Module
 {
     public:
     CalculateAvgMolModule();
-    ~CalculateAvgMolModule();
+    ~CalculateAvgMolModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_avgmol/avgmol.h
+++ b/src/modules/calculate_avgmol/avgmol.h
@@ -14,43 +14,43 @@ class CalculateAvgMolModule : public Module
 {
     public:
     CalculateAvgMolModule();
-    ~CalculateAvgMolModule() = default;
+    ~CalculateAvgMolModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -76,5 +76,5 @@ class CalculateAvgMolModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calculate_avgmol/core.cpp
+++ b/src/modules/calculate_avgmol/core.cpp
@@ -13,8 +13,6 @@ CalculateAvgMolModule::CalculateAvgMolModule() : Module(nRequiredTargets())
     initialise();
 }
 
-CalculateAvgMolModule::~CalculateAvgMolModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_axisangle/axisangle.h
+++ b/src/modules/calculate_axisangle/axisangle.h
@@ -19,43 +19,43 @@ class CalculateAxisAngleModule : public Module
 {
     public:
     CalculateAxisAngleModule();
-    ~CalculateAxisAngleModule() = default;
+    ~CalculateAxisAngleModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -85,5 +85,5 @@ class CalculateAxisAngleModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calculate_axisangle/axisangle.h
+++ b/src/modules/calculate_axisangle/axisangle.h
@@ -19,7 +19,7 @@ class CalculateAxisAngleModule : public Module
 {
     public:
     CalculateAxisAngleModule();
-    ~CalculateAxisAngleModule();
+    ~CalculateAxisAngleModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_axisangle/core.cpp
+++ b/src/modules/calculate_axisangle/core.cpp
@@ -13,8 +13,6 @@ CalculateAxisAngleModule::CalculateAxisAngleModule() : Module(nRequiredTargets()
     initialise();
 }
 
-CalculateAxisAngleModule::~CalculateAxisAngleModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_cn/cn.h
+++ b/src/modules/calculate_cn/cn.h
@@ -16,7 +16,7 @@ class CalculateCNModule : public Module
 {
     public:
     CalculateCNModule();
-    ~CalculateCNModule();
+    ~CalculateCNModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_cn/cn.h
+++ b/src/modules/calculate_cn/cn.h
@@ -16,41 +16,41 @@ class CalculateCNModule : public Module
 {
     public:
     CalculateCNModule();
-    ~CalculateCNModule() = default;
+    ~CalculateCNModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -78,5 +78,5 @@ class CalculateCNModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calculate_cn/core.cpp
+++ b/src/modules/calculate_cn/core.cpp
@@ -13,8 +13,6 @@ CalculateCNModule::CalculateCNModule() : Module(nRequiredTargets()), analyser_(P
     initialise();
 }
 
-CalculateCNModule::~CalculateCNModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_dangle/core.cpp
+++ b/src/modules/calculate_dangle/core.cpp
@@ -13,8 +13,6 @@ CalculateDAngleModule::CalculateDAngleModule() : Module(nRequiredTargets()), ana
     initialise();
 }
 
-CalculateDAngleModule::~CalculateDAngleModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_dangle/dangle.h
+++ b/src/modules/calculate_dangle/dangle.h
@@ -19,43 +19,43 @@ class CalculateDAngleModule : public Module
 {
     public:
     CalculateDAngleModule();
-    ~CalculateDAngleModule() = default;
+    ~CalculateDAngleModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -87,5 +87,5 @@ class CalculateDAngleModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calculate_dangle/dangle.h
+++ b/src/modules/calculate_dangle/dangle.h
@@ -19,7 +19,7 @@ class CalculateDAngleModule : public Module
 {
     public:
     CalculateDAngleModule();
-    ~CalculateDAngleModule();
+    ~CalculateDAngleModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_rdf/core.cpp
+++ b/src/modules/calculate_rdf/core.cpp
@@ -13,8 +13,6 @@ CalculateRDFModule::CalculateRDFModule() : Module(nRequiredTargets()), analyser_
     initialise();
 }
 
-CalculateRDFModule::~CalculateRDFModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_rdf/rdf.h
+++ b/src/modules/calculate_rdf/rdf.h
@@ -17,43 +17,43 @@ class CalculateRDFModule : public Module
 {
     public:
     CalculateRDFModule();
-    ~CalculateRDFModule() = default;
+    ~CalculateRDFModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -83,5 +83,5 @@ class CalculateRDFModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calculate_rdf/rdf.h
+++ b/src/modules/calculate_rdf/rdf.h
@@ -17,7 +17,7 @@ class CalculateRDFModule : public Module
 {
     public:
     CalculateRDFModule();
-    ~CalculateRDFModule();
+    ~CalculateRDFModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_sdf/core.cpp
+++ b/src/modules/calculate_sdf/core.cpp
@@ -13,8 +13,6 @@ CalculateSDFModule::CalculateSDFModule() : Module(nRequiredTargets()), analyser_
     initialise();
 }
 
-CalculateSDFModule::~CalculateSDFModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/calculate_sdf/sdf.h
+++ b/src/modules/calculate_sdf/sdf.h
@@ -18,7 +18,7 @@ class CalculateSDFModule : public Module
 {
     public:
     CalculateSDFModule();
-    ~CalculateSDFModule();
+    ~CalculateSDFModule() = default;
 
     /*
      * Instances

--- a/src/modules/calculate_sdf/sdf.h
+++ b/src/modules/calculate_sdf/sdf.h
@@ -18,41 +18,41 @@ class CalculateSDFModule : public Module
 {
     public:
     CalculateSDFModule();
-    ~CalculateSDFModule() = default;
+    ~CalculateSDFModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data
@@ -76,5 +76,5 @@ class CalculateSDFModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/calibration/calibration.h
+++ b/src/modules/calibration/calibration.h
@@ -18,27 +18,27 @@ class CalibrationModule : public Module
 
     public:
     CalibrationModule();
-    ~CalibrationModule() = default;
+    ~CalibrationModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
@@ -55,14 +55,14 @@ class CalibrationModule : public Module
 
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Members / Functions
@@ -80,7 +80,7 @@ class CalibrationModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };
 
 // Interface Class for Complex Cost Functions

--- a/src/modules/calibration/calibration.h
+++ b/src/modules/calibration/calibration.h
@@ -18,7 +18,7 @@ class CalibrationModule : public Module
 
     public:
     CalibrationModule();
-    ~CalibrationModule();
+    ~CalibrationModule() = default;
 
     /*
      * Instances

--- a/src/modules/calibration/core.cpp
+++ b/src/modules/calibration/core.cpp
@@ -9,8 +9,6 @@ CalibrationModule::CalibrationModule() : Module(nRequiredTargets())
     initialise();
 }
 
-CalibrationModule::~CalibrationModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -18,41 +18,41 @@ class ChecksModule : public Module
 
     public:
     ChecksModule();
-    ~ChecksModule() = default;
+    ~ChecksModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Checks

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -18,7 +18,7 @@ class ChecksModule : public Module
 
     public:
     ChecksModule();
-    ~ChecksModule();
+    ~ChecksModule() = default;
 
     /*
      * Instances

--- a/src/modules/checks/core.cpp
+++ b/src/modules/checks/core.cpp
@@ -9,8 +9,6 @@ ChecksModule::ChecksModule() : Module(nRequiredTargets())
     initialise();
 }
 
-ChecksModule::~ChecksModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/checkspecies/checkspecies.h
+++ b/src/modules/checkspecies/checkspecies.h
@@ -18,41 +18,41 @@ class CheckSpeciesModule : public Module
 {
     public:
     CheckSpeciesModule();
-    ~CheckSpeciesModule() = default;
+    ~CheckSpeciesModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions / Data

--- a/src/modules/checkspecies/checkspecies.h
+++ b/src/modules/checkspecies/checkspecies.h
@@ -18,7 +18,7 @@ class CheckSpeciesModule : public Module
 {
     public:
     CheckSpeciesModule();
-    ~CheckSpeciesModule();
+    ~CheckSpeciesModule() = default;
 
     /*
      * Instances

--- a/src/modules/checkspecies/core.cpp
+++ b/src/modules/checkspecies/core.cpp
@@ -13,8 +13,6 @@ CheckSpeciesModule::CheckSpeciesModule() : Module(nRequiredTargets())
     initialise();
 }
 
-CheckSpeciesModule::~CheckSpeciesModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/datatest/core.cpp
+++ b/src/modules/datatest/core.cpp
@@ -9,8 +9,6 @@ DataTestModule::DataTestModule() : Module(nRequiredTargets())
     initialise();
 }
 
-DataTestModule::~DataTestModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/datatest/datatest.h
+++ b/src/modules/datatest/datatest.h
@@ -18,7 +18,7 @@ class DataTestModule : public Module
 {
     public:
     DataTestModule();
-    ~DataTestModule();
+    ~DataTestModule() = default;
 
     /*
      * Instances

--- a/src/modules/datatest/datatest.h
+++ b/src/modules/datatest/datatest.h
@@ -18,41 +18,41 @@ class DataTestModule : public Module
 {
     public:
     DataTestModule();
-    ~DataTestModule() = default;
+    ~DataTestModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions
@@ -145,5 +145,5 @@ class DataTestModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/energy/core.cpp
+++ b/src/modules/energy/core.cpp
@@ -9,8 +9,6 @@ EnergyModule::EnergyModule() : Module(nRequiredTargets())
     initialise();
 }
 
-EnergyModule::~EnergyModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -17,7 +17,7 @@ class EnergyModule : public Module
 
     public:
     EnergyModule();
-    ~EnergyModule();
+    ~EnergyModule() = default;
 
     /*
      * Instances

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -17,45 +17,45 @@ class EnergyModule : public Module
 
     public:
     EnergyModule();
-    ~EnergyModule() = default;
+    ~EnergyModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions
@@ -98,5 +98,5 @@ class EnergyModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/epsr/core.cpp
+++ b/src/modules/epsr/core.cpp
@@ -9,8 +9,6 @@ EPSRModule::EPSRModule() : Module(nRequiredTargets())
     initialise();
 }
 
-EPSRModule::~EPSRModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -23,7 +23,7 @@ class EPSRModule : public Module
 
     public:
     EPSRModule();
-    ~EPSRModule();
+    ~EPSRModule() = default;
 
     /*
      * Instances

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -23,27 +23,27 @@ class EPSRModule : public Module
 
     public:
     EPSRModule();
-    ~EPSRModule() = default;
+    ~EPSRModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
@@ -61,18 +61,18 @@ class EPSRModule : public Module
 
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions
@@ -142,5 +142,5 @@ class EPSRModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/export_coordinates/core.cpp
+++ b/src/modules/export_coordinates/core.cpp
@@ -9,8 +9,6 @@ ExportCoordinatesModule::ExportCoordinatesModule() : Module(nRequiredTargets())
     initialise();
 }
 
-ExportCoordinatesModule::~ExportCoordinatesModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/export_coordinates/exportcoords.h
+++ b/src/modules/export_coordinates/exportcoords.h
@@ -18,34 +18,34 @@ class ExportCoordinatesModule : public Module
 
     public:
     ExportCoordinatesModule();
-    ~ExportCoordinatesModule() = default;
+    ~ExportCoordinatesModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Data
@@ -59,5 +59,5 @@ class ExportCoordinatesModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/export_coordinates/exportcoords.h
+++ b/src/modules/export_coordinates/exportcoords.h
@@ -18,7 +18,7 @@ class ExportCoordinatesModule : public Module
 
     public:
     ExportCoordinatesModule();
-    ~ExportCoordinatesModule();
+    ~ExportCoordinatesModule() = default;
 
     /*
      * Instances

--- a/src/modules/export_pairpotentials/core.cpp
+++ b/src/modules/export_pairpotentials/core.cpp
@@ -9,8 +9,6 @@ ExportPairPotentialsModule::ExportPairPotentialsModule() : Module(nRequiredTarge
     initialise();
 }
 
-ExportPairPotentialsModule::~ExportPairPotentialsModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/export_pairpotentials/exportpp.h
+++ b/src/modules/export_pairpotentials/exportpp.h
@@ -18,34 +18,34 @@ class ExportPairPotentialsModule : public Module
 
     public:
     ExportPairPotentialsModule();
-    ~ExportPairPotentialsModule() = default;
+    ~ExportPairPotentialsModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Data
@@ -59,5 +59,5 @@ class ExportPairPotentialsModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/export_pairpotentials/exportpp.h
+++ b/src/modules/export_pairpotentials/exportpp.h
@@ -18,7 +18,7 @@ class ExportPairPotentialsModule : public Module
 
     public:
     ExportPairPotentialsModule();
-    ~ExportPairPotentialsModule();
+    ~ExportPairPotentialsModule() = default;
 
     /*
      * Instances

--- a/src/modules/export_trajectory/core.cpp
+++ b/src/modules/export_trajectory/core.cpp
@@ -9,8 +9,6 @@ ExportTrajectoryModule::ExportTrajectoryModule() : Module(nRequiredTargets())
     initialise();
 }
 
-ExportTrajectoryModule::~ExportTrajectoryModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/export_trajectory/exporttraj.h
+++ b/src/modules/export_trajectory/exporttraj.h
@@ -18,34 +18,34 @@ class ExportTrajectoryModule : public Module
 
     public:
     ExportTrajectoryModule();
-    ~ExportTrajectoryModule() = default;
+    ~ExportTrajectoryModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Data
@@ -59,5 +59,5 @@ class ExportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/export_trajectory/exporttraj.h
+++ b/src/modules/export_trajectory/exporttraj.h
@@ -18,7 +18,7 @@ class ExportTrajectoryModule : public Module
 
     public:
     ExportTrajectoryModule();
-    ~ExportTrajectoryModule();
+    ~ExportTrajectoryModule() = default;
 
     /*
      * Instances

--- a/src/modules/forces/core.cpp
+++ b/src/modules/forces/core.cpp
@@ -9,8 +9,6 @@ ForcesModule::ForcesModule() : Module(nRequiredTargets())
     initialise();
 }
 
-ForcesModule::~ForcesModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -21,34 +21,34 @@ class ForcesModule : public Module
 
     public:
     ForcesModule();
-    ~ForcesModule() = default;
+    ~ForcesModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Data
@@ -64,11 +64,11 @@ class ForcesModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -21,7 +21,7 @@ class ForcesModule : public Module
 
     public:
     ForcesModule();
-    ~ForcesModule();
+    ~ForcesModule() = default;
 
     /*
      * Instances

--- a/src/modules/geomopt/core.cpp
+++ b/src/modules/geomopt/core.cpp
@@ -9,8 +9,6 @@ GeometryOptimisationModule::GeometryOptimisationModule() : Module(nRequiredTarge
     initialise();
 }
 
-GeometryOptimisationModule::~GeometryOptimisationModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -16,41 +16,41 @@ class GeometryOptimisationModule : public Module
 {
     public:
     GeometryOptimisationModule();
-    ~GeometryOptimisationModule() = default;
+    ~GeometryOptimisationModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions
@@ -298,5 +298,5 @@ class GeometryOptimisationModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -16,7 +16,7 @@ class GeometryOptimisationModule : public Module
 {
     public:
     GeometryOptimisationModule();
-    ~GeometryOptimisationModule();
+    ~GeometryOptimisationModule() = default;
 
     /*
      * Instances

--- a/src/modules/import/core.cpp
+++ b/src/modules/import/core.cpp
@@ -9,8 +9,6 @@ ImportModule::ImportModule() : Module(nRequiredTargets())
     initialise();
 }
 
-ImportModule::~ImportModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/import/import.h
+++ b/src/modules/import/import.h
@@ -16,34 +16,34 @@ class ImportModule : public Module
 {
     public:
     ImportModule();
-    ~ImportModule() = default;
+    ~ImportModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Data
@@ -57,5 +57,5 @@ class ImportModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/import/import.h
+++ b/src/modules/import/import.h
@@ -16,7 +16,7 @@ class ImportModule : public Module
 {
     public:
     ImportModule();
-    ~ImportModule();
+    ~ImportModule() = default;
 
     /*
      * Instances

--- a/src/modules/intrashake/core.cpp
+++ b/src/modules/intrashake/core.cpp
@@ -9,8 +9,6 @@ IntraShakeModule::IntraShakeModule() : Module(nRequiredTargets())
     initialise();
 }
 
-IntraShakeModule::~IntraShakeModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/intrashake/intrashake.h
+++ b/src/modules/intrashake/intrashake.h
@@ -17,39 +17,39 @@ class IntraShakeModule : public Module
 
     public:
     IntraShakeModule();
-    ~IntraShakeModule() = default;
+    ~IntraShakeModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/intrashake/intrashake.h
+++ b/src/modules/intrashake/intrashake.h
@@ -17,7 +17,7 @@ class IntraShakeModule : public Module
 
     public:
     IntraShakeModule();
-    ~IntraShakeModule();
+    ~IntraShakeModule() = default;
 
     /*
      * Instances

--- a/src/modules/md/core.cpp
+++ b/src/modules/md/core.cpp
@@ -9,8 +9,6 @@ MDModule::MDModule() : Module(nRequiredTargets())
     initialise();
 }
 
-MDModule::~MDModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -17,27 +17,27 @@ class MDModule : public Module
 
     public:
     MDModule();
-    ~MDModule() = default;
+    ~MDModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
@@ -48,14 +48,14 @@ class MDModule : public Module
 
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Functions

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -17,7 +17,7 @@ class MDModule : public Module
 
     public:
     MDModule();
-    ~MDModule();
+    ~MDModule() = default;
 
     /*
      * Instances

--- a/src/modules/molshake/core.cpp
+++ b/src/modules/molshake/core.cpp
@@ -9,8 +9,6 @@ MolShakeModule::MolShakeModule() : Module(nRequiredTargets())
     initialise();
 }
 
-MolShakeModule::~MolShakeModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/molshake/molshake.h
+++ b/src/modules/molshake/molshake.h
@@ -17,7 +17,7 @@ class MolShakeModule : public Module
 
     public:
     MolShakeModule();
-    ~MolShakeModule();
+    ~MolShakeModule() = default;
 
     /*
      * Instances

--- a/src/modules/molshake/molshake.h
+++ b/src/modules/molshake/molshake.h
@@ -17,39 +17,39 @@ class MolShakeModule : public Module
 
     public:
     MolShakeModule();
-    ~MolShakeModule() = default;
+    ~MolShakeModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/neutronsq/core.cpp
+++ b/src/modules/neutronsq/core.cpp
@@ -9,8 +9,6 @@ NeutronSQModule::NeutronSQModule() : Module(nRequiredTargets())
     initialise();
 }
 
-NeutronSQModule::~NeutronSQModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/neutronsq/neutronsq.h
+++ b/src/modules/neutronsq/neutronsq.h
@@ -19,27 +19,27 @@ class NeutronSQModule : public Module
 {
     public:
     NeutronSQModule();
-    ~NeutronSQModule() = default;
+    ~NeutronSQModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
@@ -54,7 +54,7 @@ class NeutronSQModule : public Module
 
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     public:
     // Return file and format for reference total F(Q)
@@ -65,11 +65,11 @@ class NeutronSQModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Members / Functions
@@ -93,5 +93,5 @@ class NeutronSQModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/neutronsq/neutronsq.h
+++ b/src/modules/neutronsq/neutronsq.h
@@ -19,7 +19,7 @@ class NeutronSQModule : public Module
 {
     public:
     NeutronSQModule();
-    ~NeutronSQModule();
+    ~NeutronSQModule() = default;
 
     /*
      * Instances

--- a/src/modules/rdf/core.cpp
+++ b/src/modules/rdf/core.cpp
@@ -9,8 +9,6 @@ RDFModule::RDFModule() : Module(nRequiredTargets())
     initialise();
 }
 
-RDFModule::~RDFModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -18,7 +18,7 @@ class RDFModule : public Module
 {
     public:
     RDFModule();
-    ~RDFModule();
+    ~RDFModule() = default;
 
     /*
      * Instances

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -18,34 +18,34 @@ class RDFModule : public Module
 {
     public:
     RDFModule();
-    ~RDFModule() = default;
+    ~RDFModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     public:
     // Partial Calculation Method enum
@@ -65,7 +65,7 @@ class RDFModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Members / Functions
@@ -116,5 +116,5 @@ class RDFModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/sanitycheck/core.cpp
+++ b/src/modules/sanitycheck/core.cpp
@@ -9,8 +9,6 @@ SanityCheckModule::SanityCheckModule() : Module(nRequiredTargets())
     initialise();
 }
 
-SanityCheckModule::~SanityCheckModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/sanitycheck/sanitycheck.h
+++ b/src/modules/sanitycheck/sanitycheck.h
@@ -17,39 +17,39 @@ class SanityCheckModule : public Module
 
     public:
     SanityCheckModule();
-    ~SanityCheckModule() = default;
+    ~SanityCheckModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/sanitycheck/sanitycheck.h
+++ b/src/modules/sanitycheck/sanitycheck.h
@@ -17,7 +17,7 @@ class SanityCheckModule : public Module
 
     public:
     SanityCheckModule();
-    ~SanityCheckModule();
+    ~SanityCheckModule() = default;
 
     /*
      * Instances

--- a/src/modules/skeleton/core.cpp
+++ b/src/modules/skeleton/core.cpp
@@ -13,8 +13,6 @@ SkeletonModule::SkeletonModule() : Module(nRequiredTargets())
     initialise();
 }
 
-SkeletonModule::~SkeletonModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -13,7 +13,7 @@ class SkeletonModule : public Module
 {
     public:
     SkeletonModule();
-    ~SkeletonModule();
+    ~SkeletonModule() = default;
 
     /*
      * Instances

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -13,46 +13,46 @@ class SkeletonModule : public Module
 {
     public:
     SkeletonModule();
-    ~SkeletonModule() = default;
+    ~SkeletonModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * GUI Widget
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/sq/core.cpp
+++ b/src/modules/sq/core.cpp
@@ -9,8 +9,6 @@ SQModule::SQModule() : Module(nRequiredTargets())
     initialise();
 }
 
-SQModule::~SQModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -17,41 +17,41 @@ class SQModule : public Module
 {
     public:
     SQModule();
-    ~SQModule() = default;
+    ~SQModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Members / Functions
@@ -71,5 +71,5 @@ class SQModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -17,7 +17,7 @@ class SQModule : public Module
 {
     public:
     SQModule();
-    ~SQModule();
+    ~SQModule() = default;
 
     /*
      * Instances

--- a/src/modules/test/core.cpp
+++ b/src/modules/test/core.cpp
@@ -9,8 +9,6 @@ TestModule::TestModule() : Module(nRequiredTargets())
     initialise();
 }
 
-TestModule::~TestModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -17,7 +17,7 @@ class TestModule : public Module
 
     public:
     TestModule();
-    ~TestModule();
+    ~TestModule() = default;
 
     /*
      * Instances

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -17,46 +17,46 @@ class TestModule : public Module
 
     public:
     TestModule();
-    ~TestModule() = default;
+    ~TestModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
      */
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     /*
      * Processing
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * GUI Widget
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };

--- a/src/modules/xraysq/core.cpp
+++ b/src/modules/xraysq/core.cpp
@@ -9,8 +9,6 @@ XRaySQModule::XRaySQModule() : Module(nRequiredTargets())
     initialise();
 }
 
-XRaySQModule::~XRaySQModule() {}
-
 /*
  * Instances
  */

--- a/src/modules/xraysq/xraysq.h
+++ b/src/modules/xraysq/xraysq.h
@@ -20,7 +20,7 @@ class XRaySQModule : public Module
 {
     public:
     XRaySQModule();
-    ~XRaySQModule();
+    ~XRaySQModule() = default;
 
     /*
      * Instances

--- a/src/modules/xraysq/xraysq.h
+++ b/src/modules/xraysq/xraysq.h
@@ -20,27 +20,27 @@ class XRaySQModule : public Module
 {
     public:
     XRaySQModule();
-    ~XRaySQModule() = default;
+    ~XRaySQModule() override = default;
 
     /*
      * Instances
      */
     public:
     // Create instance of this module
-    Module *createInstance() const;
+    Module *createInstance() const override;
 
     /*
      * Definition
      */
     public:
     // Return type of module
-    std::string_view type() const;
+    std::string_view type() const override;
     // Return category for module
-    std::string_view category() const;
+    std::string_view category() const override;
     // Return brief description of module
-    std::string_view brief() const;
+    std::string_view brief() const override;
     // Return the number of Configuration targets this Module requires
-    int nRequiredTargets() const;
+    int nRequiredTargets() const override;
 
     /*
      * Initialisation
@@ -51,7 +51,7 @@ class XRaySQModule : public Module
 
     protected:
     // Perform any necessary initialisation for the Module
-    void initialise();
+    void initialise() override;
 
     public:
     // Return file and format for reference total F(Q)
@@ -62,11 +62,11 @@ class XRaySQModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, ProcessPool &procPool);
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
 
     /*
      * Members / Functions
@@ -91,5 +91,5 @@ class XRaySQModule : public Module
      */
     public:
     // Return a new widget controlling this Module
-    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve);
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
 };


### PR DESCRIPTION
A short, boring PR to use default destructors in all modules, and mark all functions reimplemented from the `Module` base class as `override`.
