### PR TITLE
Sampled Vector

### DIFF
--- a/src/gui/widgets/sampleddoublelabel_funcs.cpp
+++ b/src/gui/widgets/sampleddoublelabel_funcs.cpp
@@ -28,6 +28,6 @@ void SampledDoubleLabel::setLabelFonts(int basePointSize)
 // Set label values
 void SampledDoubleLabel::setText(const SampledDouble &sampledDouble)
 {
-    ui_.ValueLabel->setText(QString::number(sampledDouble.mean()));
+    ui_.ValueLabel->setText(QString::number(sampledDouble.value()));
     ui_.StDevLabel->setText(QString::number(sampledDouble.stDev()));
 }

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(
   range.cpp
   regression.cpp
   sampleddouble.cpp
+  sampledvector.cpp
   svd.cpp
   transformer.cpp
   windowfunction.cpp
@@ -62,6 +63,7 @@ add_library(
   range.h
   regression.h
   sampleddouble.h
+  sampledvector.h
   sd.h
   svd.h
   transformer.h

--- a/src/math/sampleddouble.cpp
+++ b/src/math/sampleddouble.cpp
@@ -32,9 +32,6 @@ double SampledDouble::value() const { return mean_; }
 // Return number of samples contributing to averages etc.
 int SampledDouble::count() const { return count_; }
 
-// Return mean (current) value
-double SampledDouble::mean() const { return mean_; }
-
 // Return variance of sampled data
 double SampledDouble::variance() const { return (count_ < 2 ? 0.0 : m2_ / (count_ - 1)); }
 

--- a/src/math/sampleddouble.cpp
+++ b/src/math/sampleddouble.cpp
@@ -42,25 +42,27 @@ double SampledDouble::stDev() const { return (count_ < 2 ? 0.0 : sqrt(m2_ / (cou
  * Operators
  */
 
-// Conversion (double)
 SampledDouble::operator double &() { return mean_; }
+
 SampledDouble::operator const double &() const { return mean_; }
 
-// Assigment
-void SampledDouble::operator=(double x)
+SampledDouble &SampledDouble::operator=(double x)
 {
     // Clear any existing statistics and set new value
     count_ = 1;
     m2_ = 0.0;
     mean_ = x;
+
+    return *this;
 }
 
-// Assigment
-void SampledDouble::operator=(const SampledDouble &source)
+SampledDouble &SampledDouble::operator=(const SampledDouble &source)
 {
     count_ = source.count_;
     mean_ = source.mean_;
     m2_ = source.m2_;
+
+    return *this;
 }
 
 void SampledDouble::operator+=(double x)

--- a/src/math/sampleddouble.h
+++ b/src/math/sampleddouble.h
@@ -45,8 +45,8 @@ class SampledDouble : public GenericItemBase
     public:
     operator double &();
     operator const double &() const;
-    void operator=(double x);
-    void operator=(const SampledDouble &source);
+    SampledDouble &operator=(double x);
+    SampledDouble &operator=(const SampledDouble &source);
     void operator+=(double x);
     void operator+=(int i);
     void operator+=(const SampledDouble &source);

--- a/src/math/sampleddouble.h
+++ b/src/math/sampleddouble.h
@@ -34,8 +34,6 @@ class SampledDouble : public GenericItemBase
     double value() const;
     // Return number of samples contributing to averages etc.
     int count() const;
-    // Return mean (current) value
-    double mean() const;
     // Return variance of sampled data
     double variance() const;
     // Return standard deviation of sampled data

--- a/src/math/sampledvector.cpp
+++ b/src/math/sampledvector.cpp
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "math/sampledvector.h"
+#include "base/lineparser.h"
+#include "templates/algorithms.h"
+#include <math.h>
+
+SampledVector::SampledVector() : count_(0) {}
+
+/*
+ * Data
+ */
+
+// Initialise arrays
+void SampledVector::initialise(int nValues)
+{
+    mean_.resize(nValues);
+    m2_.resize(nValues);
+    stDev_.resize(nValues);
+    reset();
+}
+
+// Reset values and statistics
+void SampledVector::reset()
+{
+    count_ = 0;
+    std::fill(mean_.begin(), mean_.end(), 0.0);
+    std::fill(m2_.begin(), m2_.end(), 0.0);
+    std::fill(stDev_.begin(), stDev_.end(), 0.0);
+}
+
+// Return number of samples contributing to averages etc.
+int SampledVector::count() const { return count_; }
+
+// Return current (mean) values
+const std::vector<double> &SampledVector::values() const { return mean_; }
+
+// Return standard deviations of values
+const std::vector<double> &SampledVector::stDev() const { return stDev_; }
+
+/*
+ * Operators
+ */
+
+SampledVector &SampledVector::operator=(const SampledVector &source)
+{
+    count_ = source.count_;
+    mean_.resize(source.mean_.size());
+    std::copy(source.mean_.begin(), source.mean_.end(), mean_.begin());
+    m2_.resize(source.m2_.size());
+    std::copy(source.m2_.begin(), source.m2_.end(), m2_.begin());
+    stDev_.resize(source.stDev_.size());
+    std::copy(source.stDev_.begin(), source.stDev_.end(), stDev_.begin());
+
+    return *this;
+}
+
+SampledVector &SampledVector::operator+=(const std::vector<double> &source)
+{
+    // Accumulate value using Welford's online algorithm
+    // B. P. Welford, "Note on a method for calculating corrected sums of squares and products", Technometrics, 4(3),
+    // 419–420 (1962).
+
+    // If the sample size is currently zero, initialise to the size of the source vector
+    if (count_ == 0)
+        initialise(source.size());
+
+    // Check vector size consistency
+    if (mean_.size() != source.size())
+        throw(std::runtime_error(
+            fmt::format("Vector passed to SampledVector::operator+= has a different size ({}) to the current data ({}).\n",
+                        source.size(), mean_.size())));
+
+    // Increase sample size counter
+    ++count_;
+
+    double delta;
+    for (auto &&[mean, m2, stDev, x] : zip(mean_, m2_, stDev_, source))
+    {
+        // Determine difference between supplied value and current mean
+        delta = x - mean;
+
+        // Accumulate mean
+        mean += delta / count_;
+
+        // Accumulate m2 using deltas of new value with old and new mean
+        m2 += delta * (x - mean);
+
+        // Determine new standard deviation
+        stDev = (count_ < 2 ? 0.0 : sqrt(m2 / (count_ - 1)));
+    }
+
+    return *this;
+}
+
+SampledVector &SampledVector::operator+=(const SampledVector &source)
+{
+    // Accumulate other values using parallel algorithm of Chan
+    // T. F. Chan, G. H. Golub, R. J. LeVeque, "Updating Formulae and a Pairwise Algorithm for Computing Sample Variances.",
+    // Technical Report STAN-CS-79-773, Department of Computer Science, Stanford University (1979).
+
+    // Check vector size consistency
+    if (mean_.size() != source.values().size())
+        throw(std::runtime_error(fmt::format(
+            "SampledVector passed to SampledVector::operator+= has a different size ({}) to the current data ({}).\n",
+            source.values().size(), mean_.size())));
+
+    const auto newCount = count_ + source.count_;
+    const auto rCountNew = 1.0 / newCount;
+    double deltaMean;
+
+    for (auto &&[meanA, m2A, stDevA, meanB, m2B] : zip(mean_, m2_, stDev_, source.mean_, source.m2_))
+    {
+        // Determine difference in mean values between samples B and A
+        deltaMean = meanB - meanA;
+
+        // Calculate new mean
+        meanA += deltaMean * source.count_ * rCountNew;
+
+        // Calculate new M2
+        m2A += m2B + deltaMean * deltaMean * count_ * source.count_ * rCountNew;
+
+        // Calculate new standard deviation
+        stDevA = (count_ < 2 ? 0.0 : sqrt(m2A / (newCount - 1)));
+    }
+
+    // Set new count
+    count_ = newCount;
+
+    return *this;
+}
+
+void SampledVector::operator*=(double x)
+{
+    // Apply factor to mean_, m2_, and stDev_
+    std::transform(mean_.begin(), mean_.end(), mean_.begin(), [=](auto mean) { return mean * x; });
+    std::transform(m2_.begin(), m2_.end(), m2_.begin(), [=](auto m2) { return m2 * x; });
+    std::transform(stDev_.begin(), stDev_.end(), stDev_.begin(), [=](auto stDev) { return stDev * x; });
+}
+
+void SampledVector::operator/=(double x)
+{
+    // Apply factor to mean_, m2_, and stDev_
+    std::transform(mean_.begin(), mean_.end(), mean_.begin(), [=](auto mean) { return mean / x; });
+    std::transform(m2_.begin(), m2_.end(), m2_.begin(), [=](auto m2) { return m2 / x; });
+    std::transform(stDev_.begin(), stDev_.end(), stDev_.begin(), [=](auto stDev) { return stDev / x; });
+}
+
+/*
+ * GenericItemBase Implementations
+ */
+
+// Return class name
+std::string_view SampledVector::itemClassName() { return "SampledVector"; }
+
+// Read data through specified LineParser
+bool SampledVector::read(LineParser &parser, CoreData &coreData)
+{
+    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+        return false;
+    initialise(parser.argi(0));
+    count_ = parser.argi(1);
+
+    for (auto &&[mean, m2, stDev] : zip(mean_, m2_, stDev_))
+    {
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+            return false;
+
+        mean = parser.argd(0);
+        m2 = parser.argd(1);
+        stDev = parser.argd(2);
+    }
+
+    return true;
+}
+
+// Write data through specified LineParser
+bool SampledVector::write(LineParser &parser)
+{
+    if (!parser.writeLineF("{} {} # nData count", mean_.size(), count_))
+        return false;
+
+    for (auto &&[mean, m2, stDev] : zip(mean_, m2_, stDev_))
+        if (!parser.writeLineF("{} {} {}\n", mean, m2, stDev))
+            return false;
+
+    return true;
+}
+
+/*
+ * Parallel Comms
+ */
+
+// Sum data over all processes within the pool
+bool SampledVector::allSum(ProcessPool &procPool)
+{
+#ifdef PARALLEL
+    // All processes in the pool send their data to the zero rank, which assembles the statistics and then broadcasts the
+    // final result
+    for (auto n = 1; n < procPool.nProcesses(); ++n)
+    {
+        if (procPool.poolRank() == 0)
+        {
+            // Rank zero receives the data and sums it
+            SampledVector data;
+            if (!procPool.receive(data.count_, 0))
+                return false;
+            if (!procPool.receive(data.mean_, 0))
+                return false;
+            if (!procPool.receive(data.m2_, 0))
+                return false;
+
+            (*this) += data;
+        }
+        else
+        {
+            // Send our data to rank zero
+            if (!procPool.send(count_, 0))
+                return false;
+            if (!procPool.send(mean_, 0))
+                return false;
+            if (!procPool.send(m2_, 0))
+                return false;
+        }
+    }
+
+    if (!procPool.broadcast(count_))
+        return false;
+    if (!procPool.broadcast(mean_))
+        return false;
+    if (!procPool.broadcast(m2_))
+        return false;
+#endif
+    return true;
+}
+
+// Broadcast data
+bool SampledVector::broadcast(ProcessPool &procPool, const int root, const CoreData &coreData)
+{
+#ifdef PARALLEL
+    if (!procPool.broadcast(count_, root))
+        return false;
+    if (!procPool.broadcast(mean_, root))
+        return false;
+    if (!procPool.broadcast(m2_, root))
+        return false;
+#endif
+    return true;
+}
+
+// Check equality of all data
+bool SampledVector::equality(ProcessPool &procPool)
+{
+#ifdef PARALLEL
+    if (!procPool.equality(count_))
+        return Messenger::error("SampledVector count is not equivalent (process {} has {}).\n", procPool.poolRank(), count_);
+    if (!procPool.equality(mean_))
+        return Messenger::error("SampledVector mean value is not equivalent (process {} has {:e}).\n", procPool.poolRank(),
+                                mean_);
+    if (!procPool.equality(m2_))
+        return Messenger::error("SampledVector m2 value is not equivalent (process {} has {:e}).\n", procPool.poolRank(), m2_);
+#endif
+    return true;
+}

--- a/src/math/sampledvector.h
+++ b/src/math/sampledvector.h
@@ -66,8 +66,6 @@ class SampledVector : public GenericItemBase
      * Parallel Comms
      */
     public:
-    // Sum data over all processes within the pool
-    bool allSum(ProcessPool &procPool);
     // Broadcast data
     bool broadcast(ProcessPool &procPool, const int root, const CoreData &coreData);
     // Check equality of all data

--- a/src/math/sampledvector.h
+++ b/src/math/sampledvector.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "genericitems/base.h"
+#include <ctime>
+
+// Forward Declarations
+class ProcessPool;
+
+// Vector of double values with sampling
+class SampledVector : public GenericItemBase
+{
+    public:
+    SampledVector();
+    ~SampledVector() = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Sample size contributing to averages etc.
+    int count_;
+    // Mean of sampled data (i.e. current values)
+    std::vector<double> mean_;
+    // Aggregate of squared distance from mean values
+    std::vector<double> m2_;
+    // Standard deviations of values
+    std::vector<double> stDev_;
+
+    public:
+    // Initialise arrays
+    void initialise(int nValues);
+    // Reset values and statistics
+    void reset();
+    // Return number of samples contributing to averages etc.
+    int count() const;
+    // Return current (mean) values
+    const std::vector<double> &values() const;
+    // Return standard deviations of values
+    const std::vector<double> &stDev() const;
+
+    /*
+     * Operators
+     */
+    public:
+    SampledVector &operator+=(const std::vector<double> &source);
+    SampledVector &operator=(const SampledVector &source);
+    SampledVector &operator+=(const SampledVector &source);
+    void operator*=(double factor);
+    void operator/=(double factor);
+
+    /*
+     * GenericItemBase Implementations
+     */
+    public:
+    // Return class name
+    static std::string_view itemClassName();
+    // Read data through specified LineParser
+    bool read(LineParser &parser, CoreData &coreData);
+    // Write data through specified LineParser
+    bool write(LineParser &parser);
+
+    /*
+     * Parallel Comms
+     */
+    public:
+    // Sum data over all processes within the pool
+    bool allSum(ProcessPool &procPool);
+    // Broadcast data
+    bool broadcast(ProcessPool &procPool, const int root, const CoreData &coreData);
+    // Check equality of all data
+    bool equality(ProcessPool &procPool);
+};

--- a/src/procedure/nodes/integrate1d.cpp
+++ b/src/procedure/nodes/integrate1d.cpp
@@ -77,11 +77,11 @@ ProcedureNode::NodeExecutionResult Integrate1DProcedureNode::execute(ProcessPool
     integral_[2] += Integrator::trapezoid(processNode_->processedData(), keywords_.retrieve<Range>("RangeC"));
 
     // Print info
-    Messenger::print("Integrate1D - Range A: {:e} +/- {:e} over {:e} < x < {:e}.\n", integral_[0].mean(), integral_[0].stDev(),
+    Messenger::print("Integrate1D - Range A: {:e} +/- {:e} over {:e} < x < {:e}.\n", integral_[0].value(), integral_[0].stDev(),
                      rangeA.minimum(), rangeA.maximum());
-    Messenger::print("Integrate1D - Range B: {:e} +/- {:e} over {:e} < x < {:e}.\n", integral_[1].mean(), integral_[1].stDev(),
+    Messenger::print("Integrate1D - Range B: {:e} +/- {:e} over {:e} < x < {:e}.\n", integral_[1].value(), integral_[1].stDev(),
                      rangeB.minimum(), rangeB.maximum());
-    Messenger::print("Integrate1D - Range C: {:e} +/- {:e} over {:e} < x < {:e}.\n", integral_[2].mean(), integral_[2].stDev(),
+    Messenger::print("Integrate1D - Range C: {:e} +/- {:e} over {:e} < x < {:e}.\n", integral_[2].value(), integral_[2].stDev(),
                      rangeC.minimum(), rangeC.maximum());
 
     return ProcedureNode::Success;

--- a/src/procedure/nodes/sum1d.cpp
+++ b/src/procedure/nodes/sum1d.cpp
@@ -88,13 +88,13 @@ ProcedureNode::NodeExecutionResult Sum1DProcedureNode::execute(ProcessPool &proc
         sum_[2] += Integrator::sum(processNode_->processedData(), rangeC_);
 
     // Print info
-    Messenger::print("Sum1D - Range A: {:e} +/- {:e} over {:e} < x < {:e}.\n", sum_[0].mean(), sum_[0].stDev(),
+    Messenger::print("Sum1D - Range A: {:e} +/- {:e} over {:e} < x < {:e}.\n", sum_[0].value(), sum_[0].stDev(),
                      rangeA_.minimum(), rangeA_.maximum());
     if (rangeBEnabled_)
-        Messenger::print("Sum1D - Range B: {:e} +/- {:e} over {:e} < x < {:e}.\n", sum_[1].mean(), sum_[1].stDev(),
+        Messenger::print("Sum1D - Range B: {:e} +/- {:e} over {:e} < x < {:e}.\n", sum_[1].value(), sum_[1].stDev(),
                          rangeB_.minimum(), rangeB_.maximum());
     if (rangeCEnabled_)
-        Messenger::print("Sum1D - Range C: {:e} +/- {:e} over {:e} < x < {:e}.\n", sum_[2].mean(), sum_[2].stDev(),
+        Messenger::print("Sum1D - Range C: {:e} +/- {:e} over {:e} < x < {:e}.\n", sum_[2].value(), sum_[2].stDev(),
                          rangeC_.minimum(), rangeC_.maximum());
 
     return ProcedureNode::Success;

--- a/unit/test_sampledvalues.cpp
+++ b/unit/test_sampledvalues.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "math/sampleddouble.h"
+#include "math/sampledvector.h"
+#include "templates/algorithms.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace UnitTest
+{
+class SampledValuesTest : public ::testing::Test
+{
+    public:
+    SampledValuesTest() = default;
+
+    void testDouble(const std::vector<double> values)
+    {
+        auto mean = 0.0, stDev = 0.0;
+
+        // Two-pass computation of mean followed by standard deviation
+        for (auto value : values)
+            mean += value;
+        mean /= values.size();
+        for (auto value : values)
+            stDev += (value - mean) * (value - mean);
+        stDev /= values.size() - 1;
+        stDev = sqrt(stDev);
+
+        // One-pass with SampledDouble
+        SampledDouble x;
+        for (auto value : values)
+            x += value;
+
+        EXPECT_DOUBLE_EQ(x.value(), mean);
+        EXPECT_DOUBLE_EQ(x.stDev(), stDev);
+    }
+
+    SampledVector testVector(const std::vector<std::vector<double>> values)
+    {
+        // One-pass with SampledVector
+        SampledVector v;
+        for (auto &vs : values)
+            v += vs;
+
+        // Calculate / test mean values
+        std::vector<double> mean;
+        mean.assign(values.front().size(), 0.0);
+        for (auto &vs : values)
+            std::transform(vs.begin(), vs.end(), mean.begin(), mean.begin(), [=](auto x, auto m) { return m + x; });
+        std::transform(mean.begin(), mean.end(), mean.begin(), [=](auto m) { return m / values.size(); });
+        for (auto &&[a, b] : zip(v.values(), mean))
+            EXPECT_DOUBLE_EQ(a, b);
+
+        // Calculate / test standard deviations
+        std::vector<double> stDev;
+        stDev.assign(values.front().size(), 0.0);
+        for (auto &vs : values)
+            for (auto &&[x, m, st] : zip(vs, mean, stDev))
+                st += (x - m) * (x - m);
+        std::transform(stDev.begin(), stDev.end(), stDev.begin(), [=](auto st) { return sqrt(st / (values.size() - 1)); });
+        for (auto &&[a, b] : zip(v.stDev(), stDev))
+            EXPECT_DOUBLE_EQ(a, b);
+
+        return v;
+    }
+};
+
+TEST_F(SampledValuesTest, SampledDouble)
+{
+    testDouble({4, 7, 13, 16});
+    testDouble({10e8 + 4, 10e8 + 7, 10e8 + 13, 10e8 + 16});
+    testDouble({9.2, 4.456, 98.7, 42.2, 12.09, 55.62});
+}
+
+TEST_F(SampledValuesTest, SampledVector)
+{
+    // Data
+    std::vector<std::vector<double>> data1 = {{73.478, 4.901,  48.52,  83.77,  60.356, 84.403, 70.622, 13.638, 92.007, 39.253,
+                                               31.703, 65.619, 17.404, 27.647, 40.677, 19.453, 73.203, 25.609, 17.674, 70.748},
+                                              {15.375, 21.281, 52.272, 98.805, 38.857, 79.573, 23.458, 57.381, 50.727, 41.206,
+                                               3.116,  85.6,   82.309, 10.512, 87.126, 16.309, 62.894, 74.282, 63.45,  96.273}};
+    std::vector<std::vector<double>> data2 = {{7.433,  66.709, 6.001,  63.37,  19.852, 41.264, 42.347, 90.447, 92.651, 96.1,
+                                               34.733, 29.341, 52.652, 66.318, 84.095, 21.576, 48.902, 90.737, 31.463, 46.744},
+                                              {58.251, 79.925, 98.289, 7.341,  95.626, 32.155, 75.387, 14.633, 63.938, 3.581,
+                                               52.948, 22.764, 45.079, 48.432, 24.91,  29.928, 16.268, 79.915, 34.386, 95.738},
+                                              {84.984, 1.896, 94.278, 6.464, 57.482, 58.584, 9.001, 62.737, 59.6,  20.782,
+                                               49.915, 40.27, 1.154,  44.58, 4.285,  20.551, 9.449, 63.176, 8.468, 53.585}};
+    auto data3 = data1;
+    data3.insert(data3.end(), data2.begin(), data2.end());
+
+    // Equivalent Sums
+    testVector({{4, 7, 13, 16}, {7, 13, 16, 4}, {13, 16, 4, 7}, {16, 4, 7, 13}});
+
+    // Five sets of Real Data
+    auto sampled3 = testVector(data3);
+
+    // Combination of two sets
+    auto sampled1 = testVector(data1);
+    auto sampled2 = testVector(data2);
+    SampledVector combined = sampled1;
+    combined += sampled2;
+    for (auto &&[a, b] : zip(combined.values(), sampled3.values()))
+        EXPECT_DOUBLE_EQ(a, b);
+    for (auto &&[a, b] : zip(combined.stDev(), sampled3.stDev()))
+        EXPECT_DOUBLE_EQ(a, b);
+}
+
+TEST_F(SampledValuesTest, SampledVectorAssertions)
+{
+    // Mismatched vector sizes
+    SampledVector v;
+    v += {1, 2, 3, 4, 5};
+    EXPECT_ANY_THROW({ v += std::vector<double>({1, 2, 3, 4}); });
+}
+
+} // namespace UnitTest


### PR DESCRIPTION
This PR introduces a `SampledVector` class, complementing the single-valued `SampledDouble` class for calculating online statistical averages. A unit test is added covering both classes, and some tidying of the original `SampledDouble` is performed.

The intended immediate use-case for the new class is in the implementation of accumulated `PartialSets` (#144).
