### PR TITLE
Accumulation 3/3 - Module

### DIFF
--- a/src/classes/partialsetaccumulator.h
+++ b/src/classes/partialsetaccumulator.h
@@ -41,6 +41,8 @@ class PartialSetAccumulator
     const Array2D<SampledData1D> &unboundPartials() const;
     // Return the sampled total function
     const SampledData1D &total() const;
+    // Save all partials and total (with errors)
+    bool save(std::string_view prefix, std::string_view tag, std::string_view suffix, std::string_view abscissaUnits) const;
 
     /*
      * Searchers

--- a/src/keywords/CMakeLists.txt
+++ b/src/keywords/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(
   vec3nodevalue.cpp
   vector_intdouble.cpp
   vector_intstring.cpp
+  vector_stringpair.cpp
   atomtypereflist.h
   atomtypeselection.h
   base.h
@@ -90,6 +91,7 @@ add_library(
   vec3nodevalue.h
   vector_intdouble.h
   vector_intstring.h
+  vector_stringpair.h
 )
 
 include_directories(keywords PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/keywords/base.cpp
+++ b/src/keywords/base.cpp
@@ -64,7 +64,8 @@ std::string_view KeywordDataTypeKeywords[] = {"AtomTypeRefList",
                                               "Vec3<Integer>",
                                               "Vec3<NodeValue>",
                                               "Vector<Integer,Double>",
-                                              "Vector<Integer,String>"};
+                                              "Vector<Integer,String>",
+                                              "Vector<String,String>"};
 
 // Return ValueType name
 std::string_view KeywordBase::keywordDataType(KeywordDataType kdt) { return KeywordDataTypeKeywords[kdt]; }

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -68,7 +68,8 @@ class KeywordBase : public ListItem<KeywordBase>
         Vec3IntegerData,
         Vec3NodeValueData,
         VectorIntegerDoubleData,
-        VectorIntegerStringData
+        VectorIntegerStringData,
+        VectorStringPairData
     };
     KeywordBase(KeywordDataType type);
     virtual ~KeywordBase();

--- a/src/keywords/types.h
+++ b/src/keywords/types.h
@@ -52,3 +52,4 @@
 #include "keywords/vec3nodevalue.h"
 #include "keywords/vector_intdouble.h"
 #include "keywords/vector_intstring.h"
+#include "keywords/vector_stringpair.h"

--- a/src/keywords/vector_stringpair.cpp
+++ b/src/keywords/vector_stringpair.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/vector_stringpair.h"
+#include "base/lineparser.h"
+
+StringPairVectorKeyword::StringPairVectorKeyword(StringPairVectorKeywordData &data)
+    : KeywordData<StringPairVectorKeywordData &>(KeywordBase::VectorStringPairData, data)
+{
+}
+
+StringPairVectorKeyword::~StringPairVectorKeyword() {}
+
+// Return minimum number of arguments accepted
+int StringPairVectorKeyword::minArguments() const { return 2; }
+
+// Return maximum number of arguments accepted
+int StringPairVectorKeyword::maxArguments() const { return 99; }
+
+// Parse arguments from supplied LineParser, starting at given argument offset
+bool StringPairVectorKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+{
+    // Read value pairs
+    for (auto n = startArg; n < parser.nArgs(); n += 2)
+        data_.emplace_back(parser.argsv(n), parser.argsv(n + 1));
+
+    hasBeenSet();
+
+    return true;
+}
+
+// Write keyword data to specified LineParser
+bool StringPairVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
+{
+    for (const auto &[s1, s2] : data_)
+        if (!parser.writeLineF("{}{}  '{}'  '{}'\n", prefix, keywordName, s1, s2))
+            return false;
+
+    return true;
+}

--- a/src/keywords/vector_stringpair.h
+++ b/src/keywords/vector_stringpair.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "keywords/data.h"
+#include <optional>
+#include <tuple>
+#include <vector>
+
+typedef std::vector<std::pair<std::string, std::string>> StringPairVectorKeywordData;
+
+// Keyword with list of pairs of std::string
+class StringPairVectorKeyword : public KeywordData<StringPairVectorKeywordData &>
+{
+    public:
+    StringPairVectorKeyword(StringPairVectorKeywordData &data);
+    ~StringPairVectorKeyword();
+
+    /*
+     * Arguments
+     */
+    public:
+    // Return minimum number of arguments accepted
+    int minArguments() const override;
+    // Return maximum number of arguments accepted
+    int maxArguments() const override;
+    // Parse arguments from supplied LineParser, starting at given argument offset
+    bool read(LineParser &parser, int startArg, const CoreData &coreData) override;
+    // Write keyword data to specified LineParser
+    bool write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
+};

--- a/src/main/modules.cpp
+++ b/src/main/modules.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "main/dissolve.h"
+#include "modules/accumulate/accumulate.h"
 #include "modules/analyse/analyse.h"
 #include "modules/atomshake/atomshake.h"
 #include "modules/benchmark/benchmark.h"
