### PR TITLE
Update CMake and add PSTL and TBB to conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_minimum_required(VERSION 3.15)
 project(Dissolve)
 
 set(DESCRIPTION "Dissolve")
@@ -9,12 +10,6 @@ set(VERSION_PATCH "0")
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
-
-cmake_minimum_required(VERSION 2.8)
-
-if(COMMAND cmake_policy)
-  cmake_policy(VERSION 2.6)
-endif(COMMAND cmake_policy)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -30,7 +25,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 # Include Conan Packages
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup(CMAKE_TARGETS)
+conan_basic_setup(TARGETS)
 
 # Catch defines
 if(PARALLEL)
@@ -39,6 +34,11 @@ if(PARALLEL)
   include_directories(${MPI_INCLUDE_PATH})
   set(EXTRA_LINK_LIBS ${EXTRA_LINK_LIBS} ${MPI_LIBRARIES})
 endif(PARALLEL)
+
+if(MULTI_THREADING)
+  add_definitions("-DMULTITHREADING")
+  set(THREADING_LINK_LIBS ${THREADING_LINK_LIBS} CONAN_PKG::tbb)
+endif(MULTI_THREADING)
 
 # Add local Modules dir to cmake search path
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")
@@ -151,6 +151,10 @@ if(APPLE)
 
   set(CMAKE_OSX_ARCHITECTURES "x86_64")
   add_definitions(-D_MAC)
+
+  if(MULTI_THREADING)
+    set(THREADING_LINK_LIBS ${THREADING_LINK_LIBS} CONAN_PKG::onedpl)
+  endif(MULTI_THREADING)
 
   if(GUI)
     # Find GLUT
@@ -282,7 +286,7 @@ target_link_libraries(
          # Module 'nogui' libs
          ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
   PRIVATE # External libs
-          antlr4-runtime ${EXTRA_LINK_LIBS}
+          antlr4-runtime ${EXTRA_LINK_LIBS} ${THREADING_LINK_LIBS}
   INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11
 )
 
@@ -314,6 +318,7 @@ if(GUI)
             ${OPENGL_LIBRARIES}
             ${FREETYPE_LIBRARIES}
             ${EXTRA_LINK_LIBS}
+            ${THREADING_LINK_LIBS}
     INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11
   )
 endif(GUI)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -2,6 +2,8 @@
 CLI11/1.9.1@cliutils/stable
 fmt/7.0.3
 gtest/1.10.0
