### PR TITLE
Data Name Tidying

### DIFF
--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -5,10 +5,6 @@
 #include "base/lineparser.h"
 #include "io/import/data1d.h"
 
-Data1DStore::Data1DStore() {}
-
-Data1DStore::~Data1DStore() {}
-
 /*
  * Data
  */

--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -14,15 +14,15 @@ bool Data1DStore::addData(std::string_view dataName, LineParser &parser, int sta
                           const CoreData &coreData)
 {
     // Create new data
-    auto &data = data_.emplace_back();
-    data.first.setTag(dataName);
+    auto &[data, format] = data_.emplace_back();
+    data.setTag(dataName);
 
     // Read the file / format
-    if (!data.second.read(parser, startArg, endKeyword, coreData))
+    if (!format.read(parser, startArg, endKeyword, coreData))
         return false;
 
     // Load the data
-    return data.second.importData(data.first, parser.processPool());
+    return format.importData(data.first, parser.processPool());
 }
 
 // Check to see if the named data is present in the store

--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -14,47 +14,32 @@ bool Data1DStore::addData(std::string_view dataName, LineParser &parser, int sta
                           const CoreData &coreData)
 {
     // Create new data
-    Data1D *data = data_.add();
-    data->setName(dataName);
-
-    // Add reference to data
-    RefDataItem<Data1D, Data1DImportFileFormat> *ref = dataReferences_.append(data);
+    auto &data = data_.emplace_back();
+    data.first.setTag(dataName);
 
     // Read the file / format
-    if (!ref->data().read(parser, startArg, endKeyword, coreData))
+    if (!data.second.read(parser, startArg, endKeyword, coreData))
         return false;
 
     // Load the data
-    return ref->data().importData(*data, parser.processPool());
+    return data.second.importData(data.first, parser.processPool());
 }
 
 // Check to see if the named data is present in the store
 bool Data1DStore::containsData(std::string_view name) const
 {
-    ListIterator<Data1D> dataIterator(data_);
-    while (Data1D *data = dataIterator.iterate())
-        if (DissolveSys::sameString(name, data->name()))
-            return true;
-
-    return false;
+    return std::find_if(data_.begin(), data_.end(), [&name](auto &data) { return data.first.tag() == name; }) != data_.end();
 }
 
 // Return named data
-const Data1D &Data1DStore::data(std::string_view name) const
+OptionalReferenceWrapper<const Data1D> Data1DStore::data(std::string_view name) const
 {
-    ListIterator<Data1D> dataIterator(data_);
-    while (Data1D *xyData = dataIterator.iterate())
-        if (DissolveSys::sameString(name, xyData->name()))
-            return (*xyData);
+    auto it = std::find_if(data_.begin(), data_.end(), [&name](auto &data) { return data.first.tag() == name; });
+    if (it == data_.end())
+        return {};
 
-    static Data1D dummy;
-    Messenger::warn("Data named '{}' was requested from Data1DStore, but it does not exist. Returning an empty Data1D...\n",
-                    name);
-    return dummy;
+    return it->first;
 }
 
-// Return list of all data
-const List<Data1D> &Data1DStore::data() const { return data_; }
-
-// Return list of all data references
-const RefDataList<Data1D, Data1DImportFileFormat> &Data1DStore::dataReferences() const { return dataReferences_; }
+// Return vector of all data
+const std::list<std::pair<Data1D, Data1DImportFileFormat>> &Data1DStore::data() const { return data_; }

--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -22,7 +22,7 @@ bool Data1DStore::addData(std::string_view dataName, LineParser &parser, int sta
         return false;
 
     // Load the data
-    return format.importData(data.first, parser.processPool());
+    return format.importData(data, parser.processPool());
 }
 
 // Check to see if the named data is present in the store

--- a/src/classes/data1dstore.h
+++ b/src/classes/data1dstore.h
@@ -5,11 +5,8 @@
 
 #include "io/import/data1d.h"
 #include "math/data1d.h"
-#include "templates/list.h"
-#include "templates/refdatalist.h"
-
-// Forward Declarations
-/* none */
+#include "templates/optionalref.h"
+#include <list>
 
 // Data1D Store
 class Data1DStore
@@ -22,10 +19,8 @@ class Data1DStore
      * Data
      */
     private:
-    // List of contained data
-    List<Data1D> data_;
-    // References for Data1D and associated file/format
-    RefDataList<Data1D, Data1DImportFileFormat> dataReferences_;
+    // Vector of contained data
+    std::list<std::pair<Data1D, Data1DImportFileFormat>> data_;
 
     public:
     // Add named data reference to store, reading file and format from specified parser / starting argument
@@ -34,9 +29,7 @@ class Data1DStore
     // Check to see if the named data is present in the store
     bool containsData(std::string_view name) const;
     // Return named data
-    const Data1D &data(std::string_view name) const;
-    // Return list of all data
-    const List<Data1D> &data() const;
-    // Return list of all data references
-    const RefDataList<Data1D, Data1DImportFileFormat> &dataReferences() const;
+    OptionalReferenceWrapper<const Data1D> data(std::string_view name) const;
+    // Return vector of all data
+    const std::list<std::pair<Data1D, Data1DImportFileFormat>> &data() const;
 };

--- a/src/classes/data1dstore.h
+++ b/src/classes/data1dstore.h
@@ -15,8 +15,8 @@
 class Data1DStore
 {
     public:
-    Data1DStore();
-    ~Data1DStore();
+    Data1DStore() = default;
+    ~Data1DStore() = default;
 
     /*
      * Data

--- a/src/classes/data2dstore.cpp
+++ b/src/classes/data2dstore.cpp
@@ -14,15 +14,15 @@ bool Data2DStore::addData(std::string_view dataName, LineParser &parser, int sta
                           const CoreData &coreData)
 {
     // Create new data
-    auto &data = data_.emplace_back();
-    data.first.setTag(dataName);
+    auto &[data, format] = data_.emplace_back();
+    data.setTag(dataName);
 
     // Read the file / format
-    if (!data.second.read(parser, startArg, endKeyword, coreData))
+    if (!format.read(parser, startArg, endKeyword, coreData))
         return false;
 
     // Load the data
-    return data.second.importData(data.first, parser.processPool());
+    return format.importData(data, parser.processPool());
 }
 
 // Check to see if the named data is present in the store

--- a/src/classes/data2dstore.cpp
+++ b/src/classes/data2dstore.cpp
@@ -5,10 +5,6 @@
 #include "base/lineparser.h"
 #include "io/import/data2d.h"
 
-Data2DStore::Data2DStore() {}
-
-Data2DStore::~Data2DStore() {}
-
 /*
  * Data
  */

--- a/src/classes/data2dstore.cpp
+++ b/src/classes/data2dstore.cpp
@@ -14,47 +14,32 @@ bool Data2DStore::addData(std::string_view dataName, LineParser &parser, int sta
                           const CoreData &coreData)
 {
     // Create new data
-    Data2D *data = data_.add();
-    data->setName(dataName);
-
-    // Add reference to data
-    RefDataItem<Data2D, Data2DImportFileFormat> *ref = dataReferences_.append(data);
+    auto &data = data_.emplace_back();
+    data.first.setTag(dataName);
 
     // Read the file / format
-    if (!ref->data().read(parser, startArg, endKeyword, coreData))
+    if (!data.second.read(parser, startArg, endKeyword, coreData))
         return false;
 
     // Load the data
-    return ref->data().importData(*data, parser.processPool());
+    return data.second.importData(data.first, parser.processPool());
 }
 
 // Check to see if the named data is present in the store
 bool Data2DStore::containsData(std::string_view name) const
 {
-    ListIterator<Data2D> dataIterator(data_);
-    while (Data2D *data = dataIterator.iterate())
-        if (DissolveSys::sameString(name, data->name()))
-            return true;
-
-    return false;
+    return std::find_if(data_.begin(), data_.end(), [&name](auto &data) { return data.first.tag() == name; }) != data_.end();
 }
 
 // Return named data
-const Data2D &Data2DStore::data(std::string_view name) const
+OptionalReferenceWrapper<const Data2D> Data2DStore::data(std::string_view name) const
 {
-    ListIterator<Data2D> dataIterator(data_);
-    while (Data2D *xyData = dataIterator.iterate())
-        if (DissolveSys::sameString(name, xyData->name()))
-            return (*xyData);
+    auto it = std::find_if(data_.begin(), data_.end(), [&name](auto &data) { return data.first.tag() == name; });
+    if (it == data_.end())
+        return {};
 
-    static Data2D dummy;
-    Messenger::warn("Data named '{}' was requested from Data2DStore, but it does not exist. Returning an empty Data2D...\n",
-                    name);
-    return dummy;
+    return it->first;
 }
 
-// Return list of all data
-const List<Data2D> &Data2DStore::data() const { return data_; }
-
-// Return list of all data references
-const RefDataList<Data2D, Data2DImportFileFormat> &Data2DStore::dataReferences() const { return dataReferences_; }
+// Return vector of all data
+const std::list<std::pair<Data2D, Data2DImportFileFormat>> &Data2DStore::data() const { return data_; }

--- a/src/classes/data2dstore.h
+++ b/src/classes/data2dstore.h
@@ -15,8 +15,8 @@
 class Data2DStore
 {
     public:
-    Data2DStore();
-    ~Data2DStore();
+    Data2DStore() = default;
+    ~Data2DStore() = default;
 
     /*
      * Data

--- a/src/classes/data2dstore.h
+++ b/src/classes/data2dstore.h
@@ -5,11 +5,8 @@
 
 #include "io/import/data2d.h"
 #include "math/data2d.h"
-#include "templates/list.h"
-#include "templates/refdatalist.h"
-
-// Forward Declarations
-/* none */
+#include "templates/optionalref.h"
+#include <list>
 
 // Data2D Store
 class Data2DStore
@@ -22,10 +19,8 @@ class Data2DStore
      * Data
      */
     private:
-    // List of contained data
-    List<Data2D> data_;
-    // References for Data2D and associated file/format
-    RefDataList<Data2D, Data2DImportFileFormat> dataReferences_;
+    // Vector of contained data
+    std::list<std::pair<Data2D, Data2DImportFileFormat>> data_;
 
     public:
     // Add named data reference to store, reading file and format from specified parser / starting argument
@@ -34,9 +29,7 @@ class Data2DStore
     // Check to see if the named data is present in the store
     bool containsData(std::string_view name) const;
     // Return named data
-    const Data2D &data(std::string_view name) const;
-    // Return list of all data
-    const List<Data2D> &data() const;
-    // Return list of all data references
-    const RefDataList<Data2D, Data2DImportFileFormat> &dataReferences() const;
+    OptionalReferenceWrapper<const Data2D> data(std::string_view name) const;
+    // Return vector of all data
+    const std::list<std::pair<Data2D, Data2DImportFileFormat>> &data() const;
 };

--- a/src/classes/data3dstore.cpp
+++ b/src/classes/data3dstore.cpp
@@ -5,10 +5,6 @@
 #include "base/lineparser.h"
 #include "io/import/data3d.h"
 
-Data3DStore::Data3DStore() {}
-
-Data3DStore::~Data3DStore() {}
-
 /*
  * Data
  */

--- a/src/classes/data3dstore.cpp
+++ b/src/classes/data3dstore.cpp
@@ -14,15 +14,15 @@ bool Data3DStore::addData(std::string_view dataName, LineParser &parser, int sta
                           const CoreData &coreData)
 {
     // Create new data
-    auto &data = data_.emplace_back();
-    data.first.setTag(dataName);
+    auto &[data, format] = data_.emplace_back();
+    data.setTag(dataName);
 
     // Read the file / format
-    if (!data.second.read(parser, startArg, endKeyword, coreData))
+    if (!format.read(parser, startArg, endKeyword, coreData))
         return false;
 
     // Load the data
-    return data.second.importData(data.first, parser.processPool());
+    return format.importData(data, parser.processPool());
 }
 
 // Check to see if the named data is present in the store

--- a/src/classes/data3dstore.cpp
+++ b/src/classes/data3dstore.cpp
@@ -14,47 +14,32 @@ bool Data3DStore::addData(std::string_view dataName, LineParser &parser, int sta
                           const CoreData &coreData)
 {
     // Create new data
-    Data3D *data = data_.add();
-    data->setName(dataName);
-
-    // Add reference to data
-    RefDataItem<Data3D, Data3DImportFileFormat> *ref = dataReferences_.append(data);
+    auto &data = data_.emplace_back();
+    data.first.setTag(dataName);
 
     // Read the file / format
-    if (!ref->data().read(parser, startArg, endKeyword, coreData))
+    if (!data.second.read(parser, startArg, endKeyword, coreData))
         return false;
 
     // Load the data
-    return ref->data().importData(*data, parser.processPool());
+    return data.second.importData(data.first, parser.processPool());
 }
 
 // Check to see if the named data is present in the store
 bool Data3DStore::containsData(std::string_view name) const
 {
-    ListIterator<Data3D> dataIterator(data_);
-    while (Data3D *data = dataIterator.iterate())
-        if (DissolveSys::sameString(name, data->name()))
-            return true;
-
-    return false;
+    return std::find_if(data_.begin(), data_.end(), [&name](auto &data) { return data.first.tag() == name; }) != data_.end();
 }
 
 // Return named data
-const Data3D &Data3DStore::data(std::string_view name) const
+OptionalReferenceWrapper<const Data3D> Data3DStore::data(std::string_view name) const
 {
-    ListIterator<Data3D> dataIterator(data_);
-    while (Data3D *xyData = dataIterator.iterate())
-        if (DissolveSys::sameString(name, xyData->name()))
-            return (*xyData);
+    auto it = std::find_if(data_.begin(), data_.end(), [&name](auto &data) { return data.first.tag() == name; });
+    if (it == data_.end())
+        return {};
 
-    static Data3D dummy;
-    Messenger::warn("Data named '{}' was requested from Data3DStore, but it does not exist. Returning an empty Data3D...\n",
-                    name);
-    return dummy;
+    return it->first;
 }
 
-// Return list of all data
-const List<Data3D> &Data3DStore::data() const { return data_; }
-
-// Return list of all data references
-const RefDataList<Data3D, Data3DImportFileFormat> &Data3DStore::dataReferences() const { return dataReferences_; }
+// Return vector of all data
+const std::list<std::pair<Data3D, Data3DImportFileFormat>> &Data3DStore::data() const { return data_; }

--- a/src/classes/data3dstore.h
+++ b/src/classes/data3dstore.h
@@ -15,8 +15,8 @@
 class Data3DStore
 {
     public:
-    Data3DStore();
-    ~Data3DStore();
+    Data3DStore() = default;
+    ~Data3DStore() = default;
 
     /*
      * Data

--- a/src/classes/data3dstore.h
+++ b/src/classes/data3dstore.h
@@ -5,11 +5,8 @@
 
 #include "io/import/data3d.h"
 #include "math/data3d.h"
-#include "templates/list.h"
-#include "templates/refdatalist.h"
-
-// Forward Declarations
-/* none */
+#include "templates/optionalref.h"
+#include <list>
 
 // Data3D Store
 class Data3DStore
@@ -22,10 +19,8 @@ class Data3DStore
      * Data
      */
     private:
-    // List of contained data
-    List<Data3D> data_;
-    // References for Data3D and associated file/format
-    RefDataList<Data3D, Data3DImportFileFormat> dataReferences_;
+    // Vector of contained data
+    std::list<std::pair<Data3D, Data3DImportFileFormat>> data_;
 
     public:
     // Add named data reference to store, reading file and format from specified parser / starting argument
@@ -34,9 +29,7 @@ class Data3DStore
     // Check to see if the named data is present in the store
     bool containsData(std::string_view name) const;
     // Return named data
-    const Data3D &data(std::string_view name) const;
-    // Return list of all data
-    const List<Data3D> &data() const;
-    // Return list of all data references
-    const RefDataList<Data3D, Data3DImportFileFormat> &dataReferences() const;
+    OptionalReferenceWrapper<const Data3D> data(std::string_view name) const;
+    // Return vector of all data
+    const std::list<std::pair<Data3D, Data3DImportFileFormat>> &data() const;
 };

--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -91,16 +91,16 @@ void PairPotential::setData1DNames()
     // Check for NULL pointers
     assert(atomTypeI_ && atomTypeJ_);
 
-    uFull_.setName(fmt::format("{}-{}", atomTypeI_->name(), atomTypeJ_->name()));
+    uFull_.setTag(fmt::format("{}-{}", atomTypeI_->name(), atomTypeJ_->name()));
     uFull_.setObjectTag(fmt::format("PairPotential//{}-{}//Full", atomTypeI_->name(), atomTypeJ_->name()));
 
-    uAdditional_.setName(fmt::format("{}-{} (Add)", atomTypeI_->name(), atomTypeJ_->name()));
+    uAdditional_.setTag(fmt::format("{}-{} (Add)", atomTypeI_->name(), atomTypeJ_->name()));
     uAdditional_.setObjectTag(fmt::format("PairPotential//{}-{}//Additional", atomTypeI_->name(), atomTypeJ_->name()));
 
-    uOriginal_.setName(fmt::format("{}-{} (Orig)", atomTypeI_->name(), atomTypeJ_->name()));
+    uOriginal_.setTag(fmt::format("{}-{} (Orig)", atomTypeI_->name(), atomTypeJ_->name()));
     uOriginal_.setObjectTag(fmt::format("PairPotential//{}-{}//Original", atomTypeI_->name(), atomTypeJ_->name()));
 
-    dUFull_.setName(fmt::format("{}-{} (dU/dr)", atomTypeI_->name(), atomTypeJ_->name()));
+    dUFull_.setTag(fmt::format("{}-{} (dU/dr)", atomTypeI_->name(), atomTypeJ_->name()));
     dUFull_.setObjectTag(fmt::format("PairPotential//{}-{}//Force", atomTypeI_->name(), atomTypeJ_->name()));
 }
 

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -65,13 +65,13 @@ bool PartialSet::setUpPartials(const AtomTypeList &atomTypes, std::string_view p
     std::string title;
     for_each_pair(atomTypes_.begin(), atomTypes_.end(), [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2) {
         title = fmt::format("{}-{}-{}-{}.{}", prefix, tag, at1.atomTypeName(), at2.atomTypeName(), suffix);
-        partials_[{n, m}].setName(title);
-        boundPartials_[{n, m}].setName(title);
-        unboundPartials_[{n, m}].setName(title);
+        partials_[{n, m}].setTag(title);
+        boundPartials_[{n, m}].setTag(title);
+        unboundPartials_[{n, m}].setTag(title);
     });
 
     // Set up array for total
-    total_.setName(fmt::format("{}-{}-total.{}", prefix, tag, suffix));
+    total_.setTag(fmt::format("{}-{}-total.{}", prefix, tag, suffix));
     total_.clear();
 
     fingerprint_ = "NO_FINGERPRINT";
@@ -266,7 +266,7 @@ bool PartialSet::save() const
 
     for_each_pair_early(0, atomTypes_.nItems(), [&](int typeI, int typeJ) -> EarlyReturn<bool> {
         // Open file and check that we're OK to proceed writing to it
-        std::string filename{partials_[{typeI, typeJ}].name()};
+        std::string filename{partials_[{typeI, typeJ}].tag()};
         Messenger::printVerbose("Writing partial file '{}'...\n", filename);
 
         parser.openOutput(filename, true);
@@ -285,8 +285,8 @@ bool PartialSet::save() const
         return EarlyReturn<bool>::Continue;
     });
 
-    Messenger::printVerbose("Writing total file '{}'...\n", total_.name());
-    Data1DExportFileFormat exportFormat(total_.name());
+    Messenger::printVerbose("Writing total file '{}'...\n", total_.tag());
+    Data1DExportFileFormat exportFormat(total_.tag());
     return exportFormat.exportData(total_);
 }
 