@@ -66,6 +67,8 @@ bool Dissolve::registerMasterModule(Module *masterInstance)
 // Register master instances for all Modules
 bool Dissolve::registerMasterModules()
 {
+    if (!registerMasterModule(new AccumulateModule))
+        return false;
     if (!registerMasterModule(new AnalyseModule))
         return false;
     if (!registerMasterModule(new AtomShakeModule))

--- a/src/modules/accumulate/CMakeLists.txt
+++ b/src/modules/accumulate/CMakeLists.txt
@@ -1,0 +1,1 @@
+dissolve_add_module(accumulate.h accumulate)

--- a/src/modules/accumulate/accumulate.h
+++ b/src/modules/accumulate/accumulate.h
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "module/module.h"
+
+// Accumulate Module
+class AccumulateModule : public Module
+{
+    public:
+    AccumulateModule();
+    ~AccumulateModule() = default;
+
+    /*
+     * Instances
+     */
+    public:
+    // Create instance of this module
+    Module *createInstance() const override;
+
+    /*
+     * Definition
+     */
+    public:
+    // Return type of module
+    std::string_view type() const override;
+    // Return category for module
+    std::string_view category() const override;
+    // Return brief description of module
+    std::string_view brief() const override;
+    // Return the number of Configuration targets this Module requires
+    int nRequiredTargets() const override;
+
+    /*
+     * Initialisation
+     */
+    protected:
+    // Perform any necessary initialisation for the Module
+    void initialise() override;
+
+    /*
+     * Processing
+     */
+    public:
+    // Target PartialSet Enum
+    enum TargetPartialSet
+    {
+        GR,
+        SQ,
+        OriginalGR
+    };
+    // Return EnumOptions for TargetPartialSet
+    static EnumOptions<TargetPartialSet> targetPartialSet();
+
+    // Run main processing
+    bool process(Dissolve &dissolve, ProcessPool &procPool) override;
+
+    /*
+     * GUI Widget
+     */
+    public:
+    // Return a new widget controlling this Module
+    ModuleWidget *createWidget(QWidget *parent, Dissolve &dissolve) override;
+};

--- a/src/modules/accumulate/core.cpp
+++ b/src/modules/accumulate/core.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "modules/accumulate/accumulate.h"
+
+AccumulateModule::AccumulateModule() : Module(nRequiredTargets())
+{
+    // Set unique name for this instance of the Module
+    static int instanceId = 0;
+    uniqueName_ = fmt::format("{}{:02d}", type(), instanceId++);
+
+    // Initialise Module - set up keywords etc.
+    initialise();
+}
+
+/*
+ * Instances
+ */
+
+// Create instance of this module
+Module *AccumulateModule::createInstance() const { return new AccumulateModule; }

--- a/src/modules/accumulate/definition.cpp
+++ b/src/modules/accumulate/definition.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "modules/accumulate/accumulate.h"
+
+// Return type of module
+std::string_view AccumulateModule::type() const { return "Accumulate"; }
+
+// Return category for module
+std::string_view AccumulateModule::category() const { return "NO CATEGORY ASSIGNED"; }
+
+// Return brief description of module
+std::string_view AccumulateModule::brief() const { return "Accumulate partials data to form an average"; }
+
+// Return the number of Configuration targets this Module requires
+int AccumulateModule::nRequiredTargets() const { return Module::ZeroTargets; }

--- a/src/modules/accumulate/functions.cpp
+++ b/src/modules/accumulate/functions.cpp
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "modules/accumulate/accumulate.h"

--- a/src/modules/accumulate/gui/CMakeLists.txt
+++ b/src/modules/accumulate/gui/CMakeLists.txt
@@ -1,0 +1,1 @@
+dissolve_add_module_gui(accumulatemodule)

--- a/src/modules/accumulate/gui/gui.cpp
+++ b/src/modules/accumulate/gui/gui.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "main/dissolve.h"
+#include "modules/accumulate/accumulate.h"
+#include "modules/accumulate/gui/modulewidget.h"
+
+// Return a new widget controlling this Module
+ModuleWidget *AccumulateModule::createWidget(QWidget *parent, Dissolve &dissolve)
+{
+    return new AccumulateModuleWidget(parent, dissolve.processingModuleData(), this, dissolve);
+}

--- a/src/modules/accumulate/gui/modulewidget.h
+++ b/src/modules/accumulate/gui/modulewidget.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "gui/modulewidget.h"
+#include "modules/accumulate/gui/ui_modulewidget.h"
+
+// Forward Declarations
+class Dissolve;
+class Module;
+class PartialSetAccumulator;
+class AccumulateModule;
+class DataViewer;
+
+// Module Widget
+class AccumulateModuleWidget : public ModuleWidget
+{
+    // All Qt declarations derived from QObject must include this macro
+    Q_OBJECT
+
+    public:
+    AccumulateModuleWidget(QWidget *parent, const GenericList &processingData, AccumulateModule *module, Dissolve &dissolve);
+    ~AccumulateModuleWidget();
+
+    private:
+    // Associated Module
+    AccumulateModule *module_;
+    // Target partial data being displayed (if any)
+    OptionalReferenceWrapper<const PartialSetAccumulator> targetPartials_;
+    // Reference to Dissolve
+    Dissolve &dissolve_;
+
+    /*
+     * UI
+     */
+    private:
+    // Main form declaration
+    Ui::AccumulateModuleWidget ui_;
+    // DataViewer contained within this widget
+    DataViewer *graph_;
+
+    private:
+    // Create renderables for current target PartialSet
+    void createPartialSetRenderables(std::string_view targetPrefix);
+
+    public:
+    // Update controls within widget
+    void updateControls(ModuleWidget::UpdateType updateType) override;
+
+    /*
+     * Widgets / Functions
+     */
+    private slots:
+    void on_PartialsButton_clicked(bool checked);
+    void on_TotalButton_clicked(bool checked);
+};

--- a/src/modules/accumulate/gui/modulewidget.ui
+++ b/src/modules/accumulate/gui/modulewidget.ui
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AccumulateModuleWidget</class>
+ <widget class="QWidget" name="AccumulateModuleWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>309</width>
+    <height>163</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>8</pointsize>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Accumulate Controls</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="TotalButton">
+       <property name="toolTip">
+        <string>Show the total F(Q) formed from the partial S(Q)</string>
+       </property>
+       <property name="text">
+        <string>Total ???</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="PartialsButton">
+       <property name="toolTip">
+        <string>Show the partial S(Q) from Fourier transform of the target partial g(r)</string>
+       </property>
+       <property name="text">
+        <string>Partial ???</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QFrame" name="PlotFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="acceptDrops">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Sunken</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_7">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="DataWidget" name="PlotWidget" native="true"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DataWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/datawidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../../gui/main.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/modules/accumulate/gui/modulewidget_funcs.cpp
+++ b/src/modules/accumulate/gui/modulewidget_funcs.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "classes/partialsetaccumulator.h"
+#include "gui/dataviewer.hui"
+#include "gui/render/renderabledata1d.h"
+#include "main/dissolve.h"
+#include "modules/accumulate/accumulate.h"
+#include "modules/accumulate/gui/modulewidget.h"
+#include "templates/algorithms.h"
+
+AccumulateModuleWidget::AccumulateModuleWidget(QWidget *parent, const GenericList &processingData, AccumulateModule *module,
+                                               Dissolve &dissolve)
+    : ModuleWidget(parent, processingData), module_(module), dissolve_(dissolve)
+{
+    // Set up user interface
+    ui_.setupUi(this);
+
+    // Set up S(Q) graph
+    graph_ = ui_.PlotWidget->dataViewer();
+    auto hasSQ =
+        module_->keywords().enumeration<AccumulateModule::TargetPartialSet>("Data") == AccumulateModule::TargetPartialSet::SQ;
+
+    graph_->view().setViewType(View::FlatXYView);
+    graph_->view().axes().setTitle(0, hasSQ ? "\\it{Q}, \\sym{angstrom}\\sup{-1}" : "\\it{r}, \\sym{angstrom}");
+    graph_->view().axes().setMax(0, 10.0);
+    graph_->view().axes().setTitle(1, hasSQ ? "F(Q)" : "G(r)");
+    graph_->view().axes().setMin(1, -1.0);
+    graph_->view().axes().setMax(1, 1.0);
+    graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
+    graph_->view().setAutoFollowType(View::AllAutoFollow);
+    // -- Set group styling
+    graph_->groupManager().setGroupColouring("Full", RenderableGroup::AutomaticIndividualColouring);
+    graph_->groupManager().setGroupVerticalShifting("Full", RenderableGroup::IndividualVerticalShifting);
+    graph_->groupManager().setGroupColouring("Bound", RenderableGroup::AutomaticIndividualColouring);
+    graph_->groupManager().setGroupVerticalShifting("Bound", RenderableGroup::IndividualVerticalShifting);
+    graph_->groupManager().setGroupStipple("Bound", LineStipple::HalfDashStipple);
+    graph_->groupManager().setGroupColouring("Unbound", RenderableGroup::AutomaticIndividualColouring);
+    graph_->groupManager().setGroupVerticalShifting("Unbound", RenderableGroup::IndividualVerticalShifting);
+    graph_->groupManager().setGroupStipple("Unbound", LineStipple::DotStipple);
+
+    refreshing_ = false;
+}
+
+AccumulateModuleWidget::~AccumulateModuleWidget() {}
+
+/*
+ * UI
+ */
+
+// Create renderables for current target PartialSet
+void AccumulateModuleWidget::createPartialSetRenderables(std::string_view targetPrefix)
+{
+    if (!targetPartials_)
+        return;
+
+    const PartialSetAccumulator &ps = *targetPartials_;
+
+    for (auto &&[full, bound, unbound] : zip(ps.partials(), ps.boundPartials(), ps.unboundPartials()))
+    {
+        // Get atom type pair id from the full partial tag
+        auto id = DissolveSys::beforeChar(full.tag(), '/');
+
+        // Full partial
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->uniqueName(), targetPrefix, full.tag()),
+                                                   fmt::format("{} (Full)", id), "Full");
+
+        // Bound partial
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->uniqueName(), targetPrefix, bound.tag()),
+                                                   fmt::format("{} (Bound)", id), "Bound");
+
+        // Unbound partial
+        graph_->createRenderable<RenderableData1D>(
+            fmt::format("{}//{}//{}", module_->uniqueName(), targetPrefix, unbound.tag()), fmt::format("{} (Unbound)", id),
+            "Unbound");
+    }
+}
+
+// Update controls within widget
+void AccumulateModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+{
+    refreshing_ = true;
+
+    // Set button texts
+    auto hasSQ =
+        module_->keywords().enumeration<AccumulateModule::TargetPartialSet>("Data") == AccumulateModule::TargetPartialSet::SQ;
+    ui_.TotalButton->setText(hasSQ ? "Total F(Q)" : "Total G(r)");
+    ui_.PartialsButton->setText(hasSQ ? "Partial S(Q)" : "Partial g(r)");
+
+    // Need to recreate renderables if requested as the updateType, or if we previously had no target PartialSet and have just
+    // located it
+    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || (!ui_.TotalButton->isChecked() && !targetPartials_))
+    {
+        ui_.PlotWidget->clearRenderableData();
+
+        if (ui_.PartialsButton->isChecked())
+        {
+            targetPartials_ = processingData_.valueIf<PartialSetAccumulator>("Accumulation", module_->uniqueName());
+            createPartialSetRenderables("Accumulation");
+        }
+        else
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//Accumulation//Total", module_->uniqueName()), "Total",
+                                                       "Calc");
+    }
+
+    // Validate renderables if they need it
+    graph_->validateRenderables(processingData_);
+
+    graph_->postRedisplay();
+    ui_.PlotWidget->updateToolbar();
+
+    refreshing_ = false;
+}
+
+/*
+ * Widgets / Functions
+ */
+
+void AccumulateModuleWidget::on_TotalButton_clicked(bool checked)
+{
+    if (!checked)
+        return;
+
+    auto hasSQ =
+        module_->keywords().enumeration<AccumulateModule::TargetPartialSet>("Data") == AccumulateModule::TargetPartialSet::SQ;
+
+    graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
+    graph_->view().axes().setTitle(0, hasSQ ? "\\it{Q}, \\sym{angstrom}\\sup{-1}" : "\\it{r}, \\sym{angstrom}");
+    graph_->view().axes().setTitle(1, hasSQ ? "F(Q)" : "G(r)");
+
+    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+}
+
+void AccumulateModuleWidget::on_PartialsButton_clicked(bool checked)
+{
+    if (!checked)
+        return;
+
+    auto hasSQ =
+        module_->keywords().enumeration<AccumulateModule::TargetPartialSet>("Data") == AccumulateModule::TargetPartialSet::SQ;
+
+    graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
+    graph_->view().axes().setTitle(0, hasSQ ? "\\it{Q}, \\sym{angstrom}\\sup{-1}" : "\\it{r}, \\sym{angstrom}");
+    graph_->view().axes().setTitle(1, hasSQ ? "S(Q)" : "g(r)");
+
+    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+}

