### PR TITLE
Bugfix 22/03/21 Species Atoms/Bond Handling

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -71,6 +71,8 @@ class Species
     void removeAtom(SpeciesAtom *i);
     // Return the number of atoms in the species
     int nAtoms() const;
+    // Renumber atoms so they are sequential in the list
+    void renumberAtoms();
     // Return the first atom in the Species
     const SpeciesAtom &firstAtom() const;
     // Return the nth atom in the Species

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -38,6 +38,14 @@ void Species::removeAtom(SpeciesAtom *i)
 // Return the number of Atoms in the Species
 int Species::nAtoms() const { return atoms_.size(); }
 
+// Renumber atoms so they are sequential in the list
+void Species::renumberAtoms()
+{
+    auto count = 0;
+    for (auto &i : atoms_)
+        i.setIndex(count++);
+}
+
 // Return the first Atom in the Species
 const SpeciesAtom &Species::firstAtom() const { return atoms_.front(); }
 

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -44,12 +44,14 @@ const SpeciesAtom &Species::firstAtom() const { return atoms_.front(); }
 // Return the nth Atom in the Species
 SpeciesAtom &Species::atom(int n)
 {
+    assert(n >= 0 && n < atoms_.size());
     auto it = std::next(atoms_.begin(), n);
     return *it;
 }
 
 const SpeciesAtom &Species::atom(int n) const
 {
+    assert(n >= 0 && n < atoms_.size());
     const auto it = std::next(atoms_.begin(), n);
     return *it;
 }

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -24,13 +24,30 @@ void Species::removeAtom(SpeciesAtom *i)
      * species definitions upon which the simulation has no dependencies.
      */
 
-    // Remove any bond terms that involve 'i'
-    while (i->nBonds())
-        removeBond(i, i->bond(0).partner(i));
+    // Clear higher-order terms
+    angles_.clear();
+    torsions_.clear();
+    impropers_.clear();
+
+    // Detach & remove any bond terms that involve 'i'
+    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [i](auto &bond) {
+        if (bond.i() == i || bond.j() == i)
+        {
+            bond.detach();
+            return true;
+        }
+        else
+            return false;
+    });
+    if (it != bonds_.end())
+        bonds_.erase(it, bonds_.end());
 
     // Now remove the atom
-    atoms_.erase(std::remove_if(atoms_.begin(), atoms_.end(), [&](const auto &p) { return i == &p; }), atoms_.end());
+    auto atomIt = std::find_if(atoms_.begin(), atoms_.end(), [&](const auto &p) { return i == &p; });
+    atoms_.erase(atomIt);
     selectedAtoms_.remove(i);