@@ -323,13 +323,13 @@ void PartialSet::setFileNames(std::string_view prefix, std::string_view tag, std
     std::string title;
     for_each_pair(atomTypes_.begin(), atomTypes_.end(), [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2) {
         title = fmt::format("{}-{}-{}-{}.{}", prefix, tag, at1.atomTypeName(), at2.atomTypeName(), suffix);
-        partials_[{n, m}].setName(title);
-        boundPartials_[{n, m}].setName(title);
-        unboundPartials_[{n, m}].setName(title);
+        partials_[{n, m}].setTag(title);
+        boundPartials_[{n, m}].setTag(title);
+        unboundPartials_[{n, m}].setTag(title);
     });
 
     // Set up array for total
-    total_.setName(fmt::format("{}-{}-total.{}", prefix, tag, suffix));
+    total_.setTag(fmt::format("{}-{}-total.{}", prefix, tag, suffix));
 }
 
 /*

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -11,7 +11,7 @@
 #include "io/export/data1d.h"
 #include "templates/algorithms.h"
 
-PartialSet::PartialSet() : ListItem<PartialSet>() { fingerprint_ = "NO_FINGERPRINT"; }
+PartialSet::PartialSet() { fingerprint_ = "NO_FINGERPRINT"; }
 
 PartialSet::~PartialSet()
 {

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -262,10 +262,11 @@ Data1D PartialSet::unboundTotal(bool applyConcentrationWeights) const
 // Save all partials and total
 bool PartialSet::save(std::string_view prefix, std::string_view tag, std::string_view suffix) const
 {
+    assert(!prefix.empty());
+
     LineParser parser;
 
-    // Set titles for partials
-    std::string title;
+    // Write partials
     for_each_pair_early(atomTypes_.begin(), atomTypes_.end(),
                         [&](int typeI, const AtomTypeData &at1, int typeJ, const AtomTypeData &at2) -> EarlyReturn<bool> {
                             // Open file and check that we're OK to proceed writing to it

--- a/src/classes/partialset.h
+++ b/src/classes/partialset.h
@@ -104,13 +104,11 @@ class PartialSet : public ListItem<PartialSet>
     // Calculate and return total unbound function
     Data1D unboundTotal(bool applyConcentrationWeights) const;
     // Save all partials and total
-    bool save() const;
+    bool save(std::string_view prefix, std::string_view tag, std::string_view suffix) const;
     // Name all object based on the supplied prefix
     void setObjectTags(std::string_view prefix, std::string_view suffix = "");
     // Return prefix applied to object names
     std::string_view objectNamePrefix() const;
-    // Set underlying Data1D file names
-    void setFileNames(std::string_view prefix, std::string_view tag, std::string_view suffix);
 
     /*
      * Manipulation

--- a/src/classes/partialset.h
+++ b/src/classes/partialset.h
@@ -15,7 +15,7 @@ class Configuration;
 class Interpolator;
 
 // Set of Partials
-class PartialSet : public ListItem<PartialSet>
+class PartialSet
 {
     public:
     PartialSet();

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -147,7 +147,7 @@ void ScatteringMatrix::print(double q) const
                 break;
             }
         }
-        Messenger::print("{}  {}\n", line, data_.at(row).name());
+        Messenger::print("{}  {}\n", line, data_.at(row).tag());
 
         // Limit to sensible number of rows
         if (row >= std::max(nColsWritten, 10))
@@ -199,7 +199,7 @@ void ScatteringMatrix::printInverse(double q) const
                 break;
             }
         }
-        Messenger::print("{}  {}\n", line, data_.at(col).name());
+        Messenger::print("{}  {}\n", line, data_.at(col).tag());
 
         // Limit to sensible number of rows
         if (col >= std::max(nColsWritten, 10))
@@ -323,7 +323,7 @@ void ScatteringMatrix::initialise(const std::vector<std::shared_ptr<AtomType>> &
     auto index = 0;
     for (auto [i, j] : typePairs_)
     {
-        estimatedSQ[index].setName(fmt::format("EstimatedSQ-{}-{}-{}.sq", i->name(), j->name(), groupName));
+        estimatedSQ[index].setTag(fmt::format("EstimatedSQ-{}-{}-{}.sq", i->name(), j->name(), groupName));
         estimatedSQ[index].setObjectTag(
             fmt::format("{}//EstimatedSQ//{}//{}-{}", objectNamePrefix, groupName, i->name(), j->name()));
         ++index;
@@ -335,7 +335,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const Neutro
 {
     // Make sure that the scattering weights are valid
     if (!dataWeights.isValid())
-        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.name());
+        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.tag());
 
     // Extend the scattering matrix by one row
     A_.addRow(typePairs_.size());
@@ -374,7 +374,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
 {
     // Make sure that the scattering weights are valid
     if (!dataWeights.isValid())
-        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.name());
+        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.tag());
 
     // Extend the scattering matrix by one row
     A_.addRow(typePairs_.size());

--- a/src/gui/dataviewer_contextmenu.cpp
+++ b/src/gui/dataviewer_contextmenu.cpp
@@ -58,7 +58,7 @@ void DataViewer::showGeneralContextMenu(QPoint pos)
             if (!itemName.isEmpty())
             {
                 auto &item = dissolve_->processingModuleData().value<Data1D>(qPrintable(itemName));
-                createRenderable<RenderableData1D>(item.objectTag(), item.name(), "Default");
+                createRenderable<RenderableData1D>(item.objectTag(), item.tag(), "Default");
             }
         }
         else if (dimensionality == 2)
@@ -67,7 +67,7 @@ void DataViewer::showGeneralContextMenu(QPoint pos)
             if (!itemName.isEmpty())
             {
                 auto &item = dissolve_->processingModuleData().value<Data2D>(qPrintable(itemName));
-                createRenderable<RenderableData2D>(item.objectTag(), item.name(), "Default");
+                createRenderable<RenderableData2D>(item.objectTag(), item.tag(), "Default");
             }
         }
         else if (dimensionality == 3)
@@ -76,7 +76,7 @@ void DataViewer::showGeneralContextMenu(QPoint pos)
             if (!itemName.isEmpty())
             {
                 auto &item = dissolve_->processingModuleData().value<Data3D>(qPrintable(itemName));
-                createRenderable<RenderableData3D>(item.objectTag(), item.name(), "Default");
+                createRenderable<RenderableData3D>(item.objectTag(), item.tag(), "Default");
             }
         }
     }

--- a/src/gui/integrator1dgizmo_funcs.cpp
+++ b/src/gui/integrator1dgizmo_funcs.cpp
@@ -94,7 +94,7 @@ void Integrator1DGizmo::setGraphDataTargets()
     if (!integrationTarget_)
         return;
 
-    ui_.PlotWidget->createRenderable<RenderableData1D>(integrationTarget_->get().objectTag(), integrationTarget_->get().name());
+    ui_.PlotWidget->createRenderable<RenderableData1D>(integrationTarget_->get().objectTag(), integrationTarget_->get().tag());
 }
 
 /*

--- a/src/io/fileandformat.cpp
+++ b/src/io/fileandformat.cpp
@@ -151,13 +151,13 @@ bool FileAndFormat::read(LineParser &parser, int startArg, std::string_view endK
 }
 
 // Write format / filename to specified parser
-bool FileAndFormat::writeFilenameAndFormat(LineParser &parser, std::string_view prefix)
+bool FileAndFormat::writeFilenameAndFormat(LineParser &parser, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  '{}'\n", prefix, formatKeyword(format_), filename_);
 }
 
 // Write options and end block
-bool FileAndFormat::writeBlock(LineParser &parser, std::string_view prefix)
+bool FileAndFormat::writeBlock(LineParser &parser, std::string_view prefix) const
 {
     return keywords_.write(parser, fmt::format("{}  ", prefix));
 }

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -90,7 +90,7 @@ class FileAndFormat
     // Read format / filename from specified parser
     bool read(LineParser &parser, int startArg, std::string_view endKeyword, const CoreData &coreData);
     // Write format / filename to specified parser
-    bool writeFilenameAndFormat(LineParser &parser, std::string_view prefix);
+    bool writeFilenameAndFormat(LineParser &parser, std::string_view prefix) const;
     // Write options and end block
-    bool writeBlock(LineParser &parser, std::string_view prefix);
+    bool writeBlock(LineParser &parser, std::string_view prefix) const;
 };

--- a/src/keywords/atomtypereflist.cpp
+++ b/src/keywords/atomtypereflist.cpp
@@ -48,7 +48,7 @@ bool AtomTypeRefListKeyword::read(LineParser &parser, int startArg, const CoreDa
 }
 
 // Write keyword data to specified LineParser
-bool AtomTypeRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool AtomTypeRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Don't write anything if there are no items in the list
     if (data_.empty())

--- a/src/keywords/atomtypereflist.h
+++ b/src/keywords/atomtypereflist.h
@@ -24,13 +24,13 @@ class AtomTypeRefListKeyword : public KeywordData<std::vector<std::shared_ptr<At
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/atomtypeselection.cpp
+++ b/src/keywords/atomtypeselection.cpp
@@ -98,7 +98,7 @@ bool AtomTypeSelectionKeyword::read(LineParser &parser, int startArg, const Core
 }
 
 // Write keyword data to specified LineParser
-bool AtomTypeSelectionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool AtomTypeSelectionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over the AtomType selection list
     std::string selection;

--- a/src/keywords/atomtypeselection.h
+++ b/src/keywords/atomtypeselection.h
@@ -26,7 +26,7 @@ class AtomTypeSelectionKeyword : public KeywordData<AtomTypeList &>
 
     public:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
     // Check selection and make sure it is consistent based on the source Configurations
     void checkSelection();
     // Return selection after checking it for validity
@@ -37,13 +37,13 @@ class AtomTypeSelectionKeyword : public KeywordData<AtomTypeList &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -149,7 +149,7 @@ class KeywordBase : public ListItem<KeywordBase>
     // Parse arguments from supplied LineParser, starting at given argument offset
     virtual bool read(LineParser &parser, int startArg, const CoreData &coreData) = 0;
     // Write keyword data to specified LineParser
-    virtual bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix = "") = 0;
+    virtual bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix = "") const = 0;
 
     /*
      * Parse Result

--- a/src/keywords/bool.cpp
+++ b/src/keywords/bool.cpp
@@ -32,7 +32,7 @@ bool BoolKeyword::read(LineParser &parser, int startArg, const CoreData &coreDat
 }
 
 // Write keyword data to specified LineParser
-bool BoolKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool BoolKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {}\n", prefix, keywordName, DissolveSys::btoa(data_));
 }

--- a/src/keywords/bool.h
+++ b/src/keywords/bool.h
@@ -20,13 +20,13 @@ class BoolKeyword : public KeywordData<bool>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Conversion

--- a/src/keywords/broadeningfunction.cpp
+++ b/src/keywords/broadeningfunction.cpp
@@ -32,7 +32,7 @@ bool BroadeningFunctionKeyword::read(LineParser &parser, int startArg, const Cor
 }
 
 // Write keyword data to specified LineParser
-bool BroadeningFunctionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool BroadeningFunctionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     std::string params;
     for (auto n = 0; n < BroadeningFunction::nFunctionParameters(data_.function()); ++n)

--- a/src/keywords/broadeningfunction.h
+++ b/src/keywords/broadeningfunction.h
@@ -21,11 +21,11 @@ class BroadeningFunctionKeyword : public KeywordData<BroadeningFunction>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -62,7 +62,7 @@ bool ConfigurationRefListKeyword::read(LineParser &parser, int startArg, const C
 }
 
 // Write keyword data to specified LineParser
-bool ConfigurationRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ConfigurationRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of Configuration
     std::string configurationString;

--- a/src/keywords/configurationreflist.h
+++ b/src/keywords/configurationreflist.h
@@ -26,7 +26,7 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
 
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
 
     public:
     // Return maximum number of Configurations to allow in the list
@@ -37,13 +37,13 @@ class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/data.h
+++ b/src/keywords/data.h
@@ -24,7 +24,7 @@ template <class T> class KeywordData : public KeywordBase
 
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    virtual bool isDataEmpty() const
+    bool isDataEmpty() const override
     {
         // Override this function to handle cases where, for instance, checks for empty lists need to be made.
         return false;

--- a/src/keywords/data1dstore.cpp
+++ b/src/keywords/data1dstore.cpp
@@ -46,7 +46,7 @@ bool Data1DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &
 }
 
 // Write keyword data to specified LineParser
-bool Data1DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool Data1DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of one-dimensional data
     RefDataListIterator<Data1D, Data1DImportFileFormat> dataIterator(data_.dataReferences());

--- a/src/keywords/data1dstore.cpp
+++ b/src/keywords/data1dstore.cpp
@@ -49,13 +49,11 @@ bool Data1DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &
 bool Data1DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of one-dimensional data
-    RefDataListIterator<Data1D, Data1DImportFileFormat> dataIterator(data_.dataReferences());
-    while (Data1D *data = dataIterator.iterate())
+    for (const auto &[data, format] : data_.data())
     {
-        Data1DImportFileFormat &ff = dataIterator.currentData();
-        if (!ff.writeFilenameAndFormat(parser, fmt::format("{}{}  '{}'  ", prefix, keywordName, data->name())))
+        if (!format.writeFilenameAndFormat(parser, fmt::format("{}{}  '{}'  ", prefix, keywordName, data.tag())))
             return false;
-        if (!ff.writeBlock(parser, fmt::format("{}  ", prefix)))
+        if (!format.writeBlock(parser, fmt::format("{}  ", prefix)))
             return false;
         if (!parser.writeLineF("{}End{}\n", prefix, name()))
             return false;

--- a/src/keywords/data1dstore.h
+++ b/src/keywords/data1dstore.h
@@ -20,11 +20,11 @@ class Data1DStoreKeyword : public KeywordData<Data1DStore &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/data2dstore.cpp
+++ b/src/keywords/data2dstore.cpp
@@ -44,16 +44,14 @@ bool Data2DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &
 }
 
 // Write keyword data to specified LineParser
-bool Data2DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool Data2DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of one-dimensional data
-    RefDataListIterator<Data2D, Data2DImportFileFormat> dataIterator(data_.dataReferences());
-    while (Data2D *data = dataIterator.iterate())
+    for (const auto &[data, format] : data_.data())
     {
-        Data2DImportFileFormat &ff = dataIterator.currentData();
-        if (!ff.writeFilenameAndFormat(parser, fmt::format("{}{}  '{}'  ", prefix, keywordName, data->name())))
+        if (!format.writeFilenameAndFormat(parser, fmt::format("{}{}  '{}'  ", prefix, keywordName, data.tag())))
             return false;
-        if (!ff.writeBlock(parser, fmt::format("{}  ", prefix)))
+        if (!format.writeBlock(parser, fmt::format("{}  ", prefix)))
             return false;
         if (!parser.writeLineF("{}End{}\n", prefix, name()))
             return false;

--- a/src/keywords/data2dstore.h
+++ b/src/keywords/data2dstore.h
@@ -21,11 +21,11 @@ class Data2DStoreKeyword : public KeywordData<Data2DStore &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/data3dstore.cpp
+++ b/src/keywords/data3dstore.cpp
@@ -44,16 +44,14 @@ bool Data3DStoreKeyword::read(LineParser &parser, int startArg, const CoreData &
 }
 
 // Write keyword data to specified LineParser
-bool Data3DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool Data3DStoreKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of one-dimensional data
-    RefDataListIterator<Data3D, Data3DImportFileFormat> dataIterator(data_.dataReferences());
-    while (Data3D *data = dataIterator.iterate())
+    for (const auto &[data, format] : data_.data())
     {
-        Data3DImportFileFormat &ff = dataIterator.currentData();
-        if (!ff.writeFilenameAndFormat(parser, fmt::format("{}{}  '{}'  ", prefix, keywordName, data->name())))
+        if (!format.writeFilenameAndFormat(parser, fmt::format("{}{}  '{}'  ", prefix, keywordName, data.tag())))
             return false;
-        if (!ff.writeBlock(parser, fmt::format("{}  ", prefix)))
+        if (!format.writeBlock(parser, fmt::format("{}  ", prefix)))
             return false;
         if (!parser.writeLineF("{}End{}\n", prefix, name()))
             return false;

--- a/src/keywords/data3dstore.h
+++ b/src/keywords/data3dstore.h
@@ -21,11 +21,11 @@ class Data3DStoreKeyword : public KeywordData<Data3DStore &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/double.cpp
+++ b/src/keywords/double.cpp
@@ -98,7 +98,7 @@ bool DoubleKeyword::read(LineParser &parser, int startArg, const CoreData &coreD
 }
 
 // Write keyword data to specified LineParser
-bool DoubleKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool DoubleKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {:12.5e}\n", prefix, keywordName, data_);
 }

--- a/src/keywords/double.h
+++ b/src/keywords/double.h
@@ -43,13 +43,13 @@ class DoubleKeyword : public KeywordData<double>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Conversion

--- a/src/keywords/dynamicsitenodes.cpp
+++ b/src/keywords/dynamicsitenodes.cpp
@@ -65,7 +65,7 @@ bool DynamicSiteNodesKeyword::read(LineParser &parser, int startArg, const CoreD
 }
 
 // Write keyword data to specified LineParser
-bool DynamicSiteNodesKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool DynamicSiteNodesKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of dynamic sites in the RefList
     for (auto dynamicSite : data_)

--- a/src/keywords/dynamicsitenodes.h
+++ b/src/keywords/dynamicsitenodes.h
@@ -42,20 +42,20 @@ class DynamicSiteNodesKeyword : public KeywordData<RefList<DynamicSiteProcedureN
      */
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
 
     /*
      * Arguments
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/elementreflist.cpp
+++ b/src/keywords/elementreflist.cpp
@@ -47,7 +47,7 @@ bool ElementVectorKeyword::read(LineParser &parser, int startArg, const CoreData
 }
 
 // Write keyword data to specified LineParser
-bool ElementVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ElementVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Don't write anything if there are no items in the list
     if (data_.size() == 0)

--- a/src/keywords/elementreflist.h
+++ b/src/keywords/elementreflist.h
@@ -22,11 +22,11 @@ class ElementVectorKeyword : public KeywordData<std::vector<Elements::Element> &
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -74,9 +74,9 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword, pub
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return 1; }
+    int minArguments() const override { return 1; }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return 1; }
+    int maxArguments() const override { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -95,7 +95,7 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword, pub
         return false;
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         return parser.writeLineF("{}{}  {}\n", prefix, keywordName, KeywordData<EnumOptions<E>>::data_.keyword());
     }

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -29,7 +29,7 @@ bool ExpressionKeyword::read(LineParser &parser, int startArg, const CoreData &c
 }
 
 // Write keyword data to specified LineParser
-bool ExpressionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ExpressionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (!parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, data_.expressionString()))
         return false;

--- a/src/keywords/expression.h
+++ b/src/keywords/expression.h
@@ -29,13 +29,13 @@ class ExpressionKeyword : public KeywordData<Expression &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Set

--- a/src/keywords/expressionvariablevector.cpp
+++ b/src/keywords/expressionvariablevector.cpp
@@ -77,7 +77,7 @@ bool ExpressionVariableVectorKeyword::read(LineParser &parser, int startArg, con
 }
 
 // Write keyword data to specified LineParser
-bool ExpressionVariableVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ExpressionVariableVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of defined ExpressionNode's (ExpressionVariables)
     for (const auto node : data_)

--- a/src/keywords/expressionvariablevector.h
+++ b/src/keywords/expressionvariablevector.h
@@ -34,20 +34,20 @@ class ExpressionVariableVectorKeyword : public KeywordData<std::vector<std::shar
      */
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
 
     /*
      * Arguments
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/fileandformat.cpp
+++ b/src/keywords/fileandformat.cpp
@@ -49,7 +49,7 @@ bool FileAndFormatKeyword::read(LineParser &parser, int startArg, const CoreData
 }
 
 // Write keyword data to specified LineParser
-bool FileAndFormatKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool FileAndFormatKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (!data_.writeFilenameAndFormat(parser, fmt::format("{}{}  ", prefix, keywordName)))
         return false;

--- a/src/keywords/fileandformat.h
+++ b/src/keywords/fileandformat.h
@@ -34,11 +34,11 @@ class FileAndFormatKeyword : public KeywordData<FileAndFormat &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const;
 };

--- a/src/keywords/geometrylist.cpp
+++ b/src/keywords/geometrylist.cpp
@@ -59,7 +59,7 @@ bool GeometryListKeyword::read(LineParser &parser, int startArg, const CoreData 
 }
 
 // Write keyword data to specified LineParser
-bool GeometryListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool GeometryListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     std::string index;
 

--- a/src/keywords/geometrylist.h
+++ b/src/keywords/geometrylist.h
@@ -30,11 +30,11 @@ class GeometryListKeyword : public KeywordData<List<Geometry> &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/integer.cpp
+++ b/src/keywords/integer.cpp
@@ -97,7 +97,7 @@ bool IntegerKeyword::read(LineParser &parser, int startArg, const CoreData &core
 }
 
 // Write keyword data to specified LineParser
-bool IntegerKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool IntegerKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {}\n", prefix, keywordName, data_);
 }

--- a/src/keywords/integer.h
+++ b/src/keywords/integer.h
@@ -43,13 +43,13 @@ class IntegerKeyword : public KeywordData<int>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Conversion

--- a/src/keywords/isotopologueset.cpp
+++ b/src/keywords/isotopologueset.cpp
@@ -47,7 +47,7 @@ bool IsotopologueSetKeyword::read(LineParser &parser, int startArg, const CoreDa
 }
 
 // Write keyword data to specified LineParser
-bool IsotopologueSetKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool IsotopologueSetKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     for (auto topes : data_.isotopologues())
         for (auto isoWeight : topes.mix())

--- a/src/keywords/isotopologueset.h
+++ b/src/keywords/isotopologueset.h
@@ -23,13 +23,13 @@ class IsotopologueSetKeyword : public KeywordData<IsotopologueSet &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/linkto.cpp
+++ b/src/keywords/linkto.cpp
@@ -42,7 +42,7 @@ bool LinkToKeyword::read(LineParser &parser, int startArg, const CoreData &coreD
 }
 
 // Write keyword data to specified LineParser
-bool LinkToKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool LinkToKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     Messenger::warn("Don't call LinkToKeyword::write() - go through base().\n");
     return data_->write(parser, data_->name(), prefix);

--- a/src/keywords/linkto.h
+++ b/src/keywords/linkto.h
@@ -27,11 +27,11 @@ class LinkToKeyword : public KeywordData<KeywordBase *>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/list.cpp
+++ b/src/keywords/list.cpp
@@ -255,7 +255,7 @@ KeywordBase::ParseResult KeywordList::parse(LineParser &parser, const CoreData &
 }
 
 // Write all keywords to specified LineParser
-bool KeywordList::write(LineParser &parser, std::string_view prefix, bool onlyIfSet)
+bool KeywordList::write(LineParser &parser, std::string_view prefix, bool onlyIfSet) const
 {
     ListIterator<KeywordBase> keywordIterator(keywords_);
     while (KeywordBase *keyword = keywordIterator.iterate())
@@ -274,7 +274,7 @@ bool KeywordList::write(LineParser &parser, std::string_view prefix, bool onlyIf
 }
 
 // Write all keywords in groups to specified LineParser
-bool KeywordList::writeGroups(LineParser &parser, std::string_view prefix, bool onlyIfSet)
+bool KeywordList::writeGroups(LineParser &parser, std::string_view prefix, bool onlyIfSet) const
 {
     // Loop over keyword groups
     auto firstGroup = true;

--- a/src/keywords/list.h
+++ b/src/keywords/list.h
@@ -218,7 +218,7 @@ class KeywordList
     // Try to parse keyword in specified LineParser
     KeywordBase::ParseResult parse(LineParser &parser, const CoreData &coreData);
     // Write all keywords to specified LineParser
-    bool write(LineParser &parser, std::string_view prefix, bool onlyIfSet = true);
+    bool write(LineParser &parser, std::string_view prefix, bool onlyIfSet = true) const;
     // Write all keywords in groups to specified LineParser
-    bool writeGroups(LineParser &parser, std::string_view prefix, bool onlyIfSet = true);
+    bool writeGroups(LineParser &parser, std::string_view prefix, bool onlyIfSet = true) const;
 };

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -53,9 +53,9 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase, public Keywor
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return 1; }
+    int minArguments() const override { return 1; }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return 1; }
+    int maxArguments() const override { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -67,7 +67,7 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase, public Keywor
         return setModule(module);
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         // No need to write the keyword if the module pointer is null
         if (KeywordData<M *>::data_ == nullptr)

--- a/src/keywords/modulegroups.cpp
+++ b/src/keywords/modulegroups.cpp
@@ -59,7 +59,7 @@ bool ModuleGroupsKeyword::read(LineParser &parser, int startArg, const CoreData 
 }
 
 // Write keyword data to specified LineParser
-bool ModuleGroupsKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ModuleGroupsKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over defined groups
     ListIterator<ModuleGroup> groupIterator(data_.groups());

--- a/src/keywords/modulegroups.h
+++ b/src/keywords/modulegroups.h
@@ -21,13 +21,13 @@ class ModuleGroupsKeyword : public KeywordData<ModuleGroups &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/modulevector.cpp
+++ b/src/keywords/modulevector.cpp
@@ -76,7 +76,7 @@ bool ModuleVectorKeyword::read(LineParser &parser, int startArg, const CoreData 
 }
 
 // Write keyword data to specified LineParser
-bool ModuleVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ModuleVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of referenced Modules
     for (auto *module : data_)

--- a/src/keywords/modulevector.h
+++ b/src/keywords/modulevector.h
@@ -28,7 +28,7 @@ class ModuleVectorKeyword : public KeywordData<std::vector<Module *>>
 
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
 
     public:
     // Return the Module type(s) to allow
@@ -41,13 +41,13 @@ class ModuleVectorKeyword : public KeywordData<std::vector<Module *>>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -71,9 +71,9 @@ template <class N> class NodeKeyword : public NodeKeywordBase, public KeywordDat
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return 1; }
+    int minArguments() const override { return 1; }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return 1; }
+    int maxArguments() const override { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -91,7 +91,7 @@ template <class N> class NodeKeyword : public NodeKeywordBase, public KeywordDat
         return setNode(node);
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         // No need to write the keyword if the node pointer is null
         if (KeywordData<N *>::data_ == nullptr)

--- a/src/keywords/nodeandinteger.h
+++ b/src/keywords/nodeandinteger.h
@@ -89,9 +89,9 @@ template <class N> class NodeAndIntegerKeyword : public NodeAndIntegerKeywordBas
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return 1; }
+    int minArguments() const override { return 1; }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return 1; }
+    int maxArguments() const override { return 1; }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -109,7 +109,7 @@ template <class N> class NodeAndIntegerKeyword : public NodeAndIntegerKeywordBas
         return setNode(node);
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         // Grab the node pointer
         const N *node = std::get<0>(KeywordData<std::tuple<N *, int>>::data_);

--- a/src/keywords/nodearray.h
+++ b/src/keywords/nodearray.h
@@ -99,9 +99,15 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return NodeArrayKeywordBase::isVariableSize() ? 1 : NodeArrayKeywordBase::fixedArraySize(); }
+    int minArguments() const override
+    {
+        return NodeArrayKeywordBase::isVariableSize() ? 1 : NodeArrayKeywordBase::fixedArraySize();
+    }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return NodeArrayKeywordBase::isVariableSize() ? 99 : NodeArrayKeywordBase::fixedArraySize(); }
+    int maxArguments() const override
+    {
+        return NodeArrayKeywordBase::isVariableSize() ? 99 : NodeArrayKeywordBase::fixedArraySize();
+    }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -126,7 +132,7 @@ template <class N> class NodeArrayKeyword : public NodeArrayKeywordBase, public 
         return true;
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         if (KeywordData<Array<N *> &>::data_.nItems() == 0)
             return true;

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -51,7 +51,7 @@ bool NodeBranchKeyword::read(LineParser &parser, int startArg, const CoreData &c
 }
 
 // Write keyword data to specified LineParser
-bool NodeBranchKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool NodeBranchKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (!(*data_) || ((*data_)->nNodes() == 0))
         return true;

--- a/src/keywords/nodebranch.h
+++ b/src/keywords/nodebranch.h
@@ -30,7 +30,7 @@ class NodeBranchKeyword : public KeywordData<SequenceProcedureNode **>
      */
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
 
     /*
      * Branch Specification
@@ -44,11 +44,11 @@ class NodeBranchKeyword : public KeywordData<SequenceProcedureNode **>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/nodereflist.h
+++ b/src/keywords/nodereflist.h
@@ -69,9 +69,9 @@ template <class N> class NodeRefListKeyword : public NodeRefListKeywordBase, pub
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return 1; }
+    int minArguments() const override { return 1; }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return 99; }
+    int maxArguments() const override { return 99; }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -95,7 +95,7 @@ template <class N> class NodeRefListKeyword : public NodeRefListKeywordBase, pub
         return true;
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         if (KeywordData<RefList<N> &>::data_.nItems() == 0)
             return true;

--- a/src/keywords/nodevalue.cpp
+++ b/src/keywords/nodevalue.cpp
@@ -30,7 +30,7 @@ bool NodeValueKeyword::read(LineParser &parser, int startArg, const CoreData &co
 }
 
 // Write keyword data to specified LineParser
-bool NodeValueKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool NodeValueKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (!parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, data_.asString()))
         return false;

--- a/src/keywords/nodevalue.h
+++ b/src/keywords/nodevalue.h
@@ -29,13 +29,13 @@ class NodeValueKeyword : public KeywordData<NodeValue>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Set

--- a/src/keywords/nodevalueenumoptions.h
+++ b/src/keywords/nodevalueenumoptions.h
@@ -79,9 +79,9 @@ class NodeValueEnumOptionsKeyword : public NodeValueEnumOptionsBaseKeyword, publ
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const { return 2; }
+    int minArguments() const override { return 2; }
     // Return maximum number of arguments accepted
-    int maxArguments() const { return 2; }
+    int maxArguments() const override { return 2; }
     // Parse arguments from supplied LineParser, starting at given argument offset
     bool read(LineParser &parser, int startArg, const CoreData &coreData)
     {
@@ -112,7 +112,7 @@ class NodeValueEnumOptionsKeyword : public NodeValueEnumOptionsBaseKeyword, publ
         return false;
     }
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override
     {
         return parser.writeLineF("{}{}  '{}'  {}\n", prefix, KeywordBase::name(),
                                  KeywordData<Venum<NodeValue, E>>::data_.value().asString(),

--- a/src/keywords/pairbroadeningfunction.cpp
+++ b/src/keywords/pairbroadeningfunction.cpp
@@ -33,7 +33,7 @@ bool PairBroadeningFunctionKeyword::read(LineParser &parser, int startArg, const
 }
 
 // Write keyword data to specified LineParser
-bool PairBroadeningFunctionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool PairBroadeningFunctionKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (!parser.writeLineF("{}{}", prefix, name()))
         return false;

--- a/src/keywords/pairbroadeningfunction.h
+++ b/src/keywords/pairbroadeningfunction.h
@@ -28,11 +28,11 @@ class PairBroadeningFunctionKeyword : public KeywordData<PairBroadeningFunction>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/procedure.cpp
+++ b/src/keywords/procedure.cpp
@@ -32,7 +32,7 @@ bool ProcedureKeyword::read(LineParser &parser, int startArg, const CoreData &co
 }
 
 // Write keyword data to specified LineParser
-bool ProcedureKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool ProcedureKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Write the keyword name as the start of the data
     if (!parser.writeLineF("{}{}\n", prefix, name()))

--- a/src/keywords/procedure.h
+++ b/src/keywords/procedure.h
@@ -21,11 +21,11 @@ class ProcedureKeyword : public KeywordData<Procedure &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/range.cpp
+++ b/src/keywords/range.cpp
@@ -42,7 +42,7 @@ bool RangeKeyword::read(LineParser &parser, int startArg, const CoreData &coreDa
 }
 
 // Write keyword data to specified LineParser
-bool RangeKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool RangeKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {:12.6e}  {:12.6e}\n", prefix, keywordName, data_.minimum(), data_.maximum());
 }

--- a/src/keywords/range.h
+++ b/src/keywords/range.h
@@ -33,11 +33,11 @@ class RangeKeyword : public KeywordData<Range>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -37,7 +37,7 @@ bool SpeciesKeyword::read(LineParser &parser, int startArg, const CoreData &core
 }
 
 // Write keyword data to specified LineParser
-bool SpeciesKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool SpeciesKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (data_)
     {

--- a/src/keywords/species.h
+++ b/src/keywords/species.h
@@ -21,13 +21,13 @@ class SpeciesKeyword : public KeywordData<Species *>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/speciesreflist.cpp
+++ b/src/keywords/speciesreflist.cpp
@@ -49,7 +49,7 @@ bool SpeciesRefListKeyword::read(LineParser &parser, int startArg, const CoreDat
 }
 
 // Write keyword data to specified LineParser
-bool SpeciesRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool SpeciesRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // Loop over list of Species
     std::string speciesString;

--- a/src/keywords/speciesreflist.h
+++ b/src/keywords/speciesreflist.h
@@ -21,20 +21,20 @@ class SpeciesRefListKeyword : public KeywordData<RefList<Species> &>
      */
     protected:
     // Determine whether current data is 'empty', and should be considered as 'not set'
