### PR TITLE
Bugfix 13/04/21 String Return From Keywords

### DIFF
--- a/src/base/enumoption.h
+++ b/src/base/enumoption.h
@@ -45,9 +45,9 @@ template <class E> class EnumOption
     // Return option enumeration (i.e. from enum value)
     E enumeration() const { return enumeration_; }
     // Return option keyword
-    std::string_view keyword() const { return keyword_; }
+    std::string keyword() const { return keyword_; }
     // Return option description
-    std::string_view description() const { return description_; }
+    std::string description() const { return description_; }
     // Return minimum number of arguments the option takes
     std::optional<int> minArgs() const { return minArgs_; }
     // Return maximum number of arguments the option takes

--- a/src/base/enumoptions.h
+++ b/src/base/enumoptions.h
@@ -46,15 +46,15 @@ template <class E> class EnumOptions : public EnumOptionsBase
 
     public:
     // Return name of options (e.g. from source enumeration)
-    std::string_view name() const override { return name_; }
+    std::string name() const override { return name_; }
     // Return number of options available
     int nOptions() const override { return options_.size(); }
     // Return nth keyword in the list
-    std::string_view keywordByIndex(int index) const override { return options_[index].keyword(); }
+    std::string keywordByIndex(int index) const override { return options_[index].keyword(); }
     // Return description for the nth keyword in the list
-    std::string_view descriptionByIndex(int index) const override { return options_[index].description(); }
+    std::string descriptionByIndex(int index) const override { return options_[index].description(); }
     // Return current option keyword
-    std::string_view keyword() const { return currentOption_ == options_.cend() ? "UNDEFINED" : currentOption_->keyword(); }
+    std::string keyword() const { return currentOption_ == options_.cend() ? "UNDEFINED" : currentOption_->keyword(); }
     // Set current option keyword
     bool set(std::string_view keyword)
     {
@@ -116,7 +116,7 @@ template <class E> class EnumOptions : public EnumOptionsBase
         return currentOption_->enumeration();
     }
     // Return enumerated keyword
-    std::string_view keyword(E enumeration) const
+    std::string keyword(E enumeration) const
     {
         auto it = std::find_if(options_.cbegin(), options_.cend(),
                                [enumeration](auto &option) { return enumeration == option.enumeration(); });
@@ -127,7 +127,7 @@ template <class E> class EnumOptions : public EnumOptionsBase
         return it->keyword();
     }
     // Return enumerated keyword from uncast integer
