### PR TITLE
Change cell array to vector of unique pointers instead of c array of raw pointers

### DIFF
--- a/src/classes/cell.cpp
+++ b/src/classes/cell.cpp
@@ -6,7 +6,10 @@
 #include "classes/box.h"
 #include <algorithm>
 
-Cell::Cell() : index_(-1) {}
+Cell::Cell(int index, Vec3<int> gridReference, Vec3<double> centre)
+    : gridReference_(gridReference), index_(index), centre_(centre)
+{
+}
 
 /*
  * Identity

--- a/src/classes/cell.h
+++ b/src/classes/cell.h
@@ -18,7 +18,7 @@ class CellNeighbour;
 class Cell
 {
     public:
-    Cell();
+    Cell(int index, Vec3<int> gridReference, Vec3<double> centre);
     ~Cell() = default;
 
     /*

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -141,10 +141,7 @@ bool CellArray::generate(const Box *box, double cellSize, double pairPotentialRa
             fracCentre.z = fractionalCellSize_.z * 0.5;
             for (z = 0; z < divisions_.z; ++z)
             {
-                auto &cell = cells_.emplace_back(std::make_unique<Cell>());
-                cell->setIndex(count);
-                cell->setGridReference(x, y, z);
-                cell->setCentre(box_->fracToReal(fracCentre));
+                cells_.emplace_back(std::make_unique<Cell>(count, Vec3<int>(x, y, z), box_->fracToReal(fracCentre)));
                 fracCentre.z += fractionalCellSize_.z;
                 ++count;
             }

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -128,7 +128,7 @@ bool CellArray::generate(const Box *box, double cellSize, double pairPotentialRa
 
     // Construct Cell arrays
     clear();
-    int nCells = divisions_.x * divisions_.y * divisions_.z;
+    auto nCells = divisions_.x * divisions_.y * divisions_.z;
     Messenger::print("Constructing array of {} cells...\n", nCells);
     cells_.reserve(nCells);
     Vec3<double> fracCentre(fractionalCellSize_.x * 0.5, 0.0, 0.0);
@@ -244,7 +244,7 @@ bool CellArray::generate(const Box *box, double cellSize, double pairPotentialRa
     Messenger::print("Constructing neighbour lists for individual Cells...\n");
     std::vector<Cell *> nearNeighbours, mimNeighbours;
     Vec3<int> gridRef, delta;
-    for (auto n = 0u; n < cells_.size(); ++n)
+    for (auto n = 0; n < cells_.size(); ++n)
     {
         // Grab grid reference of central cell
         gridRef = cells_[n]->gridReference();

--- a/src/classes/cellarray.h
+++ b/src/classes/cellarray.h
@@ -34,9 +34,8 @@ class CellArray
     // Cell axes
     Matrix3 axes_;
     // Total number of Cells in Box
-    int nCells_;
     // Cell array (one-dimensional)
-    Cell *cells_;
+    std::vector<std::unique_ptr<Cell>> cells_;
     // Box associated with this cell division scheme
     const Box *box_;
 

--- a/src/classes/cellarray.h
+++ b/src/classes/cellarray.h
@@ -33,7 +33,6 @@ class CellArray
     List<ListVec3<int>> neighbourIndices_;
     // Cell axes
     Matrix3 axes_;
-    // Total number of Cells in Box
     // Cell array (one-dimensional)
     std::vector<std::unique_ptr<Cell>> cells_;
     // Box associated with this cell division scheme


### PR DESCRIPTION
This PR updates cell array to use a std::vector of unique pointers to the cells, rather than a C array of raw pointers. Also removes the `nCells_` member variable, as this should be retrievable from the vector, unless I've missed something!

Fixes #535 