### PR TITLE
Bugfix 03-03-21 Const TableWidgetUpdater

### DIFF
--- a/src/gui/addconfigurationwizard_funcs.cpp
+++ b/src/gui/addconfigurationwizard_funcs.cpp
@@ -6,7 +6,6 @@
 #include "classes/species.h"
 #include "gui/addconfigurationwizard.h"
 #include "gui/helpers/combopopulator.h"
-#include "gui/helpers/tablewidgetupdater.h"
 #include "main/dissolve.h"
 #include "templates/variantpointer.h"
 #include <QFileDialog>

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -7,12 +7,9 @@
 #include "classes/configuration.h"
 #include "classes/species.h"
 #include "gui/configurationtab.h"
-#include "gui/delegates/combolist.hui"
-#include "gui/delegates/exponentialspin.hui"
 #include "gui/getconfigurationnamedialog.h"
 #include "gui/gui.h"
 #include "gui/helpers/combopopulator.h"
-#include "gui/helpers/tablewidgetupdater.h"
 #include "main/dissolve.h"
 #include "templates/variantpointer.h"
 #include <QMessageBox>

--- a/src/gui/datamanagerdialog_funcs.cpp
+++ b/src/gui/datamanagerdialog_funcs.cpp
@@ -153,8 +153,8 @@ void DataManagerDialog::updateControls()
     ui_.SimulationDataTable->resizeColumnsToContents();
 
     // Populate reference points table
-    TableWidgetUpdater<DataManagerDialog, ReferencePoint> refPointUpdater(ui_.ReferencePointsTable, referencePoints_, this,
-                                                                          &DataManagerDialog::referencePointRowUpdate);
+    ConstTableWidgetUpdater<DataManagerDialog, ReferencePoint> refPointUpdater(ui_.ReferencePointsTable, referencePoints_, this,
+                                                                               &DataManagerDialog::referencePointRowUpdate);
     ui_.ReferencePointsTable->resizeColumnsToContents();
 }
 

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -447,27 +447,27 @@ void ForcefieldTab::updateControls()
     Locker refreshLocker(refreshLock_);
 
     // Master Bonds Table
-    TableWidgetUpdater<ForcefieldTab, MasterIntra> bondsUpdater(ui_.MasterBondsTable, dissolve_.coreData().masterBonds(), this,
-                                                                &ForcefieldTab::updateBondsTableRow);
+    ConstTableWidgetUpdater<ForcefieldTab, MasterIntra> bondsUpdater(ui_.MasterBondsTable, dissolve_.coreData().masterBonds(),
+                                                                     this, &ForcefieldTab::updateBondsTableRow);
     ui_.MasterBondsTable->resizeColumnsToContents();
 
     // Master Angles Table
-    TableWidgetUpdater<ForcefieldTab, MasterIntra> anglesUpdater(ui_.MasterAnglesTable, dissolve_.coreData().masterAngles(),
-                                                                 this, &ForcefieldTab::updateAnglesTableRow);
+    ConstTableWidgetUpdater<ForcefieldTab, MasterIntra> anglesUpdater(
+        ui_.MasterAnglesTable, dissolve_.coreData().masterAngles(), this, &ForcefieldTab::updateAnglesTableRow);
     ui_.MasterAnglesTable->resizeColumnsToContents();
 
     // Torsions Table
