### PR TITLE
Bugfix 24/03/21 Charges and Species Atoms

### DIFF
--- a/src/classes/species_ff.cpp
+++ b/src/classes/species_ff.cpp
@@ -35,7 +35,7 @@ bool Species::applyForcefieldTerms(CoreData &coreData)
         return Messenger::error("No forcefield set in Species '{}', so can't apply terms.\n", name());
 
     // Assign atom types to the species
-    if (forcefield_->assignAtomTypes(this, coreData, Forcefield::TypeAll) != 0)
+    if (forcefield_->assignAtomTypes(this, coreData, Forcefield::TypeAll, false) != 0)
         return false;
 
     // Assign intramolecular terms

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -276,7 +276,7 @@ Forcefield::getAtomTypes(const std::vector<const SpeciesAtom *> &atoms, bool det
 }
 
 // Assign suitable AtomType to the supplied atom
-bool Forcefield::assignAtomType(SpeciesAtom &i, CoreData &coreData) const
+bool Forcefield::assignAtomType(SpeciesAtom &i, CoreData &coreData, bool setSpeciesAtomCharges) const
 {
     auto optRef = determineAtomType(i);
     if (!optRef)
@@ -299,6 +299,10 @@ bool Forcefield::assignAtomType(SpeciesAtom &i, CoreData &coreData) const
     at->setShortRangeType(shortRangeType());
     at->setCharge(assignedType.charge());
 
+    // Set the charge on the SpeciesAtom if requested
+    if (setSpeciesAtomCharges)
+        i.setCharge(assignedType.charge());
+
     // Set type in the SpeciesAtom
     i.setAtomType(at);
 
@@ -306,7 +310,8 @@ bool Forcefield::assignAtomType(SpeciesAtom &i, CoreData &coreData) const
 }
 
 // Assign suitable atom types to the supplied Species, returning the number of failures
-int Forcefield::assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignmentStrategy strategy) const
+int Forcefield::assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignmentStrategy strategy,
+                                bool setSpeciesAtomCharges) const
 {
     Messenger::print("Assigning atomtypes to species '{}' from forcefield '{}'...\n", sp->name(), name());
 
@@ -323,7 +328,7 @@ int Forcefield::assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignm
         if ((strategy == Forcefield::TypeSelection) && (!i.isSelected()))
             continue;
 
-        if (!assignAtomType(i, coreData))
+        if (!assignAtomType(i, coreData, setSpeciesAtomCharges))
         {
             Messenger::error("No matching forcefield type for atom {} ({}).\n", i.userIndex(), Elements::symbol(i.Z()));
             ++nFailed;

--- a/src/data/ff/ff.h
+++ b/src/data/ff/ff.h
@@ -163,7 +163,7 @@ class Forcefield
 
     protected:
     // Assign suitable AtomType to the supplied atom
-    bool assignAtomType(SpeciesAtom &i, CoreData &coreData) const;
+    bool assignAtomType(SpeciesAtom &i, CoreData &coreData, bool setSpeciesAtomCharges) const;
     // Assign / generate bond term parameters
     virtual bool assignBondTermParameters(SpeciesBond &bond, bool determineTypes) const;
     // Assign / generate angle term parameters
@@ -191,7 +191,7 @@ class Forcefield
         SelectionOnlyFlag = 4      /* Only assign terms where all atoms are in the current selection */
     };
     // Assign suitable AtomTypes to the supplied Species, returning the number of failures
-    int assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignmentStrategy strategy) const;
+    int assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignmentStrategy strategy, bool setSpeciesAtomCharges) const;
     // Assign intramolecular parameters to the supplied Species
     bool assignIntramolecular(Species *sp, int flags = Forcefield::GenerateImpropersFlag) const;
 

--- a/src/gui/addforcefieldtermswizard.ui
+++ b/src/gui/addforcefieldtermswizard.ui
@@ -214,6 +214,49 @@ Leave current atom types as they are</string>
               </property>
              </spacer>
             </item>
+            <item>
+             <widget class="QGroupBox" name="AtomTypeOptionsGroup">
+              <property name="title">
+               <string>Options</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QCheckBox" name="KeepSpeciesAtomChargesCheck">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>If enabled, terms will not be reduced to master term entries</string>
+                 </property>
+                 <property name="text">
+                  <string>Don't overwrite charges on species atoms</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
            </layout>
           </item>
           <item>

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -129,6 +129,9 @@ bool AddForcefieldTermsWizard::applyForcefieldTerms(Dissolve &dissolve)
             original.atomType()->setCharge(modified.atomType()->charge());
             dissolve.coreData().bumpAtomTypesVersion();
         }
+
+        // Copy charge on species atom
+        original.setCharge(modified.charge());
     }
 
     // Copy intramolecular terms
@@ -258,17 +261,20 @@ bool AddForcefieldTermsWizard::prepareForNextPage(int currentIndex)
                 modifiedSpecies_->clearAtomTypes();
                 temporaryDissolve_.clearAtomTypes();
 
-                if (ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeAll) != 0)
+                if (ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeAll,
+                                        !ui_.KeepSpeciesAtomChargesCheck->isChecked()) != 0)
                     return false;
             }
             else if (ui_.AtomTypesAssignSelectionRadio->isChecked())
             {
-                if (ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeSelection) != 0)
+                if (ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeSelection,
+                                        !ui_.KeepSpeciesAtomChargesCheck->isChecked()) != 0)
                     return false;
             }
             else if (ui_.AtomTypesAssignMissingRadio->isChecked())
             {
-                if (ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeMissing) != 0)
+                if (ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeMissing,
+                                        !ui_.KeepSpeciesAtomChargesCheck->isChecked()) != 0)
                     return false;
             }
 

--- a/src/gui/addforcefieldtermswizard_funcs.cpp
+++ b/src/gui/addforcefieldtermswizard_funcs.cpp
@@ -126,7 +126,7 @@ bool AddForcefieldTermsWizard::applyForcefieldTerms(Dissolve &dissolve)
         {
             original.atomType()->setShortRangeParameters(modified.atomType()->shortRangeParameters());
             original.atomType()->setShortRangeType(modified.atomType()->shortRangeType());
-            original.atomType()->setCharge(modified.charge());
+            original.atomType()->setCharge(modified.atomType()->charge());
             dissolve.coreData().bumpAtomTypesVersion();
         }
     }

--- a/src/gui/speciestab_geometry.cpp
+++ b/src/gui/speciestab_geometry.cpp
@@ -319,7 +319,7 @@ void SpeciesTab::on_AtomTable_itemChanged(QTableWidgetItem *w)
         return;
 
     // Get target SpeciesAtom from the passed widget
-    SpeciesAtom *speciesAtom = w ? w->data(Qt::UserRole).value<SpeciesAtom *>() : nullptr;
+    SpeciesAtom *speciesAtom = w ? ui_.AtomTable->item(w->row(), 0)->data(Qt::UserRole).value<SpeciesAtom *>() : nullptr;
     if (!speciesAtom)
         return;
     Vec3<double> r = speciesAtom->r();


### PR DESCRIPTION
A bugfix PR to fix a few issues with the GUI:

- Fixes charge copying between atomtypes when assigning atom types.
- Copies charges from atom types to species atoms when assigning atom types.
- Adds option to keep existing species atom charges.
- Fix editing of `SpeciesAtom` data in the SpeciesTab.

