### PR TITLE
Range splitter

### DIFF
--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -90,7 +90,7 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     // Loop over central cell atoms
     if (applyMim)
     {
-        auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -123,7 +123,7 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     }
     else
     {
-        auto [begin, end] = cut_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
+        auto [begin, end] = chop_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -188,7 +188,7 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-            auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
             for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
@@ -226,7 +226,7 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-            auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
             for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
@@ -281,7 +281,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
 
     if (flags & KernelFlags::ApplyMinimumImageFlag)
     {
-        auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
         // Loop over other Atoms
         if (flags & KernelFlags::ExcludeSelfFlag)
             for (auto indexJ = begin; indexJ < end; ++indexJ)
@@ -383,7 +383,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
     else
     {
         // Loop over atom neighbours
-        auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
         if (flags & KernelFlags::ExcludeSelfFlag)
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
@@ -583,7 +583,7 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
 
     auto totalEnergy = 0.0;
     Cell *cell;
-    auto [begin, end] = cut_range(0, cellArray.nCells(), stride, start);
+    auto [begin, end] = chop_range(0, cellArray.nCells(), stride, start);
     for (auto cellId = begin; cellId < end; ++cellId)
     {
         cell = cellArray.cell(cellId);

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -84,13 +84,13 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     double rSq, scale;
 
     // Get start/stride for specified loop context
-    auto start = processPool_.interleavedLoopStart(strategy);
-    auto stride = processPool_.interleavedLoopStride(strategy);
+    auto offset = processPool_.interleavedLoopStart(strategy);
+    auto nChunks = processPool_.interleavedLoopStride(strategy);
 
     // Loop over central cell atoms
     if (applyMim)
     {
-        auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), nChunks, offset);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -123,7 +123,7 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     }
     else
     {
-        auto [begin, end] = chop_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
+        auto [begin, end] = chop_range(centralCell->atoms().begin(), centralCell->atoms().end(), nChunks, offset);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -174,8 +174,8 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
     double rSq, scale;
 
     // Get start/stride for specified loop context
-    auto start = processPool_.interleavedLoopStart(strategy);
-    auto stride = processPool_.interleavedLoopStride(strategy);
+    auto offset = processPool_.interleavedLoopStart(strategy);
+    auto nChunks = processPool_.interleavedLoopStride(strategy);
 
     // Straight loop over Cells *not* requiring mim
     for (auto *otherCell : centralCell->cellNeighbours())
@@ -188,7 +188,7 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-            auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), nChunks, offset);
             for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
@@ -226,7 +226,7 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-            auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), nChunks, offset);
             for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
@@ -276,12 +276,12 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
     const auto rI = i->r();
 
     // Get start/stride for specified loop context
-    auto start = processPool_.interleavedLoopStart(strategy);
-    auto stride = processPool_.interleavedLoopStride(strategy);
+    auto offset = processPool_.interleavedLoopStart(strategy);
+    auto nChunks = processPool_.interleavedLoopStride(strategy);
 
     if (flags & KernelFlags::ApplyMinimumImageFlag)
     {
-        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), nChunks, offset);
         // Loop over other Atoms
         if (flags & KernelFlags::ExcludeSelfFlag)
             for (auto indexJ = begin; indexJ < end; ++indexJ)
@@ -383,7 +383,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
     else
     {
         // Loop over atom neighbours
-        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), nChunks, offset);
         if (flags & KernelFlags::ExcludeSelfFlag)
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
@@ -578,12 +578,12 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
     ProcessPool::DivisionStrategy subStrategy = ProcessPool::subDivisionStrategy(strategy);
 
     // Set start/stride for parallel loop
-    auto start = processPool_.interleavedLoopStart(strategy);
-    auto stride = processPool_.interleavedLoopStride(strategy);
+    auto offset = processPool_.interleavedLoopStart(strategy);
+    auto nChunks = processPool_.interleavedLoopStride(strategy);
 
     auto totalEnergy = 0.0;
     Cell *cell;