-    TableWidgetUpdater<ForcefieldTab, MasterIntra> torsionsUpdater(
+    ConstTableWidgetUpdater<ForcefieldTab, MasterIntra> torsionsUpdater(
         ui_.MasterTorsionsTable, dissolve_.coreData().masterTorsions(), this, &ForcefieldTab::updateTorsionsTableRow);
     ui_.MasterTorsionsTable->resizeColumnsToContents();
 
     // Impropers Table
-    TableWidgetUpdater<ForcefieldTab, MasterIntra> impropersUpdater(
+    ConstTableWidgetUpdater<ForcefieldTab, MasterIntra> impropersUpdater(
         ui_.MasterImpropersTable, dissolve_.coreData().masterImpropers(), this, &ForcefieldTab::updateImpropersTableRow);
     ui_.MasterImpropersTable->resizeColumnsToContents();
 
     // AtomTypes Table
-    TableWidgetUpdater<ForcefieldTab, AtomType, std::shared_ptr<AtomType>> atomTypesUpdater(
+    ConstTableWidgetUpdater<ForcefieldTab, AtomType, std::shared_ptr<AtomType>> atomTypesUpdater(
         ui_.AtomTypesTable, dissolve_.atomTypes(), this, &ForcefieldTab::updateAtomTypesTableRow);
     ui_.AtomTypesTable->resizeColumnsToContents();
 
@@ -494,8 +494,8 @@ void ForcefieldTab::updateControls()
     // -- Table
     // -- Get current row index before we refresh...
     auto ppRowIndex = ui_.PairPotentialsTable->currentRow();
-    TableWidgetUpdater<ForcefieldTab, PairPotential> ppUpdater(ui_.PairPotentialsTable, dissolve_.pairPotentials(), this,
-                                                               &ForcefieldTab::updatePairPotentialsTableRow);
+    ConstTableWidgetUpdater<ForcefieldTab, PairPotential> ppUpdater(ui_.PairPotentialsTable, dissolve_.pairPotentials(), this,
+                                                                    &ForcefieldTab::updatePairPotentialsTableRow);
     ui_.PairPotentialsTable->resizeColumnsToContents();
 
     refreshLocker.unlock();
@@ -542,7 +542,7 @@ void ForcefieldTab::on_AtomTypeAddButton_clicked(bool checked)
 
     Locker refreshLocker(refreshLock_);
 
-    TableWidgetUpdater<ForcefieldTab, AtomType, std::shared_ptr<AtomType>> atomTypesUpdater(
+    ConstTableWidgetUpdater<ForcefieldTab, AtomType, std::shared_ptr<AtomType>> atomTypesUpdater(
         ui_.AtomTypesTable, dissolve_.atomTypes(), this, &ForcefieldTab::updateAtomTypesTableRow);
     ui_.AtomTypesTable->resizeColumnsToContents();
 

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -118,3 +118,83 @@ template <class T, class I, typename Raw = const I *, typename... Args> class Co
         table->setRowCount(rowCount);
     }
 };
+
+// TableWidgetUpdater - Constructor-only template class to update contents of a QTableWidget, preserving original items as
+// much as possible. This is present as a temporary fix whilst the GUI transitions to MVC-style operation.
+template <class T, class I, typename Raw = I *, typename... Args> class TableWidgetUpdater
+{
+    // Typedefs for passed functions
+    typedef void (T::*TableWidgetRowUpdateFunction)(int row, Raw item, bool createItems, Args... args);
+
+    private:
+    // For a given QTableWidget, ensure that the given dataItem is at
+    // the given rowCount index.  If there are other items in the way,
+    // remove them.  If the item isn't in the table, add it.  Finally,
+    // updateRow.
+    static void updateItemAtIndex(QTableWidget *table, int rowCount, Raw dataItem, T *functionParent,
+                                  TableWidgetRowUpdateFunction updateRow, Args... args)
+    {
+        // Our table may or may not be populated, and with different items to those in the list.
+
+        // If there is an item already on this row, check it
+        // If it represents the current pointer data, just update it and move on. Otherwise, delete it and check
+        // again
+        while (rowCount < table->rowCount())
+        {
+            auto tableItem = table->item(rowCount, 0);
+            auto rowData = (tableItem ? tableItem->data(Qt::UserRole).value<Raw>() : nullptr);
+            if (rowData == dataItem)
+            {
+                // Update the current row and quit the loop
+                (functionParent->*updateRow)(rowCount, dataItem, false, args...);
+
+                break;
+            }
+            else
+                table->removeRow(rowCount);
+        }
+
+        // If the current row index is (now) out of range, add a new row to the table
+        if (rowCount == table->rowCount())
+        {
+            // Increase row count
+            table->setRowCount(rowCount + 1);
+
+            // Create new items
+            (functionParent->*updateRow)(rowCount, dataItem, true);
+        }
+    }
+
+    public:
+    TableWidgetUpdater(QTableWidget *table, std::vector<I> &vector, T *functionParent, TableWidgetRowUpdateFunction updateRow)
+    {
+
+        int rowCount = 0;
+
+        for (auto &dataItem : vector)
+        {
+            updateItemAtIndex(table, rowCount, &dataItem, functionParent, updateRow);
+            ++rowCount;
+        }
+
+        // Set the number of table rows again here in order to catch the case where there were zero data items to
+        // iterate over
+        table->setRowCount(rowCount);
+    }
+    TableWidgetUpdater(QTableWidget *table, const List<I> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
+    {
+
+        int rowCount = 0;
+
+        ListIterator<I> dataIterator(list);
+        while (I *dataItem = dataIterator.iterate())
+        {
+            updateItemAtIndex(table, rowCount, dataItem, functionParent, updateRow);
+            ++rowCount;
+        }
+
+        // Set the number of table rows again here in order to catch the case where there were zero data items to
+        // iterate over
+        table->setRowCount(rowCount);
+    }
+};

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-// TableWidgetUpdater - Constructor-only template class to update contents of a QTableWidget, preserving original items as much
-// as possible
-template <class T, class I, typename Raw = const I *, typename... Args> class TableWidgetUpdater
+// ConstTableWidgetUpdater - Constructor-only template class to update contents of a QTableWidget, preserving original items as
+// much as possible
+template <class T, class I, typename Raw = const I *, typename... Args> class ConstTableWidgetUpdater
 {
     // Typedefs for passed functions
     typedef void (T::*TableWidgetRowUpdateFunction)(int row, Raw item, bool createItems, Args... args);
@@ -57,8 +57,8 @@ template <class T, class I, typename Raw = const I *, typename... Args> class Ta
     }
 
     public:
-    TableWidgetUpdater(QTableWidget *table, const std::vector<I> &vector, T *functionParent,
-                       TableWidgetRowUpdateFunction updateRow)
+    ConstTableWidgetUpdater(QTableWidget *table, const std::vector<I> &vector, T *functionParent,
+                            TableWidgetRowUpdateFunction updateRow)
     {
 
         int rowCount = 0;
@@ -73,7 +73,7 @@ template <class T, class I, typename Raw = const I *, typename... Args> class Ta
         // iterate over
         table->setRowCount(rowCount);
     }
-    TableWidgetUpdater(QTableWidget *table, const List<I> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
+    ConstTableWidgetUpdater(QTableWidget *table, const List<I> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
     {
 
         int rowCount = 0;
@@ -89,7 +89,8 @@ template <class T, class I, typename Raw = const I *, typename... Args> class Ta
         // iterate over
         table->setRowCount(rowCount);
     }
-    TableWidgetUpdater(QTableWidget *table, const RefList<I> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
+    ConstTableWidgetUpdater(QTableWidget *table, const RefList<I> &list, T *functionParent,
+                            TableWidgetRowUpdateFunction updateRow)
     {
         int rowCount = 0;
 
@@ -100,8 +101,8 @@ template <class T, class I, typename Raw = const I *, typename... Args> class Ta
         }
         table->setRowCount(rowCount);
     }
-    TableWidgetUpdater(QTableWidget *table, const std::vector<std::shared_ptr<I>> &list, T *functionParent,
-                       TableWidgetRowUpdateFunction updateRow)
+    ConstTableWidgetUpdater(QTableWidget *table, const std::vector<std::shared_ptr<I>> &list, T *functionParent,
+                            TableWidgetRowUpdateFunction updateRow)
     {
 
         int rowCount = 0;

--- a/src/gui/helpers/tablewidgetupdater.h
+++ b/src/gui/helpers/tablewidgetupdater.h
@@ -116,16 +116,4 @@ template <class T, class I, typename Raw = const I *, typename... Args> class Ta
         // iterate over
         table->setRowCount(rowCount);
     }
-    template <typename D>
-    TableWidgetUpdater(QTableWidget *table, RefDataList<I, D> &list, T *functionParent, TableWidgetRowUpdateFunction updateRow)
-    {
-        int rowCount = 0;
-
-        auto itemIterator(list);
-        while (I *dataItem = itemIterator.iterate())
-        {
-            updateItemAtIndex(table, rowCount, dataItem, functionParent, updateRow, itemIterator.currentData());
-            ++rowCount;
-        }
-    }
 };

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -145,7 +145,7 @@ void ExpressionVariableVectorKeywordWidget::updateValue()
     refreshing_ = true;
 
     // Update the variables list against that contained in the keyword's data
-    TableWidgetUpdater<ExpressionVariableVectorKeywordWidget, ExpressionVariable, std::shared_ptr<ExpressionVariable>>
+    ConstTableWidgetUpdater<ExpressionVariableVectorKeywordWidget, ExpressionVariable, std::shared_ptr<ExpressionVariable>>
         tableUpdater(ui_.VariablesTable, keyword_->data(), this,
                      &ExpressionVariableVectorKeywordWidget::updateVariableTableRow);
 

--- a/src/gui/keywordwidgets/modulegroups_funcs.cpp
+++ b/src/gui/keywordwidgets/modulegroups_funcs.cpp
@@ -130,8 +130,8 @@ void ModuleGroupsKeywordWidget::updateWidgetValues(const CoreData &coreData)
     RefList<Module> availableModules = coreData.findModules(keyword_->data().allowedModuleTypes());
 
     // Update the list widget
-    TableWidgetUpdater<ModuleGroupsKeywordWidget, Module> tableUpdater(ui_.SelectionTable, availableModules, this,
-                                                                       &ModuleGroupsKeywordWidget::updateSelectionRow);
+    ConstTableWidgetUpdater<ModuleGroupsKeywordWidget, Module> tableUpdater(ui_.SelectionTable, availableModules, this,
+                                                                            &ModuleGroupsKeywordWidget::updateSelectionRow);
 
     ui_.SelectionTable->resizeColumnToContents(0);
 

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -4,7 +4,6 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 #include "classes/speciessite.h"
-#include "gui/helpers/tablewidgetupdater.h"
 #include "gui/keywordwidgets/speciessite.h"
 #include "templates/variantpointer.h"
 #include <QButtonGroup>

--- a/src/gui/keywordwidgets/speciessitereflist_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitereflist_funcs.cpp
@@ -4,7 +4,6 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 #include "classes/speciessite.h"
-#include "gui/helpers/tablewidgetupdater.h"
 #include "gui/keywordwidgets/speciessitereflist.h"
 #include "templates/variantpointer.h"
 #include <QCheckBox>

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -17,11 +17,11 @@ class Isotope;
 class Isotopologue;
 class Species;
 
-Q_DECLARE_METATYPE(const SpeciesAtom *)
-Q_DECLARE_METATYPE(const SpeciesBond *)
-Q_DECLARE_METATYPE(const SpeciesAngle *)
-Q_DECLARE_METATYPE(const SpeciesTorsion *)
-Q_DECLARE_METATYPE(const SpeciesImproper *)
+Q_DECLARE_METATYPE(SpeciesAtom *)
+Q_DECLARE_METATYPE(SpeciesBond *)
+Q_DECLARE_METATYPE(SpeciesAngle *)
+Q_DECLARE_METATYPE(SpeciesTorsion *)
+Q_DECLARE_METATYPE(SpeciesImproper *)
 
 // Species Tab
 class SpeciesTab : public QWidget, public ListItem<SpeciesTab>, public MainTab
@@ -80,15 +80,15 @@ class SpeciesTab : public QWidget, public ListItem<SpeciesTab>, public MainTab
     // Return valid AtomType names for specified model index in the SpeciesAtomTable
     std::vector<std::string> validAtomTypeNames(const QModelIndex &index);
     // SpeciesAtomTable row update function
-    void updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, bool createItems);
+    void updateAtomTableRow(int row, SpeciesAtom *speciesAtom, bool createItems);
     // SpeciesBondTable row update function
-    void updateBondTableRow(int row, const SpeciesBond *speciesBond, bool createItems);
+    void updateBondTableRow(int row, SpeciesBond *speciesBond, bool createItems);
     // SpeciesAngleTable row update function
-    void updateAngleTableRow(int row, const SpeciesAngle *speciesAngle, bool createItems);
+    void updateAngleTableRow(int row, SpeciesAngle *speciesAngle, bool createItems);
     // SpeciesTorsionTable row update function
-    void updateTorsionTableRow(int row, const SpeciesTorsion *speciesTorsion, bool createItems);
+    void updateTorsionTableRow(int row, SpeciesTorsion *speciesTorsion, bool createItems);
     // SpeciesImproperTable row update function
-    void updateImproperTableRow(int row, const SpeciesImproper *speciesImproper, bool createItems);
+    void updateImproperTableRow(int row, SpeciesImproper *speciesImproper, bool createItems);
 
     private slots:
     // Update atom table selection

--- a/src/gui/speciestab_geometry.cpp
+++ b/src/gui/speciestab_geometry.cpp
@@ -33,7 +33,7 @@ std::vector<std::string> SpeciesTab::validAtomTypeNames(const QModelIndex &index
 }
 
 // SpeciesAtomTable row update function
-void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, bool createItems)
+void SpeciesTab::updateAtomTableRow(int row, SpeciesAtom *speciesAtom, bool createItems)
 {
     QTableWidgetItem *item;
 
@@ -41,7 +41,7 @@ void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, boo
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesAtom>(speciesAtom));
+        item->setData(Qt::UserRole, QVariant::fromValue(speciesAtom));
         item->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
         ui_.AtomTable->setItem(row, 0, item);
     }
@@ -49,7 +49,6 @@ void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, boo
         item = ui_.AtomTable->item(row, 0);
     item->setText(QString::fromStdString(std::string(Elements::name(speciesAtom->Z()))));
     item->setSelected(speciesAtom->isSelected());
-    printf("UPDATING row %i - spatom = %p\n", row, item->data(Qt::UserRole).value<SpeciesAtom*>());
 
     // AtomType
     if (createItems)
@@ -91,7 +90,7 @@ void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, boo
 }
 
 // BondTable row update function