-    bool isDataEmpty() const;
+    bool isDataEmpty() const override;
 
     /*
      * Arguments
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/speciessite.cpp
+++ b/src/keywords/speciessite.cpp
@@ -59,7 +59,7 @@ bool SpeciesSiteKeyword::read(LineParser &parser, int startArg, const CoreData &
 }
 
 // Write keyword data to specified LineParser
-bool SpeciesSiteKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool SpeciesSiteKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     if (data_)
     {

--- a/src/keywords/speciessite.h
+++ b/src/keywords/speciessite.h
@@ -32,13 +32,13 @@ class SpeciesSiteKeyword : public KeywordData<SpeciesSite *>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/speciessitereflist.cpp
+++ b/src/keywords/speciessitereflist.cpp
@@ -67,7 +67,7 @@ bool SpeciesSiteRefListKeyword::read(LineParser &parser, int startArg, const Cor
 }
 
 // Write keyword data to specified LineParser
-bool SpeciesSiteRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool SpeciesSiteRefListKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     // If there are no sites in the list, no need to write anything
     if (data_.nItems() == 0)

--- a/src/keywords/speciessitereflist.h
+++ b/src/keywords/speciessitereflist.h
@@ -32,13 +32,13 @@ class SpeciesSiteRefListKeyword : public KeywordData<RefList<SpeciesSite> &>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Object Management

--- a/src/keywords/stdstring.cpp
+++ b/src/keywords/stdstring.cpp
@@ -34,7 +34,7 @@ bool StringKeyword::read(LineParser &parser, int startArg, const CoreData &coreD
 }
 
 // Write keyword data to specified LineParser
-bool StringKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool StringKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, data_);
 }

--- a/src/keywords/stdstring.h
+++ b/src/keywords/stdstring.h
@@ -20,13 +20,13 @@ class StringKeyword : public KeywordData<std::string>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Conversion

--- a/src/keywords/vec3double.cpp
+++ b/src/keywords/vec3double.cpp
@@ -134,7 +134,7 @@ bool Vec3DoubleKeyword::read(LineParser &parser, int startArg, const CoreData &c
 }
 
 // Write keyword data to specified LineParser
-bool Vec3DoubleKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool Vec3DoubleKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {:12.6e}  {:12.6e}  {:12.6e}\n", prefix, keywordName, data_.x, data_.y, data_.z);
 }

--- a/src/keywords/vec3double.h
+++ b/src/keywords/vec3double.h
@@ -58,13 +58,13 @@ class Vec3DoubleKeyword : public KeywordData<Vec3<double>>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Conversion

--- a/src/keywords/vec3integer.cpp
+++ b/src/keywords/vec3integer.cpp
@@ -132,7 +132,7 @@ bool Vec3IntegerKeyword::read(LineParser &parser, int startArg, const CoreData &
 }
 
 // Write keyword data to specified LineParser
-bool Vec3IntegerKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool Vec3IntegerKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {}  {}  {}\n", prefix, keywordName, data_.x, data_.y, data_.z);
 }

--- a/src/keywords/vec3integer.h
+++ b/src/keywords/vec3integer.h
@@ -58,13 +58,13 @@ class Vec3IntegerKeyword : public KeywordData<Vec3<int>>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Conversion

--- a/src/keywords/vec3nodevalue.cpp
+++ b/src/keywords/vec3nodevalue.cpp
@@ -58,7 +58,7 @@ bool Vec3NodeValueKeyword::read(LineParser &parser, int startArg, const CoreData
 }
 
 // Write keyword data to specified LineParser
-bool Vec3NodeValueKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool Vec3NodeValueKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     return parser.writeLineF("{}{}  {}  {}  {}\n", prefix, keywordName, data_.x.asString(true), data_.y.asString(true),
                              data_.z.asString(true));

--- a/src/keywords/vec3nodevalue.h
+++ b/src/keywords/vec3nodevalue.h
@@ -40,13 +40,13 @@ class Vec3NodeValueKeyword : public KeywordData<Vec3<NodeValue>>
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 
     /*
      * Set

--- a/src/keywords/vector_intdouble.cpp
+++ b/src/keywords/vector_intdouble.cpp
@@ -59,7 +59,7 @@ bool IntegerDoubleVectorKeyword::read(LineParser &parser, int startArg, const Co
 }
 
 // Write keyword data to specified LineParser
-bool IntegerDoubleVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool IntegerDoubleVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     for (const auto &idData : data_)
     {

--- a/src/keywords/vector_intdouble.h
+++ b/src/keywords/vector_intdouble.h
@@ -32,11 +32,11 @@ class IntegerDoubleVectorKeyword : public KeywordData<IntegerDoubleVectorKeyword
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/keywords/vector_intstring.cpp
+++ b/src/keywords/vector_intstring.cpp
@@ -58,7 +58,7 @@ bool IntegerStringVectorKeyword::read(LineParser &parser, int startArg, const Co
 }
 
 // Write keyword data to specified LineParser
-bool IntegerStringVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix)
+bool IntegerStringVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     for (const auto &d : data_)
     {

--- a/src/keywords/vector_intstring.h
+++ b/src/keywords/vector_intstring.h
@@ -32,11 +32,11 @@ class IntegerStringVectorKeyword : public KeywordData<IntegerStringVectorKeyword
      */
     public:
     // Return minimum number of arguments accepted
