### PR TITLE
Bugfix 19-03-21 Missing Renderables

### DIFF
--- a/src/gui/siteviewer_funcs.cpp
+++ b/src/gui/siteviewer_funcs.cpp
@@ -50,6 +50,7 @@ void SiteViewer::setSpecies(Species *sp)
         speciesRenderable_ = std::make_shared<RenderableSpecies>(species_);
         speciesRenderable_->setName("Species");
         speciesRenderable_->setDisplayStyle(RenderableSpecies::LinesStyle);
+        addRenderable(speciesRenderable_);
 
         view_.showAllData();
     }
@@ -74,6 +75,7 @@ void SiteViewer::setSite(SpeciesSite *site)
     {
         siteRenderable_ = std::make_shared<RenderableSpeciesSite>(species_, site_);
         siteRenderable_->setName("Site");
+        addRenderable(siteRenderable_);
     }
 }
 

--- a/src/gui/speciesviewer_funcs.cpp
+++ b/src/gui/speciesviewer_funcs.cpp
@@ -47,6 +47,7 @@ void SpeciesViewer::setSpecies(Species *sp)
     if (species_)
     {
         speciesRenderable_ = std::make_shared<RenderableSpecies>(species_);
+        addRenderable(speciesRenderable_);
 
         view_.showAllData();
     }


### PR DESCRIPTION
A three-line bugfix PR to address issues with the display of species and sites.  Closes #601.