-void SpeciesTab::updateBondTableRow(int row, const SpeciesBond *speciesBond, bool createItems)
+void SpeciesTab::updateBondTableRow(int row, SpeciesBond *speciesBond, bool createItems)
 {
     QTableWidgetItem *item;
 
@@ -101,7 +100,7 @@ void SpeciesTab::updateBondTableRow(int row, const SpeciesBond *speciesBond, boo
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesBond>(speciesBond));
+            item->setData(Qt::UserRole, QVariant::fromValue(speciesBond));
             item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             ui_.BondTable->setItem(row, n, item);
         }
@@ -141,7 +140,7 @@ void SpeciesTab::updateBondTableRow(int row, const SpeciesBond *speciesBond, boo
 }
 
 // AngleTable row update function
-void SpeciesTab::updateAngleTableRow(int row, const SpeciesAngle *speciesAngle, bool createItems)
+void SpeciesTab::updateAngleTableRow(int row, SpeciesAngle *speciesAngle, bool createItems)
 {
     QTableWidgetItem *item;
 
@@ -151,7 +150,7 @@ void SpeciesTab::updateAngleTableRow(int row, const SpeciesAngle *speciesAngle, 
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesAngle>(speciesAngle));
+            item->setData(Qt::UserRole, QVariant::fromValue(speciesAngle));
             item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             ui_.AngleTable->setItem(row, n, item);
         }