-    int minArguments() const;
+    int minArguments() const override;
     // Return maximum number of arguments accepted
-    int maxArguments() const;
+    int maxArguments() const override;
     // Parse arguments from supplied LineParser, starting at given argument offset
-    bool read(LineParser &parser, int startArg, const CoreData &coreData);
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
     // Write keyword data to specified LineParser
-    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix);
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
 };

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -13,14 +13,9 @@ template <class Data1D> int ObjectStore<Data1D>::objectCount_ = 0;
 template <class Data1D> int ObjectStore<Data1D>::objectType_ = ObjectInfo::Data1DObject;
 template <class Data1D> std::string_view ObjectStore<Data1D>::objectTypeName_ = "Data1D";
 
-Data1D::Data1D() : PlottableData(PlottableData::OneAxisPlottable), ListItem<Data1D>(), ObjectStore<Data1D>(this)
+Data1D::Data1D()
+    : PlottableData(PlottableData::OneAxisPlottable), ListItem<Data1D>(), ObjectStore<Data1D>(this), hasError_(false)
 {
-    static int count = 0;
-    name_ = fmt::format("Data1D_{}", ++count);
-
-    hasError_ = false;
-
-    clear();
 }
 
 Data1D::Data1D(const Data1D &source) : PlottableData(PlottableData::OneAxisPlottable), ObjectStore<Data1D>(this)
