### PR TITLE
No local configuration data

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -179,22 +179,6 @@ void Configuration::setTemperature(double t) { temperature_ = t; }
 double Configuration::temperature() const { return temperature_; }
 
 /*
- * Modules
- */
-
-// Associate Module to the Configuration
-bool Configuration::ownModule(Module *module) { return moduleLayer_.own(module); }
-
-// Return number of Modules associated to this Configuration
-int Configuration::nModules() const { return moduleLayer_.nModules(); }
-
-// Return Module layer for this Configuration
-ModuleLayer &Configuration::moduleLayer() { return moduleLayer_; }
-
-// Return list of Modules associated to this Configuration
-ModuleList &Configuration::modules() { return moduleLayer_; }
-
-/*
  * Parallel Comms
  */
 

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -75,7 +75,8 @@ bool Configuration::generate(ProcessPool &procPool, double pairPotentialRange)
 
     // Generate the contents
     Messenger::print("\nExecuting generator procedure for Configuration '{}'...\n\n", niceName());
-    auto result = generator_.execute(procPool, this, "Generator", moduleData_);
+    GenericList dummyList;
+    auto result = generator_.execute(procPool, this, "Generator", dummyList);
     if (!result)
         return Messenger::error("Failed to generate Configuration '{}'.\n", niceName());
     Messenger::print("\n");
@@ -192,9 +193,6 @@ ModuleLayer &Configuration::moduleLayer() { return moduleLayer_; }
 
 // Return list of Modules associated to this Configuration
 ModuleList &Configuration::modules() { return moduleLayer_; }
-
-// Return list of data variables set by Modules
-GenericList &Configuration::moduleData() { return moduleData_; }
 
 /*
  * Parallel Comms

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -201,8 +201,6 @@ class Configuration : public ListItem<Configuration>
     private:
     // Module layer associated to this Configuration
     ModuleLayer moduleLayer_;
-    // Variables set by Modules
-    GenericList moduleData_;
 
     public:
     // Associate Module to the Configuration
@@ -213,8 +211,6 @@ class Configuration : public ListItem<Configuration>
     ModuleLayer &moduleLayer();
     // Return list of Modules associated to this Configuration
     ModuleList &modules();
-    // Return list of variables set by Modules
-    GenericList &moduleData();
 
     /*
      * Site Stacks

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -196,23 +196,6 @@ class Configuration : public ListItem<Configuration>
     void updateCellLocation(const std::vector<int> &targetAtoms, int indexOffset);
 
     /*
-     * Modules
-     */
-    private:
-    // Module layer associated to this Configuration
-    ModuleLayer moduleLayer_;
-
-    public:
-    // Associate Module to the Configuration
-    bool ownModule(Module *module);
-    // Return number of Modules associated to this Configuration
-    int nModules() const;
-    // Return Module layer for this Configuration
-    ModuleLayer &moduleLayer();
-    // Return list of Modules associated to this Configuration
-    ModuleList &modules();
-
-    /*
      * Site Stacks
      */
     private:

--- a/src/gui/configurationtab.ui
+++ b/src/gui/configurationtab.ui
@@ -35,696 +35,629 @@
     <number>4</number>
    </property>
    <item>
-    <widget class="QTabWidget" name="Tabs">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="spacing">
+      <number>4</number>
+     </property>
+     <item>
+      <widget class="QGroupBox" name="TemperatureGroup">
+       <property name="title">
+        <string>Temperature</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="ExponentialSpin" name="TemperatureSpin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="TemperatureLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>K</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="CurrentBoxGroup">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Current Box</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>A</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="CurrentBoxALabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>B</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="CurrentBoxBLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>C</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLabel" name="CurrentBoxCLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLabel" name="label_6">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>α</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLabel" name="CurrentBoxAlphaLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QLabel" name="label_7">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>β</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="CurrentBoxBetaLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QLabel" name="label_8">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>γ</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QLabel" name="CurrentBoxGammaLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>ρ</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="3">
+         <widget class="QLabel" name="CurrentBoxTypeLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Orthorhombic</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="3">
+         <widget class="QComboBox" name="DensityUnitsCombo"/>
+        </item>
+        <item row="4" column="1" colspan="2">
+         <widget class="QLabel" name="DensityUnitsLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>50</weight>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="CoordinatesFromFileGroup">
+       <property name="title">
+        <string>Coordinates From File</string>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLineEdit" name="CoordinatesFileEdit"/>
+        </item>
+        <item row="0" column="1">
+         <widget class="QToolButton" name="CoordinatesFileSelectButton">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset resource="main.qrc">
+            <normaloff>:/menu/icons/menu_open.svg</normaloff>:/menu/icons/menu_open.svg</iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QComboBox" name="CoordinatesFileFormatCombo"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="SizeFactorGroup">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Size Factor Scaling</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="horizontalSpacing">
+         <number>4</number>
+        </property>
+        <property name="verticalSpacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_15">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Requested</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="ExponentialSpin" name="RequestedSizeFactorSpin">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Requested size factor scaling for the Configuration's Box and contents (will be applied at start of next iteration)</string>
+          </property>
+          <property name="minimum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_16">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Applied</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="ExponentialSpin" name="AppliedSizeFactorSpin">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Current size factor scaling of the Configuration's Box and contents</string>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+          <property name="minimum">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="GeneratorGroup">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>4</horstretch>
+      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+       <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="currentIndex">
-      <number>0</number>
+     <property name="title">
+      <string>Generator</string>
      </property>
-     <widget class="QWidget" name="ViewGenerateTab">
-      <attribute name="title">
-       <string>View / Generate</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0">
-       <property name="spacing">
-        <number>4</number>
-       </property>
-       <property name="leftMargin">
-        <number>4</number>
-       </property>
-       <property name="topMargin">
-        <number>4</number>
-       </property>
-       <property name="rightMargin">
-        <number>4</number>
-       </property>
-       <property name="bottomMargin">
-        <number>4</number>
-       </property>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <item>
-          <widget class="QGroupBox" name="TemperatureGroup">
-           <property name="title">
-            <string>Temperature</string>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="ExponentialSpin" name="TemperatureSpin">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="TemperatureLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>K</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="CurrentBoxGroup">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Current Box</string>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_2">
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>A</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="CurrentBoxALabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_4">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>B</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="CurrentBoxBLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label_5">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>C</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QLabel" name="CurrentBoxCLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QLabel" name="label_6">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>α</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="3">
-             <widget class="QLabel" name="CurrentBoxAlphaLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="label_7">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>β</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QLabel" name="CurrentBoxBetaLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="2">
-             <widget class="QLabel" name="label_8">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>γ</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="3">
-             <widget class="QLabel" name="CurrentBoxGammaLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Type</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_3">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>ρ</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" colspan="3">
-             <widget class="QLabel" name="CurrentBoxTypeLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Orthorhombic</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="3">
-             <widget class="QComboBox" name="DensityUnitsCombo"/>
-            </item>
-            <item row="4" column="1" colspan="2">
-             <widget class="QLabel" name="DensityUnitsLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <bold>false</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>0.0</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="CoordinatesFromFileGroup">
-           <property name="title">
-            <string>Coordinates From File</string>
-           </property>
-           <property name="checkable">
-            <bool>false</bool>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout">
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLineEdit" name="CoordinatesFileEdit"/>
-            </item>
-            <item row="0" column="1">
-             <widget class="QToolButton" name="CoordinatesFileSelectButton">
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset resource="main.qrc">
-                <normaloff>:/menu/icons/menu_open.svg</normaloff>:/menu/icons/menu_open.svg</iconset>
-              </property>
-              <property name="iconSize">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QComboBox" name="CoordinatesFileFormatCombo"/>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="SizeFactorGroup">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Size Factor Scaling</string>
-           </property>
-           <layout class="QFormLayout" name="formLayout">
-            <property name="horizontalSpacing">
-             <number>4</number>
-            </property>
-            <property name="verticalSpacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_15">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Requested</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="ExponentialSpin" name="RequestedSizeFactorSpin">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Requested size factor scaling for the Configuration's Box and contents (will be applied at start of next iteration)</string>
-              </property>
-              <property name="minimum">
-               <double>1.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_16">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Applied</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="ExponentialSpin" name="AppliedSizeFactorSpin">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Current size factor scaling of the Configuration's Box and contents</string>
-              </property>
-              <property name="readOnly">
-               <bool>false</bool>
-              </property>
-              <property name="buttonSymbols">
-               <enum>QAbstractSpinBox::NoButtons</enum>
-              </property>
-              <property name="minimum">
-               <double>1.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="GeneratorGroup">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Generator</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="spacing">
-           <number>4</number>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="leftMargin">
-           <number>4</number>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
           </property>
-          <property name="topMargin">
-           <number>4</number>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="GeneratorRegenerateButton">
+          <property name="text">
+           <string>Generate</string>
           </property>
-          <property name="rightMargin">
-           <number>4</number>
+          <property name="icon">
+           <iconset resource="main.qrc">
+            <normaloff>:/general/icons/general_repeat.svg</normaloff>:/general/icons/general_repeat.svg</iconset>
           </property>
-          <property name="bottomMargin">
-           <number>4</number>
-          </property>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="GeneratorRegenerateButton">
-              <property name="text">
-               <string>Generate</string>
-              </property>
-              <property name="icon">
-               <iconset resource="main.qrc">
-                <normaloff>:/general/icons/general_repeat.svg</normaloff>:/general/icons/general_repeat.svg</iconset>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="ProcedureEditor" name="ProcedureWidget" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="ConfigurationWidget" name="ViewerWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>1</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="ModulesTab">
-      <attribute name="title">
-       <string>Local Processing</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_4">
-       <property name="spacing">
-        <number>4</number>
-       </property>
-       <property name="leftMargin">
-        <number>4</number>
-       </property>
-       <property name="topMargin">
-        <number>4</number>
-       </property>
-       <property name="rightMargin">
-        <number>4</number>
-       </property>
-       <property name="bottomMargin">
-        <number>4</number>
-       </property>
-       <item>
-        <widget class="ModuleListEditor" name="LayerPanel" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="ProcedureEditor" name="ProcedureWidget" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ConfigurationWidget" name="ViewerWidget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
     </widget>
    </item>
   </layout>
@@ -745,12 +678,6 @@
    <class>ProcedureEditor</class>
    <extends>QWidget</extends>
    <header>gui/procedureeditor.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ModuleListEditor</class>
-   <extends>QWidget</extends>
-   <header>gui/modulelisteditor.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -37,9 +37,6 @@ ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dis
     // Set target for ProcedureEditor, and connect signals
     ui_.ProcedureWidget->setUp(&configuration_->generator(), dissolve.coreData());
     connect(ui_.ProcedureWidget, SIGNAL(dataModified()), dissolveWindow, SLOT(setModified()));
-
-    // Set up the ModuleEditor
-    ui_.LayerPanel->setUp(dissolveWindow, &cfg->moduleLayer(), configuration_);
 }
 
 ConfigurationTab::~ConfigurationTab()

--- a/src/gui/datamanagerdialog.h
+++ b/src/gui/datamanagerdialog.h
@@ -38,8 +38,7 @@ class DataManagerDialog : public QDialog
 
     private:
     // Append GenericItems to table under specified source
-    void addItemsToTable(QTableWidget *table, List<GenericItem> &items, const QString locationName,
-                         const QString locationIconResource);
+    void addItemsToTable(QTableWidget *table, List<GenericItem> &items);
     // Update the specified table of GenericItems, optionally filtering them by name and description
     void filterTable(QTableWidget *table, GenericItem *current, QString filter);
     // Update ReferencePoint table row

--- a/src/gui/datamanagerdialog.ui
+++ b/src/gui/datamanagerdialog.ui
@@ -148,11 +148,6 @@
             <string>Version</string>
            </property>
           </column>
-          <column>
-           <property name="text">
-            <string>Location</string>
-           </property>
-          </column>
          </widget>
         </item>
        </layout>

--- a/src/gui/datamanagerdialog_funcs.cpp
+++ b/src/gui/datamanagerdialog_funcs.cpp
@@ -26,12 +26,8 @@ DataManagerDialog::~DataManagerDialog() {}
  */
 
 // Append GenericItems to table under specified source