@@ -193,7 +192,7 @@ void SpeciesTab::updateAngleTableRow(int row, const SpeciesAngle *speciesAngle, 
 }
 
 // TorsionTable row update function
-void SpeciesTab::updateTorsionTableRow(int row, const SpeciesTorsion *speciesTorsion, bool createItems)
+void SpeciesTab::updateTorsionTableRow(int row, SpeciesTorsion *speciesTorsion, bool createItems)
 {
     QTableWidgetItem *item;
 
@@ -203,7 +202,7 @@ void SpeciesTab::updateTorsionTableRow(int row, const SpeciesTorsion *speciesTor
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesTorsion>(speciesTorsion));
+            item->setData(Qt::UserRole, QVariant::fromValue(speciesTorsion));
             item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             ui_.TorsionTable->setItem(row, n, item);
         }
@@ -243,7 +242,7 @@ void SpeciesTab::updateTorsionTableRow(int row, const SpeciesTorsion *speciesTor
 }
 
 // ImproperTable row update function
-void SpeciesTab::updateImproperTableRow(int row, const SpeciesImproper *speciesImproper, bool createItems)
+void SpeciesTab::updateImproperTableRow(int row, SpeciesImproper *speciesImproper, bool createItems)
 {
     QTableWidgetItem *item;
 
@@ -253,7 +252,7 @@ void SpeciesTab::updateImproperTableRow(int row, const SpeciesImproper *speciesI
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesImproper>(speciesImproper));
+            item->setData(Qt::UserRole, QVariant::fromValue(speciesImproper));
             item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             ui_.ImproperTable->setItem(row, n, item);
         }