-    auto [begin, end] = chop_range(0, cellArray.nCells(), stride, start);
+    auto [begin, end] = chop_range(0, cellArray.nCells(), nChunks, offset);
     for (auto cellId = begin; cellId < end; ++cellId)
     {
         cell = cellArray.cell(cellId);

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -583,7 +583,8 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
 
     auto totalEnergy = 0.0;
     Cell *cell;
-    for (auto cellId = start; cellId < cellArray.nCells(); cellId += stride)
+    auto [begin, end] = cut_range(0, cellArray.nCells(), stride, start);
+    for (auto cellId = begin; cellId < end; ++cellId)
     {
         cell = cellArray.cell(cellId);
 

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -188,8 +188,8 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-	    auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
-	    for (auto indexI = begin; indexI < end; ++indexI)
+            auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+            for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
 
@@ -226,8 +226,8 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-	    auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
-	    for (auto indexI = begin; indexI < end; ++indexI)
+            auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+            for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
 

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -9,6 +9,7 @@
 #include "classes/molecule.h"
 #include "classes/potentialmap.h"
 #include "classes/species.h"
+#include "templates/algorithms.h"
 #include <iterator>
 #include <numeric>
 
@@ -89,7 +90,8 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     // Loop over central cell atoms
     if (applyMim)
     {
-        for (auto indexI = centralAtoms.begin() + start; indexI < centralAtoms.end(); indexI += stride)
+        auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+        for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
             molI = ii->molecule();
@@ -121,7 +123,8 @@ double EnergyKernel::energy(Cell *centralCell, Cell *otherCell, bool applyMim, b
     }
     else
     {
-        for (auto indexI = centralCell->atoms().begin() + start; indexI < centralCell->atoms().end(); indexI += stride)
+        auto [begin, end] = cut_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
+        for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
             molI = ii->molecule();
@@ -185,7 +188,8 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-            for (auto indexI = centralAtoms.begin() + start; indexI < centralAtoms.end(); indexI += stride)
+	    auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+	    for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
 
@@ -222,7 +226,8 @@ double EnergyKernel::energy(Cell *centralCell, bool excludeIgeJ, bool interMolec
             rJ = jj->r();
 
             // Loop over central cell atoms
-            for (auto indexI = centralAtoms.begin() + start; indexI < centralAtoms.end(); indexI += stride)
+	    auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+	    for (auto indexI = begin; indexI < end; ++indexI)
             {
                 ii = *indexI;
 
@@ -276,9 +281,10 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
 
     if (flags & KernelFlags::ApplyMinimumImageFlag)
     {
+        auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
         // Loop over other Atoms
         if (flags & KernelFlags::ExcludeSelfFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -303,7 +309,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
                 }
             }
         else if (flags & KernelFlags::ExcludeIGEJFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -328,7 +334,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
                 }
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -353,7 +359,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
                 }
             }
         else
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -377,8 +383,9 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
     else
     {
         // Loop over atom neighbours
+        auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
         if (flags & KernelFlags::ExcludeSelfFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -403,7 +410,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
                 }
             }
         else if (flags & KernelFlags::ExcludeIGEJFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -428,7 +435,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
                 }
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -453,7 +460,7 @@ double EnergyKernel::energy(const std::shared_ptr<Atom> i, const Cell *cell, int
                 }
             }
         else
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -9,6 +9,7 @@
 #include "classes/molecule.h"
 #include "classes/potentialmap.h"
 #include "classes/species.h"
+#include "templates/algorithms.h"
 #include <iterator>
 
 ForceKernel::ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, Array<double> &fx,
@@ -108,7 +109,8 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     // Loop over central cell atoms
     if (applyMim)
     {
-        for (auto indexI = centralAtoms.begin() + start; indexI < centralAtoms.end(); indexI += stride)
+        auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+        for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
             molI = ii->molecule();
@@ -135,7 +137,8 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     }
     else
     {
-        for (auto indexI = centralCell->atoms().begin() + start; indexI < centralCell->atoms().end(); indexI += stride)
+        auto [begin, end] = cut_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
+	for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
             molI = ii->molecule();
@@ -232,7 +235,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
         {
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+	    auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+	    for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -254,7 +258,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
         }
         else
         {
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+	    auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+	    for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -274,8 +279,9 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
     else
     {
         // Loop over atom neighbours
+        auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
         if (flags & KernelFlags::ExcludeSelfFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -295,7 +301,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
                 }
             }
         else if (flags & KernelFlags::ExcludeIGEJFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -315,7 +321,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
                 }
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -335,7 +341,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
                 }
             }
         else
-            for (auto indexJ = otherAtoms.begin() + start; indexJ < otherAtoms.end(); indexJ += stride)
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -103,13 +103,13 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     double scale;
 
     // Get start/stride for specified loop context
-    auto start = processPool_.interleavedLoopStart(strategy);
-    auto stride = processPool_.interleavedLoopStride(strategy);
+    auto offset = processPool_.interleavedLoopStart(strategy);
+    auto nChunks = processPool_.interleavedLoopStride(strategy);
 
     // Loop over central cell atoms
     if (applyMim)
     {
-        auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), nChunks, offset);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -137,7 +137,7 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     }
     else
     {
-        auto [begin, end] = chop_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
+        auto [begin, end] = chop_range(centralCell->atoms().begin(), centralCell->atoms().end(), nChunks, offset);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -192,8 +192,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
     auto &otherAtoms = cell->atoms();
 
     // Get start/stride for specified loop context
-    auto start = processPool_.interleavedLoopStart(strategy);
-    auto stride = processPool_.interleavedLoopStride(strategy);
+    auto offset = processPool_.interleavedLoopStart(strategy);
+    auto nChunks = processPool_.interleavedLoopStride(strategy);
 
     // Loop over cell atoms
     if (flags & KernelFlags::ApplyMinimumImageFlag)
@@ -235,7 +235,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
         {
-            auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), nChunks, offset);
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
@@ -258,7 +258,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
         }
         else
         {
-            auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), nChunks, offset);
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
@@ -279,7 +279,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
     else
     {
         // Loop over atom neighbours
-        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), nChunks, offset);
         if (flags & KernelFlags::ExcludeSelfFlag)
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -138,7 +138,7 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     else
     {
         auto [begin, end] = cut_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
-	for (auto indexI = begin; indexI < end; ++indexI)
+        for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
             molI = ii->molecule();
@@ -235,8 +235,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
         {
-	    auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
-	    for (auto indexJ = begin; indexJ < end; ++indexJ)
+            auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;
@@ -258,8 +258,8 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
         }
         else
         {
-	    auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
-	    for (auto indexJ = begin; indexJ < end; ++indexJ)
+            auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+            for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
                 jj = *indexJ;

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -109,7 +109,7 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     // Loop over central cell atoms
     if (applyMim)
     {
-        auto [begin, end] = cut_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(centralAtoms.begin(), centralAtoms.end(), stride, start);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -137,7 +137,7 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
     }
     else
     {
-        auto [begin, end] = cut_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
+        auto [begin, end] = chop_range(centralCell->atoms().begin(), centralCell->atoms().end(), stride, start);
         for (auto indexI = begin; indexI < end; ++indexI)
         {
             ii = *indexI;
@@ -235,7 +235,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
         {
-            auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
@@ -258,7 +258,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
         }
         else
         {
-            auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+            auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {
                 // Grab other Atom pointer
@@ -279,7 +279,7 @@ void ForceKernel::forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, P
     else
     {
         // Loop over atom neighbours
-        auto [begin, end] = cut_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
+        auto [begin, end] = chop_range(otherAtoms.begin(), otherAtoms.end(), stride, start);
         if (flags & KernelFlags::ExcludeSelfFlag)
             for (auto indexJ = begin; indexJ < end; ++indexJ)
             {

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -7,6 +7,7 @@
 #include "classes/species.h"
 #include "genericitems/listhelper.h"
 #include "modules/energy/energy.h"
+#include "templates/algorithms.h"
 #include <numeric>
 
 // Return total interatomic energy of Configuration
@@ -145,10 +146,11 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *
 
     std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    for (auto m = start; m < cfg->nMolecules(); m += stride)
+    auto [begin, end] = cut_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
+    for (auto it = begin; it < end; ++it)
     {
         // Get Molecule pointer
-        mol = molecules[m];
+        mol = *it;
 
         // Loop over Bond
         bondEnergy += std::accumulate(mol->species()->bonds().cbegin(), mol->species()->bonds().cend(), 0.0,

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -146,7 +146,7 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *
 
     std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    auto [begin, end] = cut_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
+    auto [begin, end] = chop_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
     for (auto it = begin; it < end; ++it)
     {
         // Get Molecule pointer

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -34,7 +34,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
     auto start = procPool.interleavedLoopStart(strategy);
     auto stride = procPool.interleavedLoopStride(strategy);
 
-    auto [begin, end] = cut_range(0, cellArray.nCells(), stride, start);
+    auto [begin, end] = chop_range(0, cellArray.nCells(), stride, start);
     for (auto cellId = begin; cellId < end; ++cellId)
     {
         cell = cellArray.cell(cellId);
@@ -76,7 +76,7 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
     auto stride = procPool.interleavedLoopStride(strategy);
 
     // Loop over supplied atom indices
-    auto [begin, end] = cut_range(0, targetIndices.nItems(), stride, start);
+    auto [begin, end] = chop_range(0, targetIndices.nItems(), stride, start);
     for (auto n = begin; n < end; ++n)
         kernel.forces(cfg->atoms()[targetIndices.at(n)], ProcessPool::subDivisionStrategy(strategy));
 }
@@ -146,7 +146,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
 
     // Loop over supplied atom indices
     const auto &atoms = cfg->atoms();
-    auto [begin, end] = cut_range(0, targetIndices.nItems(), stride, start);
+    auto [begin, end] = chop_range(0, targetIndices.nItems(), stride, start);
     for (auto n = begin; n < end; ++n)
     {
         const auto i = atoms[targetIndices.at(n)];
@@ -197,7 +197,7 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
     // Loop over Molecules
     std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    auto [begin, end] = cut_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
+    auto [begin, end] = chop_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
     for (auto it = begin; it < end; ++it)
     {
         // Get Molecule pointer

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -7,6 +7,7 @@
 #include "classes/potentialmap.h"
 #include "classes/species.h"
 #include "modules/forces/forces.h"
+#include "templates/algorithms.h"
 
 // Calculate interatomic forces within the supplied Configuration
 void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
@@ -33,7 +34,8 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
     auto start = procPool.interleavedLoopStart(strategy);
     auto stride = procPool.interleavedLoopStride(strategy);
 
-    for (auto cellId = start; cellId < cellArray.nCells(); cellId += stride)
+    auto [begin, end] = cut_range(0, cellArray.nCells(), stride, start);
+    for (auto cellId = begin; cellId < end; ++cellId)
     {
         cell = cellArray.cell(cellId);
 
@@ -74,7 +76,8 @@ void ForcesModule::interAtomicForces(ProcessPool &procPool, Configuration *cfg, 
     auto stride = procPool.interleavedLoopStride(strategy);
 
     // Loop over supplied atom indices
-    for (auto n = start; n < targetIndices.nItems(); n += stride)
+    auto [begin, end] = cut_range(0, targetIndices.nItems(), stride, start);
+    for (auto n = begin; n < end; ++n)
         kernel.forces(cfg->atoms()[targetIndices.at(n)], ProcessPool::subDivisionStrategy(strategy));
 }
 
@@ -143,7 +146,8 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
 
     // Loop over supplied atom indices
     const auto &atoms = cfg->atoms();
-    for (auto n = start; n < targetIndices.nItems(); n += stride)
+    auto [begin, end] = cut_range(0, targetIndices.nItems(), stride, start);
+    for (auto n = begin; n < end; ++n)
     {
         const auto i = atoms[targetIndices.at(n)];
         const SpeciesAtom *spAtom = i->speciesAtom();
@@ -193,10 +197,11 @@ void ForcesModule::intraMolecularForces(ProcessPool &procPool, Configuration *cf
     // Loop over Molecules
     std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    for (auto m = start; m < cfg->nMolecules(); m += stride)
+    auto [begin, end] = cut_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
+    for (auto it = begin; it < end; ++it)
     {
         // Get Molecule pointer
-        mol = molecules[m];
+        mol = *it;
 
         // Loop over bonds
         for (const auto &bond : mol->species()->bonds())

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -326,9 +326,10 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
 
     // Loop over molecules...
     std::shared_ptr<Atom> i, j;
-    for (auto m = start; m < cfg->nMolecules(); m += stride)
+    auto [begin, end] = cut_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
+    for (auto it = begin; it < end; ++it)
     {
-        std::shared_ptr<Molecule> mol = cfg->molecule(m);
+        std::shared_ptr<Molecule> mol = *it;
         auto &atoms = mol->atoms();
 
         for (auto ii = atoms.begin(); ii < std::prev(atoms.end()); ++ii)

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -89,13 +89,14 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
         auto &histogram = partialSet.fullHistogram(typeI, typeI).bins();
         bins = binss[typeI];
         nPoints = partialSet.fullHistogram(typeI, typeI).nBins();
-	for_each_pair(ri, ri + maxr[typeI], stride, start,
-		      [box, bins, rbin, nPoints, &histogram](int i, auto centre, int j, auto other){
-			if (i == j) return;
-			bins[j] = box->minimumDistance(centre, other) * rbin;
-			if (bins[j] < nPoints)
-			  ++histogram[bins[j]];
-		      });
+        for_each_pair(ri, ri + maxr[typeI], stride, start,
+                      [box, bins, rbin, nPoints, &histogram](int i, auto centre, int j, auto other) {
+                          if (i == j)
+                              return;
+                          bins[j] = box->minimumDistance(centre, other) * rbin;
+                          if (bins[j] < nPoints)
+                              ++histogram[bins[j]];
+                      });
     }
 
     Messenger::printVerbose("Cross terms..\n");
@@ -119,8 +120,8 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
             auto &histogram = partialSet.fullHistogram(typeI, typeJ).bins();
             bins = binss[typeJ];
             nPoints = partialSet.fullHistogram(typeI, typeJ).nBins();
-	    auto [begin, end] = cut_range(0, maxr[typeI], stride, start);
-	    for (i = begin; i < end; ++i)
+            auto [begin, end] = cut_range(0, maxr[typeI], stride, start);
+            for (i = begin; i < end; ++i)
             {
                 centre = ri[i];
                 for (j = 0; j < maxr[typeJ]; ++j)

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -693,8 +693,7 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data->name()};
-        std::replace_if(
-            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments
@@ -725,8 +724,7 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data->name()};
-        std::replace_if(
-            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -332,17 +332,18 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
     {
         auto &atoms = (*it)->atoms();
 
-	for_each_pair(atoms.begin(), atoms.end(), [box, &originalgr](int index, auto &i, int jndex, auto &j) {
-	  // Ignore atom on itself
-	  if (index == jndex) return;
+        for_each_pair(atoms.begin(), atoms.end(), [box, &originalgr](int index, auto &i, int jndex, auto &j) {
+            // Ignore atom on itself
+            if (index == jndex)
+                return;
 
-	  double distance;
-	  if (i->cell()->mimRequired(j->cell()))
-	    distance = box->minimumDistance(i, j);
-	  else
-	    distance = (i->r() - j->r()).magnitude();
-	  originalgr.boundHistogram(i->localTypeIndex(), j->localTypeIndex()).bin(distance);
-	});
+            double distance;
+            if (i->cell()->mimRequired(j->cell()))
+                distance = box->minimumDistance(i, j);
+            else
+                distance = (i->r() - j->r()).magnitude();
+            originalgr.boundHistogram(i->localTypeIndex(), j->localTypeIndex()).bin(distance);
+        });
     }
 
     timer.stop();
@@ -358,19 +359,19 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
     procPool.resetAccumulatedTime();
     timer.start();
     for_each_pair(0, originalgr.nAtomTypes(), [&originalgr, &procPool, method](auto typeI, auto typeJ) {
-            // Sum histogram data from all processes (except if using RDFModule::TestMethod, where all processes
-            // have all data already)
-            if (method != RDFModule::TestMethod)
-            {
-                if (!originalgr.fullHistogram(typeI, typeJ).allSum(procPool))
-                    return false;
-                if (!originalgr.boundHistogram(typeI, typeJ).allSum(procPool))
-                    return false;
-            }
+        // Sum histogram data from all processes (except if using RDFModule::TestMethod, where all processes
+        // have all data already)
+        if (method != RDFModule::TestMethod)
+        {
+            if (!originalgr.fullHistogram(typeI, typeJ).allSum(procPool))
+                return false;
+            if (!originalgr.boundHistogram(typeI, typeJ).allSum(procPool))
+                return false;
+        }
 
-            // Create unbound histogram from total and bound data
-            originalgr.unboundHistogram(typeI, typeJ) = originalgr.fullHistogram(typeI, typeJ);
-            originalgr.unboundHistogram(typeI, typeJ).add(originalgr.boundHistogram(typeI, typeJ), -1.0);
+        // Create unbound histogram from total and bound data
+        originalgr.unboundHistogram(typeI, typeJ) = originalgr.fullHistogram(typeI, typeJ);
+        originalgr.unboundHistogram(typeI, typeJ).add(originalgr.boundHistogram(typeI, typeJ), -1.0);
     });
 
     // Transform histogram data into radial distribution functions

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -89,15 +89,13 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
         auto &histogram = partialSet.fullHistogram(typeI, typeI).bins();
         bins = binss[typeI];
         nPoints = partialSet.fullHistogram(typeI, typeI).nBins();
-        for (i = start; i < maxr[typeI]; i += stride)
-        {
-            centre = ri[i];
-            for (j = i + 1; j < maxr[typeI]; ++j)
-                bins[j] = box->minimumDistance(centre, ri[j]) * rbin;
-            for (j = i + 1; j < maxr[typeI]; ++j)
-                if (bins[j] < nPoints)
-                    ++histogram[bins[j]];
-        }
+	for_each_pair(ri, ri + maxr[typeI], stride, start,
+		      [box, bins, rbin, nPoints, &histogram](int i, auto centre, int j, auto other){
+			if (i == j) return;
+			bins[j] = box->minimumDistance(centre, other) * rbin;
+			if (bins[j] < nPoints)
+			  ++histogram[bins[j]];
+		      });
     }
 
     Messenger::printVerbose("Cross terms..\n");
@@ -121,7 +119,8 @@ bool RDFModule::calculateGRSimple(ProcessPool &procPool, Configuration *cfg, Par
             auto &histogram = partialSet.fullHistogram(typeI, typeJ).bins();
             bins = binss[typeJ];
             nPoints = partialSet.fullHistogram(typeI, typeJ).nBins();
-            for (i = start; i < maxr[typeI]; i += stride)
+	    auto [begin, end] = cut_range(0, maxr[typeI], stride, start);
+	    for (i = begin; i < end; ++i)
             {
                 centre = ri[i];
                 for (j = 0; j < maxr[typeJ]; ++j)
@@ -160,7 +159,8 @@ bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, Part
     auto start = procPool.interleavedLoopStart(ProcessPool::PoolStrategy);
     auto stride = procPool.interleavedLoopStride(ProcessPool::PoolStrategy);
 
-    for (n = start; n < cellArray.nCells(); n += stride)
+    auto [begin, end] = cut_range(0, cellArray.nCells(), stride, start);
+    for (n = begin; n < end; ++n)
     {
         cellI = cellArray.cell(n);
         auto &atomsI = cellI->atoms();

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -325,12 +325,12 @@ bool RDFModule::calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule
     timer.start();
 
     // Loop over molecules...
-    std::shared_ptr<Atom> i, j;
-    auto [begin, end] = cut_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
-    for (auto it = begin; it < end; ++it)
+    // NOTE: If you attempt to use cut_range for this loop, instead of stride, it will fail.
+    // The problem does not seem to be in cut_range, but rather in how the loops are merged.
+    // This is GitHub issue #562
+    for (auto it = cfg->molecules().begin() + start; it < cfg->molecules().end(); it += stride)
     {
-        std::shared_ptr<Molecule> mol = *it;
-        auto &atoms = mol->atoms();
+        auto &atoms = (*it)->atoms();
 
 	for_each_pair(atoms.begin(), atoms.end(), [box, &originalgr](int index, auto &i, int jndex, auto &j) {
 	  // Ignore atom on itself

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -8,13 +8,12 @@
 #include <tuple>
 
 // Cut a range into a smaller segment for MPI
-template<typename T>
-auto cut_range(const T begin, const T end, const int count, const int step)
+template <typename T> auto cut_range(const T begin, const T end, const int count, const int step)
 {
-  auto diff = end - begin;
-  T start = begin + std::div((const long int) step * diff, (const long int) count).quot;
-  T stop  = begin + std::div((const long int) (step + 1) * diff, (const long int) count).quot;
-  return std::make_tuple(start, stop);
+    auto diff = end - begin;
+    T start = begin + std::div((const long int)step * diff, (const long int)count).quot;
+    T stop = begin + std::div((const long int)(step + 1) * diff, (const long int)count).quot;
+    return std::make_tuple(start, stop);
 }
 
 // Perform an operation on every pair of elements in a container
@@ -35,7 +34,7 @@ template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam la
 template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, int count, int step, Lam lambda)
 {
     auto [start, stop] = cut_range(begin, end, count, step);
-    int i = start-begin;
+    int i = start - begin;
     for (auto elem1 = start; elem1 != stop; ++elem1, ++i)
     {
         int j = i;

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -11,8 +11,8 @@
 template <typename T> auto cut_range(const T begin, const T end, const int count, const int step)
 {
     auto diff = end - begin;
-    T start = begin + std::div((const long int)step * diff, (const long int)count).quot;
-    T stop = begin + std::div((const long int)(step + 1) * diff, (const long int)count).quot;
+    T start = begin + std::ldiv((const long int)step * diff, (const long int)count).quot;
+    T stop = begin + std::ldiv((const long int)(step + 1) * diff, (const long int)count).quot;
     return std::make_tuple(start, stop);
 }
 

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -31,6 +31,21 @@ template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam la
     }
 }
 
+// Perform an operation on every pair of elements in a container
+template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, int count, int step, Lam lambda)
+{
+    auto [start, stop] = cut_range(begin, end, count, step);
+    int i = start-begin;
+    for (auto elem1 = start; elem1 != stop; ++elem1, ++i)
+    {
+        int j = i;
+        for (auto elem2 = elem1; elem2 != end; ++elem2, ++j)
+        {
+            lambda(i, *elem1, j, *elem2);
+        }
+    }
+}
+
 // Perform an operation on every pair of elements in a range (begin <= i < end)
 template <class Lam> void for_each_pair(int begin, int end, Lam lambda)
 {

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -8,7 +8,7 @@
 #include <tuple>
 
 // Cut a range into a smaller segment for MPI
-template <typename T> auto cut_range(const T begin, const T end, const int count, const int step)
+template <typename T> auto chop_range(const T begin, const T end, const int count, const int step)
 {
     auto diff = end - begin;
     T start = begin + std::ldiv((const long int)step * diff, (const long int)count).quot;

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -12,8 +12,8 @@ template<typename T>
 auto cut_range(const T begin, const T end, const int count, const int step)
 {
   auto diff = end - begin;
-  T start = begin + std::div(step * diff, (const long int) count).quot;
-  T stop  = begin + std::div((step + 1) * diff, (const long int) count).quot;
+  T start = begin + std::div((const long int) step * diff, (const long int) count).quot;
+  T stop  = begin + std::div((const long int) (step + 1) * diff, (const long int) count).quot;
   return std::make_tuple(start, stop);
 }
 

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -7,6 +7,16 @@
 #include <optional>
 #include <tuple>
 
+// Cut a range into a smaller segment for MPI
+template<typename T>
+auto cut_range(const T begin, const T end, const int count, const int step)
+{
+  auto diff = end - begin;
+  T start = begin + std::div(step * diff, (const long int) count).quot;
+  T stop  = begin + std::div((step + 1) * diff, (const long int) count).quot;
+  return std::make_tuple(start, stop);
+}
+
 // Perform an operation on every pair of elements in a container
 template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam lambda)
 {

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -8,11 +8,11 @@
 #include <tuple>
 
 // Cut a range into a smaller segment for MPI
-template <typename T> auto chop_range(const T begin, const T end, const int count, const int step)
+template <typename T> auto chop_range(const T begin, const T end, const int nChunks, const int index)
 {
     auto diff = end - begin;
-    T start = begin + std::ldiv((const long int)step * diff, (const long int)count).quot;
-    T stop = begin + std::ldiv((const long int)(step + 1) * diff, (const long int)count).quot;
+    T start = begin + std::ldiv((const long int)index * diff, (const long int)nChunks).quot;
+    T stop = begin + std::ldiv((const long int)(index + 1) * diff, (const long int)nChunks).quot;
     return std::make_tuple(start, stop);
 }
 
@@ -31,9 +31,9 @@ template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, Lam la
 }
 
 // Perform an operation on every pair of elements in a container
-template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, int count, int step, Lam lambda)
+template <class Iter, class Lam> void for_each_pair(Iter begin, Iter end, int nChunks, int index, Lam lambda)
 {
-    auto [start, stop] = cut_range(begin, end, count, step);
+    auto [start, stop] = chop_range(begin, end, nChunks, index);
     int i = start - begin;
     for (auto elem1 = start; elem1 != stop; ++elem1, ++i)
     {

--- a/unit/test_aragorn.cpp
+++ b/unit/test_aragorn.cpp
@@ -26,7 +26,7 @@ TEST(AragornTest, ArithmaticSeries)
         // Sum each cut, then take the sum of the cuts
         for (int n = 0; n < cuts; ++n)
         {
-            auto [begin, end] = cut_range(ints.begin(), ints.end(), cuts, n);
+            auto [begin, end] = chop_range(ints.begin(), ints.end(), cuts, n);
             count += std::accumulate(begin, end, 0);
         }
         // Make sure that the sum of the cuts in equal to the total

--- a/unit/test_aragorn.cpp
+++ b/unit/test_aragorn.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "templates/algorithms.h"
+#include <algorithm>
+#include <numeric>
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace UnitTest
+{
+
+TEST(AragornTest, ArithmaticSeries)
+{
+    unsigned int size = 100000;
+    std::vector<int> ints(size);
+    std::iota(ints.begin(), ints.end(), 1);
+    int total = std::accumulate(ints.begin(), ints.end(), 0);
+
+    EXPECT_EQ(total, size*(size+1)>>1);
+
+    // Try many different cut lengs
+    for (int cuts = 1; cuts < 40; ++cuts) {
+      int count = 0;
+      // Sum each cut, then take the sum of the cuts
+      for (int n = 0; n < cuts; ++n) {
+	auto [begin, end] = cut_range(ints.begin(), ints.end(), cuts, n);
+	count += std::accumulate(begin, end, 0);
+      }
+      // Make sure that the sum of the cuts in equal to the total
+      EXPECT_EQ(total, count);
+    }
+}
+
+} // namespace UnitTest

--- a/unit/test_aragorn.cpp
+++ b/unit/test_aragorn.cpp
@@ -3,8 +3,8 @@
 
 #include "templates/algorithms.h"
 #include <algorithm>
-#include <numeric>
 #include <gtest/gtest.h>
+#include <numeric>
 #include <vector>
 
 namespace UnitTest
@@ -17,18 +17,20 @@ TEST(AragornTest, ArithmaticSeries)
     std::iota(ints.begin(), ints.end(), 1);
     int total = std::accumulate(ints.begin(), ints.end(), 0);
 
-    EXPECT_EQ(total, size*(size+1)>>1);
+    EXPECT_EQ(total, size * (size + 1) >> 1);
 
     // Try many different cut lengs
-    for (int cuts = 1; cuts < 40; ++cuts) {
-      int count = 0;
-      // Sum each cut, then take the sum of the cuts
-      for (int n = 0; n < cuts; ++n) {
-	auto [begin, end] = cut_range(ints.begin(), ints.end(), cuts, n);
-	count += std::accumulate(begin, end, 0);
-      }
-      // Make sure that the sum of the cuts in equal to the total
-      EXPECT_EQ(total, count);
+    for (int cuts = 1; cuts < 40; ++cuts)
+    {
+        int count = 0;
+        // Sum each cut, then take the sum of the cuts
+        for (int n = 0; n < cuts; ++n)
+        {
+            auto [begin, end] = cut_range(ints.begin(), ints.end(), cuts, n);
+            count += std::accumulate(begin, end, 0);
+        }
+        // Make sure that the sum of the cuts in equal to the total
+        EXPECT_EQ(total, count);
     }
 }
 


### PR DESCRIPTION
Use a general range splitter during MPI instead of using a stride step.  This will make it easier to switch to using algorithms, since they always look at every element.