### PR TITLE
Remove list item inheritance from species info

### DIFF
--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -82,7 +82,7 @@ class Configuration : public ListItem<Configuration>
      */
     private:
     // List of Species used by the Configuration and their populations
-    List<SpeciesInfo> usedSpecies_;
+    std::vector<SpeciesInfo> usedSpecies_;
     // AtomType list, containing unique (non-isotopic) atom types over all Species used in this configuration
     AtomTypeList usedAtomTypes_;
     // Contents version, incremented whenever Configuration content or Atom positions change
@@ -110,7 +110,7 @@ class Configuration : public ListItem<Configuration>
     // Return SpeciesInfo for specified Species
     SpeciesInfo *usedSpeciesInfo(Species *sp);
     // Return list of SpeciesInfo for the Configuration
-    List<SpeciesInfo> &usedSpecies();
+    std::vector<SpeciesInfo> &usedSpecies();
     // Return if the specified Species is present in the usedSpecies list
     bool hasUsedSpecies(Species *sp);
     // Return the total atomic mass present in the Configuration

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -108,7 +108,7 @@ class Configuration : public ListItem<Configuration>
     // Add Species to list of those used by the Configuration, setting/adding the population specified
     SpeciesInfo *addUsedSpecies(Species *sp, int population);
     // Return SpeciesInfo for specified Species
-    SpeciesInfo *usedSpeciesInfo(Species *sp);
+    OptionalReferenceWrapper<SpeciesInfo> usedSpeciesInfo(Species *sp);
     // Return list of SpeciesInfo for the Configuration
     std::vector<SpeciesInfo> &usedSpecies();
     // Return if the specified Species is present in the usedSpecies list

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -49,8 +49,9 @@ SpeciesInfo *Configuration::addUsedSpecies(Species *sp, int population)
     SpeciesInfo *spInfo = usedSpeciesInfo(sp);
     if (!spInfo)
     {
-        spInfo = usedSpecies_.add();
-        spInfo->setSpecies(sp);
+        auto &spIn = usedSpecies_.emplace_back();
+        spIn.setSpecies(sp);
+        spInfo = &spIn;
     }
 
     // Increase the population
@@ -62,21 +63,21 @@ SpeciesInfo *Configuration::addUsedSpecies(Species *sp, int population)
 // Return SpeciesInfo for specified Species
 SpeciesInfo *Configuration::usedSpeciesInfo(Species *sp)
 {
-    for (auto *spInfo = usedSpecies_.first(); spInfo != nullptr; spInfo = spInfo->next())
-        if (spInfo->species() == sp)
-            return spInfo;
+    for (auto &spInfo : usedSpecies_)
+        if (spInfo.species() == sp)
+            return &spInfo;
 
     return nullptr;
 }
 
 // Return list of SpeciesInfo for the Configuration