@@ -309,8 +308,7 @@ void SpeciesTab::updateAtomTableSelection()
     for (auto n = 0; n < ui_.AtomTable->rowCount(); ++n)
     {
         item = ui_.AtomTable->item(n, 0);
-        i = VariantPointer<SpeciesAtom>(item->data(Qt::UserRole));
-
+        i = item->data(Qt::UserRole).value<SpeciesAtom *>();
         if (i->isSelected())
             for (auto m = 0; m < 6; ++m)
                 ui_.AtomTable->item(n, m)->setSelected(true);
@@ -326,7 +324,7 @@ void SpeciesTab::on_AtomTable_itemChanged(QTableWidgetItem *w)
         return;
 
     // Get target SpeciesAtom from the passed widget
-    SpeciesAtom *speciesAtom = w ? VariantPointer<SpeciesAtom>(w->data(Qt::UserRole)) : nullptr;
+    SpeciesAtom *speciesAtom = w ? w->data(Qt::UserRole).value<SpeciesAtom *>() : nullptr;
     if (!speciesAtom)
         return;
     Vec3<double> r = speciesAtom->r();
@@ -393,7 +391,7 @@ void SpeciesTab::on_AtomTable_itemSelectionChanged()
     for (auto n = 0; n < ui_.AtomTable->rowCount(); ++n)
     {
         item = ui_.AtomTable->item(n, 0);
-        i = VariantPointer<SpeciesAtom>(item->data(Qt::UserRole));
+        i = item->data(Qt::UserRole).value<SpeciesAtom *>();
 
         if (item->isSelected())
             species_->selectAtom(i);
@@ -412,7 +410,7 @@ void SpeciesTab::on_BondTable_itemChanged(QTableWidgetItem *w)
         return;
 
     // Get target SpeciesBond from the passed widget
-    SpeciesBond *speciesBond = w ? VariantPointer<SpeciesBond>(w->data(Qt::UserRole)) : nullptr;
+    SpeciesBond *speciesBond = w ? w->data(Qt::UserRole).value<SpeciesBond *>() : nullptr;
     if (!speciesBond)
         return;
 
@@ -471,7 +469,7 @@ void SpeciesTab::on_AngleTable_itemChanged(QTableWidgetItem *w)
         return;
 
     // Get target SpeciesAngle from the passed widget
-    SpeciesAngle *speciesAngle = w ? VariantPointer<SpeciesAngle>(w->data(Qt::UserRole)) : nullptr;
+    SpeciesAngle *speciesAngle = w ? w->data(Qt::UserRole).value<SpeciesAngle *>() : nullptr;
     if (!speciesAngle)
         return;
 
@@ -531,7 +529,7 @@ void SpeciesTab::on_TorsionTable_itemChanged(QTableWidgetItem *w)
         return;
 
     // Get target SpeciesTorsion from the passed widget
-    SpeciesTorsion *speciesTorsion = w ? VariantPointer<SpeciesTorsion>(w->data(Qt::UserRole)) : nullptr;
+    SpeciesTorsion *speciesTorsion = w ? w->data(Qt::UserRole).value<SpeciesTorsion *>() : nullptr;
     if (!speciesTorsion)
         return;
 
@@ -592,7 +590,7 @@ void SpeciesTab::on_ImproperTable_itemChanged(QTableWidgetItem *w)
         return;
 
     // Get target SpeciesImproper from the passed widget
-    SpeciesImproper *speciesImproper = w ? VariantPointer<SpeciesImproper>(w->data(Qt::UserRole)) : nullptr;
+    SpeciesImproper *speciesImproper = w ? w->data(Qt::UserRole).value<SpeciesImproper *>() : nullptr;
     if (!speciesImproper)
         return;
 

--- a/src/gui/speciestab_geometry.cpp
+++ b/src/gui/speciestab_geometry.cpp
@@ -49,12 +49,12 @@ void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, boo
         item = ui_.AtomTable->item(row, 0);
     item->setText(QString::fromStdString(std::string(Elements::name(speciesAtom->Z()))));
     item->setSelected(speciesAtom->isSelected());
+    printf("UPDATING row %i - spatom = %p\n", row, item->data(Qt::UserRole).value<SpeciesAtom*>());
 
     // AtomType
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesAtom>(speciesAtom));
         ui_.AtomTable->setItem(row, 1, item);
     }
     else