--- a/src/modules/accumulate/init.cpp
+++ b/src/modules/accumulate/init.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/types.h"
+#include "modules/accumulate/accumulate.h"
+
+// Perform any necessary initialisation for the Module
+void AccumulateModule::initialise()
+{
+    keywords_.add("Control", new ModuleVectorKeyword({"NeutronSQ", "XRaySQ", "SQ", "RDF"}, 1), "Target",
+                  "Module containing the target partial set data to accumulate", "<ModuleName>");
+    keywords_.add("Control", new EnumOptionsKeyword<AccumulateModule::TargetPartialSet>(AccumulateModule::targetPartialSet()),
+                  "Data", "Data type to accumulate");
+    keywords_.add("Export", new BoolKeyword(false), "Export", "Whether to save the accumulated partials to disk");
+}

--- a/src/modules/accumulate/nogui.cpp
+++ b/src/modules/accumulate/nogui.cpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "modules/accumulate/accumulate.h"
+
+// Return a new widget controlling this Module
+ModuleWidget *AccumulateModule::createWidget(QWidget *parent, Dissolve &dissolve) { return nullptr; }

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "base/sysfunc.h"
+#include "classes/partialsetaccumulator.h"
+#include "main/dissolve.h"
+#include "modules/accumulate/accumulate.h"
+
+// Valid Target Modules / Data
+const std::map<std::string, std::vector<std::string>> validTargets = {{"RDF", {"UnweightedGR", "", "OriginalGR"}},
+                                                                      {"SQ", {"", "UnweightedSQ", ""}},
+                                                                      {"NeutronSQ", {"WeightedGR", "WeightedSQ", ""}},
+                                                                      {"XRaySQ", {"WeightedGR", "WeightedSQ", ""}}};
+
+// Return EnumOptions for TargetPartialSet
+EnumOptions<AccumulateModule::TargetPartialSet> AccumulateModule::targetPartialSet()
+{
+    return EnumOptions<AccumulateModule::TargetPartialSet>(
+        "TargetPartialSet",
+        {{TargetPartialSet::GR, "RDF"}, {TargetPartialSet::SQ, "SQ"}, {TargetPartialSet::OriginalGR, "OriginalRDF"}});
+}
+
+// Run main processing
+bool AccumulateModule::process(Dissolve &dissolve, ProcessPool &procPool)
+{
+    // Get keyword data
+    const auto &targets = keywords_.retrieve<std::vector<Module *>>("Target");
+    if (targets.empty())
+        return Messenger::error("No target module set.");
+    const auto targetData = keywords_.enumeration<AccumulateModule::TargetPartialSet>("Data");
+    const auto saveData = keywords_.asBool("Save");
+
+    // Get the module and decide on the PartialSet data name we're looking for
+    const auto *targetModule = targets.front();
+    if (!targetModule)
+        return Messenger::error("No target module set.\n");
+
+    // Print summary of parameters
+    Messenger::print("Accumulate: Source module is '{}'.\n", targetModule->uniqueName());
+    Messenger::print("Accumulate: Target data to accumulate is '{}'.\n", targetPartialSet().keyword(targetData));
+    Messenger::print("Accumulate: Save data is {}.\n", DissolveSys::onOff(saveData));
+    Messenger::print("\n");
+
+    // Is the target module / data type a valid combination?
+    auto targetsIt = std::find_if(validTargets.begin(), validTargets.end(),
+                                  [targetModule](const auto &target) { return target.first == targetModule->type(); });
+    if (targetsIt == validTargets.end())
+        return Messenger::error("Module of type '{}' is not a valid target.\n", targetModule->type());
+    auto dataName = targetsIt->second[targetData];
+    if (dataName.empty())
+        return Messenger::error("This data type ('{}') is not valid for a module of type '{}'.\n",
+                                targetPartialSet().keyword(targetData), targetModule->type());
+
+    // Find the target data
+    auto targetSet = dissolve.processingModuleData().valueIf<PartialSet>(dataName, targetModule->uniqueName());
+    if (!targetSet)
+    {
+        Messenger::print("Target PartialSet data '{}' in module '{}' does not yet exist.\n",
+                         targetPartialSet().keyword(targetData), targetModule->uniqueName());
+        return true;
+    }
+
+    // Realise the accumulated partial set
+    auto &accumulated = dissolve.processingModuleData().realise<PartialSetAccumulator>(
+        "Accumulation", uniqueName(), GenericItem::ItemFlag::InRestartFileFlag);
+
+    accumulated += *targetSet;
+
+    Messenger::print("Accumulated data count = {}.\n", accumulated.nAccumulated());
+
+    // Save data if requested
+    std::vector<std::string> suffixes = {"gr", "sq", "gr"};
+    std::vector<std::string> units = {"r, Angstroms", "Q, Angstroms**-1", "r, Angstroms"};
+    if (saveData && (!MPIRunMaster(procPool, accumulated.save(uniqueName_, dataName, suffixes[targetData], units[targetData]))))
+        return false;
+
+    return true;
+}