@@ -116,15 +111,11 @@ void Data1D::addPoint(double x, double value)
 // Add new data point with error
 void Data1D::addPoint(double x, double value, double error)
 {
+    assert(hasError_);
+
     x_.push_back(x);
     values_.push_back(value);
-
-    if (hasError_)
-        errors_.push_back(error);
-    else
-        Messenger::warn("Tried to addPoint() with an error to Data1D, but this Data1D (name='{}', tag='{}') has no "
-                        "error information associated with it.\n",
-                        name(), objectTag());
+    errors_.push_back(error);
 
     ++version_;
 }
@@ -235,13 +226,7 @@ bool Data1D::valuesHaveErrors() const { return hasError_; }
 // Return error value specified
 double &Data1D::error(int index)
 {
-    if (!hasError_)
-    {
-        static double dummy = 0.0;
-        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
-                        objectTag());
-        return dummy;
-    }
+    assert(hasError_);
 
     ++version_;
 
@@ -250,13 +235,7 @@ double &Data1D::error(int index)
 
 const double &Data1D::error(int index) const
 {
-    if (!hasError_)
-    {
-        static double dummy;
-        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
-                        objectTag());
-        return dummy;
-    }
+    assert(hasError_);
 
     return errors_[index];
 }
@@ -264,9 +243,7 @@ const double &Data1D::error(int index) const
 // Return error Array
 std::vector<double> &Data1D::errors()
 {
-    if (!hasError_)
-        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
-                        objectTag());
+    assert(hasError_);
 
     ++version_;
 
@@ -275,9 +252,7 @@ std::vector<double> &Data1D::errors()
 
 const std::vector<double> &Data1D::errors() const
 {
-    if (!hasError_)
-        Messenger::warn("This Data1D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
-                        objectTag());
+    assert(hasError_);
 
     return errors_;
 }

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -13,10 +13,7 @@ template <class Data1D> int ObjectStore<Data1D>::objectCount_ = 0;
 template <class Data1D> int ObjectStore<Data1D>::objectType_ = ObjectInfo::Data1DObject;
 template <class Data1D> std::string_view ObjectStore<Data1D>::objectTypeName_ = "Data1D";
 