@@ -68,7 +68,6 @@ void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, boo
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesAtom>(speciesAtom));
             ui_.AtomTable->setItem(row, n + 2, item);
         }
         else
@@ -81,7 +80,6 @@ void SpeciesTab::updateAtomTableRow(int row, const SpeciesAtom *speciesAtom, boo
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesAtom>(speciesAtom));
         ui_.AtomTable->setItem(row, 5, item);
     }
     else
@@ -117,7 +115,6 @@ void SpeciesTab::updateBondTableRow(int row, const SpeciesBond *speciesBond, boo
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesBond>(speciesBond));
         ui_.BondTable->setItem(row, 2, item);
     }
     else
@@ -132,7 +129,6 @@ void SpeciesTab::updateBondTableRow(int row, const SpeciesBond *speciesBond, boo
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesBond>(speciesBond));
             ui_.BondTable->setItem(row, n + 3, item);
         }
         else
@@ -169,7 +165,6 @@ void SpeciesTab::updateAngleTableRow(int row, const SpeciesAngle *speciesAngle, 
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesAngle>(speciesAngle));
         ui_.AngleTable->setItem(row, 3, item);
     }
     else
@@ -186,7 +181,6 @@ void SpeciesTab::updateAngleTableRow(int row, const SpeciesAngle *speciesAngle, 
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesAngle>(speciesAngle));
             ui_.AngleTable->setItem(row, n + 4, item);
         }
         else