-void DataManagerDialog::addItemsToTable(QTableWidget *table, List<GenericItem> &items, const QString locationName,
-                                        const QString locationIconResource)
+void DataManagerDialog::addItemsToTable(QTableWidget *table, List<GenericItem> &items)
 {
-    // Create icon
-    QIcon locationIcon = QPixmap(locationIconResource);
-
     QTableWidgetItem *item;
     auto count = table->rowCount();
     table->setRowCount(count + items.nItems());
@@ -53,12 +49,6 @@ void DataManagerDialog::addItemsToTable(QTableWidget *table, List<GenericItem> &
         item = new QTableWidgetItem(QString::number(genericItem->version()));
         item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         table->setItem(count, 2, item);
-
-        // Location
-        item = new QTableWidgetItem(locationName);
-        item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
-        item->setIcon(locationIcon);
-        table->setItem(count, 3, item);
 
         ++count;
     }
@@ -144,8 +134,7 @@ void DataManagerDialog::updateControls()
 {
     // Clear and re-populate simulation data table
     ui_.SimulationDataTable->setRowCount(0);
-    addItemsToTable(ui_.SimulationDataTable, dissolve_.processingModuleData().items(), "Main Processing",
-                    ":/dissolve/icons/dissolve.png");
+    addItemsToTable(ui_.SimulationDataTable, dissolve_.processingModuleData().items());
     ui_.SimulationDataTable->resizeColumnsToContents();
 
     // Populate reference points table

--- a/src/gui/datamanagerdialog_funcs.cpp
+++ b/src/gui/datamanagerdialog_funcs.cpp
@@ -146,10 +146,6 @@ void DataManagerDialog::updateControls()
     ui_.SimulationDataTable->setRowCount(0);
     addItemsToTable(ui_.SimulationDataTable, dissolve_.processingModuleData().items(), "Main Processing",
                     ":/dissolve/icons/dissolve.png");
-    ListIterator<Configuration> configIterator(dissolve_.configurations());
-    while (Configuration *cfg = configIterator.iterate())
-        addItemsToTable(ui_.SimulationDataTable, cfg->moduleData().items(), QString::fromStdString(std::string(cfg->name())),
-                        ":/tabs/icons/tabs_configuration.svg");
     ui_.SimulationDataTable->resizeColumnsToContents();
 
     // Populate reference points table
@@ -171,11 +167,7 @@ void DataManagerDialog::on_ReferencePointRemoveButton_clicked(bool checked)
     if (!refPoint)
         return;
 
-    // For the provided suffix, we need to prune all processing data lists of associated data
     dissolve_.processingModuleData().pruneWithSuffix(refPoint->suffix());
-    ListIterator<Configuration> configIterator(dissolve_.configurations());
-    while (Configuration *cfg = configIterator.iterate())
-        cfg->moduleData().pruneWithSuffix(refPoint->suffix());
 
     updateControls();
 }

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -100,11 +100,6 @@ void DissolveWindow::on_SimulationClearModuleDataAction_triggered(bool checked)
         // Clear main processing data
         dissolve_.processingModuleData().clear();
 
-        // Clear local processing data in configurations
-        ListIterator<Configuration> configIterator(dissolve_.configurations());
-        while (Configuration *cfg = configIterator.iterate())
-            cfg->moduleData().clear();
-
         // Set iteration counter to zero
         dissolve_.resetIterationCounter();
 

--- a/src/gui/modulewidget.cpp
+++ b/src/gui/modulewidget.cpp
@@ -3,7 +3,10 @@
 
 #include "gui/modulewidget.h"
 
-ModuleWidget::ModuleWidget(QWidget *parent) : QWidget(parent) { refreshing_ = false; }
+ModuleWidget::ModuleWidget(QWidget *parent, const GenericList &processingData)
+    : QWidget(parent), processingData_(processingData), refreshing_(false)
+{
+}
 
 ModuleWidget::~ModuleWidget() {}
 

--- a/src/gui/modulewidget.h
+++ b/src/gui/modulewidget.h
@@ -6,19 +6,22 @@
 #include <QWidget>
 
 // Forward Declarations
+class GenericList;
 class LineParser;
 
 // ModuleWidget, base class for any Module-specific control widget
 class ModuleWidget : public QWidget
 {
     public:
-    ModuleWidget(QWidget *parent);
+    ModuleWidget(QWidget *parent, const GenericList &processingData);
     virtual ~ModuleWidget();
 
     /*
      * UI
      */
     protected:
+    // Processing data source
+    const GenericList &processingData_;
     // Whether widget is currently refreshing
     bool refreshing_;
 

--- a/src/main/configurations.cpp
+++ b/src/main/configurations.cpp
@@ -33,11 +33,6 @@ void Dissolve::removeConfiguration(Configuration *cfg)
     if (!cfg)
         return;
 
-    // Remove any references to the Modules in the Configuration's local processing layer before we delete it
-    ListIterator<Module> moduleIterator(cfg->modules());
-    while (Module *module = moduleIterator.iterate())
-        removeReferencesTo(module);
-
     // Remove references to the Configuration itself
     removeReferencesTo(cfg);
 

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -324,33 +324,6 @@ bool Dissolve::saveInput(std::string_view filename)
                                cfg->requestedSizeFactor()))
             return false;
 
-        // Modules
-        if (!parser.writeLineF("\n  # Modules\n"))
-            return false;
-        if ((cfg->nModules() == 0) && (!parser.writeLineF("  # -- None\n")))
-            return false;
-        ListIterator<Module> moduleIterator(cfg->modules().modules());
-        while (Module *module = moduleIterator.iterate())
-        {
-            if (!parser.writeLineF("  {}  {}  '{}'\n",
-                                   ConfigurationBlock::keywords().keyword(ConfigurationBlock::ModuleKeyword), module->type(),
-                                   module->uniqueName()))
-                return false;
-
-            // Write frequency and disabled keywords
-            if (!parser.writeLineF("    Frequency  {}\n", module->frequency()))
-                return false;
-            if (module->isDisabled() && (!parser.writeLineF("    Disabled\n")))
-                return false;
-
-            // Write keyword options
-            if (!module->keywords().write(parser, "    ", true))
-                return false;
-
-            if (!parser.writeLineF("  {}\n", ModuleBlock::keywords().keyword(ModuleBlock::EndModuleKeyword)))
-                return false;
-        }
-
         if (!parser.writeLineF("{}\n", ConfigurationBlock::keywords().keyword(ConfigurationBlock::EndConfigurationKeyword)))
             return false;
     }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -462,36 +462,6 @@ bool Dissolve::loadRestart(std::string_view filename)
                 break;
             }
         }
-        else if (DissolveSys::sameString(parser.argsv(0), "Local"))
-        {
-            // Let the user know what we are doing
-            Messenger::print("Reading item '{}' ({}) into Configuration '{}'...\n", parser.argsv(2), parser.argsv(3),
-                             parser.argsv(1));
-
-            // Local processing data - find the parent Configuration...
-            cfg = findConfiguration(parser.argsv(1));
-            if (!cfg)
-            {
-                Messenger::error("No Configuration named '{}' exists.\n", parser.argsv(1));
-                error = true;
-                break;
-            }
-
-            // Realise the item in the list
-            GenericItem *item = cfg->moduleData().create(parser.argsv(2), parser.argsv(3), parser.argi(4),
-                                                         parser.hasArg(5) ? parser.argi(5) : 0);
-
-            // Read in the data
-            if ((!item) || (!item->read(parser, coreData_)))
-            {
-                Messenger::error("Failed to read item data '{}' from restart file.\n", item->name());
-                error = true;
-                break;
-            }
-
-            // Add the InRestartFileFlag for the item
-            item->addFlag(GenericItem::InRestartFileFlag);
-        }
         else if (DissolveSys::sameString(parser.argsv(0), "Processing"))
         {
             // Let the user know what we are doing
@@ -582,7 +552,6 @@ bool Dissolve::loadRestartAsReference(std::string_view filename, std::string_vie
         return false;
 
     // Variables
-    Configuration *cfg;
     std::string newName;
     auto error = false, skipCurrentItem = false;
 
@@ -602,43 +571,6 @@ bool Dissolve::loadRestartAsReference(std::string_view filename, std::string_vie
             Messenger::print("Ignoring entry for keyword '{}' (module '{}')...\n", parser.argsv(2), parser.argsv(1));
 
             skipCurrentItem = true;
-        }
-        else if (DissolveSys::sameString(parser.argsv(0), "Local"))
-        {
-            // Create new suffixed name
-            newName = fmt::format("{}@{}", parser.argsv(2), dataSuffix);
-
-            // Let the user know what we are doing
-            Messenger::print("Reading item '{}' => '{}' ({}) into Configuration '{}'...\n", parser.argsv(2), newName,
-                             parser.argsv(3), parser.argsv(1));
-
-            // Local processing data - find the parent Configuration...
-            cfg = findConfiguration(parser.argsv(1));
-            if (!cfg)
-            {
-                Messenger::error("No Configuration named '{}' exists, so skipping this data...\n", parser.argsv(1));
-                skipCurrentItem = true;
-            }
-            else
-            {
-                // Realise the item in the list
-                GenericItem *item =
-                    cfg->moduleData().create(newName, parser.argsv(3), parser.argi(4), parser.hasArg(5) ? parser.argi(5) : 0);
-
-                // Read in the data
-                if ((!item) || (!item->read(parser, coreData_)))
-                {
-                    Messenger::error("Failed to read item data '{}' from restart file.\n", item->name());
-                    error = true;
-                    break;
-                }
-
-                // Add the ReferencePointData flag for the item, and remove the InRestartFileFlag
-                item->addFlag(GenericItem::IsReferencePointDataFlag);
-                item->removeFlag(GenericItem::InRestartFileFlag);
-
-                skipCurrentItem = false;
-            }
         }
         else if (DissolveSys::sameString(parser.argsv(0), "Processing"))
         {
@@ -737,25 +669,6 @@ bool Dissolve::saveRestart(std::string_view filename)
                 continue;
 
             if (!keyword->write(parser, fmt::format("Keyword  {}  {}  ", module->uniqueName(), keyword->name())))
-                return false;
-        }
-    }
-
-    // Configuration Module Data
-    for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
-    {
-        // Cycle over data store in the Configuration
-        ListIterator<GenericItem> itemIterator(cfg->moduleData().items());
-        while (GenericItem *item = itemIterator.iterate())
-        {
-            // If it is not flagged to be saved in the restart file, skip it
-            if (!(item->flags() & GenericItem::InRestartFileFlag))
-                continue;
-
-            if (!parser.writeLineF("Local  {}  {}  {}  {}  {}\n", cfg->name(), item->name(), item->itemClassName(),
-                                   item->version(), item->flags()))
-                return false;
-            if (!item->write(parser))
                 return false;
         }
     }

--- a/src/main/keywords.h
+++ b/src/main/keywords.h
@@ -53,7 +53,6 @@ enum ConfigurationKeyword
     EndConfigurationKeyword,   /* 'EndConfiguration' - Signals the end of the Configuration block */
     GeneratorKeyword,          /* 'Generator' - Define the generator procedure for the Configuration */
     InputCoordinatesKeyword,   /* 'InputCoordinates' - Specifies the file which contains the starting coordinates */
-    ModuleKeyword,             /* 'Module' - Starts the set up of a Module for this configuration */
     SizeFactorKeyword,         /* 'SizeFactor' - Scaling factor for Box lengths, Cell size, and Molecule centres-of-geometry */
     TemperatureKeyword         /* 'Temperature' - Defines the temperature of the simulation */
 };

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -130,7 +130,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
 
                 // Parse rest of Module block
                 module->setConfigurationLocal(true);
-                if (!ModuleBlock::parse(parser, dissolve, module, cfg->moduleData(), true))
+                if (!ModuleBlock::parse(parser, dissolve, module, dissolve->processingModuleData(), true))
                     error = true;
                 else if (!module->setUp(*dissolve, dissolve->worldPool()))
                     error = true;

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -16,7 +16,6 @@ EnumOptions<ConfigurationBlock::ConfigurationKeyword> ConfigurationBlock::keywor
                                  {ConfigurationBlock::EndConfigurationKeyword, "EndConfiguration"},
                                  {ConfigurationBlock::GeneratorKeyword, "Generator"},
                                  {ConfigurationBlock::InputCoordinatesKeyword, "InputCoordinates", 2},
-                                 {ConfigurationBlock::ModuleKeyword, "Module", OptionArguments::OptionalSecond},
                                  {ConfigurationBlock::SizeFactorKeyword, "SizeFactor", 1},
                                  {ConfigurationBlock::TemperatureKeyword, "Temperature", 1}});
 }
@@ -74,66 +73,6 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 }
                 Messenger::printVerbose("Initial coordinates will be loaded from file '{}' ({})\n",
                                         cfg->inputCoordinates().filename(), cfg->inputCoordinates().format());