--- a/src/modules/datatest/datatest.h
+++ b/src/modules/datatest/datatest.h
@@ -54,6 +54,8 @@ class DataTestModule : public Module
      * Functions
      */
     private:
+    // Internal 1D data testing
+    std::vector<std::pair<std::string, std::string>> internal1DData_;
     // Test 1D datasets
     Data1DStore test1DData_;
     // Test 2D datasets

--- a/src/modules/datatest/init.cpp
+++ b/src/modules/datatest/init.cpp
@@ -15,6 +15,7 @@ void DataTestModule::initialise()
                   "<target> <fileformat> <filename> [options...]");
     keywords_.add("Test", new EnumOptionsKeyword<Error::ErrorType>(Error::errorTypes() = Error::EuclideanError), "ErrorType",
                   "Type of error calculation to use");
-    keywords_.add("Test", new DoubleKeyword(5.0e-3, 1.0e-5), "Threshold", "Threshold for error metric above which test fails",
-                  "<threshold[0.1]>");
+    keywords_.add("Test", new StringPairVectorKeyword(internal1DData_), "InternalData1D",
+                  "Specify one-dimensional internal reference and test data", "<target1> <target2>");
+    keywords_.add("Test", new DoubleKeyword(5.0e-3, 1.0e-5), "Threshold", "Threshold for error metric above which test fails");
 }

