### PR TITLE
FIX osx

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -22,6 +22,7 @@ stages:
     jobs:
       - job: 'linux_serialgui'
         displayName: 'Build Linux (Serial/GUI, ubuntu-18.04)'
+        condition: eq(1,0)
         pool:
           vmImage: 'ubuntu-18.04' 
         steps:
@@ -39,6 +40,7 @@ stages:
               ArtifactName: 'linux-tests-serial'
             displayName: 'Publish Serial Test Artifacts'
       - job: 'linux_parallel'
+        condition: eq(1,0)
         displayName: 'Build Linux (Parallel, ubuntu-18.04)'
         pool:
           vmImage: 'ubuntu-18.04' 
@@ -71,6 +73,7 @@ stages:
               ArtifactName: 'osx-artifacts'
             displayName: 'Publish OSX Artifacts'
       - job: 'windows_serialgui'
+        condition: eq(1,0)
         displayName: 'Build Windows (Serial/GUI, windows-latest)'
         timeoutInMinutes: 120
         pool:

--- a/.azure-pipelines/templates/build-osx-serial-gui.yml
+++ b/.azure-pipelines/templates/build-osx-serial-gui.yml
@@ -17,13 +17,14 @@ steps:
     displayName: 'Install Conan'
   - bash: |
       set -ex
-      QTVER=`ls -d /usr/local/Cellar/qt/* | sed "s/.*\(5\.[0-9][0-9]\.[0-9]\)/\1/g"`
-      export Qt5_DIR=/usr/local/Cellar/qt/$QTVER/lib/cmake/Qt5
-      export Qt5Core_DIR=/usr/local/Cellar/qt/$QTVER/lib/cmake/Qt5Core
-      export Qt5Widgets_DIR=/usr/local/Cellar/qt/$QTVER/lib/cmake/Qt5Widgets
-      export Qt5PrintSupport_DIR=/usr/local/Cellar/qt/$QTVER/lib/cmake/Qt5PrintSupport
-      export Qt5Gui_DIR=/usr/local/Cellar/qt/$QTVER/lib/cmake/Qt5Gui
-      Qt5_ROOT=/usr/local/Cellar/qt/${QTVER}
+      QT_INSTALL_DIR=/usr/local/Cellar/qt@5
+      QTVER=`ls -d ${QT_INSTALL_DIR}/* | sed "s/.*\(5\.[0-9][0-9]\.[0-9]\)/\1/g"`
+      export Qt5_DIR=${QT_INSTALL_DIR}/$QTVER/lib/cmake/Qt5
+      export Qt5Core_DIR=${QT_INSTALL_DIR}/$QTVER/lib/cmake/Qt5Core
+      export Qt5Widgets_DIR=${QT_INSTALL_DIR}/$QTVER/lib/cmake/Qt5Widgets
+      export Qt5PrintSupport_DIR=${QT_INSTALL_DIR}/$QTVER/lib/cmake/Qt5PrintSupport
+      export Qt5Gui_DIR=${QT_INSTALL_DIR}/$QTVER/lib/cmake/Qt5Gui
+      Qt5_ROOT=${QT_INSTALL_DIR}/${QTVER}
       ANTLR_EXE=`find /usr/local/Cellar/antlr/4.9* -iname antlr`
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
       mkdir build

--- a/.azure-pipelines/templates/package-osx-serial-gui.yml
+++ b/.azure-pipelines/templates/package-osx-serial-gui.yml
@@ -1,7 +1,3 @@
-parameters:
-  - name: qtver
-    default: 5.15.2
-
 steps:
   - bash: |
       pip3 install dmgbuild biplist
@@ -9,7 +5,9 @@ steps:
   - bash: |
       set -ex
       # Set Qt dir - assume that it is somewhere in /usr/local/Cellar
-      Qt5_ROOT=/usr/local/Cellar/qt/${{ parameters.qtver }}
+      QT_INSTALL_DIR=/usr/local/Cellar/qt@5
+      QTVER=`ls -d ${QT_INSTALL_DIR}/* | sed "s/.*\(5\.[0-9][0-9]\.[0-9]\)/\1/g"`
+      Qt5_ROOT=${QT_INSTALL_DIR}/${QTVER}
       # Get program version
       DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
       ci/scripts/prep-dmg -a Dissolve-GUI -v ${DISSOLVE_VERSION} -b build/bin/dissolve-gui.app/Contents/MacOS/dissolve-gui -d ${Qt5_ROOT} -i icon/icon-1024x1024.png -p build/bin/dissolve-gui.app/Contents/Info.plist


### PR DESCRIPTION
- TEMPORARY Disable non-OSX builds.
- Probe new Qt5 installation path.
- Probe new Qt5 installation path (more).