@@ -223,7 +217,6 @@ void SpeciesTab::updateTorsionTableRow(int row, const SpeciesTorsion *speciesTor
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesTorsion>(speciesTorsion));
         ui_.TorsionTable->setItem(row, 4, item);
     }
     else
@@ -239,7 +232,6 @@ void SpeciesTab::updateTorsionTableRow(int row, const SpeciesTorsion *speciesTor
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesTorsion>(speciesTorsion));
             item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
             ui_.TorsionTable->setItem(row, n + 5, item);
         }
@@ -274,7 +266,6 @@ void SpeciesTab::updateImproperTableRow(int row, const SpeciesImproper *speciesI
     if (createItems)
     {
         item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, VariantPointer<SpeciesImproper>(speciesImproper));
         ui_.ImproperTable->setItem(row, 4, item);
     }
     else
@@ -291,7 +282,6 @@ void SpeciesTab::updateImproperTableRow(int row, const SpeciesImproper *speciesI
         if (createItems)
         {
             item = new QTableWidgetItem;
-            item->setData(Qt::UserRole, VariantPointer<SpeciesImproper>(speciesImproper));
             ui_.ImproperTable->setItem(row, n + 5, item);
         }
         else


### PR DESCRIPTION
This bugfix PR addresses crashes in the GUI caused by a previous merge commit which `const`-qualified data types attached to `QTableWIdgetItem`s. This, in turn, led to pointer casting failures when the widgets were interacted with, and since no checks were made on the legitimacy of the pointer, crashes occurred.

The present PR tidies a few things around the issue, and circumvents the problem temporarily by introducing a specific version of `TableWidgetUpdated` which passes non-`const` pointers. Forthcoming work on introducing proper Model-View-Controller design patterns to the GUI will remove the need for these classes entirely.