--- a/src/modules/datatest/process.cpp
+++ b/src/modules/datatest/process.cpp
@@ -30,7 +30,7 @@ bool DataTestModule::process(Dissolve &dissolve, ProcessPool &procPool)
         auto optData = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(referenceData.tag());
         if (!optData)
             return Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
-        const Data1D data = optData->get();
+        const Data1D &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
 
         // Generate the error estimate and compare against the threshold value

--- a/src/modules/datatest/process.cpp
+++ b/src/modules/datatest/process.cpp
@@ -4,6 +4,7 @@
 #include "base/sysfunc.h"
 #include "main/dissolve.h"
 #include "math/error.h"
+#include "math/sampleddata1d.h"
 #include "modules/datatest/datatest.h"
 
 // Run main processing
@@ -26,16 +27,39 @@ bool DataTestModule::process(Dissolve &dissolve, ProcessPool &procPool)
     for (auto &[referenceData, format] : test1DData_.data())
     {
         // Locate the target reference data
-        auto optData = dissolve.processingModuleData().search<const Data1D>(referenceData.tag());
+        auto optData = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(referenceData.tag());
         if (!optData)
             return Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
-        const Data1D &data = *optData;
+        const Data1D data = optData->get();
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
 
         // Generate the error estimate and compare against the threshold value
         double error = Error::error(errorType, data, referenceData, true);
         Messenger::print("Target data '{}' has error of {:7.3e} with reference data and is {} (threshold is {:6.3e})\n\n",
                          referenceData.tag(), error, isnan(error) || error > testThreshold ? "NOT OK" : "OK", testThreshold);
+        if (isnan(error) || error > testThreshold)
+            return false;
+    }
+
+    // Loop over internal one-dimensional data tests
+    for (auto &[tag1, tag2] : internal1DData_)
+    {
+        // Locate the target reference datasets
+        auto optData1 = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(tag1);
+        if (!optData1)
+            return Messenger::error("No data with tag '{}' exists.\n", tag1);
+        const Data1D data1 = optData1->get();
+        Messenger::print("Located reference data '{}'.\n", tag1);
+        auto optData2 = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(tag2);
+        if (!optData2)
+            return Messenger::error("No data with tag '{}' exists.\n", tag2);
+        const Data1D data2 = optData2->get();
+        Messenger::print("Located reference data '{}'.\n", tag2);
+
+        // Generate the error estimate and compare against the threshold value
+        double error = Error::error(errorType, data1, data2, true);
+        Messenger::print("Internal data '{}' has error of {:7.3e} with data '{}' and is {} (threshold is {:6.3e})\n\n", tag1,
+                         error, tag2, isnan(error) || error > testThreshold ? "NOT OK" : "OK", testThreshold);
         if (isnan(error) || error > testThreshold)
             return false;
     }

--- a/tests/accumulate/CMakeLists.txt
+++ b/tests/accumulate/CMakeLists.txt
@@ -1,0 +1,1 @@
+dissolve_system_test(accumulate accumulate 20)

--- a/tests/accumulate/README
+++ b/tests/accumulate/README
@@ -1,0 +1,5 @@
+RDF Accumulation System Test
+Test Accumulate module against data calculated from RDF and CalculateRDF modules.
+
+System comprises 267 SPC/FW molecules, read from an xyz trajectory.
+