-List<SpeciesInfo> &Configuration::usedSpecies() { return usedSpecies_; }
+std::vector<SpeciesInfo> &Configuration::usedSpecies() { return usedSpecies_; }
 
 // Return if the specified Species is present in the usedSpecies list
 bool Configuration::hasUsedSpecies(Species *sp)
 {
-    for (auto *spInfo = usedSpecies_.first(); spInfo != nullptr; spInfo = spInfo->next())
-        if (spInfo->species() == sp)
+    for (auto &spInfo : usedSpecies_)
+        if (spInfo.species() == sp)
             return true;
 
     return false;
@@ -88,9 +89,8 @@ double Configuration::atomicMass() const
     double mass = 0.0;
 
     // Get total molar mass in configuration
-    ListIterator<SpeciesInfo> speciesIterator(usedSpecies_);
-    while (SpeciesInfo *spInfo = speciesIterator.iterate())
-        mass += spInfo->species()->mass() * spInfo->population();
+    for (auto spInfo : usedSpecies_)
+        mass += spInfo.species()->mass() * spInfo.population();
 
     // Convert to absolute mass
     return mass / AVOGADRO;

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -46,28 +46,28 @@ int Configuration::nUsedAtomTypes() const { return usedAtomTypes_.nItems(); }
 SpeciesInfo *Configuration::addUsedSpecies(Species *sp, int population)
 {
     // Check if we have an existing info for this Species
-    SpeciesInfo *spInfo = usedSpeciesInfo(sp);
+    auto spInfo = usedSpeciesInfo(sp);
     if (!spInfo)
     {
         auto &spIn = usedSpecies_.emplace_back();
         spIn.setSpecies(sp);
-        spInfo = &spIn;
+        spInfo = spIn;
     }
 
     // Increase the population
-    spInfo->addPopulation(population);
+    spInfo->get().addPopulation(population);
 
-    return spInfo;
+    return &spInfo->get();
 }
 
 // Return SpeciesInfo for specified Species
-SpeciesInfo *Configuration::usedSpeciesInfo(Species *sp)
+OptionalReferenceWrapper<SpeciesInfo> Configuration::usedSpeciesInfo(Species *sp)
 {
     for (auto &spInfo : usedSpecies_)
         if (spInfo.species() == sp)
-            return &spInfo;
+            return spInfo;
 
-    return nullptr;
+    return std::nullopt;
 }
 
 // Return list of SpeciesInfo for the Configuration

--- a/src/classes/speciesinfo.cpp
+++ b/src/classes/speciesinfo.cpp
@@ -4,7 +4,7 @@
 #include "classes/speciesinfo.h"
 #include "base/sysfunc.h"
 
-SpeciesInfo::SpeciesInfo() : ListItem<SpeciesInfo>()
+SpeciesInfo::SpeciesInfo()
 {
     species_ = nullptr;
     population_ = 0;

--- a/src/classes/speciesinfo.h
+++ b/src/classes/speciesinfo.h
@@ -11,7 +11,7 @@ class Species;
 /*
  * Species Information
  */
-class SpeciesInfo : public ListItem<SpeciesInfo>
+class SpeciesInfo
 {
     public:
     SpeciesInfo();

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -64,20 +64,20 @@ void XRayWeights::clear()
 }
 
 // Set-up from supplied SpeciesInfo list
-bool XRayWeights::setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors)
+bool XRayWeights::setUp(std::vector<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors)
 {
     valid_ = false;
 
     // Fill atomTypes_ list with AtomType populations, based on Isotopologues relative populations and associated Species
     // populations
     atomTypes_.clear();
-    for (auto *spInfo = speciesInfoList.first(); spInfo != nullptr; spInfo = spInfo->next())
+    for (auto &spInfo : speciesInfoList)
     {
-        const Species *sp = spInfo->species();
+        const Species *sp = spInfo.species();
 
         // Loop over Atoms in the Species
         for (const auto &i : sp->atoms())
-            atomTypes_.add(i.atomType(), spInfo->population());
+            atomTypes_.add(i.atomType(), spInfo.population());
     }
 
     // Perform final setup based on now-completed atomtypes list

--- a/src/classes/xrayweights.h
+++ b/src/classes/xrayweights.h
@@ -44,7 +44,7 @@ class XRayWeights : public GenericItemBase
     // Clear contents
     void clear();
     // Set-up from supplied SpeciesInfo list
-    bool setUp(List<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
+    bool setUp(std::vector<SpeciesInfo> &speciesInfoList, XRayFormFactors::XRayFormFactorData formFactors);
     // Add Species to weights in the specified population
     void addSpecies(const Species *sp, int population);
     // Finalise weights after addition of all individual Species

--- a/src/gui/delegates/usedspeciescombo_funcs.cpp
+++ b/src/gui/delegates/usedspeciescombo_funcs.cpp
@@ -22,10 +22,10 @@ QWidget *UsedSpeciesComboDelegate::createEditor(QWidget *parent, const QStyleOpt
     Configuration *cfg = VariantPointer<Configuration>(index.data(Qt::UserRole));
     if (cfg)
     {
-        for (auto *spInfo = cfg->usedSpecies().first(); spInfo != nullptr; spInfo = spInfo->next())
+        for (auto &spInfo : cfg->usedSpecies())
         {
-            editor->addItem(QString::fromStdString(std::string(spInfo->species()->name())),
-                            VariantPointer<Species>(spInfo->species()));
+            editor->addItem(QString::fromStdString(std::string(spInfo.species()->name())),
+                            VariantPointer<Species>(spInfo.species()));
         }
     }
     else

--- a/src/gui/delegates/usedspeciescombo_funcs.cpp
+++ b/src/gui/delegates/usedspeciescombo_funcs.cpp
@@ -21,13 +21,9 @@ QWidget *UsedSpeciesComboDelegate::createEditor(QWidget *parent, const QStyleOpt
     // Get the model UserData for the current index - it should be a Configuration
     Configuration *cfg = VariantPointer<Configuration>(index.data(Qt::UserRole));
     if (cfg)
-    {
         for (auto &spInfo : cfg->usedSpecies())
-        {
             editor->addItem(QString::fromStdString(std::string(spInfo.species()->name())),
                             VariantPointer<Species>(spInfo.species()));
-        }
-    }
     else
         Messenger::error("Underlying model did not contain a Configuration*, so UsedSpeciesCombo cannot provide options.\n");
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -57,9 +57,8 @@ bool Dissolve::prepare()
 
         // Check total charge of Configuration
         auto totalQ = 0.0;
-        ListIterator<SpeciesInfo> spInfoIterator(cfg->usedSpecies());
-        while (auto *spInfo = spInfoIterator.iterate())
-            totalQ += spInfo->species()->totalCharge(pairPotentialsIncludeCoulomb_) * spInfo->population();
+        for (auto &spInfo : cfg->usedSpecies())
+            totalQ += spInfo.species()->totalCharge(pairPotentialsIncludeCoulomb_) * spInfo.population();
 
         if (fabs(totalQ) > 1.0e-5)
             return Messenger::error("Total charge for Configuration '{}' is non-zero ({:e}). Refusing to proceed!\n",

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -56,10 +56,10 @@ bool Dissolve::prepare()
         }
 
         // Check total charge of Configuration
-        auto totalQ = 0.0;
-        for (auto &spInfo : cfg->usedSpecies())
-            totalQ += spInfo.species()->totalCharge(pairPotentialsIncludeCoulomb_) * spInfo.population();
-
+        auto totalQ =
+            std::accumulate(cfg->usedSpecies().begin(), cfg->usedSpecies().end(), 0.0, [&](const auto &acc, auto &spInfo) {
+                return acc + spInfo.species()->totalCharge(pairPotentialsIncludeCoulomb_) * spInfo.population();
+            });
         if (fabs(totalQ) > 1.0e-5)
             return Messenger::error("Total charge for Configuration '{}' is non-zero ({:e}). Refusing to proceed!\n",
                                     cfg->name(), totalQ);

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -91,10 +91,9 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
         procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
 
         // Ensure that the Species used in the present Configuration have attached atom lists
-        ListIterator<SpeciesInfo> speciesInfoIterator(cfg->usedSpecies());
-        while (SpeciesInfo *spInfo = speciesInfoIterator.iterate())
+        for (auto &spInfo : cfg->usedSpecies())
         {
-            Species *sp = spInfo->species();
+            Species *sp = spInfo.species();
             if (!sp->attachedAtomListsGenerated())
             {
                 Messenger::print("Performing one-time generation of attached atom lists for intramolecular "

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -243,15 +243,14 @@ std::vector<std::pair<const Species *, double>> RDFModule::speciesPopulations() 
         // TODO Get weight for configuration
         auto weight = 1.0;
 
-        ListIterator<SpeciesInfo> spInfoIterator(cfg->usedSpecies());
-        while (auto *spInfo = spInfoIterator.iterate())
+        for (auto &spInfo : cfg->usedSpecies())
         {
             auto it = std::find_if(populations.begin(), populations.end(),
-                                   [&spInfo](auto &data) { return data.first == spInfo->species(); });
+                                   [&spInfo](auto &data) { return data.first == spInfo.species(); });
             if (it != populations.end())
-                it->second += spInfo->population() * weight;
+                it->second += spInfo.population() * weight;
             else
-                populations.emplace_back(spInfo->species(), spInfo->population() * weight);
+                populations.emplace_back(spInfo.species(), spInfo.population() * weight);
         }
     }
 


### PR DESCRIPTION
This PR removes the list item inheritance from the species info class. 

Do not merge before #573 as this will likely need a rebase.