-    std::string_view keywordFromInt(int uncastEnumeration) const
+    std::string keywordFromInt(int uncastEnumeration) const
     {
         auto it = std::find_if(options_.cbegin(), options_.cend(),
                                [uncastEnumeration](auto &option) { return uncastEnumeration == option.enumeration(); });

--- a/src/base/enumoptionsbase.h
+++ b/src/base/enumoptionsbase.h
@@ -17,15 +17,15 @@ class EnumOptionsBase
      */
     public:
     // Return name of options (e.g. from source enumeration)
-    virtual std::string_view name() const = 0;
+    virtual std::string name() const = 0;
 
     public:
     // Return number of options available
     virtual int nOptions() const = 0;
     // Return nth keyword in the list
-    virtual std::string_view keywordByIndex(int index) const = 0;
+    virtual std::string keywordByIndex(int index) const = 0;
     // Return description for the nth keyword in the list
-    virtual std::string_view descriptionByIndex(int index) const = 0;
+    virtual std::string descriptionByIndex(int index) const = 0;
     // Return index of current option
     virtual int index() const = 0;
     // Set current option index

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -31,13 +31,10 @@ EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> CoordinateExport
 int CoordinateExportFileFormat::nFormats() const { return CoordinateExportFileFormat::nCoordinateExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view CoordinateExportFileFormat::formatKeyword(int id) const
-{
-    return coordinateExportFormats().keywordByIndex(id);
-}
+std::string CoordinateExportFileFormat::formatKeyword(int id) const { return coordinateExportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view CoordinateExportFileFormat::formatDescription(int id) const
+std::string CoordinateExportFileFormat::formatDescription(int id) const
 {
     return coordinateExportFormats().descriptionByIndex(id);
 }

--- a/src/io/export/coordinates.h
+++ b/src/io/export/coordinates.h
@@ -30,9 +30,9 @@ class CoordinateExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as CoordinateExportFormat
     CoordinateExportFormat coordinateFormat() const;
 

--- a/src/io/export/data1d.cpp
+++ b/src/io/export/data1d.cpp
@@ -27,13 +27,10 @@ EnumOptions<Data1DExportFileFormat::Data1DExportFormat> Data1DExportFileFormat::
 int Data1DExportFileFormat::nFormats() const { return Data1DExportFileFormat::nData1DExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view Data1DExportFileFormat::formatKeyword(int id) const { return data1DExportFormats().keywordByIndex(id); }
+std::string Data1DExportFileFormat::formatKeyword(int id) const { return data1DExportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view Data1DExportFileFormat::formatDescription(int id) const
-{
-    return data1DExportFormats().descriptionByIndex(id);
-}
+std::string Data1DExportFileFormat::formatDescription(int id) const { return data1DExportFormats().descriptionByIndex(id); }
 
 // Return current format as CoordinateExportFormat
 Data1DExportFileFormat::Data1DExportFormat Data1DExportFileFormat::data1DFormat() const

--- a/src/io/export/data1d.h
+++ b/src/io/export/data1d.h
@@ -31,9 +31,9 @@ class Data1DExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as Data1DExportFormat
     Data1DExportFormat data1DFormat() const;
 

--- a/src/io/export/data2d.cpp
+++ b/src/io/export/data2d.cpp
@@ -27,13 +27,10 @@ EnumOptions<Data2DExportFileFormat::Data2DExportFormat> Data2DExportFileFormat::
 int Data2DExportFileFormat::nFormats() const { return Data2DExportFileFormat::nData2DExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view Data2DExportFileFormat::formatKeyword(int id) const { return data2DExportFormats().keywordByIndex(id); }
+std::string Data2DExportFileFormat::formatKeyword(int id) const { return data2DExportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view Data2DExportFileFormat::formatDescription(int id) const
-{
-    return data2DExportFormats().descriptionByIndex(id);
-}
+std::string Data2DExportFileFormat::formatDescription(int id) const { return data2DExportFormats().descriptionByIndex(id); }
 
 // Return current format as CoordinateExportFormat
 Data2DExportFileFormat::Data2DExportFormat Data2DExportFileFormat::data2DFormat() const

--- a/src/io/export/data2d.h
+++ b/src/io/export/data2d.h
@@ -32,9 +32,9 @@ class Data2DExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as Data2DExportFormat
     Data2DExportFormat data2DFormat() const;
 

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -28,13 +28,10 @@ EnumOptions<Data3DExportFileFormat::Data3DExportFormat> Data3DExportFileFormat::
 int Data3DExportFileFormat::nFormats() const { return Data3DExportFileFormat::nData3DExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view Data3DExportFileFormat::formatKeyword(int id) const { return data3DExportFormats().keywordByIndex(id); }
+std::string Data3DExportFileFormat::formatKeyword(int id) const { return data3DExportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view Data3DExportFileFormat::formatDescription(int id) const
-{
-    return data3DExportFormats().descriptionByIndex(id);
-}
+std::string Data3DExportFileFormat::formatDescription(int id) const { return data3DExportFormats().descriptionByIndex(id); }
 
 // Return current format as CoordinateExportFormat
 Data3DExportFileFormat::Data3DExportFormat Data3DExportFileFormat::data3DFormat() const

--- a/src/io/export/data3d.h
+++ b/src/io/export/data3d.h
@@ -33,9 +33,9 @@ class Data3DExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as Data3DExportFormat
     Data3DExportFormat data3DFormat() const;
 

--- a/src/io/export/forces.cpp
+++ b/src/io/export/forces.cpp
@@ -30,10 +30,10 @@ EnumOptions<ForceExportFileFormat::ForceExportFormat> ForceExportFileFormat::for
 int ForceExportFileFormat::nFormats() const { return ForceExportFileFormat::nForceExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view ForceExportFileFormat::formatKeyword(int id) const { return forceExportFormats().keywordByIndex(id); }
+std::string ForceExportFileFormat::formatKeyword(int id) const { return forceExportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view ForceExportFileFormat::formatDescription(int id) const { return forceExportFormats().descriptionByIndex(id); }
+std::string ForceExportFileFormat::formatDescription(int id) const { return forceExportFormats().descriptionByIndex(id); }
 
 // Return current format as ForceExportFormat
 ForceExportFileFormat::ForceExportFormat ForceExportFileFormat::forceFormat() const

--- a/src/io/export/forces.h
+++ b/src/io/export/forces.h
@@ -29,9 +29,9 @@ class ForceExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as ForceExportFormat
     ForceExportFormat forceFormat() const;
 

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -30,13 +30,13 @@ PairPotentialExportFileFormat::pairPotentialExportFormats()
 int PairPotentialExportFileFormat::nFormats() const { return PairPotentialExportFileFormat::nPairPotentialExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view PairPotentialExportFileFormat::formatKeyword(int id) const
+std::string PairPotentialExportFileFormat::formatKeyword(int id) const
 {
     return pairPotentialExportFormats().keywordByIndex(id);
 }
 
 // Return description string for supplied index
-std::string_view PairPotentialExportFileFormat::formatDescription(int id) const
+std::string PairPotentialExportFileFormat::formatDescription(int id) const
 {
     return pairPotentialExportFormats().descriptionByIndex(id);
 }

--- a/src/io/export/pairpotential.h
+++ b/src/io/export/pairpotential.h
@@ -32,9 +32,9 @@ class PairPotentialExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as PairPotentialExportFormat
     PairPotentialExportFormat pairPotentialFormat() const;
 

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -28,13 +28,10 @@ EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat> TrajectoryExport
 int TrajectoryExportFileFormat::nFormats() const { return TrajectoryExportFileFormat::nTrajectoryExportFormats; }
 
 // Return format keyword for supplied index
-std::string_view TrajectoryExportFileFormat::formatKeyword(int id) const
-{
-    return trajectoryExportFormats().keywordByIndex(id);
-}
+std::string TrajectoryExportFileFormat::formatKeyword(int id) const { return trajectoryExportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view TrajectoryExportFileFormat::formatDescription(int id) const
+std::string TrajectoryExportFileFormat::formatDescription(int id) const
 {
     return trajectoryExportFormats().descriptionByIndex(id);
 }

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -31,9 +31,9 @@ class TrajectoryExportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as TrajectoryExportFormat
     TrajectoryExportFormat trajectoryFormat() const;
 

--- a/src/io/fileandformat.cpp
+++ b/src/io/fileandformat.cpp
@@ -32,7 +32,7 @@ void FileAndFormat::setFormatIndex(int id) { format_ = id; }
 int FileAndFormat::formatIndex() const { return format_; }
 
 // Return format string
-std::string_view FileAndFormat::format() const
+std::string FileAndFormat::format() const
 {
     if ((format_ < 0) || (format_ >= nFormats()))
         return "???";
@@ -41,7 +41,7 @@ std::string_view FileAndFormat::format() const
 }
 
 // Return nice format string
-std::string_view FileAndFormat::description() const
+std::string FileAndFormat::description() const
 {
     if ((format_ < 0) || (format_ >= nFormats()))
         return "???";

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -30,9 +30,9 @@ class FileAndFormat
     // Return number of available formats
     virtual int nFormats() const = 0;
     // Return format keyword for supplied index
-    virtual std::string_view formatKeyword(int id) const = 0;
+    virtual std::string formatKeyword(int id) const = 0;
     // Return description string for supplied index
-    virtual std::string_view formatDescription(int id) const = 0;
+    virtual std::string formatDescription(int id) const = 0;
     // Convert text string to format index
     int format(std::string_view fmtString) const;
     // Set format index
@@ -40,9 +40,9 @@ class FileAndFormat
     // Return format index
     int formatIndex() const;
     // Return format string
-    std::string_view format() const;
+    std::string format() const;
     // Return description string
-    std::string_view description() const;
+    std::string description() const;
     // Print available formats
     void printAvailableFormats() const;
 

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -44,13 +44,10 @@ EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> CoordinateImport
 int CoordinateImportFileFormat::nFormats() const { return CoordinateImportFileFormat::nCoordinateImportFormats; }
 
 // Return format keyword for supplied index
-std::string_view CoordinateImportFileFormat::formatKeyword(int id) const
-{
-    return coordinateImportFormats().keywordByIndex(id);
-}
+std::string CoordinateImportFileFormat::formatKeyword(int id) const { return coordinateImportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view CoordinateImportFileFormat::formatDescription(int id) const
+std::string CoordinateImportFileFormat::formatDescription(int id) const
 {
     return coordinateImportFormats().descriptionByIndex(id);
 }

--- a/src/io/import/coordinates.h
+++ b/src/io/import/coordinates.h
@@ -44,9 +44,9 @@ class CoordinateImportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as CoordinateImportFormat
     CoordinateImportFormat coordinateFormat() const;
 

--- a/src/io/import/data1d.cpp
+++ b/src/io/import/data1d.cpp
@@ -54,13 +54,10 @@ EnumOptions<Data1DImportFileFormat::Data1DImportFormat> Data1DImportFileFormat::
 int Data1DImportFileFormat::nFormats() const { return Data1DImportFileFormat::nData1DImportFormats; }
 
 // Return format keyword for supplied index
-std::string_view Data1DImportFileFormat::formatKeyword(int id) const { return data1DImportFormats().keywordByIndex(id); }
+std::string Data1DImportFileFormat::formatKeyword(int id) const { return data1DImportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view Data1DImportFileFormat::formatDescription(int id) const
-{
-    return data1DImportFormats().descriptionByIndex(id);
-}
+std::string Data1DImportFileFormat::formatDescription(int id) const { return data1DImportFormats().descriptionByIndex(id); }
 
 // Return current format as Data1DImportFormat
 Data1DImportFileFormat::Data1DImportFormat Data1DImportFileFormat::data1DFormat() const

--- a/src/io/import/data1d.h
+++ b/src/io/import/data1d.h
@@ -44,9 +44,9 @@ class Data1DImportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as Data1DImportFormat
     Data1DImportFormat data1DFormat() const;
 

--- a/src/io/import/data2d.cpp
+++ b/src/io/import/data2d.cpp
@@ -46,13 +46,10 @@ EnumOptions<Data2DImportFileFormat::Data2DImportFormat> Data2DImportFileFormat::
 int Data2DImportFileFormat::nFormats() const { return Data2DImportFileFormat::nData2DImportFormats; }
 
 // Return format keyword for supplied index
-std::string_view Data2DImportFileFormat::formatKeyword(int id) const { return data2DImportFormats().keywordByIndex(id); }
+std::string Data2DImportFileFormat::formatKeyword(int id) const { return data2DImportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view Data2DImportFileFormat::formatDescription(int id) const
-{
-    return data2DImportFormats().descriptionByIndex(id);
-}
+std::string Data2DImportFileFormat::formatDescription(int id) const { return data2DImportFormats().descriptionByIndex(id); }
 
 // Return current format as Data2DImportFormat
 Data2DImportFileFormat::Data2DImportFormat Data2DImportFileFormat::data2DFormat() const

--- a/src/io/import/data2d.h
+++ b/src/io/import/data2d.h
@@ -44,9 +44,9 @@ class Data2DImportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as Data2DImportFormat
     Data2DImportFormat data2DFormat() const;
 

--- a/src/io/import/data3d.cpp
+++ b/src/io/import/data3d.cpp
@@ -39,13 +39,10 @@ EnumOptions<Data3DImportFileFormat::Data3DImportFormat> Data3DImportFileFormat::
 int Data3DImportFileFormat::nFormats() const { return Data3DImportFileFormat::nData3DImportFormats; }
 
 // Return format keyword for supplied index
-std::string_view Data3DImportFileFormat::formatKeyword(int id) const { return data3DImportFormats().keywordByIndex(id); }
+std::string Data3DImportFileFormat::formatKeyword(int id) const { return data3DImportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view Data3DImportFileFormat::formatDescription(int id) const
-{
-    return data3DImportFormats().descriptionByIndex(id);
-}
+std::string Data3DImportFileFormat::formatDescription(int id) const { return data3DImportFormats().descriptionByIndex(id); }
 
 // Return current format as Data3DImportFormat
 Data3DImportFileFormat::Data3DImportFormat Data3DImportFileFormat::data3DFormat() const

--- a/src/io/import/data3d.h
+++ b/src/io/import/data3d.h
@@ -43,9 +43,9 @@ class Data3DImportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as Data3DImportFormat
     Data3DImportFormat data3DFormat() const;
 

--- a/src/io/import/forces.cpp
+++ b/src/io/import/forces.cpp
@@ -45,10 +45,10 @@ EnumOptions<ForceImportFileFormat::ForceImportFormat> ForceImportFileFormat::for
 int ForceImportFileFormat::nFormats() const { return ForceImportFileFormat::nForceImportFormats; }
 
 // Return format keyword for supplied index
-std::string_view ForceImportFileFormat::formatKeyword(int id) const { return forceImportFormats().keywordByIndex(id); }
+std::string ForceImportFileFormat::formatKeyword(int id) const { return forceImportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view ForceImportFileFormat::formatDescription(int id) const { return forceImportFormats().descriptionByIndex(id); }
+std::string ForceImportFileFormat::formatDescription(int id) const { return forceImportFormats().descriptionByIndex(id); }
 
 // Return current format as ForceImportFormat
 ForceImportFileFormat::ForceImportFormat ForceImportFileFormat::forceFormat() const

--- a/src/io/import/forces.h
+++ b/src/io/import/forces.h
@@ -43,9 +43,9 @@ class ForceImportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as ForceImportFormat
     ForceImportFormat forceFormat() const;
 

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -40,13 +40,10 @@ EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> TrajectoryImport
 int TrajectoryImportFileFormat::nFormats() const { return TrajectoryImportFileFormat::nTrajectoryImportFormats; }
 
 // Return format keyword for supplied index
-std::string_view TrajectoryImportFileFormat::formatKeyword(int id) const
-{
-    return trajectoryImportFormats().keywordByIndex(id);
-}
+std::string TrajectoryImportFileFormat::formatKeyword(int id) const { return trajectoryImportFormats().keywordByIndex(id); }
 
 // Return description string for supplied index
-std::string_view TrajectoryImportFileFormat::formatDescription(int id) const
+std::string TrajectoryImportFileFormat::formatDescription(int id) const
 {
     return trajectoryImportFormats().descriptionByIndex(id);
 }

--- a/src/io/import/trajectory.h
+++ b/src/io/import/trajectory.h
@@ -40,9 +40,9 @@ class TrajectoryImportFileFormat : public FileAndFormat
     // Return number of available formats
     int nFormats() const;
     // Return format keyword for supplied index
-    std::string_view formatKeyword(int id) const;
+    std::string formatKeyword(int id) const;
     // Return description string for supplied index
-    std::string_view formatDescription(int id) const;
+    std::string formatDescription(int id) const;
     // Return current format as TrajectoryImportFormat
     TrajectoryImportFormat trajectoryFormat() const;
 


### PR DESCRIPTION
Quick bugfix PR to address corrupt strings in the printed output.

Since all `EnumOptions` objects containing keyword names & descriptions are now returned as full objects (rather than references to static objects) the data they contain is not long-lived. Hence, when printing retrieved `std::string_view`s of keyword names or descriptions, corruption of the text occurred as the `std::string_view`s no longer point to valid `std::string`s.

This PR switches to returning full `std::string`s instead of `std::string_view`s from keyword-related classes.