--- a/tests/accumulate/accumulate.txt
+++ b/tests/accumulate/accumulate.txt
@@ -1,0 +1,151 @@
+#------------------------#
+#  Define Master Terms   #
+#------------------------#
+
+Master
+  Bond   OH   Harmonic  4431.53  1.0
+  Angle  HOH  Harmonic  317.5656 113.24
+EndMaster
+
+#------------------------#
+#     Define Species     #
+#------------------------#
+
+Species 'Water'
+  # Atoms
+  Atom    1    H     0.757    0.013    0.217   'HW'
+  Atom    2    O     0.015   -0.009   -0.373   'OW'
+  Atom    3    H    -0.771   -0.003    0.157   'HW'
+
+  # Intramolecular Terms
+  Bond  1    2  @OH
+  Bond  3    2  @OH
+  Angle 1    2    3  @HOH
+
+  # Isotopologues
+  Isotopologue  'Natural'  OW=0  HW=0
+  Isotopologue  'Deuteriated'  OW=0  HW=2
+
+  # Analysis Sites
+  Site  'origin'
+    Origin  2
+    XAxis  1 3
+    YAxis  3
+  EndSite
+  Site  'O'
+    Origin  2
+  EndSite
+  Site  'H1'
+    Origin  1
+  EndSite
+  Site  'H2'
+    Origin  3
+  EndSite
+  Site  'COM'
+    Origin  1  2  3
+    OriginMassWeighted  True
+  EndSite
+EndSpecies
+
+#------------------------#
+#     Pair Potentials    #
+#------------------------#
+
+PairPotentials
+  Range  9.000000
+  Delta  0.050000
+  Parameters  'OW'  O  -0.82  LJGeometric    0.65	3.165492
+  Parameters  'HW'  H  0.41   LJGeometric    0.0      0.0
+EndPairPotentials
+
+#------------------------#
+#  Define Configuration  #
+#------------------------#
+
+Configuration  'Bulk'
+  Generator
+    AddSpecies
+      Density  9.99999642E-02 atoms/A3
+      Population  267
+      Species  'Water'
+    EndAddSpecies
+  EndGenerator
+EndConfiguration
+
+#------------------------#
+#   Define Processing    #
+#------------------------#
+
+Layer  'Processing'
+
+  # Trajectory Processing
+  Module  Import
+    Configuration  'Bulk'
+    ReadTrajectory  True
+    # Trajectory file contains 95 frames
+    TrajectoryFile  xyz  '../_data/dlpoly/water267-analysis/water-267-298K.xyz'
+    EndTrajectoryFile
+  EndModule
+
+  # Calculate RDFs (no averaging)
+  Module  RDF  'RDF01'
+    Configuration  'Bulk'
+    Range  10.0
+    BinWidth  0.01
+    IntraBroadening  None
+    Averaging  0
+    Save  On
+  EndModule
+
+  # Accumulate RDFs
+  Module  Accumulate  'Accumulate01'
+    Target  'RDF01'
+    Data  'RDF'
+    Save  On
+  EndModule
+
+  # Calculate RDFs (with averaging)
+  Module  RDF  'AveragedRDF'
+    Configuration  'Bulk'
+    Range  10.0
+    BinWidth  0.01
+    IntraBroadening  None
+    Averaging  20
+    Save  On
+  EndModule
+
+  # Oxygen-oxygen radial distribution function
+  Module  CalculateRDF  'RDF(OW-OW)'
+    Configuration  'Bulk'
+    SiteA  Water  'O'
+    SiteB  Water  'O'
+    DistanceRange  0.0  10.0  0.01
+  EndModule
+
+  # Hydrogen-hydrogen (H1-H2, 1-3) radial distribution function, excluding intramolecular correlations
+  Module  CalculateRDF  'RDF(H1-H2)'
+    Configuration  'Bulk'
+    SiteA  Water  'H1'
+    SiteB  Water  'H2'
+    ExcludeSameMolecule  On
+    DistanceRange  0.0  10.0  0.01
+  EndModule
+
+  # Hydrogen-hydrogen (O-H, 1-1) radial distribution function, excluding intramolecular correlations
+  Module  CalculateRDF  'RDF(O-H1/H2)'
+    Configuration  'Bulk'
+    SiteA  Water  'O'
+    SiteB  Water  'H1'  Water  'H2'
+    ExcludeSameMolecule  On
+    DistanceRange  0.0  10.0  0.01
+  EndModule
+
+  Module  DataTest  'Totals'
+    InternalData1D  'Accumulate01//Accumulation//Total'  'AveragedRDF//UnweightedGR//Total'
+    InternalData1D  'Accumulate01//Accumulation//OW-OW//Full'  'RDF(OW-OW)//Process1D//RDF'
+    InternalData1D  'Accumulate01//Accumulation//OW-OW//Unbound'  'RDF(OW-OW)//Process1D//RDF'
+    InternalData1D  'Accumulate01//Accumulation//HW-OW//Unbound'  'RDF(O-H1/H2)//Process1D//RDF'
+    InternalData1D  'Accumulate01//Accumulation//HW-HW//Unbound'  'RDF(H1-H2)//Process1D//RDF'
+  EndModule
+
+EndLayer