+tbb/2020.3
+onedpl/20200330
 
 [generators]
 cmake

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -28,3 +28,4 @@ add_library(
 )
 
 include_directories(base PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(base PUBLIC CONAN_PKG::fmt)

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -123,3 +123,4 @@ add_library(
 )
 
 include_directories(classes PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(classes PRIVATE base)

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
 )
 
 include_directories(data PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(data PRIVATE base)
 
 add_subdirectory(ff)
 add_subdirectory(sg)

--- a/src/data/ff/CMakeLists.txt
+++ b/src/data/ff/CMakeLists.txt
@@ -21,6 +21,7 @@ macro(dissolve_add_forcefield ffname)
 
   # Set common include dirs
   include_directories(ff_${ffname} PRIVATE ${PROJECT_SOURCE_DIR}/src)
+  target_link_libraries(ff_${ffname} PRIVATE base)
 endmacro()
 
 # Main Forcefield Library
@@ -43,6 +44,7 @@ add_library(
 )
 
 include_directories(ff PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(ff PRIVATE base)
 
 # Forcefield subdirectories
 message(STATUS "Looking for forcefields in ${CMAKE_CURRENT_SOURCE_DIR}...")

--- a/src/data/sg/CMakeLists.txt
+++ b/src/data/sg/CMakeLists.txt
@@ -11,3 +11,4 @@ add_library(
 )
 
 include_directories(sg PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(sg PRIVATE base)

--- a/src/expression/CMakeLists.txt
+++ b/src/expression/CMakeLists.txt
@@ -57,3 +57,5 @@ target_include_directories(
   expression PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${ANTLRRUNTIME_INCLUDE_DIRS}
                      ${ANTLR_ExpressionGrammarLexer_OUTPUT_DIR} ${ANTLR_ExpressionGrammarParser_OUTPUT_DIR}
 )
+
+target_link_libraries(expression base)

--- a/src/genericitems/CMakeLists.txt
+++ b/src/genericitems/CMakeLists.txt
@@ -10,3 +10,4 @@ add_library(
 )
 
 include_directories(genericitems PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(genericitems PRIVATE base)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -168,7 +168,7 @@ target_include_directories(
   components PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt5Widgets_INCLUDE_DIRS} ${FREETYPE_INCLUDE_DIRS}
 )
 
-target_link_libraries(components widgets)
+target_link_libraries(components widgets base)
 
 # -----------------
 # Main Dissolve GUI
@@ -266,7 +266,15 @@ add_library(gui ${gui_RES} ${gui_UIS_H} ${gui_SRCS} ${gui_MOC_SRCS})
 target_include_directories(
   gui PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt5Widgets_INCLUDE_DIRS} ${FREETYPE_INCLUDE_DIRS}
 )
-target_link_libraries(gui keywordwidgets charts delegates widgets components)
+target_link_libraries(
+  gui
+  keywordwidgets
+  charts
+  delegates
+  widgets
+  components
+  base
+)
 
 # Subdirectories
 add_subdirectory(keywordwidgets)

--- a/src/gui/charts/CMakeLists.txt
+++ b/src/gui/charts/CMakeLists.txt
@@ -30,3 +30,4 @@ set(charts_SRCS
 # Target 'charts'
 add_library(charts ${charts_UIS_H} ${charts_SRCS} ${charts_MOC_SRCS})
 target_include_directories(charts PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt5Widgets_INCLUDE_DIRS})
+target_link_libraries(charts PRIVATE base)

--- a/src/gui/delegates/CMakeLists.txt
+++ b/src/gui/delegates/CMakeLists.txt
@@ -26,3 +26,4 @@ add_library(
   ${delegates_SRCS} ${delegates_MOC_SRCS}
 )
 target_include_directories(delegates PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt5Widgets_INCLUDE_DIRS})
+target_link_libraries(delegates PRIVATE base)

--- a/src/gui/keywordwidgets/CMakeLists.txt
+++ b/src/gui/keywordwidgets/CMakeLists.txt
@@ -109,3 +109,4 @@ set(keywordwidgets_SRCS
 # Target 'keywordwidgets'
 add_library(keywordwidgets ${keywordwidgets_UIS_H} ${keywordwidgets_SRCS} ${keywordwidgets_MOC_SRCS})
 target_include_directories(keywordwidgets PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt5Widgets_INCLUDE_DIRS})
+target_link_libraries(keywordwidgets PRIVATE base)

--- a/src/gui/render/CMakeLists.txt
+++ b/src/gui/render/CMakeLists.txt
@@ -104,3 +104,5 @@ target_include_directories(
           ${ANTLR_TextPrimitiveGrammarLexer_OUTPUT_DIR}
           ${ANTLR_TextPrimitiveGrammarParser_OUTPUT_DIR}
 )
+
+target_link_libraries(render PRIVATE base)

--- a/src/gui/widgets/CMakeLists.txt
+++ b/src/gui/widgets/CMakeLists.txt
@@ -38,3 +38,4 @@ set(widgets_SRCS
 # Target 'gui'
 add_library(widgets ${widgets_UIS_H} ${widgets_SRCS} ${widgets_MOC_SRCS})
 target_include_directories(widgets PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt5Widgets_INCLUDE_DIRS})
+target_link_libraries(widgets PRIVATE base)

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(io fileandformat.cpp fileandformat.h)
 
 include_directories(io PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(io PRIVATE base)
 
 # Subdirectories
 add_subdirectory(export)

--- a/src/io/export/CMakeLists.txt
+++ b/src/io/export/CMakeLists.txt
@@ -17,3 +17,4 @@ add_library(
 )
 
 include_directories(export PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
+target_link_libraries(export PRIVATE base)

--- a/src/io/import/CMakeLists.txt
+++ b/src/io/import/CMakeLists.txt
@@ -26,3 +26,4 @@ add_library(
 )
 
 include_directories(import PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
+target_link_libraries(import PRIVATE base)

--- a/src/keywords/CMakeLists.txt
+++ b/src/keywords/CMakeLists.txt
@@ -93,3 +93,4 @@ add_library(
 )
 
 include_directories(keywords PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(keywords PRIVATE base)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -28,3 +28,4 @@ add_library(
 )
 
 include_directories(main PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(main PRIVATE CONAN_PKG::fmt CONAN_PKG::CLI11)

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -71,3 +71,4 @@ add_library(
 )
 
 include_directories(math PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(math PRIVATE base)

--- a/src/module/CMakeLists.txt
+++ b/src/module/CMakeLists.txt
@@ -13,3 +13,4 @@ add_library(
 )
 
 include_directories(module PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(module PRIVATE base)

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -24,6 +24,7 @@ macro(dissolve_add_module header modulename)
         ${MODULENOGUI_LINK_LIBS} "module_${modulename}_nogui"
         CACHE INTERNAL "" FORCE
     )
+    target_link_libraries(module_${modulename}_nogui PRIVATE base)
   endif()
 
   # Add library target
@@ -43,6 +44,7 @@ macro(dissolve_add_module header modulename)
     ${CMAKE_BINARY_DIR}
     ${CMAKE_BINARY_DIR}/src
   )
+  target_link_libraries(module_${modulename} PRIVATE base)
 endmacro()
 macro(dissolve_add_module_gui modulename)
   message(STATUS "...    GUI component 'module_${modulename}_gui'")
@@ -90,6 +92,7 @@ macro(dissolve_add_module_gui modulename)
     ${Qt5Widgets_INCLUDE_DIRS}
     ${FREETYPE_INCLUDE_DIRS}
   )
+  target_link_libraries(module_${modulename}_gui PRIVATE base)
 endmacro()
 
 # Module subdirectories

--- a/src/neta/CMakeLists.txt
+++ b/src/neta/CMakeLists.txt
@@ -51,3 +51,5 @@ target_include_directories(
   neta PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${ANTLRRUNTIME_INCLUDE_DIRS} ${ANTLR_NETAGrammarLexer_OUTPUT_DIR}
                ${ANTLR_NETAGrammarParser_OUTPUT_DIR}
 )
+
+target_link_libraries(neta PRIVATE base)

--- a/src/procedure/CMakeLists.txt
+++ b/src/procedure/CMakeLists.txt
@@ -3,3 +3,4 @@ add_subdirectory(nodes)
 add_library(procedure procedure.cpp nodevalue.cpp procedure.h nodevalue.h)
 
 include_directories(procedure PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(procedure PRIVATE CONAN_PKG::fmt)

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -68,3 +68,4 @@ add_library(
 )
 
 include_directories(procedurenodes PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(procedurenodes PRIVATE base)

--- a/src/templates/parallel_defs.h
+++ b/src/templates/parallel_defs.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+#pragma once
+#ifdef MULTITHREADING
+#if defined(__clang__)
+#include <pstl/algorithm>
+#include <pstl/execution>
+namespace ParallelPolicies
+{
+constexpr auto par = pstl::execution::par;
+constexpr auto seq = pstl::execution::seq;
+constexpr auto par_unseq = pstl::execution::par_unseq;
+} // namespace ParallelPolicies
+#else
+#include <algorithm>
+#include <execution>
+namespace ParallelPolicies
+{
+constexpr auto par = std::execution::par;
+constexpr auto seq = std::execution::seq;
+constexpr auto par_unseq = std::execution::par_unseq;
+} // namespace ParallelPolicies
+#endif // end #if defined(__clang__)
+#endif // end #ifdef MULTITHREADING

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -18,16 +18,16 @@ foreach(SRCFILE ${tests_SRC})
   # Configure target
   target_include_directories(
     ${NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${ANTLR4_INCLUDE_DIRS} ${ANTLR_OUTPUT_DIRS}
+                    ${CONAN_INCLUDE_DIRS_GTEST}
   )
   target_link_libraries(
     ${NAME}
-    PUBLIC ${CONAN_LIBS} ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS}
+    PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS}
            # Module 'nogui' libs
            ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
-    PRIVATE antlr4-runtime ${EXTRA_LINK_LIBS}
-    INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11 CONAN_PKG::GTest
+    PRIVATE antlr4-runtime ${EXTRA_LINK_LIBS} GTest::gtest_main
+    INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11
   )
+  add_test(NAME ${NAME} COMMAND ${NAME})
 
-  # Register the test
-  gtest_discover_tests(${NAME})
 endforeach(SRCFILE)


### PR DESCRIPTION
Adds the parallel STL (PSTL) and TBB to conan. The parallel STL is only included for OSX/clang (where Libc++ is yet to implement its own PSTL). This also adds a basic parallel definition file to define the parallel policies. 

This also updates the cmake minimum version to 3.15. In doing so it permits a more "target" based approach. 