-Data1D::Data1D()
-    : PlottableData(PlottableData::OneAxisPlottable), ListItem<Data1D>(), ObjectStore<Data1D>(this), hasError_(false)
-{
-}
+Data1D::Data1D() : PlottableData(PlottableData::OneAxisPlottable), ObjectStore<Data1D>(this), hasError_(false) {}
 
 Data1D::Data1D(const Data1D &source) : PlottableData(PlottableData::OneAxisPlottable), ObjectStore<Data1D>(this)
 {

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -35,6 +35,12 @@ void Data1D::clear()
  * Data
  */
 
+// Set tag
+void Data1D::setTag(std::string_view tag) { tag_ = tag; }
+
+// Return tag
+std::string_view Data1D::tag() const { return tag_; }
+
 // Initialise arrays to specified size
 void Data1D::initialise(int size, bool withError)
 {
@@ -263,7 +269,7 @@ const std::vector<double> &Data1D::errors() const
 
 void Data1D::operator=(const Data1D &source)
 {
-    name_ = source.name_;
+    tag_ = source.tag_;
     x_ = source.x_;
     values_ = source.values_;
     hasError_ = source.hasError_;
@@ -380,7 +386,7 @@ bool Data1D::deserialise(LineParser &parser)
     // Read object name
     if (parser.readNextLine(LineParser::KeepBlanks) != LineParser::Success)
         return false;
-    name_ = parser.line();
+    tag_ = parser.line();
 
     // Read number of points and whether errors are present
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -409,7 +415,7 @@ bool Data1D::serialise(LineParser &parser) const
     // Write object tag and name
     if (!parser.writeLineF("{}\n", objectTag()))
         return false;
-    if (!parser.writeLineF("{}\n", name()))
+    if (!parser.writeLineF("{}\n", tag_))
         return false;
 
     // Write axis size and errors flag

--- a/src/math/data1d.cpp
+++ b/src/math/data1d.cpp
@@ -23,8 +23,6 @@ Data1D::Data1D() : PlottableData(PlottableData::OneAxisPlottable), ListItem<Data
     clear();
 }
 
-Data1D::~Data1D() {}
-
 Data1D::Data1D(const Data1D &source) : PlottableData(PlottableData::OneAxisPlottable), ObjectStore<Data1D>(this)
 {
     (*this) = source;

--- a/src/math/data1d.h
+++ b/src/math/data1d.h
@@ -8,7 +8,7 @@
 #include "templates/objectstore.h"
 
 // One-Dimensional Data
-class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore<Data1D>
+class Data1D : public PlottableData, public ObjectStore<Data1D>
 {
     public:
     Data1D();

--- a/src/math/data1d.h
+++ b/src/math/data1d.h
@@ -12,7 +12,7 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
 {
     public:
     Data1D();
-    virtual ~Data1D();
+    virtual ~Data1D() = default;
     Data1D(const Data1D &source);
     // Clear data
     void clear();

--- a/src/math/data1d.h
+++ b/src/math/data1d.h
@@ -21,6 +21,8 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
      * Data
      */
     private:
+    // Tag for data (optional)
+    std::string tag_;
     // X array
     std::vector<double> x_;
     // Values at each x
@@ -33,6 +35,10 @@ class Data1D : public PlottableData, public ListItem<Data1D>, public ObjectStore
     VersionCounter version_;
 
     public:
+    // Set tag
+    void setTag(std::string_view tag);
+    // Return tag
+    std::string_view tag() const;
     // Initialise arrays to specified size
     void initialise(int size, bool withError = false);
     // Initialise to be consistent in size and x axis with supplied object

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -39,6 +39,12 @@ void Data2D::clear()
  * Data
  */
 
+// Set tag
+void Data2D::setTag(std::string_view tag) { tag_ = tag; }
+
+// Return tag
+std::string_view Data2D::tag() const { return tag_; }
+
 // Initialise arrays to specified size
 void Data2D::initialise(int xSize, int ySize, bool withError)
 {
@@ -277,7 +283,7 @@ const Array2D<double> &Data2D::errors2D() const
 
 void Data2D::operator=(const Data2D &source)
 {
-    name_ = source.name_;
+    tag_ = source.tag_;
     x_ = source.x_;
     y_ = source.y_;
     values_ = source.values_;
@@ -336,7 +342,7 @@ bool Data2D::deserialise(LineParser &parser)
     // Read object name
     if (parser.readNextLine(LineParser::KeepBlanks) != LineParser::Success)
         return false;
-    name_ = parser.line();
+    tag_ = parser.line();
 
     // Read axis sizes and initialise arrays
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -398,7 +404,7 @@ bool Data2D::serialise(LineParser &parser) const
     // Write object tag and name
     if (!parser.writeLineF("{}\n", objectTag()))
         return false;
-    if (!parser.writeLineF("{}\n", name()))
+    if (!parser.writeLineF("{}\n", tag_))
         return false;
 
     // Write axis sizes and errors flag

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -240,13 +240,7 @@ bool Data2D::valuesHaveErrors() const { return hasError_; }
 // Return error value specified
 double &Data2D::error(int xIndex, int yIndex)
 {
-    if (!hasError_)
-    {
-        static double dummy = 0.0;
-        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
-                        objectTag());
-        return dummy;
-    }
+    assert(hasError_);
 
     ++version_;
 
@@ -255,13 +249,7 @@ double &Data2D::error(int xIndex, int yIndex)
 
 const double &Data2D::error(int xIndex, int yIndex) const
 {
-    if (!hasError_)
-    {
-        static double dummy = 0.0;
-        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but error(int,int) was requested.\n",
-                        name(), objectTag());
-        return dummy;
-    }
+    assert(hasError_);
 
     return errors_[{xIndex, yIndex}];
 }
@@ -269,9 +257,7 @@ const double &Data2D::error(int xIndex, int yIndex) const
 // Return two-dimensional errors Array
 Array2D<double> &Data2D::errors2D()
 {
-    if (!hasError_)
-        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
-                        objectTag());
+    assert(hasError_);
 
     ++version_;
 
@@ -280,9 +266,7 @@ Array2D<double> &Data2D::errors2D()
 
 const Array2D<double> &Data2D::errors2D() const
 {
-    if (!hasError_)
-        Messenger::warn("This Data2D (name='{}', tag='{}') has no errors to return, but errors2D() was requested.\n", name(),
-                        objectTag());
+    assert(hasError_);
 
     return errors_;
 }

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -14,10 +14,7 @@ template <class Data2D> int ObjectStore<Data2D>::objectCount_ = 0;
 template <class Data2D> int ObjectStore<Data2D>::objectType_ = ObjectInfo::Data2DObject;
 template <class Data2D> std::string_view ObjectStore<Data2D>::objectTypeName_ = "Data2D";
 
-Data2D::Data2D()
-    : PlottableData(PlottableData::TwoAxisPlottable), ListItem<Data2D>(), ObjectStore<Data2D>(this), hasError_(false)
-{
-}
+Data2D::Data2D() : PlottableData(PlottableData::TwoAxisPlottable), ObjectStore<Data2D>(this), hasError_(false) {}
 
 Data2D::Data2D(const Data2D &source) : PlottableData(PlottableData::TwoAxisPlottable), ObjectStore<Data2D>(this)
 {

--- a/src/math/data2d.cpp
+++ b/src/math/data2d.cpp
@@ -14,14 +14,10 @@ template <class Data2D> int ObjectStore<Data2D>::objectCount_ = 0;
 template <class Data2D> int ObjectStore<Data2D>::objectType_ = ObjectInfo::Data2DObject;
 template <class Data2D> std::string_view ObjectStore<Data2D>::objectTypeName_ = "Data2D";
 
-Data2D::Data2D() : PlottableData(PlottableData::TwoAxisPlottable), ListItem<Data2D>(), ObjectStore<Data2D>(this)
+Data2D::Data2D()
+    : PlottableData(PlottableData::TwoAxisPlottable), ListItem<Data2D>(), ObjectStore<Data2D>(this), hasError_(false)
 {
-    hasError_ = false;
-
-    clear();
 }
-
-Data2D::~Data2D() {}
 
 Data2D::Data2D(const Data2D &source) : PlottableData(PlottableData::TwoAxisPlottable), ObjectStore<Data2D>(this)
 {

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -26,6 +26,8 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
      * Data
      */
     private:
+    // Tag for data (optional)
+    std::string tag_;
     // X axis array
     std::vector<double> x_;
     // Y axis array
@@ -40,6 +42,10 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
     VersionCounter version_;
 
     public:
+    // Set tag
+    void setTag(std::string_view tag);
+    // Return tag
+    std::string_view tag() const;
     // Initialise arrays to specified size
     void initialise(int xSize, int ySize, bool withError = false);
     // Initialise to be consistent in size and axes with supplied object

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -13,7 +13,7 @@
 class Histogram2D;
 
 // One-Dimensional Data
-class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore<Data2D>
+class Data2D : public PlottableData, public ObjectStore<Data2D>
 {
     public:
     Data2D();

--- a/src/math/data2d.h
+++ b/src/math/data2d.h
@@ -17,7 +17,7 @@ class Data2D : public PlottableData, public ListItem<Data2D>, public ObjectStore
 {
     public:
     Data2D();
-    virtual ~Data2D();
+    virtual ~Data2D() = default;
     Data2D(const Data2D &source);
     // Clear data
     void clear();

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -12,14 +12,10 @@ template <class Data3D> int ObjectStore<Data3D>::objectCount_ = 0;
 template <class Data3D> int ObjectStore<Data3D>::objectType_ = ObjectInfo::Data3DObject;
 template <class Data3D> std::string_view ObjectStore<Data3D>::objectTypeName_ = "Data3D";
 
-Data3D::Data3D() : PlottableData(PlottableData::TwoAxisPlottable), ListItem<Data3D>(), ObjectStore<Data3D>(this)
+Data3D::Data3D()
+    : PlottableData(PlottableData::TwoAxisPlottable), ListItem<Data3D>(), ObjectStore<Data3D>(this), hasError_(false)
 {
-    hasError_ = false;
-
-    clear();
 }
-
-Data3D::~Data3D() {}
 
 Data3D::Data3D(const Data3D &source) : PlottableData(PlottableData::TwoAxisPlottable), ObjectStore<Data3D>(this)
 {

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -12,10 +12,7 @@ template <class Data3D> int ObjectStore<Data3D>::objectCount_ = 0;
 template <class Data3D> int ObjectStore<Data3D>::objectType_ = ObjectInfo::Data3DObject;
 template <class Data3D> std::string_view ObjectStore<Data3D>::objectTypeName_ = "Data3D";
 
-Data3D::Data3D()
-    : PlottableData(PlottableData::TwoAxisPlottable), ListItem<Data3D>(), ObjectStore<Data3D>(this), hasError_(false)
-{
-}
+Data3D::Data3D() : PlottableData(PlottableData::TwoAxisPlottable), ObjectStore<Data3D>(this), hasError_(false) {}
 
 Data3D::Data3D(const Data3D &source) : PlottableData(PlottableData::TwoAxisPlottable), ObjectStore<Data3D>(this)
 {

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -219,13 +219,7 @@ bool Data3D::valuesHaveErrors() const { return hasError_; }
 // Return error value specified
 double &Data3D::error(int xIndex, int yIndex, int zIndex)
 {
-    if (!hasError_)
-    {
-        static double dummy;
-        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but error(int) was requested.\n", name(),
-                        objectTag());
-        return dummy;
-    }
+    assert(hasError_);
 
     ++version_;
 
@@ -234,13 +228,7 @@ double &Data3D::error(int xIndex, int yIndex, int zIndex)
 
 const double &Data3D::error(int xIndex, int yIndex, int zIndex) const
 {
-    if (!hasError_)
-    {
-        static double dummy;
-        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but error(int,int) was requested.\n",
-                        name(), objectTag());
-        return dummy;
-    }
+    assert(hasError_);
 
     return errors_[{xIndex, yIndex, zIndex}];
 }
@@ -248,9 +236,7 @@ const double &Data3D::error(int xIndex, int yIndex, int zIndex) const
 // Return three-dimensional errors Array
 Array3D<double> &Data3D::errors3D()
 {
-    if (!hasError_)
-        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
-                        objectTag());
+    assert(hasError_);
 
     ++version_;
 
@@ -259,9 +245,7 @@ Array3D<double> &Data3D::errors3D()
 
 const Array3D<double> &Data3D::errors3D() const
 {
-    if (!hasError_)
-        Messenger::warn("This Data3D (name='{}', tag='{}') has no errors to return, but errors() was requested.\n", name(),
-                        objectTag());
+    assert(hasError_);
 
     return errors_;
 }

--- a/src/math/data3d.cpp
+++ b/src/math/data3d.cpp
@@ -38,6 +38,12 @@ void Data3D::clear()
  * Data
  */
 
+// Set tag
+void Data3D::setTag(std::string_view tag) { tag_ = tag; }
+
+// Return tag
+std::string_view Data3D::tag() const { return tag_; }
+
 // Initialise arrays to specified size
 void Data3D::initialise(int xSize, int ySize, int zSize, bool withError)
 {
@@ -256,7 +262,7 @@ const Array3D<double> &Data3D::errors3D() const
 
 void Data3D::operator=(const Data3D &source)
 {
-    name_ = source.name_;
+    tag_ = source.tag_;
     x_ = source.x_;
     y_ = source.y_;
     z_ = source.z_;
@@ -318,7 +324,7 @@ bool Data3D::deserialise(LineParser &parser)
     // Read object name
     if (parser.readNextLine(LineParser::KeepBlanks) != LineParser::Success)
         return false;
-    name_ = parser.line();
+    tag_ = parser.line();
 
     // Read axis sizes and initialise arrays
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -389,7 +395,7 @@ bool Data3D::serialise(LineParser &parser) const
     // Write object tag and name
     if (!parser.writeLineF("{}\n", objectTag()))
         return false;
-    if (!parser.writeLineF("{}\n", name()))
+    if (!parser.writeLineF("{}\n", tag_))
         return false;
 
     // Write axis sizes and errors flag

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -25,6 +25,8 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
      * Data
      */
     private:
+    // Tag for data (optional)
+    std::string tag_;
     // X axis array
     std::vector<double> x_;
     // Y axis array
@@ -41,6 +43,10 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
     VersionCounter version_;
 
     public:
+    // Set tag
+    void setTag(std::string_view tag);
+    // Return tag
+    std::string_view tag() const;
     // Initialise arrays to specified size
     void initialise(int xSize, int ySize, int zSize, bool withError = false);
     // Initialise to be consistent in size and axes with supplied object

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -16,7 +16,7 @@ class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore
 {
     public:
     Data3D();
-    virtual ~Data3D();
+    virtual ~Data3D() = default;
     Data3D(const Data3D &source);
     // Clear data
     void clear();

--- a/src/math/data3d.h
+++ b/src/math/data3d.h
@@ -12,7 +12,7 @@
 class Histogram3D;
 
 // One-Dimensional Data
-class Data3D : public PlottableData, public ListItem<Data3D>, public ObjectStore<Data3D>
+class Data3D : public PlottableData, public ObjectStore<Data3D>
 {
     public:
     Data3D();

--- a/src/math/pairbroadeningfunction.cpp
+++ b/src/math/pairbroadeningfunction.cpp
@@ -110,7 +110,7 @@ bool PairBroadeningFunction::readAsKeyword(LineParser &parser, int startArg, con
 }
 
 // Write function data to LineParser source
-bool PairBroadeningFunction::writeAsKeyword(LineParser &parser, std::string_view prefix, bool writeBlockMarker)
+bool PairBroadeningFunction::writeAsKeyword(LineParser &parser, std::string_view prefix, bool writeBlockMarker) const
 {
     // If the functional form requires a block rather than a single line, write an '&' and start a new line
     if (writeBlockMarker && (function_ == PairBroadeningFunction::GaussianElementPairFunction))

--- a/src/math/pairbroadeningfunction.h
+++ b/src/math/pairbroadeningfunction.h
@@ -56,7 +56,7 @@ class PairBroadeningFunction
     // Read function data from LineParser source
     bool readAsKeyword(LineParser &parser, int startArg, const CoreData &coreData);
     // Write function data to LineParser source
-    bool writeAsKeyword(LineParser &parser, std::string_view prefix, bool writeBlockMarker = true);
+    bool writeAsKeyword(LineParser &parser, std::string_view prefix, bool writeBlockMarker = true) const;
     // Set function type
     void setFunction(FunctionType function);
     // Return function type

--- a/src/math/plottable.cpp
+++ b/src/math/plottable.cpp
@@ -8,16 +8,6 @@
 PlottableData::PlottableData(PlottableData::PlottableDataType type) { type_ = type; }
 
 /*
- * Basic Information
- */
-
-// Set name of plottable
-void PlottableData::setName(std::string_view name) { name_ = name; }
-
-// Return name of plottable
-std::string_view PlottableData::name() const { return name_; }
-
-/*
  * Axis Information
  */
 

--- a/src/math/plottable.h
+++ b/src/math/plottable.h
@@ -19,7 +19,7 @@ class PlottableData
     {
         OneAxisPlottable,  /* Contains data points plotted against one axis (x) */
         TwoAxisPlottable,  /* Contains data points plotted against two axes (x and y) */
-        ThreeAxisPlottable /* Contains data points plotted againas three axes (x, y, and z) */
+        ThreeAxisPlottable /* Contains data points plotted against three axes (x, y, and z) */
     };
     PlottableData(PlottableDataType type);
 
@@ -29,16 +29,6 @@ class PlottableData
     private:
     // Type of plottable
     PlottableDataType type_;
-
-    protected:
-    // Name of plottable
-    std::string name_;
-
-    public:
-    // Set name of plottable
-    void setName(std::string_view name);
-    // Return name of plottable
-    std::string_view name() const;
 
     /*
      * Axis Information

--- a/src/modules/datatest/process.cpp
+++ b/src/modules/datatest/process.cpp
@@ -29,43 +29,43 @@ bool DataTestModule::process(Dissolve &dissolve, ProcessPool &procPool)
     Messenger::print("\n");
 
     // Loop over reference one-dimensional data supplied
-    ListIterator<Data1D> data1DIterator(test1DData_.data());
-    while (Data1D *testData1D = data1DIterator.iterate())
+    for (auto &[referenceData, format] : test1DData_.data())
     {
         // Locate the target reference data
-        const auto optData = findReferenceData<const Data1D>(testData1D->name(), targetModule, dissolve.processingModuleData());
+        const auto optData =
+            findReferenceData<const Data1D>(referenceData.tag(), targetModule, dissolve.processingModuleData());
         if (!optData)
         {
             if (targetModule)
                 return Messenger::error("No data named '{}_{}' or '{}', or tagged '{}', exists.\n", targetModule->uniqueName(),
-                                        testData1D->name(), testData1D->name(), testData1D->name());
+                                        referenceData.tag(), referenceData.tag(), referenceData.tag());
             else
-                return Messenger::error("No data with name '{}' exists.\n", testData1D->name());
+                return Messenger::error("No data with name '{}' exists.\n", referenceData.tag());
         }
         const Data1D &data = *optData;
         Messenger::print("Located reference data with name '{}'.\n", data.objectTag());
 
         // Generate the error estimate and compare against the threshold value
-        double error = Error::error(errorType, data, *testData1D, true);
-        Messenger::print("Target data '{}' has error of {:7.3e} with calculated data and is {} (threshold is {:6.3e})\n\n",
-                         testData1D->name(), error, isnan(error) || error > testThreshold ? "NOT OK" : "OK", testThreshold);
+        double error = Error::error(errorType, data, referenceData, true);
+        Messenger::print("Target data '{}' has error of {:7.3e} with reference data and is {} (threshold is {:6.3e})\n\n",
+                         referenceData.tag(), error, isnan(error) || error > testThreshold ? "NOT OK" : "OK", testThreshold);
         if (isnan(error) || error > testThreshold)
             return false;
     }
 
     // Loop over reference two-dimensional data supplied
-    ListIterator<Data2D> data2DIterator(test2DData_.data());
-    while (Data2D *testData2D = data2DIterator.iterate())
+    for (auto &[referenceData, format] : test2DData_.data())
     {
         // Locate the target reference data
-        const auto optData = findReferenceData<const Data2D>(testData2D->name(), targetModule, dissolve.processingModuleData());
+        const auto optData =
+            findReferenceData<const Data2D>(referenceData.tag(), targetModule, dissolve.processingModuleData());
         if (!optData)
         {
             if (targetModule)
                 return Messenger::error("No data named '{}_{}' or '{}', or tagged '{}', exists.\n", targetModule->uniqueName(),
-                                        testData2D->name(), testData2D->name(), testData2D->name());
+                                        referenceData.tag(), referenceData.tag(), referenceData.tag());
             else
-                return Messenger::error("No data with tag '{}' exists.\n", testData2D->name());
+                return Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
         }
         const Data2D &data = *optData;
         Messenger::print("Located reference data with name '{}'.\n", data.objectTag());

--- a/src/modules/epsr/gui/modulewidget.h
+++ b/src/modules/epsr/gui/modulewidget.h
@@ -55,7 +55,7 @@ class EPSRModuleWidget : public ModuleWidget
      */
     private:
     // Temporary data currently shown on debug tab
-    List<Data1D> debugFunctionData_;
+    std::list<Data1D> debugFunctionData_;
 
     private:
     // Update data shown on EP functions viewer

--- a/src/modules/epsr/gui/modulewidget_funcs.cpp
+++ b/src/modules/epsr/gui/modulewidget_funcs.cpp
@@ -363,9 +363,9 @@ void EPSRModuleWidget::updateDebugEPFunctionsGraph(int from, int to)
         // Generate data for function range specified
         for (auto n = from; n <= to; ++n)
         {
-            auto *data = debugFunctionData_.add();
-            (*data) = module_->generateEmpiricalPotentialFunction(dissolve_, i, j, n);
-            data->setObjectTag(fmt::format("PairPotential//{}//Function//{}", id, n));
+            auto &data = debugFunctionData_.emplace_back();
+            data = module_->generateEmpiricalPotentialFunction(dissolve_, i, j, n);
+            data.setObjectTag(fmt::format("PairPotential//{}//Function//{}", id, n));
             auto rend = viewer->createRenderable<RenderableData1D>(fmt::format("PairPotential//{}//Function//{}", id, n),
                                                                    fmt::format("{}/{}", id, n), id);
             rend->setColour(StockColours::RedStockColour);

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -171,7 +171,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     auto [weightedSQ, wSQstatus] =
         dissolve.processingModuleData().realiseIf<PartialSet>("WeightedSQ", uniqueName_, GenericItem::InRestartFileFlag);
     if (wSQstatus == GenericItem::ItemStatus::Created)
-        weightedSQ.setUpPartials(unweightedSQ.atomTypes(), uniqueName(), "weighted", "sq", "Q, 1/Angstroms");
+        weightedSQ.setUpPartials(unweightedSQ.atomTypes(), uniqueName_, "weighted", "sq", "Q, 1/Angstroms");
 
     // Calculate weighted S(Q)
     calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normalisation);
@@ -180,7 +180,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     weightedSQ.setObjectTags(fmt::format("{}//{}", uniqueName_, "WeightedSQ"));
 
     // Save data if requested
-    if (saveSQ && (!MPIRunMaster(procPool, weightedSQ.save())))
+    if (saveSQ && (!MPIRunMaster(procPool, weightedSQ.save(uniqueName_, "weighted", "sq"))))
         return false;
 
     /*
@@ -205,7 +205,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     weightedGR.setObjectTags(fmt::format("{}//{}", uniqueName_, "WeightedGR"));
 
     // Save data if requested
-    if (saveGR && (!MPIRunMaster(procPool, weightedGR.save())))
+    if (saveGR && (!MPIRunMaster(procPool, weightedGR.save(uniqueName_, "weighted", "gr"))))
         return false;
 
     // Calculate representative total g(r) from FT of calculated S(Q)

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -71,14 +71,14 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
                              WindowFunction::forms().keyword(wf));
 
         // Store the reference data in processing
-        referenceData.setName(uniqueName());
+        referenceData.setTag(uniqueName());
         auto &storedData =
             dissolve.processingModuleData().realise<Data1D>("ReferenceData", uniqueName(), GenericItem::ProtectedFlag);
         storedData.setObjectTag(fmt::format("{}//ReferenceData", uniqueName()));
         storedData = referenceData;
 
         // Calculate and store the FT of the reference data in processing
-        referenceData.setName(uniqueName());
+        referenceData.setTag(uniqueName());
         auto &storedDataFT =
             dissolve.processingModuleData().realise<Data1D>("ReferenceDataFT", uniqueName(), GenericItem::ProtectedFlag);
         storedDataFT.setObjectTag(fmt::format("{}//ReferenceDataFT", uniqueName()));

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -704,8 +704,8 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
         if (!DissolveSys::sameString(prefix, parser.argsv(0)))
             return Messenger::error("Unrecognised test data name '{}'.\n", data.tag());
 
-        if (!testReferencePartial(partials, testThreshold, data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : nullptr,
-                                  parser.hasArg(3) ? parser.argsv(3) : nullptr))
+        if (!testReferencePartial(partials, testThreshold, data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : "",
+                                  parser.hasArg(3) ? parser.argsv(3) : ""))
             return false;
     }
 
@@ -740,8 +740,8 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
             return Messenger::error("Unrecognised test data name '{}'.\n", data.tag());
         const PartialSet &targetSet = (setA ? partialsA : partialsB);
 
-        if (!testReferencePartial(targetSet, testThreshold, data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : nullptr,
-                                  parser.hasArg(3) ? parser.argsv(3) : nullptr))
+        if (!testReferencePartial(targetSet, testThreshold, data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : "",
+                                  parser.hasArg(3) ? parser.argsv(3) : ""))
             return false;
     }
 

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -652,7 +652,7 @@ bool RDFModule::testReferencePartial(const PartialSet &partials, double testThre
         testResult = (error <= testThreshold);
         Messenger::print("Test reference data '{}' has error of {:7.3f}% with calculated data and is {} (threshold is "
                          "{:6.3f}%)\n\n",
-                         testData.name(), error, testResult ? "OK" : "NOT OK", testThreshold);
+                         testData.tag(), error, testResult ? "OK" : "NOT OK", testThreshold);
     }
     else
     {
@@ -660,7 +660,7 @@ bool RDFModule::testReferencePartial(const PartialSet &partials, double testThre
         auto indexI = partials.atomTypes().indexOf(typeIorTotal);
         auto indexJ = partials.atomTypes().indexOf(typeJ);
         if ((indexI == -1) || (indexJ == -1))
-            return Messenger::error("Unrecognised test data name '{}'.\n", testData.name());
+            return Messenger::error("Unrecognised test data name '{}'.\n", testData.tag());
 
         // AtomTypes are valid, so check the 'target'
         double error = -1.0;
@@ -671,12 +671,12 @@ bool RDFModule::testReferencePartial(const PartialSet &partials, double testThre
         else if (DissolveSys::sameString(target, "full"))
             error = Error::percent(partials.partial(indexI, indexJ), testData);
         else
-            return Messenger::error("Unrecognised test data name '{}'.\n", testData.name());
+            return Messenger::error("Unrecognised test data name '{}'.\n", testData.tag());
 
         testResult = (error <= testThreshold);
         Messenger::print("Test reference data '{}' has error of {:7.3f}% with calculated data and is {} (threshold is "
                          "{:6.3f}%)\n\n",
-                         testData.name(), error, testResult ? "OK" : "NOT OK", testThreshold);
+                         testData.tag(), error, testResult ? "OK" : "NOT OK", testThreshold);
     }
 
     return testResult;
@@ -689,11 +689,10 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     LineParser parser;
 
     // Loop over supplied test data and see if we can locate it amongst our PartialSets
-    ListIterator<Data1D> dataIterator(testData.data());
-    while (Data1D *data = dataIterator.iterate())
+    for (auto &[data, format] : testData.data())
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
-        std::string dataName{data->name()};
+        std::string dataName{data.tag()};
         std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
@@ -703,9 +702,9 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
 
         // Check first argument to check it has the corect prefix
         if (!DissolveSys::sameString(prefix, parser.argsv(0)))
-            return Messenger::error("Unrecognised test data name '{}'.\n", data->name());
+            return Messenger::error("Unrecognised test data name '{}'.\n", data.tag());
 
-        if (!testReferencePartial(partials, testThreshold, *data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : nullptr,
+        if (!testReferencePartial(partials, testThreshold, data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : nullptr,
                                   parser.hasArg(3) ? parser.argsv(3) : nullptr))
             return false;
     }
@@ -720,11 +719,10 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
     LineParser parser;
 
     // Loop over supplied test data and see if we can locate it amongst our PartialSets
-    ListIterator<Data1D> dataIterator(testData.data());
-    while (Data1D *data = dataIterator.iterate())
+    for (auto &[data, format] : testData.data())
     {
         // Grab the name, replace hyphens with '-', and parse the string into arguments
-        std::string dataName{data->name()};
+        std::string dataName{data.tag()};
         std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
@@ -739,11 +737,11 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
         else if (DissolveSys::sameString(prefixB, parser.argsv(0)))
             setA = false;
         else
-            return Messenger::error("Unrecognised test data name '{}'.\n", data->name());
+            return Messenger::error("Unrecognised test data name '{}'.\n", data.tag());
         const PartialSet &targetSet = (setA ? partialsA : partialsB);
 
-        if (!testReferencePartial(targetSet, testThreshold, *data, parser.argsv(1),
-                                  parser.hasArg(2) ? parser.argsv(2) : nullptr, parser.hasArg(3) ? parser.argsv(3) : nullptr))
+        if (!testReferencePartial(targetSet, testThreshold, data, parser.argsv(1), parser.hasArg(2) ? parser.argsv(2) : nullptr,
+                                  parser.hasArg(3) ? parser.argsv(3) : nullptr))
             return false;
     }
 

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -136,10 +136,9 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
         // Set names of resources and filename in Data1D within the PartialSet
         unweightedgr.setObjectTags(fmt::format("{}//{}//UnweightedGR", cfg->niceName(), uniqueName_));
-        unweightedgr.setFileNames(cfg->niceName(), "unweighted", "rdf");
 
         // Save data if requested
-        if (saveData && (!MPIRunMaster(procPool, unweightedgr.save())))
+        if (saveData && (!MPIRunMaster(procPool, unweightedgr.save(cfg->niceName(), "unweighted", "rdf"))))
             return false;
     }
 

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -224,7 +224,7 @@ bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                             dissolve.processingModuleData().version("UnweightedGR", rdfModule->uniqueName()),
                                             includeBragg ? dissolve.processingModuleData().version("BraggReflections") : -1));
     // Save data if requested
-    if (saveData && !MPIRunMaster(procPool, unweightedsq.save()))
+    if (saveData && !MPIRunMaster(procPool, unweightedsq.save(uniqueName_, "unweighted", "sq")))
         return false;
 
     return true;

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -173,7 +173,7 @@ bool XRaySQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     auto [weightedSQ, wSQtatus] =
         dissolve.processingModuleData().realiseIf<PartialSet>("WeightedSQ", uniqueName_, GenericItem::InRestartFileFlag);
     if (wSQtatus == GenericItem::ItemStatus::Created)
-        weightedSQ.setUpPartials(unweightedSQ.atomTypes(), uniqueName(), "weighted", "sq", "Q, 1/Angstroms");
+        weightedSQ.setUpPartials(unweightedSQ.atomTypes(), uniqueName_, "weighted", "sq", "Q, 1/Angstroms");
 
     // Calculate weighted S(Q)
     calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normalisation);
@@ -182,7 +182,7 @@ bool XRaySQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     weightedSQ.setObjectTags(fmt::format("{}//{}", uniqueName_, "WeightedSQ"));
 
     // Save data if requested
-    if (saveSQ && (!MPIRunMaster(procPool, weightedSQ.save())))
+    if (saveSQ && (!MPIRunMaster(procPool, weightedSQ.save(uniqueName_, "weighted", "sq"))))
         return false;
     if (saveFormFactors)
     {
@@ -254,7 +254,7 @@ bool XRaySQModule::process(Dissolve &dissolve, ProcessPool &procPool)
     repGR.setObjectTag(fmt::format("{}//RepresentativeTotalGR", uniqueName_));
 
     // Save data if requested
-    if (saveSQ && (!MPIRunMaster(procPool, weightedSQ.save())))
+    if (saveSQ && (!MPIRunMaster(procPool, weightedSQ.save(uniqueName_, "weighted", "sq"))))
         return false;
 
     return true;

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -74,14 +74,14 @@ bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
                              WindowFunction::forms().keyword(wf));
 
         // Store the reference data in processing
-        referenceData.setName(uniqueName());
+        referenceData.setTag(uniqueName());
         Data1D &storedData =
             dissolve.processingModuleData().realise<Data1D>("ReferenceData", uniqueName(), GenericItem::ProtectedFlag);
         storedData.setObjectTag(fmt::format("{}//ReferenceData", uniqueName()));
         storedData = referenceData;
 
         // Calculate and store the FT of the reference data in processing
-        referenceData.setName(uniqueName());
+        referenceData.setTag(uniqueName());
         Data1D &storedDataFT =
             dissolve.processingModuleData().realise<Data1D>("ReferenceDataFT", uniqueName(), GenericItem::ProtectedFlag);
         storedDataFT.setObjectTag(fmt::format("{}//ReferenceDataFT", uniqueName()));

--- a/src/procedure/nodes/fit1d.cpp
+++ b/src/procedure/nodes/fit1d.cpp
@@ -178,7 +178,7 @@ bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std
     auto &data =
         targetList.realise<Data1D>(fmt::format("{}_{}", name(), cfg->niceName()), prefix, GenericItem::InRestartFileFlag);
 
-    data.setName(name());
+    data.setTag(name());
     data.setObjectTag(fmt::format("{}//Fit1D//{}//{}", prefix, cfg->name(), name()));
     data.clear();
 

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -116,7 +116,7 @@ ProcedureNode::NodeExecutionResult Process1DProcedureNode::execute(ProcessPool &
         targetList.realise<Data1D>(fmt::format("{}_{}", name(), cfg->niceName()), prefix, GenericItem::InRestartFileFlag);
     processedData_ = &data;
 
-    data.setName(name());
+    data.setTag(name());
     data.setObjectTag(fmt::format("{}//Process1D//{}//{}", prefix, cfg->name(), name()));
 
     // Copy the averaged data from the associated Process1D node

--- a/src/procedure/nodes/process2d.cpp
+++ b/src/procedure/nodes/process2d.cpp
@@ -116,7 +116,7 @@ ProcedureNode::NodeExecutionResult Process2DProcedureNode::execute(ProcessPool &
         targetList.realise<Data2D>(fmt::format("{}_{}", name(), cfg->niceName()), prefix, GenericItem::InRestartFileFlag);
     processedData_ = &data;
 
-    data.setName(name());
+    data.setTag(name());
     data.setObjectTag(fmt::format("{}//Process2D//{}//{}", prefix, cfg->name(), name()));
 
     // Copy the averaged data from the associated Process1D node

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -118,7 +118,7 @@ ProcedureNode::NodeExecutionResult Process3DProcedureNode::execute(ProcessPool &
         targetList.realise<Data3D>(fmt::format("{}_{}", name(), cfg->niceName()), prefix, GenericItem::InRestartFileFlag);
     processedData_ = &data;
 
-    data.setName(name());
+    data.setTag(name());
     data.setObjectTag(fmt::format("{}//Process3D//{}//{}", prefix, cfg->name(), name()));
 
     // Copy the averaged data from the associated Process3D node


### PR DESCRIPTION
This PR tidies up the "naming" of the `DataND` classes ahead of their removal from `ObjectStore`.

### Background

There are currently multiple ways to name or tag a `DataND` object:

1. Through a base-class member `name_`, inherited from `PlottableData`
2. Through the `tag_` member of `ObjectInfo`, accessed via an `ObjectStore`
3. Through the association of a name within a `GenericList`
4. Through a display name given when creating a `Renderable` based off of the `DataND`

Obviously, this is horribly confusing. 3) and 4) separates the name from the underlying `DataND` object and should remain as-is, while 2) will be removed once #586 is merged. This leaves 1), which is used inconsistently and variously as:

a. Storing the names of reference data (akin to a matching object `tag_`) within a `DataNDStore`.
b. Storing filenames used when exporting data.
c. To identify the object with a searchable tag

This PR makes the following changes:
- Removes the inherited `name_` member from `PlottableData`
- Adds a `tag_` member to each of the `DataND` to allow tagging with relevant data (e.g. `ObjectInfo`-like names)
- Generate filenames dynamically rather than relying on the stored names
- Reworks the `DataNDStore` classes accordingly, using an `std::list` rather than an `std::vector` to sidestep the need for immediate modernisation of other classes (namely those related to keyword storage).

Related to other modernisation projects, it removes inheritance from `ListItem` from the `DataND` classesi (part of #257), as well as uses of `List` and `RefDataList` from `DataNDStore`.

### Related PR Hierarchy

Listed in order of review / merge ordering (rebasing required at each stage):

- ~#575 Remove state I/O for tabs, views, and charts~
- ~#576 Move `Renderable` and `RenderableGroup` to `std:vector`~
- #581 Use template-guided renderable creation
- ~#582 No local configuration data~
- ~#586 New GenericList~
- `THIS` Data Name Tidying
- #606 Remove ObjectStore 2