--- a/web/content/docs/modules/correlation/accumulate/_index.md
+++ b/web/content/docs/modules/correlation/accumulate/_index.md
@@ -1,0 +1,27 @@
+---
+title: Accumulate (Module)
+linkTitle: Accumulate
+description: Accumulate (average) g(r) and S(Q) partial
+---
+
+## Overview
+
+The `Accumulate` takes radial distribution function or structure factor data from a correlation module (such as [`RDF`]({{< ref "rdf" >}}) or [`NeutronSQ`]({{< ref "neutronsq" >}})) and accumulates an online average. As such it can be used to form a smoothed set of partials (and their total) for further analysis, saving to plot in production-quality graphs etc. 
+
+The averaging performed by the `Accumulation` module differs from that performed in the correlation modules themselves - there, the average is a moving average, with `N` sets of partials stored in memory or in the restart file. Much like the various `Calculate` modules, the `Accumulation` module forms an online average with no history. 
+
+A target module containing partial set data must be provided, along with the type of target data to accumulate (since in the case of the [`NeutronSQ`]({{< ref "neutronsq" >}}), for instance, both g(r) and S(Q) partial sets are generated).
+
+## Configuration
+
+### Test Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Data1D`|`TargetData`<br/>[`Data1DFileAndFormat`]({{< ref "data1d" >}})|--|Filename and format of external one-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`Data2D`|`TargetData`<br/>[`Data2DFileAndFormat`]({{< ref "data2d" >}})|--|Filename and format of external two-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`Data3D`|`TargetData`<br/>[`Data3DFileAndFormat`]({{< ref "data3d" >}})|--|Filename and format of external three-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`ErrorType`|[`ErrorType`]({{< ref "errortype" >}})|`Euclidean`|Error metric to use when comparing the datasets within this module instance.|
+|`InternalData1D`|`TargetDataA`<br/>`TargetDataB`|--|Target internal datasets `TargetDataA` amd `TargetDataB` to compare and calculate error. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`Threshold`|`double`|`5.0e-3`|Threshold value for error, above which the test fails.|
+

--- a/web/content/docs/modules/correlation/accumulate/_index.md
+++ b/web/content/docs/modules/correlation/accumulate/_index.md
@@ -6,22 +6,23 @@ description: Accumulate (average) g(r) and S(Q) partial
 
 ## Overview
 
-The `Accumulate` takes radial distribution function or structure factor data from a correlation module (such as [`RDF`]({{< ref "rdf" >}}) or [`NeutronSQ`]({{< ref "neutronsq" >}})) and accumulates an online average. As such it can be used to form a smoothed set of partials (and their total) for further analysis, saving to plot in production-quality graphs etc. 
+The `Accumulate` takes radial distribution function or structure factor data from a correlation module (such as [`RDF`]({{< ref "rdf" >}}) or [`NeutronSQ`]({{< ref "neutronsq" >}})) and accumulates an online average. As such it can be used to form a smoothed set of partials (and their total) for further analysis, saving to plot in production-quality graphs etc.
 
-The averaging performed by the `Accumulation` module differs from that performed in the correlation modules themselves - there, the average is a moving average, with `N` sets of partials stored in memory or in the restart file. Much like the various `Calculate` modules, the `Accumulation` module forms an online average with no history. 
+The averaging performed by the `Accumulation` module differs from that performed in the correlation modules themselves - there, the average is a moving average, with `N` sets of partials stored in memory or in the restart file. Much like the various `Calculate` modules, the `Accumulation` module forms an online average with no history.
 
 A target module containing partial set data must be provided, along with the type of target data to accumulate (since in the case of the [`NeutronSQ`]({{< ref "neutronsq" >}}), for instance, both g(r) and S(Q) partial sets are generated).
 
 ## Configuration
 
-### Test Keywords
+### Control Keywords
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
-|`Data1D`|`TargetData`<br/>[`Data1DFileAndFormat`]({{< ref "data1d" >}})|--|Filename and format of external one-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
-|`Data2D`|`TargetData`<br/>[`Data2DFileAndFormat`]({{< ref "data2d" >}})|--|Filename and format of external two-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
-|`Data3D`|`TargetData`<br/>[`Data3DFileAndFormat`]({{< ref "data3d" >}})|--|Filename and format of external three-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
-|`ErrorType`|[`ErrorType`]({{< ref "errortype" >}})|`Euclidean`|Error metric to use when comparing the datasets within this module instance.|
-|`InternalData1D`|`TargetDataA`<br/>`TargetDataB`|--|Target internal datasets `TargetDataA` amd `TargetDataB` to compare and calculate error. This keyword may be specified multiple times in order to test many datasets sequentially.|
-|`Threshold`|`double`|`5.0e-3`|Threshold value for error, above which the test fails.|
+|`Data`|`Module`|--|{{< required-label >}}Name of the source module from which to take partial set data|
+|`Target`|`RDF|SQ|OriginalRDF`|`RDF`|Partial set type to take from the target module. Not all partial set types are relevant to all target module types - e.g. `SQ` has no meaning for an [`RDF`]({{< ref "rdf" >}}) module, but both `RDF` and `SQ` are relevant for an [`XRqySQ`]({{< ref "xraysq" >}}) module. The `OriginalRDF` option is specific to the [`RDF`]({{< ref "rdf" >}}) module, and refers to the as-calculated partials before any intramolecular broadening has been applied.
 
+### Export Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Export`|`true|false`|`false`|Whether to save accumulated partials to disk after calculation. A separate file is written for each individual atomic partial between types $i$ and $j$, as well as the summed total.|

--- a/web/content/docs/modules/tests/datatest/_index.md
+++ b/web/content/docs/modules/tests/datatest/_index.md
@@ -1,7 +1,24 @@
 ---
 title: DataTest (Module)
 linkTitle: DataTest
