### PR TITLE
More ListItem Removal

### DIFF
--- a/src/classes/cellarray.h
+++ b/src/classes/cellarray.h
@@ -29,8 +29,6 @@ class CellArray
     Vec3<double> realCellSize_;
     // Cell extents out from given central cell
     Vec3<int> extents_;
-    // List of Cell neighbour indices (within pair potential range)
-    List<ListVec3<int>> neighbourIndices_;
     // Cell axes
     Matrix3 axes_;
     // Cell array (one-dimensional)
@@ -53,8 +51,6 @@ class CellArray
     Vec3<double> realCellSize() const;
     // Return cell extents out from given central cell
     Vec3<int> extents() const;
-    // Return list of Cell neighbour indices
-    List<ListVec3<int>> neighbourIndices() const;
     // Retrieve Cell with (wrapped) grid reference specified
     Cell *cell(int x, int y, int z) const;
     // Retrieve Cell with id specified

--- a/src/math/histogram1d.cpp
+++ b/src/math/histogram1d.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 #include "base/messenger.h"
 
-Histogram1D::Histogram1D() : ListItem<Histogram1D>()
+Histogram1D::Histogram1D()
 {
     accumulatedData_.addErrors();
 

--- a/src/math/histogram1d.cpp
+++ b/src/math/histogram1d.cpp
@@ -12,8 +12,6 @@ Histogram1D::Histogram1D() : ListItem<Histogram1D>()
     clear();
 }
 
-Histogram1D::~Histogram1D() {}
-
 Histogram1D::Histogram1D(const Histogram1D &source) { (*this) = source; }
 
 // Clear Data

--- a/src/math/histogram1d.h
+++ b/src/math/histogram1d.h
@@ -6,14 +6,12 @@
 #include "math/data1d.h"
 #include "math/sampleddouble.h"
 
-// Forward Declarations
-
 // One-Dimensional Histogram
 class Histogram1D : public ListItem<Histogram1D>
 {
     public:
     Histogram1D();
-    ~Histogram1D();
+    ~Histogram1D() = default;
     Histogram1D(const Histogram1D &source);
     // Clear data
     void clear();

--- a/src/math/histogram1d.h
+++ b/src/math/histogram1d.h
@@ -7,7 +7,7 @@
 #include "math/sampleddouble.h"
 
 // One-Dimensional Histogram
-class Histogram1D : public ListItem<Histogram1D>
+class Histogram1D
 {
     public:
     Histogram1D();

--- a/src/math/histogram2d.cpp
+++ b/src/math/histogram2d.cpp
@@ -13,8 +13,6 @@ Histogram2D::Histogram2D() : ListItem<Histogram2D>()
     clear();
 }
 
-Histogram2D::~Histogram2D() {}
-
 Histogram2D::Histogram2D(const Histogram2D &source) { (*this) = source; }
 
 // Clear Data

--- a/src/math/histogram2d.cpp
+++ b/src/math/histogram2d.cpp
@@ -6,7 +6,7 @@
 #include "base/messenger.h"
 #include "math/histogram1d.h"
 
-Histogram2D::Histogram2D() : ListItem<Histogram2D>()
+Histogram2D::Histogram2D()
 {
     accumulatedData_.addErrors();
 

--- a/src/math/histogram2d.h
+++ b/src/math/histogram2d.h
@@ -7,7 +7,7 @@
 #include "math/sampleddouble.h"
 #include "templates/array2d.h"
 
-// One-Dimensional Histogram
+// Two-Dimensional Histogram
 class Histogram2D
 {
     public:

--- a/src/math/histogram2d.h
+++ b/src/math/histogram2d.h
@@ -8,7 +8,7 @@
 #include "templates/array2d.h"
 
 // One-Dimensional Histogram
-class Histogram2D : public ListItem<Histogram2D>
+class Histogram2D
 {
     public:
     Histogram2D();

--- a/src/math/histogram2d.h
+++ b/src/math/histogram2d.h
@@ -7,14 +7,12 @@
 #include "math/sampleddouble.h"
 #include "templates/array2d.h"
 
-// Forward Declarations
-
 // One-Dimensional Histogram
 class Histogram2D : public ListItem<Histogram2D>
 {
     public:
     Histogram2D();
-    ~Histogram2D();
+    ~Histogram2D() = default;
     Histogram2D(const Histogram2D &source);
     // Clear data
     void clear();

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -6,7 +6,7 @@
 #include "base/messenger.h"
 #include "math/histogram1d.h"
 
-Histogram3D::Histogram3D() : ListItem<Histogram3D>()
+Histogram3D::Histogram3D()
 {
     accumulatedData_.addErrors();
 

--- a/src/math/histogram3d.cpp
+++ b/src/math/histogram3d.cpp
@@ -13,8 +13,6 @@ Histogram3D::Histogram3D() : ListItem<Histogram3D>()
     clear();
 }
 
-Histogram3D::~Histogram3D() {}
-
 Histogram3D::Histogram3D(const Histogram3D &source) { (*this) = source; }
 
 // Clear Data

--- a/src/math/histogram3d.h
+++ b/src/math/histogram3d.h
@@ -8,7 +8,7 @@
 #include "templates/array3d.h"
 
 // One-Dimensional Histogram
-class Histogram3D : public ListItem<Histogram3D>
+class Histogram3D
 {
     public:
     Histogram3D();

--- a/src/math/histogram3d.h
+++ b/src/math/histogram3d.h
@@ -7,7 +7,7 @@
 #include "math/sampleddouble.h"
 #include "templates/array3d.h"
 
-// One-Dimensional Histogram
+// Three-Dimensional Histogram
 class Histogram3D
 {
     public:

--- a/src/math/histogram3d.h
+++ b/src/math/histogram3d.h
@@ -7,14 +7,12 @@
 #include "math/sampleddouble.h"
 #include "templates/array3d.h"
 
-// Forward Declarations
-
 // One-Dimensional Histogram
 class Histogram3D : public ListItem<Histogram3D>
 {
     public:
     Histogram3D();
-    ~Histogram3D();
+    ~Histogram3D() = default;
     Histogram3D(const Histogram3D &source);
     // Clear data
     void clear();

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -5,7 +5,6 @@
 
 #include "math/constants.h"
 #include "math/mathfunc.h"
-#include "templates/listitem.h"
 #include <fmt/core.h>
 #include <math.h>
 
@@ -409,26 +408,5 @@ template <class T> class Vec3
         T temp = get(a);
         set(a, get(b));
         set(b, temp);
-    }
-};
-
-/*
- * 3D vector with List Pointers
- */
-template <class T> class ListVec3 : public Vec3<T>, public ListItem<ListVec3<T>>
-{
-    public:
-    ListVec3<T>(T xx = 0, T yy = 0, T zz = 0) : Vec3<T>(xx, yy, zz), ListItem<ListVec3>() {}
-    ListVec3<T>(const Vec3<T> &source)
-    {
-        Vec3<T>::x = source.x;
-        Vec3<T>::y = source.y;
-        Vec3<T>::z = source.z;
-    }
-    void operator=(const Vec3<T> &source)
-    {
-        Vec3<T>::x = source.x;
-        Vec3<T>::y = source.y;
-        Vec3<T>::z = source.z;
     }
 };


### PR DESCRIPTION
This PR comprises a little bit of tidying following on from the recent `remove-objectstore-2` merge, and removes some further uses of `ListItem` (#257).

In summary:
- Small modernisations to the `HistogramND` classes.
- Removal of `ListItem` dependency from `HistogramND` classes.
- Remove single use of `ListVec3` class (in `CellArray`), replacing with `std::vector<Vec3<int>>`.
