### PR TITLE
Remove ObjectStore 1

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -12,14 +12,7 @@
 #include "classes/species.h"
 #include "modules/energy/energy.h"
 
-// Static Members (ObjectStore)
-template <class Configuration> RefDataList<Configuration, int> ObjectStore<Configuration>::objects_;
-template <class Configuration> int ObjectStore<Configuration>::objectCount_ = 0;
-template <class Configuration> int ObjectStore<Configuration>::objectType_ = ObjectInfo::ConfigurationObject;
-template <class Configuration> std::string_view ObjectStore<Configuration>::objectTypeName_ = "Configuration";
-
-Configuration::Configuration()
-    : ListItem<Configuration>(), ObjectStore<Configuration>(this), generator_(ProcedureNode::GenerationContext, "EndGenerator")
+Configuration::Configuration() : ListItem<Configuration>(), generator_(ProcedureNode::GenerationContext, "EndGenerator")
 {
     box_ = nullptr;
 

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -19,7 +19,6 @@
 #include "module/layer.h"
 #include "procedure/procedure.h"
 #include "templates/array.h"
-#include "templates/objectstore.h"
 #include "templates/vector3.h"
 #include <deque>
 #include <memory>
@@ -32,7 +31,7 @@ class PotentialMap;
 class Species;
 
 // Configuration
-class Configuration : public ListItem<Configuration>, public ObjectStore<Configuration>
+class Configuration : public ListItem<Configuration>
 {
     public:
     Configuration();

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -8,13 +8,7 @@
 #include "classes/masterintra.h"
 #include "data/isotopes.h"
 
-// Static Members (ObjectStore)
-template <class Species> RefDataList<Species, int> ObjectStore<Species>::objects_;
-template <class Species> int ObjectStore<Species>::objectCount_ = 0;
-template <class Species> int ObjectStore<Species>::objectType_ = ObjectInfo::SpeciesObject;
-template <class Species> std::string_view ObjectStore<Species>::objectTypeName_ = "Species";
-
-Species::Species() : ListItem<Species>(), ObjectStore<Species>(this)
+Species::Species() : ListItem<Species>()
 {
     forcefield_ = nullptr;
     autoUpdateIntramolecularTerms_ = true;

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -21,7 +21,7 @@ class Box;
 class Forcefield;
 
 // Species Definition
-class Species : public ListItem<Species>, public ObjectStore<Species>
+class Species : public ListItem<Species>
 {
     public:
     Species();

--- a/src/gui/configurationviewer_funcs.cpp
+++ b/src/gui/configurationviewer_funcs.cpp
@@ -44,7 +44,7 @@ void ConfigurationViewer::setConfiguration(Configuration *cfg)
     // Create a new Renderable for the supplied Configuration
     if (configuration_)
     {
-        configurationRenderable_ = new RenderableConfiguration(configuration_, configuration_->objectTag());
+        configurationRenderable_ = new RenderableConfiguration(configuration_);
         ownRenderable(configurationRenderable_);
         view_.showAllData();
     }

--- a/src/gui/render/renderableconfiguration.cpp
+++ b/src/gui/render/renderableconfiguration.cpp
@@ -11,8 +11,8 @@
 #include "gui/render/renderablegroupmanager.h"
 #include "gui/render/view.h"
 
-RenderableConfiguration::RenderableConfiguration(const Configuration *source, std::string_view objectTag)
-    : Renderable(Renderable::ConfigurationRenderable, objectTag), source_(source)
+RenderableConfiguration::RenderableConfiguration(const Configuration *source)
+    : Renderable(Renderable::ConfigurationRenderable, "UNUSED"), source_(source)
 {
     // Set defaults
     displayStyle_ = LinesStyle;
@@ -44,10 +44,6 @@ bool RenderableConfiguration::validateDataSource()
     // Don't try to access source_ if we are not currently permitted to do so
     if (!sourceDataAccessEnabled_)
         return false;
-
-    // If there is no valid source set, attempt to set it now...
-    if (!source_)
-        source_ = Configuration::findObject(objectTag_);
 
     return source_;
 }

--- a/src/gui/render/renderableconfiguration.h
+++ b/src/gui/render/renderableconfiguration.h
@@ -13,7 +13,7 @@ class Axes;
 class RenderableConfiguration : public Renderable
 {
     public:
-    RenderableConfiguration(const Configuration *source, std::string_view objectTag);
+    RenderableConfiguration(const Configuration *source);
     ~RenderableConfiguration();
 
     /*

--- a/src/gui/render/renderablefactory.cpp
+++ b/src/gui/render/renderablefactory.cpp
@@ -18,8 +18,6 @@ Renderable *RenderableFactory::create(Renderable::RenderableType renderableType,
         renderable = new RenderableData2D(Data2D::findObject(objectTag), objectTag);
     else if (renderableType == Renderable::Data3DRenderable)
         renderable = new RenderableData3D(Data3D::findObject(objectTag), objectTag);
-    else if (renderableType == Renderable::SpeciesRenderable)
-        renderable = new RenderableSpecies(Species::findObject(objectTag), objectTag);
     else
         fmt::print("Don't know how to create a Renderable of type '{}' (object tag = '{}').\n",
                    Renderable::renderableTypes().keyword(renderableType), objectTag);

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -8,8 +8,8 @@
 #include "gui/render/renderablegroupmanager.h"
 #include "gui/render/view.h"
 
-RenderableSpecies::RenderableSpecies(const Species *source, std::string_view objectTag)
-    : Renderable(Renderable::SpeciesRenderable, objectTag), source_(source)
+RenderableSpecies::RenderableSpecies(const Species *source)
+    : Renderable(Renderable::SpeciesRenderable, "UNUSED"), source_(source)
 {
     // Set defaults
     displayStyle_ = SpheresStyle;
@@ -48,10 +48,6 @@ bool RenderableSpecies::validateDataSource()
     // Don't try to access source_ if we are not currently permitted to do so
     if (!sourceDataAccessEnabled_)
         return false;
-
-    // If there is no valid source set, attempt to set it now...
-    if (!source_)
-        source_ = Species::findObject(objectTag_);
 
     return source_;
 }

--- a/src/gui/render/renderablespecies.h
+++ b/src/gui/render/renderablespecies.h
@@ -13,7 +13,7 @@ class Axes;
 class RenderableSpecies : public Renderable
 {
     public:
-    RenderableSpecies(const Species *source, std::string_view objectTag);
+    RenderableSpecies(const Species *source);
     ~RenderableSpecies();
 
     /*

--- a/src/gui/siteviewer_funcs.cpp
+++ b/src/gui/siteviewer_funcs.cpp
@@ -47,7 +47,7 @@ void SiteViewer::setSpecies(Species *sp)
     // Create a new Renderable for the supplied Species
     if (species_)
     {
-        speciesRenderable_ = new RenderableSpecies(species_, species_->objectTag());
+        speciesRenderable_ = new RenderableSpecies(species_);
         speciesRenderable_->setName("Species");
         speciesRenderable_->setDisplayStyle(RenderableSpecies::LinesStyle);
         ownRenderable(speciesRenderable_);

--- a/src/gui/speciesviewer_funcs.cpp
+++ b/src/gui/speciesviewer_funcs.cpp
@@ -46,7 +46,7 @@ void SpeciesViewer::setSpecies(Species *sp)
     // Create a new Renderable for the supplied Species
     if (species_)
     {
-        speciesRenderable_ = new RenderableSpecies(species_, species_->objectTag());
+        speciesRenderable_ = new RenderableSpecies(species_);
         ownRenderable(speciesRenderable_);
         view_.showAllData();
     }

--- a/src/math/histogram1d.cpp
+++ b/src/math/histogram1d.cpp
@@ -5,13 +5,7 @@
 #include "base/lineparser.h"
 #include "base/messenger.h"
 
-// Static Members (ObjectStore)
-template <class Histogram1D> RefDataList<Histogram1D, int> ObjectStore<Histogram1D>::objects_;
-template <class Histogram1D> int ObjectStore<Histogram1D>::objectCount_ = 0;
-template <class Histogram1D> int ObjectStore<Histogram1D>::objectType_ = ObjectInfo::Histogram1DObject;
-template <class Histogram1D> std::string_view ObjectStore<Histogram1D>::objectTypeName_ = "Histogram1D";
-
-Histogram1D::Histogram1D() : ListItem<Histogram1D>(), ObjectStore<Histogram1D>(this)
+Histogram1D::Histogram1D() : ListItem<Histogram1D>()
 {
     accumulatedData_.addErrors();
 
@@ -20,7 +14,7 @@ Histogram1D::Histogram1D() : ListItem<Histogram1D>(), ObjectStore<Histogram1D>(t
 
 Histogram1D::~Histogram1D() {}
 
-Histogram1D::Histogram1D(const Histogram1D &source) : ObjectStore<Histogram1D>(this) { (*this) = source; }
+Histogram1D::Histogram1D(const Histogram1D &source) { (*this) = source; }
 
 // Clear Data
 void Histogram1D::clear()
@@ -197,10 +191,6 @@ bool Histogram1D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 
-    if (parser.readNextLine(LineParser::Defaults) != LineParser::Success)
-        return false;
-    setObjectTag(parser.line());
-
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     initialise(parser.argd(0), parser.argd(1), parser.argd(2));
@@ -220,8 +210,6 @@ bool Histogram1D::read(LineParser &parser, CoreData &coreData)
 // Write data through specified LineParser
 bool Histogram1D::write(LineParser &parser)
 {
-    if (!parser.writeLineF("{}\n", objectTag()))
-        return false;
     if (!parser.writeLineF("{} {} {}\n", minimum_, maximum_, binWidth_))
         return false;
     if (!parser.writeLineF("{}  {}\n", nBinned_, nMissed_))

--- a/src/math/histogram1d.h
+++ b/src/math/histogram1d.h
@@ -6,13 +6,12 @@
 #include "genericitems/base.h"
 #include "math/data1d.h"
 #include "math/sampleddouble.h"
-#include "templates/objectstore.h"
 
 // Forward Declarations
 class ProcessPool;
 
 // One-Dimensional Histogram
-class Histogram1D : public ListItem<Histogram1D>, public ObjectStore<Histogram1D>, public GenericItemBase
+class Histogram1D : public ListItem<Histogram1D>, public GenericItemBase
 {
     public:
     Histogram1D();

--- a/src/math/histogram2d.cpp
+++ b/src/math/histogram2d.cpp
@@ -6,13 +6,7 @@
 #include "base/messenger.h"
 #include "math/histogram1d.h"
 
-// Static Members (ObjectStore)
-template <class Histogram2D> RefDataList<Histogram2D, int> ObjectStore<Histogram2D>::objects_;
-template <class Histogram2D> int ObjectStore<Histogram2D>::objectCount_ = 0;
-template <class Histogram2D> int ObjectStore<Histogram2D>::objectType_ = ObjectInfo::Histogram2DObject;
-template <class Histogram2D> std::string_view ObjectStore<Histogram2D>::objectTypeName_ = "Histogram2D";
-
-Histogram2D::Histogram2D() : ListItem<Histogram2D>(), ObjectStore<Histogram2D>(this)
+Histogram2D::Histogram2D() : ListItem<Histogram2D>()
 {
     accumulatedData_.addErrors();
 
@@ -21,7 +15,7 @@ Histogram2D::Histogram2D() : ListItem<Histogram2D>(), ObjectStore<Histogram2D>(t
 
 Histogram2D::~Histogram2D() {}
 
-Histogram2D::Histogram2D(const Histogram2D &source) : ObjectStore<Histogram2D>(this) { (*this) = source; }
+Histogram2D::Histogram2D(const Histogram2D &source) { (*this) = source; }
 
 // Clear Data
 void Histogram2D::clear()
@@ -215,10 +209,6 @@ bool Histogram2D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 
-    if (parser.readNextLine(LineParser::Defaults) != LineParser::Success)
-        return false;
-    setObjectTag(parser.line());
-
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     initialise(parser.argd(0), parser.argd(1), parser.argd(2), parser.argd(3), parser.argd(4), parser.argd(5));
@@ -241,8 +231,6 @@ bool Histogram2D::read(LineParser &parser, CoreData &coreData)
 // Write data through specified LineParser
 bool Histogram2D::write(LineParser &parser)
 {
-    if (!parser.writeLineF("{}\n", objectTag()))
-        return false;
     if (!parser.writeLineF("{} {} {} {} {} {}\n", xMinimum_, xMaximum_, xBinWidth_, yMinimum_, yMaximum_, yBinWidth_))
         return false;
     if (!parser.writeLineF("{}  {}\n", nBinned_, nMissed_))

--- a/src/math/histogram2d.h
+++ b/src/math/histogram2d.h
@@ -7,13 +7,12 @@
 #include "math/data2d.h"
 #include "math/sampleddouble.h"
 #include "templates/array2d.h"
-#include "templates/objectstore.h"
 
 // Forward Declarations
 class ProcessPool;
 
 // One-Dimensional Histogram
-class Histogram2D : public ListItem<Histogram2D>, public ObjectStore<Histogram2D>, public GenericItemBase
+class Histogram2D : public ListItem<Histogram2D>, public GenericItemBase
 {
     public:
     Histogram2D();

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -6,13 +6,7 @@
 #include "base/messenger.h"
 #include "math/histogram1d.h"
 
-// Static Members (ObjectStore)
-template <class Histogram3D> RefDataList<Histogram3D, int> ObjectStore<Histogram3D>::objects_;
-template <class Histogram3D> int ObjectStore<Histogram3D>::objectCount_ = 0;
-template <class Histogram3D> int ObjectStore<Histogram3D>::objectType_ = ObjectInfo::Histogram3DObject;
-template <class Histogram3D> std::string_view ObjectStore<Histogram3D>::objectTypeName_ = "Histogram3D";
-
-Histogram3D::Histogram3D() : ListItem<Histogram3D>(), ObjectStore<Histogram3D>(this)
+Histogram3D::Histogram3D() : ListItem<Histogram3D>()
 {
     accumulatedData_.addErrors();
 
@@ -21,7 +15,7 @@ Histogram3D::Histogram3D() : ListItem<Histogram3D>(), ObjectStore<Histogram3D>(t
 
 Histogram3D::~Histogram3D() {}
 
-Histogram3D::Histogram3D(const Histogram3D &source) : ObjectStore<Histogram3D>(this) { (*this) = source; }
+Histogram3D::Histogram3D(const Histogram3D &source) { (*this) = source; }
 
 // Clear Data
 void Histogram3D::clear()
@@ -252,10 +246,6 @@ bool Histogram3D::read(LineParser &parser, CoreData &coreData)
 {
     clear();
 
-    if (parser.readNextLine(LineParser::Defaults) != LineParser::Success)
-        return false;
-    setObjectTag(parser.line());
-
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     initialise(parser.argd(0), parser.argd(1), parser.argd(2), parser.argd(3), parser.argd(4), parser.argd(5), parser.argd(6),
@@ -276,8 +266,6 @@ bool Histogram3D::read(LineParser &parser, CoreData &coreData)
 // Write data through specified LineParser
 bool Histogram3D::write(LineParser &parser)
 {
-    if (!parser.writeLineF("{}\n", objectTag()))
-        return false;
     if (!parser.writeLineF("{} {} {} {} {} {} {} {} {}\n", xMinimum_, xMaximum_, xBinWidth_, yMinimum_, yMaximum_, yBinWidth_,
                            zMinimum_, zMaximum_, zBinWidth_))
         return false;

--- a/src/math/histogram3d.h
+++ b/src/math/histogram3d.h
@@ -7,13 +7,12 @@
 #include "math/data3d.h"
 #include "math/sampleddouble.h"
 #include "templates/array3d.h"
-#include "templates/objectstore.h"
 
 // Forward Declarations
 class ProcessPool;
 
 // One-Dimensional Histogram
-class Histogram3D : public ListItem<Histogram3D>, public ObjectStore<Histogram3D>, public GenericItemBase
+class Histogram3D : public ListItem<Histogram3D>, public GenericItemBase
 {
     public:
     Histogram3D();

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -41,7 +41,6 @@ bool CalculateAvgMolModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
 
     // Set name and object tag for average species
     averageSpecies_.setName(fmt::format("{}@{}", site ? site->name() : "???", targetSpecies_ ? targetSpecies_->name() : "???"));
-    averageSpecies_.setObjectTag(fmt::format("CalculateAvgMol_{}", averageSpecies_.name()));
 
     // Realise arrays
     updateArrays(dissolve);

--- a/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
@@ -155,8 +155,11 @@ void CalculateSDFModuleWidget::setGraphDataTargets()
 
         // Reference molecule
         if (referenceMolecule_)
-            referenceMoleculeRenderable_ = dynamic_cast<RenderableSpecies *>(sdfGraph_->createRenderable(
-                Renderable::SpeciesRenderable, referenceMolecule_->objectTag(), "Reference Molecule"));
+        {
+            referenceMoleculeRenderable_ = new RenderableSpecies(referenceMolecule_);
+            referenceMoleculeRenderable_->setName("Reference Molecule");
+            sdfGraph_->ownRenderable(referenceMoleculeRenderable_);
+        }
     }
 }
 

--- a/src/templates/objectstore.h
+++ b/src/templates/objectstore.h
@@ -22,7 +22,6 @@ class ObjectInfo
     enum ObjectType
     {
         NoObject = 0,
-        ConfigurationObject,
         Data1DObject,
         Data2DObject,
         Data3DObject,

--- a/src/templates/objectstore.h
+++ b/src/templates/objectstore.h
@@ -25,7 +25,6 @@ class ObjectInfo
         Data1DObject,
         Data2DObject,
         Data3DObject,
-        SpeciesObject,
         nObjectTypes
     };
 

--- a/src/templates/objectstore.h
+++ b/src/templates/objectstore.h
@@ -26,9 +26,6 @@ class ObjectInfo
         Data1DObject,
         Data2DObject,
         Data3DObject,
-        Histogram1DObject,
-        Histogram2DObject,
-        Histogram3DObject,
         SpeciesObject,
         nObjectTypes
     };


### PR DESCRIPTION
This PR is part of a series aiming to remove the `ObjectStore` class from the code. `ObjectStore` is a legacy custom class designed to facilitate tracking, handling, and searching of objects of a given type. Each object is assigned a tag
 that can be searched on anywhere in the code via static member functions.

This method is heavily used at present in the location of specific data by modules, and particularly in the GUI when visualising data (e.g. via `DataViewer`). However the functionality is made largely redundant by the presence of `Generi
cList`. The class also adds an unnecessary layer of object management, and potentially introduces hard-to-find bugs (e.g. when checking for the existence of an object named simply after its class/memory address). 
 
This initial PR removes the somewhat trivial dependency from the `Species`, `Configuration`, and `HistogramND` classes. Subsequent PRs will address the more complex `DataND` classes, which also require some rehashing of how data is locat
ed by the GUI.