-description: Compare calculated data from modules with external references
+description: Compare calculated data from modules with external or internal references
 ---
 
-{{< todo-label >}}
+## Overview
+
+`DataTest` is predominantly used in Dissolve's system tests for checking calculated one-, two-, or three-dimensional properties against external reference data. It also allows comparison between datasets within Dissolve, for example when ensuring the correctness and consistency of two different methods calculating the same thing.
+
+## Configuration
+
+### Control Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Data`|`Module`|--|{{< required-label >}}Name of the source module from which to take partial set data|
+|`Target`|`RDF|SQ|OriginalRDF`|`RDF`|Partial set type to take from the target module. Not all partial set types are relevant to all target module types - e.g. `SQ` has no meaning for an [`RDF`]({{< ref "rdf" >}}) module, but both `RDF` and `SQ` are relevant for an [`XRqySQ`]({{< ref "xraysq" >}}) module. The `OriginalRDF` option is specific to the [`RDF`]({{< ref "rdf" >}}) module, and refers to the as-calculated partials before any intramolecular broadening has been applied.
+
+### Export Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Export`|`true|false`|`false`|Whether to save accumulated partials to disk after calculation. A separate file is written for each individual atomic partial between types $i$ and $j$, as well as the summed total.|

--- a/web/content/docs/modules/tests/datatest/_index.md
+++ b/web/content/docs/modules/tests/datatest/_index.md
@@ -10,15 +10,13 @@ description: Compare calculated data from modules with external or internal refe
 
 ## Configuration
 
-### Control Keywords
+### Test Keywords
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
-|`Data`|`Module`|--|{{< required-label >}}Name of the source module from which to take partial set data|
-|`Target`|`RDF|SQ|OriginalRDF`|`RDF`|Partial set type to take from the target module. Not all partial set types are relevant to all target module types - e.g. `SQ` has no meaning for an [`RDF`]({{< ref "rdf" >}}) module, but both `RDF` and `SQ` are relevant for an [`XRqySQ`]({{< ref "xraysq" >}}) module. The `OriginalRDF` option is specific to the [`RDF`]({{< ref "rdf" >}}) module, and refers to the as-calculated partials before any intramolecular broadening has been applied.
-
-### Export Keywords
-
-|Keyword|Arguments|Default|Description|
-|:------|:--:|:-----:|-----------|
-|`Export`|`true|false`|`false`|Whether to save accumulated partials to disk after calculation. A separate file is written for each individual atomic partial between types $i$ and $j$, as well as the summed total.|
+|`Data1D`|`TargetData`<br/>[`Data1DFileAndFormat`]({{< ref "data1dformat" >}})|--|Filename and format of external one-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`Data2D`|`TargetData`<br/>[`Data2DFileAndFormat`]({{< ref "data2dformat" >}})|--|Filename and format of external two-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`Data3D`|`TargetData`<br/>[`Data3DFileAndFormat`]({{< ref "data3dformat" >}})|--|Filename and format of external three-dimensional data to be read in and tested against the named internal `TargetData`. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`ErrorType`|[`ErrorType`]({{< ref "errortype" >}})|`Euclidean`|Error metric to use when comparing the datasets within this module instance.|
+|`InternalData1D`|`TargetDataA`<br/>`TargetDataB`|--|Target internal datasets `TargetDataA` amd `TargetDataB` to compare and calculate error. This keyword may be specified multiple times in order to test many datasets sequentially.|
+|`Threshold`|`double`|`5.0e-3`|Threshold value for error, above which the test fails.|

--- a/web/content/docs/reference/errortype.md
+++ b/web/content/docs/reference/errortype.md
@@ -1,0 +1,13 @@
+---
+title: Error Types
+description: Error types used when comparing datasets
+---
+
+|Keyword|Description|
+|:---:|-----------|
+|`RMSE`|Root mean squared error: $$\Delta x = \sqrt{\sum_{i=1}^{N} (x_i - x_i^{ref})^2 \frac{1}{N}}$$|
+|`MAAPE`|Mean arctangent average percentage error: $$\Delta x = 100 \sum_{i=1}^{N} \arctan{\left\|\frac{x_i - x_i^{ref}}{x_i}\right\|}$$|
+|`MAPE`|Mean average percentage error: $$\Delta x = 100 \sum_{i=1}^{N} \left\|\frac{x_i - x_i^{ref}}{x_i}\right\|$$|
+|`Percent`|Basic percentage error: $$\Delta x = 100 \frac{\sum_{i=1}^{N} \left\|x_i - x_i^{ref}\right\|}{\sum_{i=1}^{N} \left\|y_i\right\|}$$|
+|`RFactor`|EPSR-style r-factor, equivalent to the mean squared error: $$\Delta x = \sum_{i=1}^{N} (x_i - x_i^{ref})^2 \frac{1}{N}$$|
+|`Euclidean`|Euclidean distance: $$\Delta x = \frac{\sum_{i=1}^{N} \left\|x_i - x_i^{ref}\right\|}{\sum_{i=1}^{N} \left\|x_i^2\right\|}$$|


### PR DESCRIPTION
This PR adds the `AccumulateModule` whose purpose is to accumulate statistics on a target `PartialSet` within another module.

The `DataTest` module has been extended to allow comparison between internal datasets, rather than just internal vs external, and a new keyword type `StringPairVectorKeyword` added to store, as might be guessed from the name, a `std::vector` of `std::pair`s of `std::string`s.

A new system test has been added (`accumulate`) to test the ongoing accumulation of RDF data over short runs.