-                break;
-            case (ConfigurationBlock::ModuleKeyword):
-                // The argument following the keyword is the module name, so try to create an instance of that
-                // Module
-                module = dissolve->createModuleInstance(parser.argsv(1));
-                if (!module)
-                {
-                    error = true;
-                    break;
-                }
-
-                // Add the new instance to the current Configuration
-                if (cfg->ownModule(module))
-                {
-                    // Add our pointer to the Module's list of associated Configurations
-                    if (!module->addTargetConfiguration(cfg))
-                    {
-                        Messenger::error("Failed to add Configuration '{}' to Module '{}' as a target.\n", cfg->name(),
-                                         module->type());
-                        error = true;
-                    }
-                }
-                else
-                {
-                    Messenger::error("Failed to add Module '{}' to Configuration.\n", parser.argsv(1));
-                    error = true;
-                }
-                if (error)
-                    break;
-
-                // Set unique name, if it was provided - need to check if it has been used elsewhere (in any
-                // Module or instance of it, or any Configuration)
-                if (parser.hasArg(2))
-                {
-                    niceName = DissolveSys::niceName(parser.argsv(2));
-                    Module *existingModule = dissolve->findModuleInstance(niceName);
-                    if (existingModule && (existingModule != module))
-                    {
-                        Messenger::error("A Module with the unique name '{}' already exist.\n", niceName);
-                        error = true;
-                        break;
-                    }
-                    else if (dissolve->findConfigurationByNiceName(niceName))
-                    {
-                        Messenger::error("A Configuration with the unique name '{}' already exist, and so "
-                                         "cannot be used as a Module name.\n",
-                                         niceName);
-                        error = true;
-                        break;
-                    }
-                    else
-                        module->setUniqueName(niceName);
-                }
-
-                // Parse rest of Module block
-                module->setConfigurationLocal(true);
-                if (!ModuleBlock::parse(parser, dissolve, module, dissolve->processingModuleData(), true))
-                    error = true;
-                else if (!module->setUp(*dissolve, dissolve->worldPool()))
-                    error = true;
                 break;
             case (ConfigurationBlock::SizeFactorKeyword):
                 cfg->setRequestedSizeFactor(parser.argd(1));

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -160,29 +160,18 @@ bool Dissolve::iterate(int nIterations)
         }
 
         /*
-         *  1)	Loop over Configurations and run their modules in the sequence in which they are defined.
-         * 	If a process is not involved in the Configuration's ProcessPool, it can move on.
+         *  1)	Loop over Configurations and perform any upkeep tasks
          */
-        Messenger::banner("Configuration Processing");
+        Messenger::banner("Configuration Upkeep");
 
-        auto result = true;
         for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
         {
-            // Check for failure of one or more processes / processing tasks
-            if (!worldPool().allTrue(result))
-            {
-                Messenger::error("One or more processes experienced failures. Exiting now.\n");
-                return false;
-            }
-
             Messenger::heading("'{}'", cfg->name());
 
             // Perform any necessary actions before we start processing this Configuration's Modules
             // -- Apply the current size factor
             cfg->applySizeFactor(potentialMap_);
         }
-        if (!result)
-            return false;
 
         // Sync up all processes
         Messenger::printVerbose("Waiting for other processes at end of Configuration processing...\n");
@@ -225,7 +214,7 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", module->type(), module->uniqueName());
 
-                result = module->executeProcessing(*this, worldPool());
+                auto result = module->executeProcessing(*this, worldPool());
 
                 if (!result)
                 {

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -244,10 +244,6 @@ bool Dissolve::iterate(int nIterations)
             Messenger::printVerbose("Broadcasting data for Configuration '{}'...\n", cfg->name());
             if (!cfg->broadcastCoordinates(worldPool(), cfg->processPool().rootWorldRank()))
                 return false;
-
-            Messenger::printVerbose("Broadcasting Module data for Configuration '{}'...\n", cfg->name());
-            if (!cfg->moduleData().broadcast(worldPool(), cfg->processPool().rootWorldRank(), coreData_))
-                return false;
         }
 
         // Sync up all processes

--- a/src/math/averaging.cpp
+++ b/src/math/averaging.cpp
@@ -14,12 +14,12 @@ EnumOptions<Averaging::AveragingScheme> averagingSchemes()
 }
 
 // Establish the number of stored datasets, shift indices down, and lose oldest dataset if necessary