+
+    renumberAtoms();
 
     ++version_;
 }

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -115,77 +115,23 @@ SpeciesBond &Species::addBond(int i, int j) { return addBond(&atom(i), &atom(j))
 // Remove bond between specified SpeciesAtoms
 void Species::removeBond(SpeciesAtom *j, SpeciesAtom *k)
 {
+    // Find the bond
+    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [j, k](const auto &bond) { return bond.matches(j, k); });
+    if (it == bonds_.end())
+        return;
+
+    // Clear higher-order terms
     angles_.clear();
     torsions_.clear();
     impropers_.clear();
-    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [j, k](const auto &bond) { return bond.matches(j, k); });
-    if (it != bonds_.end())
-        ++version_;
-    std::for_each(it, bonds_.end(), [&, j, k](auto &jk) {
-        // Remove any higher-order terms that contain this bond
 
-        // Loop over bonds 'ij'
-        for (SpeciesBond &ij : j->bonds())
-        {
-            // Avoid 'ij' == 'jk'
-            if (&ij == &jk)
-                continue;
+    // Detach the bond from its atoms
+    it->detach();
 
-            // Get atom 'i'
-            auto *i = ij.partner(j);
-
-            // Remove angle term 'ijk' if it exists
-            auto ijkIt =
-                std::remove_if(angles_.begin(), angles_.end(), [&, i, j, k](auto &angle) { return angle.matches(i, j, k); });
-            if (ijkIt != angles_.end())
-                angles_.erase(ijkIt);
-
-            // Loop over bonds 'kl'
-            for (SpeciesBond &kl : k->bonds())
-            {
-                // Avoid 'kl' == 'jk'
-                if (&kl == &jk)
-                    continue;
-
-                // Get atom 'l'
-                auto *l = kl.partner(k);
-
-                // Remove angle term 'jkl' if it exists
-                auto jklIt = std::remove_if(angles_.begin(), angles_.end(),
-                                            [&, j, k, l](auto &angle) { return angle.matches(j, k, l); });
-                if (jklIt != angles_.end())
-                    angles_.erase(jklIt);
-
-                // Remove torsion term 'ijkl' if it exists
-                auto torsionIt = std::remove_if(torsions_.begin(), torsions_.end(),
-                                                [&, i, j, k, l](auto &torsion) { return torsion.matches(i, j, k, l); });
-                if (torsionIt != torsions_.end())
-                    torsions_.erase(torsionIt);
-            }
-
-            // Loop over bonds 'jl'
-            for (SpeciesBond &jl : j->bonds())
-            {
-                // Avoid 'jl' == 'ij' and 'jl' == 'jk'
-                if (&jl == &ij || &jl == &jk)
-                    continue;
-
-                auto *l = jl.partner(j);
-
-                // Remove improper term 'ijkl' if it exists
-                auto improperIt = std::remove_if(impropers_.begin(), impropers_.end(),
-                                                 [&, i, j, k, l](auto &improper) { return improper.matches(i, j, k, l); });
-                if (improperIt != impropers_.end())
-                    impropers_.erase(improperIt);
-            }
-        }
-
-        // Finally, detach the bond from its atoms
-        jk.detach();
-    });
-
-    // Erase the now-redundant objects from the vector
+    // Erase the bond
     bonds_.erase(it);
+
+    ++version_;
 }
 
 // Return number of SpeciesBonds defined

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -70,10 +70,10 @@ void SpeciesAtom::setAtomType(std::shared_ptr<AtomType> at)
 // Return SpeciesAtomType of SpeciesAtom
 std::shared_ptr<AtomType> SpeciesAtom::atomType() const { return atomType_; }
 
-// Set List index (0->[N-1])
+// Set index (0->[N-1])
 void SpeciesAtom::setIndex(int id) { index_ = id; }
 
-// Return List index (0->[N-1])
+// Return index (0->[N-1])
 int SpeciesAtom::index() const { return index_; }
 
 // Return 'user' index (1->N)

--- a/src/classes/speciesatom.h
+++ b/src/classes/speciesatom.h
@@ -70,9 +70,9 @@ class SpeciesAtom
     void setAtomType(std::shared_ptr<AtomType> at);
     // Return AtomType of Atom
     std::shared_ptr<AtomType> atomType() const;
-    // Set List index (0->[N-1])
+    // Set index (0->[N-1])
     void setIndex(int id);
-    // Return List index (0->[N-1])
+    // Return index (0->[N-1])
     int index() const;
     // Return 'user' index (1->N)
     int userIndex() const;

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -35,6 +35,9 @@ void DissolveWindow::on_SpeciesCreateDrawAction_triggered(bool checked)
     EditSpeciesDialog editSpeciesDialog(this, newSpecies);
     if (editSpeciesDialog.editSpecies())
     {
+        // Renumber the atoms so they are sequential
+        newSpecies->renumberAtoms();
+
         setModified();
         fullUpdate();
         ui_.MainTabs->setCurrentTab(newSpecies);


### PR DESCRIPTION
A bugfix PR to address a crash observed when deleting an atom (in the EditSPeciesDialog) that was in the middle of the std::list.

Removal of objects from the `std::list` does not invalidate references to the remaining objects, but odd behaviour (crashes) were observed when deleting anything but the last atom in the list.  This was traced to the use of the erase/remove idiom when removing the `SpeciesAtom` from the list - replacing this with find_if/erase causes no such problems, and the container functions as expected.