-int pruneOldData(GenericList &moduleData, std::string_view name, std::string_view prefix, int nSetsInAverage)
+int pruneOldData(GenericList &processingData, std::string_view name, std::string_view prefix, int nSetsInAverage)
 {
     // Establish how many stored datasets we have
     int nStored = 0;
     for (nStored = 0; nStored < nSetsInAverage; ++nStored)
-        if (!moduleData.contains(fmt::format("{}_{}", name, nStored + 1), prefix))
+        if (!processingData.contains(fmt::format("{}_{}", name, nStored + 1), prefix))
             break;
     Messenger::print("Average requested over {} datasets - {} available in module data ({} max).\n", nSetsInAverage, nStored,
                      nSetsInAverage - 1);
@@ -27,11 +27,11 @@ int pruneOldData(GenericList &moduleData, std::string_view name, std::string_vie
     // Remove the oldest dataset if it exists, and shuffle the others down
     if (nStored == nSetsInAverage)
     {
-        moduleData.remove(fmt::format("{}_{}", name, nStored), prefix);
+        processingData.remove(fmt::format("{}_{}", name, nStored), prefix);
         --nStored;
     }
     for (auto n = nStored; n > 0; --n)
-        moduleData.rename(fmt::format("{}_{}", name, n), prefix, fmt::format("{}_{}", name, n + 1), prefix);
+        processingData.rename(fmt::format("{}_{}", name, n), prefix, fmt::format("{}_{}", name, n + 1), prefix);
 
     return nStored;
 }

--- a/src/math/averaging.h
+++ b/src/math/averaging.h
@@ -21,7 +21,7 @@ enum AveragingScheme
 EnumOptions<Averaging::AveragingScheme> averagingSchemes();
 
 // Establish the number of stored datasets, shift indices down, and lose oldest dataset if necessary
-int pruneOldData(GenericList &moduleData, std::string_view name, std::string_view prefix, int nSetsInAverage);
+int pruneOldData(GenericList &processingData, std::string_view name, std::string_view prefix, int nSetsInAverage);
 // Return exponential decay factor
 double expDecay();
 
@@ -30,19 +30,19 @@ double normalisationFactor(Averaging::AveragingScheme scheme, int nData);
 
 // Perform averaging of named data
 template <class T>
-bool average(GenericList &moduleData, std::string_view name, std::string_view prefix, int nSetsInAverage,
+bool average(GenericList &processingData, std::string_view name, std::string_view prefix, int nSetsInAverage,
              AveragingScheme averagingScheme)
 {
     // Find the 'root' data of type T, which should currently contain the most recently-calculated data
-    if (!moduleData.contains(name, prefix))
+    if (!processingData.contains(name, prefix))
         return Messenger::error("Couldn't find root data '{}' (prefix = '{}') in order to perform averaging.\n", name, prefix);
-    T &currentData = moduleData.retrieve<T>(name, prefix);
+    T &currentData = processingData.retrieve<T>(name, prefix);
 
     // Establish the number of existing datasets, and perform management on them
-    int nData = pruneOldData(moduleData, name, prefix, nSetsInAverage);
+    int nData = pruneOldData(processingData, name, prefix, nSetsInAverage);
 
     // Store the current T as the earliest data (index == 1)
-    T &recentData = moduleData.realise<T>(fmt::format("{}_1", name), prefix, GenericItem::InRestartFileFlag);
+    T &recentData = processingData.realise<T>(fmt::format("{}_1", name), prefix, GenericItem::InRestartFileFlag);
     recentData = currentData;
     ++nData;
 
@@ -55,7 +55,7 @@ bool average(GenericList &moduleData, std::string_view name, std::string_view pr
     for (auto n = 0; n < nData; ++n)
     {
         // Get a copy of the (n+1)'th dataset
-        T data = moduleData.value<T>(fmt::format("{}_{}", name, n + 1), prefix);
+        T data = processingData.value<T>(fmt::format("{}_{}", name, n + 1), prefix);
 
         // Determine the weighting factor
         if (averagingScheme == Averaging::LinearAveraging)
@@ -75,22 +75,22 @@ bool average(GenericList &moduleData, std::string_view name, std::string_view pr
 
 // Perform averaging of named array data
 template <class T>
-static bool arrayAverage(GenericList &moduleData, std::string_view name, std::string_view prefix, int nSetsInAverage,
+static bool arrayAverage(GenericList &processingData, std::string_view name, std::string_view prefix, int nSetsInAverage,
                          AveragingScheme averagingScheme)
 {
     // Find the 'root' data of type T, which should currently contain the most recently-calculated data
-    if (!moduleData.contains(name, prefix))
+    if (!processingData.contains(name, prefix))
     {
         Messenger::error("Couldn't find root data '{}' (prefix = '{}') in order to perform averaging.\n", name, prefix);
         return false;
     }
-    T &currentData = moduleData.retrieve<T>(name, prefix);
+    T &currentData = processingData.retrieve<T>(name, prefix);
 
     // Establish the number of existing datasets, and perform management on them
-    int nData = pruneOldData(moduleData, name, prefix, nSetsInAverage);
+    int nData = pruneOldData(processingData, name, prefix, nSetsInAverage);
 
     // Store the current T as the earliest data (index == 1)
-    T &recentData = moduleData.realise<T>(fmt::format("{}_1", name), prefix, GenericItem::InRestartFileFlag);
+    T &recentData = processingData.realise<T>(fmt::format("{}_1", name), prefix, GenericItem::InRestartFileFlag);
     recentData = currentData;
     ++nData;
 
@@ -106,7 +106,7 @@ static bool arrayAverage(GenericList &moduleData, std::string_view name, std::st
     for (auto n = 0; n < nData; ++n)
     {
         // Get a copy of the (n+1)'th dataset
-        T data = moduleData.value<T>(fmt::format("{}_{}", name, n + 1), prefix);
+        T data = processingData.value<T>(fmt::format("{}_{}", name, n + 1), prefix);
 
         // Determine the weighting factor
         if (averagingScheme == Averaging::LinearAveraging)

--- a/src/modules/analyse/gui/gui.cpp
+++ b/src/modules/analyse/gui/gui.cpp
@@ -8,5 +8,5 @@
 // Return a new widget controlling this Module
 ModuleWidget *AnalyseModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new AnalyseModuleWidget(parent, this, dissolve.coreData());
+    return new AnalyseModuleWidget(parent, dissolve.processingModuleData(), this, dissolve.coreData());
 }

--- a/src/modules/analyse/gui/modulewidget.h
+++ b/src/modules/analyse/gui/modulewidget.h
@@ -18,7 +18,7 @@ class AnalyseModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    AnalyseModuleWidget(QWidget *parent, AnalyseModule *module, const CoreData &coreData);
+    AnalyseModuleWidget(QWidget *parent, const GenericList &processingData, AnalyseModule *module, const CoreData &coreData);
 
     private:
     // Associated Module

--- a/src/modules/analyse/gui/modulewidget_funcs.cpp
+++ b/src/modules/analyse/gui/modulewidget_funcs.cpp
@@ -4,8 +4,9 @@
 #include "modules/analyse/analyse.h"
 #include "modules/analyse/gui/modulewidget.h"
 
-AnalyseModuleWidget::AnalyseModuleWidget(QWidget *parent, AnalyseModule *module, const CoreData &coreData)
-    : ModuleWidget(parent), module_(module)
+AnalyseModuleWidget::AnalyseModuleWidget(QWidget *parent, const GenericList &processingData, AnalyseModule *module,
+                                         const CoreData &coreData)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/atomshake/gui/gui.cpp
+++ b/src/modules/atomshake/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/atomshake/atomshake.h"
 #include "modules/atomshake/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *AtomShakeModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new AtomShakeModuleWidget(parent, this);
+    return new AtomShakeModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/atomshake/gui/modulewidget.h
+++ b/src/modules/atomshake/gui/modulewidget.h
@@ -20,7 +20,7 @@ class AtomShakeModuleWidget : public ModuleWidget
     AtomShakeModule *module_;
 
     public:
-    AtomShakeModuleWidget(QWidget *parent, AtomShakeModule *module);
+    AtomShakeModuleWidget(QWidget *parent, const GenericList &processingData, AtomShakeModule *module);
     ~AtomShakeModuleWidget();
 
     /*

--- a/src/modules/atomshake/gui/modulewidget_funcs.cpp
+++ b/src/modules/atomshake/gui/modulewidget_funcs.cpp
@@ -4,7 +4,8 @@
 #include "modules/atomshake/atomshake.h"
 #include "modules/atomshake/gui/modulewidget.h"
 
-AtomShakeModuleWidget::AtomShakeModuleWidget(QWidget *parent, AtomShakeModule *module) : ModuleWidget(parent), module_(module)
+AtomShakeModuleWidget::AtomShakeModuleWidget(QWidget *parent, const GenericList &processingData, AtomShakeModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/benchmark/gui/gui.cpp
+++ b/src/modules/benchmark/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/benchmark/benchmark.h"
 #include "modules/benchmark/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *BenchmarkModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new BenchmarkModuleWidget(parent, this);
+    return new BenchmarkModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/benchmark/gui/modulewidget.h
+++ b/src/modules/benchmark/gui/modulewidget.h
@@ -20,7 +20,7 @@ class BenchmarkModuleWidget : public ModuleWidget
     BenchmarkModule *module_;
 
     public:
-    BenchmarkModuleWidget(QWidget *parent, BenchmarkModule *module);
+    BenchmarkModuleWidget(QWidget *parent, const GenericList &processingData, BenchmarkModule *module);
 
     /*
      * UI

--- a/src/modules/benchmark/gui/modulewidget_funcs.cpp
+++ b/src/modules/benchmark/gui/modulewidget_funcs.cpp
@@ -4,7 +4,8 @@
 #include "modules/benchmark/benchmark.h"
 #include "modules/benchmark/gui/modulewidget.h"
 
-BenchmarkModuleWidget::BenchmarkModuleWidget(QWidget *parent, BenchmarkModule *module) : ModuleWidget(parent), module_(module)
+BenchmarkModuleWidget::BenchmarkModuleWidget(QWidget *parent, const GenericList &processingData, BenchmarkModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -70,8 +70,8 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 bool upToDate;
                 Timer timer;
                 Messenger::mute();
-                rdfModule.calculateGR(procPool, cfg, RDFModule::CellsMethod, cfg->box()->inscribedSphereRadius(), 0.05,
-                                      upToDate);
+                rdfModule.calculateGR(dissolve.processingModuleData(), procPool, cfg, RDFModule::CellsMethod,
+                                      cfg->box()->inscribedSphereRadius(), 0.05, upToDate);
                 Messenger::unMute();
                 timing += timer.split();
             }
@@ -96,8 +96,8 @@ bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 bool upToDate;
                 Timer timer;
                 Messenger::mute();
-                rdfModule.calculateGR(procPool, cfg, RDFModule::SimpleMethod, cfg->box()->inscribedSphereRadius(), 0.05,
-                                      upToDate);
+                rdfModule.calculateGR(dissolve.processingModuleData(), procPool, cfg, RDFModule::SimpleMethod,
+                                      cfg->box()->inscribedSphereRadius(), 0.05, upToDate);
                 Messenger::unMute();
                 timing += timer.split();
             }

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -57,13 +57,13 @@ class BraggModule : public Module
      */
     public:
     // Calculate Bragg terms for specified Configuration
-    bool calculateBraggTerms(ProcessPool &procPool, Configuration *cfg, const double qMin, const double qDelta,
-                             const double qMax, Vec3<int> multiplicity, bool &alreadyUpToDate);
+    bool calculateBraggTerms(GenericList &moduleData, ProcessPool &procPool, Configuration *cfg, const double qMin,
+                             const double qDelta, const double qMax, Vec3<int> multiplicity, bool &alreadyUpToDate);
     // Form partial and total reflection functions from calculated reflection data
-    bool formReflectionFunctions(ProcessPool &procPool, Configuration *cfg, const double qMin, const double qDelta,
-                                 const double qMax);
+    bool formReflectionFunctions(GenericList &moduleData, ProcessPool &procPool, Configuration *cfg, const double qMin,
+                                 const double qDelta, const double qMax);
     // Re-bin reflection data into supplied arrays
-    static bool reBinReflections(ProcessPool &procPool, Configuration *cfg, Array2D<Data1D> &braggPartials);
+    bool reBinReflections(GenericList &moduleData, ProcessPool &procPool, Configuration *cfg, Array2D<Data1D> &braggPartials);
 
     /*
      * GUI Widget

--- a/src/modules/bragg/gui/gui.cpp
+++ b/src/modules/bragg/gui/gui.cpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/bragg/bragg.h"
 #include "modules/bragg/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
-ModuleWidget *BraggModule::createWidget(QWidget *parent, Dissolve &dissolve) { return new BraggModuleWidget(parent, this); }
+ModuleWidget *BraggModule::createWidget(QWidget *parent, Dissolve &dissolve)
+{
+    return new BraggModuleWidget(parent, dissolve.processingModuleData(), this);
+}

--- a/src/modules/bragg/gui/modulewidget.h
+++ b/src/modules/bragg/gui/modulewidget.h
@@ -21,7 +21,7 @@ class BraggModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    BraggModuleWidget(QWidget *parent, BraggModule *module);
+    BraggModuleWidget(QWidget *parent, const GenericList &processingData, BraggModule *module);
     ~BraggModuleWidget();
 
     private:

--- a/src/modules/bragg/gui/modulewidget_funcs.cpp
+++ b/src/modules/bragg/gui/modulewidget_funcs.cpp
@@ -11,7 +11,8 @@
 #include "templates/algorithms.h"
 #include "templates/variantpointer.h"
 
-BraggModuleWidget::BraggModuleWidget(QWidget *parent, BraggModule *module) : ModuleWidget(parent), module_(module)
+BraggModuleWidget::BraggModuleWidget(QWidget *parent, const GenericList &processingData, BraggModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_angle/gui/gui.cpp
+++ b/src/modules/calculate_angle/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calculate_angle/angle.h"
 #include "modules/calculate_angle/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalculateAngleModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateAngleModuleWidget(parent, this);
+    return new CalculateAngleModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calculate_angle/gui/modulewidget.h
+++ b/src/modules/calculate_angle/gui/modulewidget.h
@@ -21,7 +21,7 @@ class CalculateAngleModuleWidget : public ModuleWidget
     CalculateAngleModule *module_;
 
     public:
-    CalculateAngleModuleWidget(QWidget *parent, CalculateAngleModule *module);
+    CalculateAngleModuleWidget(QWidget *parent, const GenericList &processingData, CalculateAngleModule *module);
 
     /*
      * UI

--- a/src/modules/calculate_angle/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_angle/gui/modulewidget_funcs.cpp
@@ -7,8 +7,9 @@
 #include "modules/calculate_angle/angle.h"
 #include "modules/calculate_angle/gui/modulewidget.h"
 
-CalculateAngleModuleWidget::CalculateAngleModuleWidget(QWidget *parent, CalculateAngleModule *module)
-    : ModuleWidget(parent), module_(module)
+CalculateAngleModuleWidget::CalculateAngleModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                       CalculateAngleModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_avgmol/gui/gui.cpp
+++ b/src/modules/calculate_avgmol/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calculate_avgmol/avgmol.h"
 #include "modules/calculate_avgmol/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalculateAvgMolModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateAvgMolModuleWidget(parent, this);
+    return new CalculateAvgMolModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calculate_avgmol/gui/modulewidget.h
+++ b/src/modules/calculate_avgmol/gui/modulewidget.h
@@ -20,7 +20,7 @@ class CalculateAvgMolModuleWidget : public ModuleWidget
     CalculateAvgMolModule *module_;
 
     public:
-    CalculateAvgMolModuleWidget(QWidget *parent, CalculateAvgMolModule *module);
+    CalculateAvgMolModuleWidget(QWidget *parent, const GenericList &processingData, CalculateAvgMolModule *module);
 
     /*
      * UI

--- a/src/modules/calculate_avgmol/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_avgmol/gui/modulewidget_funcs.cpp
@@ -4,8 +4,9 @@
 #include "modules/calculate_avgmol/avgmol.h"
 #include "modules/calculate_avgmol/gui/modulewidget.h"
 
-CalculateAvgMolModuleWidget::CalculateAvgMolModuleWidget(QWidget *parent, CalculateAvgMolModule *module)
-    : ModuleWidget(parent), module_(module)
+CalculateAvgMolModuleWidget::CalculateAvgMolModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                         CalculateAvgMolModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_axisangle/gui/gui.cpp
+++ b/src/modules/calculate_axisangle/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calculate_axisangle/axisangle.h"
 #include "modules/calculate_axisangle/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalculateAxisAngleModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateAxisAngleModuleWidget(parent, this);
+    return new CalculateAxisAngleModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calculate_axisangle/gui/modulewidget.h
+++ b/src/modules/calculate_axisangle/gui/modulewidget.h
@@ -21,7 +21,7 @@ class CalculateAxisAngleModuleWidget : public ModuleWidget
     CalculateAxisAngleModule *module_;
 
     public:
-    CalculateAxisAngleModuleWidget(QWidget *parent, CalculateAxisAngleModule *module);
+    CalculateAxisAngleModuleWidget(QWidget *parent, const GenericList &processingData, CalculateAxisAngleModule *module);
 
     /*
      * UI

--- a/src/modules/calculate_axisangle/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_axisangle/gui/modulewidget_funcs.cpp
@@ -7,8 +7,9 @@
 #include "modules/calculate_axisangle/axisangle.h"
 #include "modules/calculate_axisangle/gui/modulewidget.h"
 
-CalculateAxisAngleModuleWidget::CalculateAxisAngleModuleWidget(QWidget *parent, CalculateAxisAngleModule *module)
-    : ModuleWidget(parent), module_(module)
+CalculateAxisAngleModuleWidget::CalculateAxisAngleModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                               CalculateAxisAngleModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_cn/gui/gui.cpp
+++ b/src/modules/calculate_cn/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calculate_cn/cn.h"
 #include "modules/calculate_cn/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalculateCNModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateCNModuleWidget(parent, this);
+    return new CalculateCNModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calculate_cn/gui/modulewidget.h
+++ b/src/modules/calculate_cn/gui/modulewidget.h
@@ -16,7 +16,7 @@ class CalculateCNModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    CalculateCNModuleWidget(QWidget *parent, CalculateCNModule *cnModule);
+    CalculateCNModuleWidget(QWidget *parent, const GenericList &processingData, CalculateCNModule *cnModule);
 
     /*
      * Data

--- a/src/modules/calculate_cn/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_cn/gui/modulewidget_funcs.cpp
@@ -7,8 +7,9 @@
 #include "modules/calculate_rdf/rdf.h"
 #include "procedure/nodes/process1d.h"
 
-CalculateCNModuleWidget::CalculateCNModuleWidget(QWidget *parent, CalculateCNModule *cnModule)
-    : ModuleWidget(parent), module_(cnModule)
+CalculateCNModuleWidget::CalculateCNModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                 CalculateCNModule *cnModule)
+    : ModuleWidget(parent, processingData), module_(cnModule)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_dangle/gui/gui.cpp
+++ b/src/modules/calculate_dangle/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calculate_dangle/dangle.h"
 #include "modules/calculate_dangle/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalculateDAngleModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateDAngleModuleWidget(parent, this);
+    return new CalculateDAngleModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calculate_dangle/gui/modulewidget.h
+++ b/src/modules/calculate_dangle/gui/modulewidget.h
@@ -21,7 +21,7 @@ class CalculateDAngleModuleWidget : public ModuleWidget
     CalculateDAngleModule *module_;
 
     public:
-    CalculateDAngleModuleWidget(QWidget *parent, CalculateDAngleModule *module);
+    CalculateDAngleModuleWidget(QWidget *parent, const GenericList &processingData, CalculateDAngleModule *module);
 
     /*
      * UI

--- a/src/modules/calculate_dangle/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_dangle/gui/modulewidget_funcs.cpp
@@ -7,8 +7,9 @@
 #include "modules/calculate_dangle/dangle.h"
 #include "modules/calculate_dangle/gui/modulewidget.h"
 
-CalculateDAngleModuleWidget::CalculateDAngleModuleWidget(QWidget *parent, CalculateDAngleModule *module)
-    : ModuleWidget(parent), module_(module)
+CalculateDAngleModuleWidget::CalculateDAngleModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                         CalculateDAngleModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_rdf/gui/gui.cpp
+++ b/src/modules/calculate_rdf/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calculate_rdf/gui/modulewidget.h"
 #include "modules/calculate_rdf/rdf.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalculateRDFModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateRDFModuleWidget(parent, this);
+    return new CalculateRDFModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calculate_rdf/gui/modulewidget.h
+++ b/src/modules/calculate_rdf/gui/modulewidget.h
@@ -23,7 +23,7 @@ class CalculateRDFModuleWidget : public ModuleWidget
     DataViewer *rdfGraph_;
 
     public:
-    CalculateRDFModuleWidget(QWidget *parent, CalculateRDFModule *module);
+    CalculateRDFModuleWidget(QWidget *parent, const GenericList &processingData, CalculateRDFModule *module);
 
     /*
      * UI

--- a/src/modules/calculate_rdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_rdf/gui/modulewidget_funcs.cpp
@@ -6,8 +6,9 @@
 #include "modules/calculate_rdf/gui/modulewidget.h"
 #include "modules/calculate_rdf/rdf.h"
 
-CalculateRDFModuleWidget::CalculateRDFModuleWidget(QWidget *parent, CalculateRDFModule *module)
-    : ModuleWidget(parent), module_(module)
+CalculateRDFModuleWidget::CalculateRDFModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                   CalculateRDFModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calculate_sdf/gui/gui.cpp
+++ b/src/modules/calculate_sdf/gui/gui.cpp
@@ -8,5 +8,5 @@
 // Return a new widget controlling this Module
 ModuleWidget *CalculateSDFModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalculateSDFModuleWidget(parent, this, dissolve.coreData());
+    return new CalculateSDFModuleWidget(parent, dissolve.processingModuleData(), this, dissolve.coreData());
 }

--- a/src/modules/calculate_sdf/gui/modulewidget.h
+++ b/src/modules/calculate_sdf/gui/modulewidget.h
@@ -21,7 +21,8 @@ class CalculateSDFModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    CalculateSDFModuleWidget(QWidget *parent, CalculateSDFModule *module, const CoreData &coreData);
+    CalculateSDFModuleWidget(QWidget *parent, const GenericList &processingData, CalculateSDFModule *module,
+                             const CoreData &coreData);
 
     private:
     // Associated Module

--- a/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
@@ -11,8 +11,9 @@
 #include "modules/calculate_sdf/gui/modulewidget.h"
 #include "modules/calculate_sdf/sdf.h"
 
-CalculateSDFModuleWidget::CalculateSDFModuleWidget(QWidget *parent, CalculateSDFModule *module, const CoreData &coreData)
-    : ModuleWidget(parent), module_(module), coreData_(coreData)
+CalculateSDFModuleWidget::CalculateSDFModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                   CalculateSDFModule *module, const CoreData &coreData)
+    : ModuleWidget(parent, processingData), module_(module), coreData_(coreData)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/calibration/functions.cpp
+++ b/src/modules/calibration/functions.cpp
@@ -34,8 +34,8 @@ double CalibrationModuleCostFunctions::intraBroadeningCost(const std::vector<dou
         auto smoothing = rdfModule->keywords().asInt("Smoothing");
         for (Configuration *cfg : rdfModule->targetConfigurations())
         {
-            const auto &originalGR = cfg->moduleData().value<PartialSet>("OriginalGR");
-            auto &unweightedGR = cfg->moduleData().realise<PartialSet>("UnweightedGR");
+            const auto &originalGR = dissolve_.processingModuleData().value<PartialSet>("OriginalGR", cfg->niceName());
+            auto &unweightedGR = dissolve_.processingModuleData().realise<PartialSet>("UnweightedGR", cfg->niceName());
             RDFModule::calculateUnweightedGR(processPool_, cfg, originalGR, unweightedGR, broadening, smoothing);
         }
     }
@@ -52,7 +52,7 @@ double CalibrationModuleCostFunctions::intraBroadeningCost(const std::vector<dou
         // Make sure the structure factors will be updated by the NeutronSQ module - set flag in the target
         // Configurations
         for (Configuration *cfg : module->targetConfigurations())
-            cfg->moduleData().realise<bool>("_ForceNeutronSQ") = true;
+            dissolve_.processingModuleData().realise<bool>("_ForceNeutronSQ", cfg->niceName()) = true;
 
         // Run the NeutronSQModule (quietly)
         Messenger::mute();

--- a/src/modules/calibration/gui/gui.cpp
+++ b/src/modules/calibration/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/calibration/calibration.h"
 #include "modules/calibration/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *CalibrationModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new CalibrationModuleWidget(parent, this);
+    return new CalibrationModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/calibration/gui/modulewidget.h
+++ b/src/modules/calibration/gui/modulewidget.h
@@ -20,7 +20,7 @@ class CalibrationModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    CalibrationModuleWidget(QWidget *parent, CalibrationModule *module);
+    CalibrationModuleWidget(QWidget *parent, const GenericList &processingData, CalibrationModule *module);
     ~CalibrationModuleWidget();
 
     private:

--- a/src/modules/calibration/gui/modulewidget_funcs.cpp
+++ b/src/modules/calibration/gui/modulewidget_funcs.cpp
@@ -9,8 +9,8 @@
 #include "modules/calibration/gui/modulewidget.h"
 #include "templates/variantpointer.h"
 
-CalibrationModuleWidget::CalibrationModuleWidget(QWidget *parent, CalibrationModule *module)
-    : ModuleWidget(parent), module_(module)
+CalibrationModuleWidget::CalibrationModuleWidget(QWidget *parent, const GenericList &processingData, CalibrationModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/datatest/datatest.h
+++ b/src/modules/datatest/datatest.h
@@ -77,43 +77,38 @@ class DataTestModule : public Module
         // If a target module was supplied, search there first
         if (targetModule)
         {
-            // Get target module data list
-            GenericList &moduleData = targetModule->configurationLocal()
-                                          ? targetModule->targetConfigurations().firstItem()->moduleData()
-                                          : processingModuleData;
-
             // The 'dataIdentifier' is the actual name of the data (possibly with module prefix) - does it exist in
             // the target list?
-            if (moduleData.contains(dataIdentifier, targetModule->uniqueName()))
+            if (processingModuleData.contains(dataIdentifier, targetModule->uniqueName()))
             {
                 // Try to retrieve the data as the current type
                 found = false;
-                const T &data = moduleData.retrieve<T>(dataIdentifier, targetModule->uniqueName(), T(), &found);
+                const T &data = processingModuleData.retrieve<T>(dataIdentifier, targetModule->uniqueName(), T(), &found);
 
                 if (!found)
                 {
                     Messenger::error("Data named '{}_{}' exists, but is not of the correct type (is {} rather than "
                                      "{}).\n",
                                      targetModule->uniqueName(), dataIdentifier,
-                                     moduleData.find(dataIdentifier, targetModule->uniqueName())->itemClassName(),
+                                     processingModuleData.find(dataIdentifier, targetModule->uniqueName())->itemClassName(),
                                      T::itemClassName());
                     return dummy;
                 }
                 else
                     return data;
             }
-            else if (moduleData.contains(dataIdentifier))
+            else if (processingModuleData.contains(dataIdentifier))
             {
                 // Try to retrieve the data as the current type
                 found = false;
-                const T &data = moduleData.value<T>(dataIdentifier, "", T(), &found);
+                const T &data = processingModuleData.value<T>(dataIdentifier, "", T(), &found);
 
                 if (!found)
                 {
                     Messenger::error("Data named '{}' exists, but is not of the correct type (is {} rather than "
                                      "{}).\n",
                                      dataIdentifier,
-                                     moduleData.find(dataIdentifier, targetModule->uniqueName())->itemClassName(),
+                                     processingModuleData.find(dataIdentifier, targetModule->uniqueName())->itemClassName(),
                                      T::itemClassName());
                     return dummy;
                 }

--- a/src/modules/datatest/gui/gui.cpp
+++ b/src/modules/datatest/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/datatest/datatest.h"
 #include "modules/datatest/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *DataTestModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new DataTestModuleWidget(parent, this);
+    return new DataTestModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/datatest/gui/modulewidget.h
+++ b/src/modules/datatest/gui/modulewidget.h
@@ -20,7 +20,7 @@ class DataTestModuleWidget : public ModuleWidget
     DataTestModule *module_;
 
     public:
-    DataTestModuleWidget(QWidget *parent, DataTestModule *module);
+    DataTestModuleWidget(QWidget *parent, const GenericList &processingData, DataTestModule *module);
 
     /*
      * UI

--- a/src/modules/datatest/gui/modulewidget_funcs.cpp
+++ b/src/modules/datatest/gui/modulewidget_funcs.cpp
@@ -4,7 +4,8 @@
 #include "modules/datatest/datatest.h"
 #include "modules/datatest/gui/modulewidget.h"
 
-DataTestModuleWidget::DataTestModuleWidget(QWidget *parent, DataTestModule *module) : ModuleWidget(parent), module_(module)
+DataTestModuleWidget::DataTestModuleWidget(QWidget *parent, const GenericList &processingData, DataTestModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -89,9 +89,9 @@ class EnergyModule : public Module
     // Return total energy (interatomic and intramolecular) of Species
     static double totalEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap);
     // Check energy stability of specified Configuration
-    static EnergyStability checkStability(Configuration *cfg);
+    static EnergyStability checkStability(GenericList &processingData, Configuration *cfg);
     // Check energy stability of specified Configurations, returning the number that are unstable
-    static int nUnstable(const RefList<Configuration> &configurations);
+    static int nUnstable(GenericList &processingData, const RefList<Configuration> &configurations);
 
     /*
      * GUI Widget

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -252,10 +252,10 @@ double EnergyModule::totalEnergy(ProcessPool &procPool, Species *sp, const Poten
 }
 
 // Check energy stability of specified Configuration
-EnergyModule::EnergyStability EnergyModule::checkStability(Configuration *cfg)
+EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processingData, Configuration *cfg)
 {
     // First, check if the Configuration is targetted by an EnergyModule
-    if (!cfg->moduleData().value<bool>("_IsEnergyModuleTarget", "", false))
+    if (!processingData.value<bool>("IsEnergyModuleTarget", cfg->niceName(), false))
     {
         Messenger::error("Configuration '{}' is not targeted by any EnergyModule, so stability cannot be assessed. "
                          "Check your setup!\n",
@@ -264,9 +264,9 @@ EnergyModule::EnergyStability EnergyModule::checkStability(Configuration *cfg)
     }
 
     // Retrieve the EnergyStable flag from the Configuration's module data
-    if (cfg->moduleData().contains("EnergyStable"))
+    if (processingData.contains("EnergyStable", cfg->niceName()))
     {
-        auto stable = cfg->moduleData().value<bool>("EnergyStable");
+        auto stable = processingData.value<bool>("EnergyStable", cfg->niceName());
         if (!stable)
         {
             Messenger::print("Energy for Configuration '{}' is not yet stable.\n", cfg->name());
@@ -284,14 +284,14 @@ EnergyModule::EnergyStability EnergyModule::checkStability(Configuration *cfg)
 }
 
 // Check energy stability of specified Configurations, returning the number that failed
-int EnergyModule::nUnstable(const RefList<Configuration> &configurations)
+int EnergyModule::nUnstable(GenericList &processingData, const RefList<Configuration> &configurations)
 {
     auto nFailed = 0;
 
-    for (Configuration *cfg : configurations)
+    for (auto *cfg : configurations)
     {
         // Check the stability of this Configuration
-        auto result = checkStability(cfg);
+        auto result = checkStability(processingData, cfg);
 
         if (result == EnergyModule::EnergyStable)
             ++nFailed;

--- a/src/modules/energy/gui/gui.cpp
+++ b/src/modules/energy/gui/gui.cpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/energy/energy.h"
 #include "modules/energy/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
-ModuleWidget *EnergyModule::createWidget(QWidget *parent, Dissolve &dissolve) { return new EnergyModuleWidget(parent, this); }
+ModuleWidget *EnergyModule::createWidget(QWidget *parent, Dissolve &dissolve)
+{
+    return new EnergyModuleWidget(parent, dissolve.processingModuleData(), this);
+}

--- a/src/modules/energy/gui/modulewidget.h
+++ b/src/modules/energy/gui/modulewidget.h
@@ -21,7 +21,7 @@ class EnergyModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    EnergyModuleWidget(QWidget *parent, EnergyModule *module);
+    EnergyModuleWidget(QWidget *parent, const GenericList &processingData, EnergyModule *module);
     ~EnergyModuleWidget();
 
     private:

--- a/src/modules/energy/gui/modulewidget_funcs.cpp
+++ b/src/modules/energy/gui/modulewidget_funcs.cpp
@@ -10,7 +10,8 @@
 #include "modules/energy/gui/modulewidget.h"
 #include "templates/variantpointer.h"
 
-EnergyModuleWidget::EnergyModuleWidget(QWidget *parent, EnergyModule *module) : ModuleWidget(parent), module_(module)
+EnergyModuleWidget::EnergyModuleWidget(QWidget *parent, const GenericList &processingData, EnergyModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/energy/gui/modulewidget_funcs.cpp
+++ b/src/modules/energy/gui/modulewidget_funcs.cpp
@@ -63,17 +63,19 @@ void EnergyModuleWidget::updateControls(int flags)
     QPalette labelPalette = ui_.StableLabel->palette();
     if (currentConfiguration_)
     {
-        const auto &totalEnergyArray =
-            currentConfiguration_->moduleData().value<Data1D>("Total", module_->uniqueName(), Data1D());
+        const auto &totalEnergyArray = processingData_.value<Data1D>(
+            fmt::format("{}//Total", currentConfiguration_->niceName()), module_->uniqueName(), Data1D());
         if (totalEnergyArray.nValues() < stabilityWindow)
             ui_.GradientValueLabel->setText("N/A");
         else
         {
-            auto grad = currentConfiguration_->moduleData().value<double>("EnergyGradient", "", 0.0);
+            auto grad = processingData_.value<double>(fmt::format("{}//EnergyGradient", currentConfiguration_->niceName()),
+                                                      module_->uniqueName(), 0.0);
             ui_.GradientValueLabel->setText(QString::number(grad));
         }
 
-        auto stable = currentConfiguration_->moduleData().value<bool>("EnergyStable", "", false);
+        auto stable = processingData_.value<bool>(fmt::format("{}//EnergyStable", currentConfiguration_->niceName()),
+                                                  module_->uniqueName(), false);
 
         if (stable)
         {

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -16,7 +16,8 @@ bool EnergyModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
     // For each Configuration target, add a flag to its moduleData (which is *not* stored in the restart file) that we are
     // targeting it
     for (auto *cfg : targetConfigurations_)
-        cfg->moduleData().realise<bool>("_IsEnergyModuleTarget", "", GenericItem::ProtectedFlag) = true;
+        dissolve.processingModuleData().realise<bool>("IsEnergyModuleTarget", cfg->niceName(), GenericItem::ProtectedFlag) =
+            true;
 
     return true;
 }
@@ -341,24 +342,30 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                              bondEnergy, angleEnergy, torsionEnergy);
 
             // Store current energies in the Configuration in case somebody else needs them
-            auto &interData = cfg->moduleData().realise<Data1D>("Inter", uniqueName(), GenericItem::InRestartFileFlag);
+            auto &interData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Inter", cfg->niceName()),
+                                                                              uniqueName(), GenericItem::InRestartFileFlag);
             interData.addPoint(dissolve.iteration(), interEnergy);
             interData.setObjectTag(fmt::format("{}//{}//Inter", cfg->niceName(), uniqueName()));
-            auto &intraData = cfg->moduleData().realise<Data1D>("Intra", uniqueName(), GenericItem::InRestartFileFlag);
+            auto &intraData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Intra", cfg->niceName()),
+                                                                              uniqueName(), GenericItem::InRestartFileFlag);
             intraData.addPoint(dissolve.iteration(), intraEnergy);
             intraData.setObjectTag(fmt::format("{}//{}//Intra", cfg->niceName(), uniqueName()));
-            auto &bondData = cfg->moduleData().realise<Data1D>("Bond", uniqueName(), GenericItem::InRestartFileFlag);
+            auto &bondData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Bond", cfg->niceName()),
+                                                                             uniqueName(), GenericItem::InRestartFileFlag);
             bondData.addPoint(dissolve.iteration(), bondEnergy);
             bondData.setObjectTag(fmt::format("{}//{}//Bond", cfg->niceName(), uniqueName()));
-            auto &angleData = cfg->moduleData().realise<Data1D>("Angle", uniqueName(), GenericItem::InRestartFileFlag);
+            auto &angleData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Angle", cfg->niceName()),
+                                                                              uniqueName(), GenericItem::InRestartFileFlag);
             angleData.addPoint(dissolve.iteration(), angleEnergy);
             angleData.setObjectTag(fmt::format("{}//{}//Angle", cfg->niceName(), uniqueName()));
-            auto &torsionData = cfg->moduleData().realise<Data1D>("Torsion", uniqueName(), GenericItem::InRestartFileFlag);
+            auto &torsionData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Torsions", cfg->niceName()),
+                                                                                uniqueName(), GenericItem::InRestartFileFlag);
             torsionData.addPoint(dissolve.iteration(), torsionEnergy);
             torsionData.setObjectTag(fmt::format("{}//{}//Torsion", cfg->niceName(), uniqueName()));
 
             // Append to arrays of total energies
-            auto &totalEnergyArray = cfg->moduleData().realise<Data1D>("Total", uniqueName(), GenericItem::InRestartFileFlag);
+            auto &totalEnergyArray = dissolve.processingModuleData().realise<Data1D>(
+                fmt::format("{}//Total", cfg->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
             totalEnergyArray.addPoint(dissolve.iteration(), interEnergy + intraEnergy);
             totalEnergyArray.setObjectTag(fmt::format("{}//{}//Total", cfg->niceName(), uniqueName()));
 
@@ -381,10 +388,13 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
             }
 
             // Set variable in Configuration
-            cfg->moduleData().realise<double>("EnergyGradient", "", GenericItem::InRestartFileFlag) = grad;
-            cfg->moduleData().realise<bool>("EnergyStable", "", GenericItem::InRestartFileFlag) = stable;
-            cfg->moduleData()
-                .realise<Data1D>("EnergyStability", "", GenericItem::InRestartFileFlag)
+            dissolve.processingModuleData().realise<double>(fmt::format("{}//EnergyGradient", cfg->niceName()), uniqueName(),
+                                                            GenericItem::InRestartFileFlag) = grad;
+            dissolve.processingModuleData().realise<bool>(fmt::format("{}//EnergyStable", cfg->niceName()), uniqueName(),
+                                                          GenericItem::InRestartFileFlag) = stable;
+            dissolve.processingModuleData()
+                .realise<Data1D>(fmt::format("{}//EnergyStability", cfg->niceName()), uniqueName(),
+                                 GenericItem::InRestartFileFlag)
                 .addPoint(dissolve.iteration(), stable);
 
             // If writing to a file, append it here

--- a/src/modules/epsr/gui/gui.cpp
+++ b/src/modules/epsr/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/epsr/epsr.h"
 #include "modules/epsr/gui/modulewidget.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *EPSRModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new EPSRModuleWidget(parent, this, dissolve);
+    return new EPSRModuleWidget(parent, dissolve.processingModuleData(), this, dissolve);
 }

--- a/src/modules/epsr/gui/modulewidget.h
+++ b/src/modules/epsr/gui/modulewidget.h
@@ -20,7 +20,7 @@ class EPSRModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    EPSRModuleWidget(QWidget *parent, EPSRModule *module, Dissolve &dissolve);
+    EPSRModuleWidget(QWidget *parent, const GenericList &processingData, EPSRModule *module, Dissolve &dissolve);
     ~EPSRModuleWidget();
 
     private:

--- a/src/modules/epsr/gui/modulewidget_funcs.cpp
+++ b/src/modules/epsr/gui/modulewidget_funcs.cpp
@@ -14,8 +14,8 @@
 #include "templates/algorithms.h"
 #include "templates/variantpointer.h"
 
-EPSRModuleWidget::EPSRModuleWidget(QWidget *parent, EPSRModule *module, Dissolve &dissolve)
-    : ModuleWidget(parent), dissolve_(dissolve), module_(module)
+EPSRModuleWidget::EPSRModuleWidget(QWidget *parent, const GenericList &processingData, EPSRModule *module, Dissolve &dissolve)
+    : ModuleWidget(parent, processingData), dissolve_(dissolve), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -185,7 +185,7 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
     // Is the ctarget configuration's energy stable?
     if (onlyWhenEnergyStable)
     {
-        auto stabilityResult = EnergyModule::checkStability(targetConfiguration_);
+        auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), targetConfiguration_);
         if (stabilityResult == EnergyModule::NotAssessable)
             return false;
         else if (stabilityResult > 0)

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -479,22 +479,22 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
             auto nFailed2 = 0, nFailed3 = 0;
             Vec3<double> totalRatio;
             sumError = 0.0;
-            GenericList &moduleData = dissolve.processingModuleData();
-            if (moduleData.contains("ReferenceFX", uniqueName()) && moduleData.contains("ReferenceFY", uniqueName()) &&
-                moduleData.contains("ReferenceFZ", uniqueName()))
+            GenericList &processingData = dissolve.processingModuleData();
+            if (processingData.contains("ReferenceFX", uniqueName()) && processingData.contains("ReferenceFY", uniqueName()) &&
+                processingData.contains("ReferenceFZ", uniqueName()))
             {
                 // Grab reference force arrays and check sizes
-                const auto &referenceFx = moduleData.value<Array<double>>("ReferenceFX", uniqueName());
+                const auto &referenceFx = processingData.value<Array<double>>("ReferenceFX", uniqueName());
                 if (referenceFx.nItems() != cfg->nAtoms())
                     return Messenger::error("Number of force components in ReferenceFX is {}, but the "
                                             "Configuration '{}' contains {} atoms.\n",
                                             referenceFx.nItems(), cfg->name(), cfg->nAtoms());
-                const auto &referenceFy = moduleData.value<Array<double>>("ReferenceFY", uniqueName());
+                const auto &referenceFy = processingData.value<Array<double>>("ReferenceFY", uniqueName());
                 if (referenceFy.nItems() != cfg->nAtoms())
                     return Messenger::error("Number of force components in ReferenceFY is {}, but the "
                                             "Configuration '{}' contains {} atoms.\n",
                                             referenceFy.nItems(), cfg->name(), cfg->nAtoms());
-                const auto &referenceFz = moduleData.value<Array<double>>("ReferenceFZ", uniqueName());
+                const auto &referenceFz = processingData.value<Array<double>>("ReferenceFZ", uniqueName());
                 if (referenceFz.nItems() != cfg->nAtoms())
                     return Messenger::error("Number of force components in ReferenceFZ is {}, but the "
                                             "Configuration '{}' contains {} atoms.\n",
@@ -598,9 +598,12 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
             Messenger::print("Calculating total forces for Configuration '{}'...\n", cfg->name());
 
             // Realise the force arrays
-            auto &fx = cfg->moduleData().realise<Array<double>>("FX", uniqueName());
-            auto &fy = cfg->moduleData().realise<Array<double>>("FY", uniqueName());
-            auto &fz = cfg->moduleData().realise<Array<double>>("FZ", uniqueName());
+            auto &fx =
+                dissolve.processingModuleData().realise<Array<double>>(fmt::format("{}//FX", cfg->niceName()), uniqueName());
+            auto &fy =
+                dissolve.processingModuleData().realise<Array<double>>(fmt::format("{}//FY", cfg->niceName()), uniqueName());
+            auto &fz =
+                dissolve.processingModuleData().realise<Array<double>>(fmt::format("{}//FZ", cfg->niceName()), uniqueName());
             fx.initialise(cfg->nAtoms());
             fy.initialise(cfg->nAtoms());
             fz.initialise(cfg->nAtoms());

--- a/src/modules/geomopt/gui/gui.cpp
+++ b/src/modules/geomopt/gui/gui.cpp
@@ -7,5 +7,5 @@
 // Return a new widget controlling this Module
 ModuleWidget *GeometryOptimisationModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new GeometryOptimisationModuleWidget(parent, this);
+    return new GeometryOptimisationModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/geomopt/gui/modulewidget.h
+++ b/src/modules/geomopt/gui/modulewidget.h
@@ -20,7 +20,7 @@ class GeometryOptimisationModuleWidget : public ModuleWidget
     GeometryOptimisationModule *module_;
 
     public:
-    GeometryOptimisationModuleWidget(QWidget *parent, GeometryOptimisationModule *module);
+    GeometryOptimisationModuleWidget(QWidget *parent, const GenericList &processingData, GeometryOptimisationModule *module);
 
     /*
      * UI

--- a/src/modules/geomopt/gui/modulewidget_funcs.cpp
+++ b/src/modules/geomopt/gui/modulewidget_funcs.cpp
@@ -4,8 +4,9 @@
 #include "modules/geomopt/geomopt.h"
 #include "modules/geomopt/gui/modulewidget.h"
 
-GeometryOptimisationModuleWidget::GeometryOptimisationModuleWidget(QWidget *parent, GeometryOptimisationModule *module)
-    : ModuleWidget(parent), module_(module)
+GeometryOptimisationModuleWidget::GeometryOptimisationModuleWidget(QWidget *parent, const GenericList &processingData,
+                                                                   GeometryOptimisationModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -26,9 +26,6 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
     if (targetConfigurations_.nItems() == 0)
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
-    GenericList &moduleData =
-        configurationLocal_ ? targetConfigurations_.firstItem()->moduleData() : dissolve.processingModuleData();
-
     // Get control parameters
     const auto capForce = keywords_.asBool("CapForces");
     const auto maxForce = keywords_.asDouble("CapForcesAt") * 100.0; // To convert from kJ/mol to 10 J/mol
@@ -84,7 +81,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
         if (onlyWhenEnergyStable)
         {
-            auto stabilityResult = EnergyModule::checkStability(cfg);
+            auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), cfg);
             if (stabilityResult == EnergyModule::NotAssessable)
                 return false;
             else if (stabilityResult == EnergyModule::EnergyUnstable)
@@ -126,7 +123,8 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Read in or assign random velocities
         // Realise the velocity array from the moduleData
         bool created;
-        auto &v = moduleData.realise<Array<Vec3<double>>>("Velocities", uniqueName(), GenericItem::NoFlag, &created);
+        auto &v = dissolve.processingModuleData().realise<Array<Vec3<double>>>(fmt::format("{}//Velocities", cfg->niceName()),
+                                                                               uniqueName(), GenericItem::NoFlag, &created);
         if (created)
         {
             randomVelocities = true;

--- a/src/modules/neutronsq/gui/gui.cpp
+++ b/src/modules/neutronsq/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/neutronsq/gui/modulewidget.h"
 #include "modules/neutronsq/neutronsq.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *NeutronSQModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new NeutronSQModuleWidget(parent, this, dissolve);
+    return new NeutronSQModuleWidget(parent, dissolve.processingModuleData(), this, dissolve);
 }

--- a/src/modules/neutronsq/gui/modulewidget.h
+++ b/src/modules/neutronsq/gui/modulewidget.h
@@ -19,7 +19,7 @@ class NeutronSQModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    NeutronSQModuleWidget(QWidget *parent, NeutronSQModule *module, Dissolve &dissolve);
+    NeutronSQModuleWidget(QWidget *parent, const GenericList &processingData, NeutronSQModule *module, Dissolve &dissolve);
     ~NeutronSQModuleWidget();
 
     private:

--- a/src/modules/neutronsq/gui/modulewidget_funcs.cpp
+++ b/src/modules/neutronsq/gui/modulewidget_funcs.cpp
@@ -11,8 +11,9 @@
 #include "templates/algorithms.h"
 #include "templates/variantpointer.h"
 
-NeutronSQModuleWidget::NeutronSQModuleWidget(QWidget *parent, NeutronSQModule *module, Dissolve &dissolve)
-    : ModuleWidget(parent), module_(module), dissolve_(dissolve)
+NeutronSQModuleWidget::NeutronSQModuleWidget(QWidget *parent, const GenericList &processingData, NeutronSQModule *module,
+                                             Dissolve &dissolve)
+    : ModuleWidget(parent, processingData), module_(module), dissolve_(dissolve)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/rdf/gui/gui.cpp
+++ b/src/modules/rdf/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/rdf/gui/modulewidget.h"
 #include "modules/rdf/rdf.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *RDFModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new RDFModuleWidget(parent, this, dissolve);
+    return new RDFModuleWidget(parent, dissolve.processingModuleData(), this, dissolve);
 }

--- a/src/modules/rdf/gui/modulewidget.h
+++ b/src/modules/rdf/gui/modulewidget.h
@@ -21,7 +21,7 @@ class RDFModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    RDFModuleWidget(QWidget *parent, RDFModule *module, Dissolve &dissolve);
+    RDFModuleWidget(QWidget *parent, const GenericList &processingData, RDFModule *module, Dissolve &dissolve);
     ~RDFModuleWidget();
 
     private:

--- a/src/modules/rdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/rdf/gui/modulewidget_funcs.cpp
@@ -11,8 +11,8 @@
 #include "templates/algorithms.h"
 #include "templates/variantpointer.h"
 
-RDFModuleWidget::RDFModuleWidget(QWidget *parent, RDFModule *module, Dissolve &dissolve)
-    : ModuleWidget(parent), module_(module), dissolve_(dissolve)
+RDFModuleWidget::RDFModuleWidget(QWidget *parent, const GenericList &processingData, RDFModule *module, Dissolve &dissolve)
+    : ModuleWidget(parent, processingData), module_(module), dissolve_(dissolve)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -87,8 +87,9 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
         // Calculate unweighted partials for this Configuration
         bool alreadyUpToDate;
-        calculateGR(procPool, cfg, method, rdfRange, binWidth, alreadyUpToDate);
-        auto &originalgr = cfg->moduleData().retrieve<PartialSet>("OriginalGR", uniqueName_);
+        calculateGR(dissolve.processingModuleData(), procPool, cfg, method, rdfRange, binWidth, alreadyUpToDate);
+        auto &originalgr =
+            dissolve.processingModuleData().retrieve<PartialSet>(fmt::format("{}//OriginalGR", cfg->niceName()), uniqueName_);
 
         // Perform averaging of unweighted partials if requested, and if we're not already up-to-date
         if ((averaging > 1) && (!alreadyUpToDate))
@@ -96,14 +97,17 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // Store the current fingerprint, since we must ensure we retain it in the averaged T.
             std::string currentFingerprint{originalgr.fingerprint()};
 
-            Averaging::average<PartialSet>(cfg->moduleData(), "OriginalGR", uniqueName_, averaging, averagingScheme);
+            Averaging::average<PartialSet>(dissolve.processingModuleData(), fmt::format("{}//OriginalGR", cfg->niceName()),
+                                           uniqueName_, averaging, averagingScheme);
 
             // Need to rename data within the contributing datasets to avoid clashes with the averaged data
             for (auto n = averaging; n > 0; --n)
             {
-                if (!cfg->moduleData().contains(fmt::format("OriginalGR_{}", n), uniqueName_))
+                if (!dissolve.processingModuleData().contains(fmt::format("{}//OriginalGR_{}", cfg->niceName(), n),
+                                                              uniqueName_))
                     continue;
-                auto &p = cfg->moduleData().retrieve<PartialSet>(fmt::format("OriginalGR_{}", n), uniqueName_);
+                auto &p = dissolve.processingModuleData().retrieve<PartialSet>(
+                    fmt::format("{}//OriginalGR_{}", cfg->niceName(), n), uniqueName_);
                 p.setObjectTags(fmt::format("{}//{}//OriginalGR", cfg->niceName(), uniqueName_), fmt::format("Avg{}", n));
             }
 
@@ -119,14 +123,15 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         {
             // Copy the already-calculated g(r), then calculate a new set using the Test method
             PartialSet referencePartials = originalgr;
-            calculateGR(procPool, cfg, RDFModule::TestMethod, rdfRange, binWidth, alreadyUpToDate);
+            calculateGR(dissolve.processingModuleData(), procPool, cfg, RDFModule::TestMethod, rdfRange, binWidth,
+                        alreadyUpToDate);
             if (!testReferencePartials(referencePartials, originalgr, 1.0e-6))
                 return false;
         }
 
         // Form unweighted g(r) from original g(r), applying any requested smoothing / intramolecular broadening
-        PartialSet &unweightedgr =
-            cfg->moduleData().realise<PartialSet>("UnweightedGR", uniqueName_, GenericItem::InRestartFileFlag);
+        auto &unweightedgr = dissolve.processingModuleData().realise<PartialSet>(
+            fmt::format("{}//UnweightedGR", cfg->niceName()), uniqueName_, GenericItem::InRestartFileFlag);
         calculateUnweightedGR(procPool, cfg, originalgr, unweightedgr, intraBroadening, smoothing);
 
         // Set names of resources and filename in Data1D within the PartialSet
@@ -143,7 +148,7 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         dissolve.processingModuleData().realise<PartialSet>("UnweightedGR", uniqueName_, GenericItem::InRestartFileFlag);
 
     // Sum the partials from the associated Configurations
-    if (!RDFModule::sumUnweightedGR(procPool, this, this, dissolve.processingModuleData(), summedUnweightedGR))
+    if (!RDFModule::sumUnweightedGR(dissolve.processingModuleData(), procPool, this, this, summedUnweightedGR))
         return false;
 
     return true;

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -88,17 +88,17 @@ class RDFModule : public Module
     // Calculate and return used species populations based on target Configurations
     std::vector<std::pair<const Species *, double>> speciesPopulations() const;
     // (Re)calculate partial g(r) for the specified Configuration
-    bool calculateGR(ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method, const double rdfRange,
-                     const double rdfBinWidth, bool &alreadyUpToDate);
+    bool calculateGR(GenericList &processingData, ProcessPool &procPool, Configuration *cfg, RDFModule::PartialsMethod method,
+                     const double rdfRange, const double rdfBinWidth, bool &alreadyUpToDate);
     // Calculate smoothed/broadened partial g(r) from supplied partials
     static bool calculateUnweightedGR(ProcessPool &procPool, Configuration *cfg, const PartialSet &originalgr,
                                       PartialSet &weightedgr, PairBroadeningFunction &intraBroadening, int smoothing);
     // Sum unweighted g(r) over the supplied Module's target Configurations
-    static bool sumUnweightedGR(ProcessPool &procPool, Module *parentModule, const RDFModule *rdfModule,
-                                GenericList &processingModuleData, PartialSet &summedUnweightedGR);
+    static bool sumUnweightedGR(GenericList &processingData, ProcessPool &procPool, Module *parentModule,
+                                const RDFModule *rdfModule, PartialSet &summedUnweightedGR);
     // Sum unweighted g(r) over all Configurations targeted by the specified ModuleGroup
-    static bool sumUnweightedGR(ProcessPool &procPool, Module *parentModule, ModuleGroup *moduleGroup,
-                                GenericList &processingModuleData, PartialSet &summedUnweightedGR);
+    static bool sumUnweightedGR(GenericList &processingData, ProcessPool &procPool, Module *parentModule,
+                                ModuleGroup *moduleGroup, PartialSet &summedUnweightedGR);
     // Test supplied PartialSets against each other
     static bool testReferencePartials(PartialSet &setA, PartialSet &setB, double testThreshold);
     // Test calculated partial against supplied reference data

--- a/src/modules/sanitycheck/process.cpp
+++ b/src/modules/sanitycheck/process.cpp
@@ -58,11 +58,6 @@ bool SanityCheckModule::process(Dissolve &dissolve, ProcessPool &procPool)
                 return Messenger::error("Failed sanity check for Configuration '{}' atom position {} ({} {} {}).\n",
                                         cfg->name(), n, r.x, r.y, r.z);
         }
-
-        // Module data within the Configuration
-        Messenger::printVerbose("Sanity checking Configuration {} module data...\n", cfg->name());
-        if (!cfg->moduleData().equality(procPool))
-            return Messenger::error("Failed sanity check for Configuration '{}' module data.\n", cfg->name());
     }
 
     // Processing module data

--- a/src/modules/skeleton/gui/gui.cpp
+++ b/src/modules/skeleton/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/skeleton/gui/modulewidget.h"
 #include "modules/skeleton/skeleton.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *SkeletonModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new SkeletonModuleWidget(parent, this);
+    return new SkeletonModuleWidget(parent, dissolve.processingModuleData(), this);
 }

--- a/src/modules/skeleton/gui/modulewidget.h
+++ b/src/modules/skeleton/gui/modulewidget.h
@@ -20,7 +20,7 @@ class SkeletonModuleWidget : public ModuleWidget
     SkeletonModule *module_;
 
     public:
-    SkeletonModuleWidget(QWidget *parent, SkeletonModule *module);
+    SkeletonModuleWidget(QWidget *parent, const GenericList &processingData, SkeletonModule *module);
 
     /*
      * UI

--- a/src/modules/skeleton/gui/modulewidget_funcs.cpp
+++ b/src/modules/skeleton/gui/modulewidget_funcs.cpp
@@ -4,7 +4,8 @@
 #include "modules/skeleton/gui/modulewidget.h"
 #include "modules/skeleton/skeleton.h"
 
-SkeletonModuleWidget::SkeletonModuleWidget(QWidget *parent, SkeletonModule *module) : ModuleWidget(parent), module_(module)
+SkeletonModuleWidget::SkeletonModuleWidget(QWidget *parent, const GenericList &processingData, SkeletonModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/sq/gui/gui.cpp
+++ b/src/modules/sq/gui/gui.cpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/sq/gui/modulewidget.h"
 #include "modules/sq/sq.h"
 
 // Return a new widget controlling this Module
-ModuleWidget *SQModule::createWidget(QWidget *parent, Dissolve &dissolve) { return new SQModuleWidget(parent, this, dissolve); }
+ModuleWidget *SQModule::createWidget(QWidget *parent, Dissolve &dissolve)
+{
+    return new SQModuleWidget(parent, dissolve.processingModuleData(), this, dissolve);
+}

--- a/src/modules/sq/gui/modulewidget.h
+++ b/src/modules/sq/gui/modulewidget.h
@@ -20,7 +20,7 @@ class SQModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    SQModuleWidget(QWidget *parent, SQModule *module, Dissolve &dissolve);
+    SQModuleWidget(QWidget *parent, const GenericList &processingData, SQModule *module, Dissolve &dissolve);
     ~SQModuleWidget();
 
     private:

--- a/src/modules/sq/gui/modulewidget_funcs.cpp
+++ b/src/modules/sq/gui/modulewidget_funcs.cpp
@@ -10,8 +10,8 @@
 #include "modules/sq/sq.h"
 #include "templates/algorithms.h"
 
-SQModuleWidget::SQModuleWidget(QWidget *parent, SQModule *module, Dissolve &dissolve)
-    : ModuleWidget(parent), module_(module), dissolve_(dissolve)
+SQModuleWidget::SQModuleWidget(QWidget *parent, const GenericList &processingData, SQModule *module, Dissolve &dissolve)
+    : ModuleWidget(parent, processingData), module_(module), dissolve_(dissolve)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/test/gui/gui.cpp
+++ b/src/modules/test/gui/gui.cpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/test/gui/modulewidget.h"
 #include "modules/test/test.h"
 
 // Return a new widget controlling this Module
-ModuleWidget *TestModule::createWidget(QWidget *parent, Dissolve &dissolve) { return new TestModuleWidget(parent, this); }
+ModuleWidget *TestModule::createWidget(QWidget *parent, Dissolve &dissolve)
+{
+    return new TestModuleWidget(parent, dissolve.processingModuleData(), this);
+}

--- a/src/modules/test/gui/modulewidget.h
+++ b/src/modules/test/gui/modulewidget.h
@@ -20,7 +20,7 @@ class TestModuleWidget : public ModuleWidget
     TestModule *module_;
 
     public:
-    TestModuleWidget(QWidget *parent, TestModule *module);
+    TestModuleWidget(QWidget *parent, const GenericList &processingData, TestModule *module);
 
     /*
      * UI

--- a/src/modules/test/gui/modulewidget_funcs.cpp
+++ b/src/modules/test/gui/modulewidget_funcs.cpp
@@ -4,7 +4,8 @@
 #include "modules/test/gui/modulewidget.h"
 #include "modules/test/test.h"
 
-TestModuleWidget::TestModuleWidget(QWidget *parent, TestModule *module) : ModuleWidget(parent), module_(module)
+TestModuleWidget::TestModuleWidget(QWidget *parent, const GenericList &processingData, TestModule *module)
+    : ModuleWidget(parent, processingData), module_(module)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/src/modules/xraysq/gui/gui.cpp
+++ b/src/modules/xraysq/gui/gui.cpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "main/dissolve.h"
 #include "modules/xraysq/gui/modulewidget.h"
 #include "modules/xraysq/xraysq.h"
 
 // Return a new widget controlling this Module
 ModuleWidget *XRaySQModule::createWidget(QWidget *parent, Dissolve &dissolve)
 {
-    return new XRaySQModuleWidget(parent, this, dissolve);
+    return new XRaySQModuleWidget(parent, dissolve.processingModuleData(), this, dissolve);
 }

--- a/src/modules/xraysq/gui/modulewidget.h
+++ b/src/modules/xraysq/gui/modulewidget.h
@@ -19,7 +19,7 @@ class XRaySQModuleWidget : public ModuleWidget
     Q_OBJECT
 
     public:
-    XRaySQModuleWidget(QWidget *parent, XRaySQModule *module, Dissolve &dissolve);
+    XRaySQModuleWidget(QWidget *parent, const GenericList &processingData, XRaySQModule *module, Dissolve &dissolve);
     ~XRaySQModuleWidget();
 
     private:

--- a/src/modules/xraysq/gui/modulewidget_funcs.cpp
+++ b/src/modules/xraysq/gui/modulewidget_funcs.cpp
@@ -11,8 +11,9 @@
 #include "templates/algorithms.h"
 #include "templates/variantpointer.h"
 
-XRaySQModuleWidget::XRaySQModuleWidget(QWidget *parent, XRaySQModule *module, Dissolve &dissolve)
-    : ModuleWidget(parent), module_(module), dissolve_(dissolve)
+XRaySQModuleWidget::XRaySQModuleWidget(QWidget *parent, const GenericList &processingData, XRaySQModule *module,
+                                       Dissolve &dissolve)
+    : ModuleWidget(parent, processingData), module_(module), dissolve_(dissolve)
 {
     // Set up user interface
     ui_.setupUi(this);

--- a/tests/atomshake/singlewater.txt
+++ b/tests/atomshake/singlewater.txt
@@ -25,22 +25,24 @@ Configuration  'Water'
 
   Temperature  0.0
 
-  Module  AtomShake
-  EndModule
 EndConfiguration
 
 Layer  'Processing'
 
-Module  Checks
-  Configuration  'Water'
-  Frequency  100
-  Distance  1  2  1.012
-  Distance  1  3  1.012
-  Angle  2  1  3  113.24
-EndModule
+  Module  AtomShake
+    Configuration  'Water'
+  EndModule
 
-Module SanityCheck
-EndModule
+  Module  Checks
+    Configuration  'Water'
+    Frequency  100
+    Distance  1  2  1.012
+    Distance  1  3  1.012
+    Angle  2  1  3  113.24
+  EndModule
+
+  Module SanityCheck
+  EndModule
 
 EndLayer
 

--- a/tests/energyforce1/water3000-coul.txt
+++ b/tests/energyforce1/water3000-coul.txt
@@ -29,8 +29,13 @@ Configuration  'Bulk'
   InputCoordinates  dlpoly  '../_data/dlpoly/water3000_coul/CONFIG'
   EndInputCoordinates
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test analytical energy against production and reference energy
   Module Energy
+    Configuration  'Bulk'
     Test on
     TestAnalytic on
     TestReferenceInter    -34173.942995962962   # Straight Coulomb sum (no truncation)
@@ -38,14 +43,12 @@ Configuration  'Bulk'
 
   # Test production forces against reference forces
   Module Forces
+    Configuration  'Bulk'
     Test on
     TestAnalytic  on
     TestReference  dlpoly  '../_data/dlpoly/water3000_coul/REVCON'
     EndTestReference
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule

--- a/tests/energyforce1/water3000-elec.txt
+++ b/tests/energyforce1/water3000-elec.txt
@@ -29,8 +29,13 @@ Configuration  'Bulk'
   InputCoordinates  dlpoly  '../_data/dlpoly/water3000_elec/CONFIG'
   EndInputCoordinates
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test analytical energy against production and reference energy
   Module Energy
+    Configuration  'Bulk'
     Test on
     TestAnalytic on
     TestReferenceInter    -29163.384451743802  # Shifted potential
@@ -38,15 +43,13 @@ Configuration  'Bulk'
 
   # Test production forces against reference forces
   Module Forces
+    Configuration  'Bulk'
     Test on
     TestAnalytic  on
     TestThreshold  3.5		# See README
     TestReference  dlpoly  '../_data/dlpoly/water3000_elec/REVCON'
     EndTestReference
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule

--- a/tests/energyforce1/water3000-full.txt
+++ b/tests/energyforce1/water3000-full.txt
@@ -29,8 +29,13 @@ Configuration  'Bulk'
   InputCoordinates  dlpoly  '../_data/dlpoly/water3000_full/CONFIG'
   EndInputCoordinates
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test analytical energy against production and reference energy
   Module Energy
+    Configuration  'Bulk'
     Test on
     TestAnalytic on
     TestReferenceInter  -27393.217815     # 1770.1666370083758 LJ + -29163.384451743802 Coulomb (LJ correction accounted for)
@@ -39,15 +44,13 @@ Configuration  'Bulk'
 
   # Test production forces against reference forces
   Module Forces
+    Configuration  'Bulk'
     Test on
     TestAnalytic  on
     TestThreshold  3.0		# See README
     TestReference  dlpoly  '../_data/dlpoly/water3000_full/REVCON'
     EndTestReference
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule

--- a/tests/energyforce1/water3000-intra.txt
+++ b/tests/energyforce1/water3000-intra.txt
@@ -29,8 +29,13 @@ Configuration  'Bulk'
   InputCoordinates  dlpoly  '../_data/dlpoly/water3000_intra/CONFIG'
   EndInputCoordinates
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test analytical energy against production and reference energy
   Module Energy
+    Configuration  'Bulk'
     Test on
     TestAnalytic on
     TestReferenceIntra  5584.45180873
@@ -38,13 +43,11 @@ Configuration  'Bulk'
 
   # Test production forces against reference forces
   Module Forces
+    Configuration  'Bulk'
     Test on
     TestReference  dlpoly  '../_data/dlpoly/water3000_intra/REVCON'
     EndTestReference
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule

--- a/tests/energyforce1/water3000-vdw.txt
+++ b/tests/energyforce1/water3000-vdw.txt
@@ -29,8 +29,13 @@ Configuration  'Bulk'
   InputCoordinates  dlpoly  '../_data/dlpoly/water3000_vdw/CONFIG'
   EndInputCoordinates
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test analytical energy against production and reference energy
   Module Energy
+    Configuration  'Bulk'
     Test on
     TestAnalytic on
     TestReferenceInter    1770.1666370083758
@@ -38,15 +43,13 @@ Configuration  'Bulk'
 
   # Test production forces against reference forces
   Module Forces
+    Configuration  'Bulk'
     Test on
     TestAnalytic  on
     TestThreshold  3.2   # See README
     TestReference  dlpoly  '../_data/dlpoly/water3000_vdw/REVCON'
     EndTestReference
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule

--- a/tests/rdfmethod/cells.txt
+++ b/tests/rdfmethod/cells.txt
@@ -19,15 +19,17 @@ Configuration  'Box'
   EndGenerator
   CellDivisionLength  5.0
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test 'Cells' method of RDF calculation
   Module  RDF
+    COnfiguration  'Box'
     Frequency  1
     InternalTest  On
     Method  Cells
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule

--- a/tests/rdfmethod/simple.txt
+++ b/tests/rdfmethod/simple.txt
@@ -19,15 +19,17 @@ Configuration  'Box'
   EndGenerator
   CellDivisionLength  5.0
 
+EndConfiguration
+
+Layer  'Processing'
+
   # Test 'Simple' Method
   Module  RDF
+    Configuration  'Box'
     Frequency  1
     InternalTest  On
     Method  Simple
   EndModule
-EndConfiguration
-
-Layer  'Processing'
 
   Module SanityCheck
   EndModule


### PR DESCRIPTION
This PR removes storage for module data (via `GenericList`) on `Configuration`s. All such data is now stored in the main (and only) `Dissolve::processingModuleData_`, prefixed by the configuration name. The advantages of doing this are:

- All relevant data is contained in a single location, facilitating searching (particularly when `ObjectStore` is removed).
- `Configuration`s are now pure elements of the simulation (making them more like `Species`), rather than containing data produced by the simulation.

The benefit of storing data locally on `Configuration`s is that it is easily separated from other data. However, suitable prefixing of the data names in the main `GenericList` handles this well enough. If more separation is required at a later stage (e.g. for access speed when searching for data) the `GenericList` class can be overhauled to "bucket" data into relevant groups (e.g. by prefix).

Notes:
- Module widget constructors now take the processing data list as an argument to enable relevant data to be extracted for display where necessary.
- The "restart" system test has been basically hacked to work. A near-future PR will break it again, so replacing it properly is left until then.

This is part of a sequence of PRs updating the general storage and location of data within the code.

### Related PR Hierarchy

Listed in order of review / merge ordering (rebasing required at each stage):

- ~#575 Remove state I/O for tabs, views, and charts~
- ~#576 Move `Renderable` and `RenderableGroup` to `std:vector`~
- ~#581 Use template-guided renderable creation~
- `THIS` No local configuration data
- #586 New GenericList
- #599 Data Name Tidying
- #606 Remove ObjectStore 2