### PR TITLE
Bugfix 15/04/21 Deserialisation

### DIFF
--- a/.azure-pipelines/templates/build-linux-parallel.yml
+++ b/.azure-pipelines/templates/build-linux-parallel.yml
@@ -18,8 +18,7 @@ steps:
       set -ex
       mkdir build
       cd build
-      conan remote add conan-center-2 https://api.bintray.com/conan/conan/conan-center
-      conan install --remote=conan-center-2 -s compiler.libcxx=libstdc++11 ../
+      conan install ../ -s compiler.libcxx=libstdc++11
       cmake -G "Ninja" -DPARALLEL:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
       ninja
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-linux-serial-gui.yml
+++ b/.azure-pipelines/templates/build-linux-serial-gui.yml
@@ -29,8 +29,7 @@ steps:
       export LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
       mkdir build
       cd build
-      conan remote add conan-center-2 https://api.bintray.com/conan/conan/conan-center
-      conan install --remote=conan-center-2 -s compiler.libcxx=libstdc++11 ../
+      conan install .. -s compiler.libcxx=libstdc++11
       cmake -G "Ninja" -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
       ninja
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-osx-serial-gui.yml
+++ b/.azure-pipelines/templates/build-osx-serial-gui.yml
@@ -29,8 +29,7 @@ steps:
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
       mkdir build
       cd build
-      conan remote add conan-center-2 https://api.bintray.com/conan/conan/conan-center
-      conan install --remote=conan-center-2 ../
+      conan install ..
       cmake -DGUI:bool=true -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ parameters.extraflags }} ../
       make
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-windows-serial-gui.yml
+++ b/.azure-pipelines/templates/build-windows-serial-gui.yml
@@ -55,8 +55,7 @@ steps:
       $env:LIB += "$(Build.BinariesDirectory)\ftgl-install\lib;"
       mkdir build
       cd build
-      conan remote add conan-center-2 https://api.bintray.com/conan/conan/conan-center
-      conan install --remote=conan-center-2 ../
+      conan install ..
       cmake ../ -G "Visual Studio 16 2019" -A "x64" -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DBUILD_ANTLR_LINK_LIB:string="dist\Release\antlr4-runtime.lib" -DCMAKE_BUILD_TYPE:STRING="Release" ${{ parameters.extraflags }}
       cmake --build . --config Release --target keywordwidgets
       cmake --build . --config Release

--- a/src/genericitems/deserialisers.h
+++ b/src/genericitems/deserialisers.h
@@ -57,9 +57,10 @@ class GenericItemDeserialiser
                 fmt::format("Item of type '{}' cannot be deserialised as no suitable deserialiser has been registered.\n",
                             typeid(T).name())));
 
-        auto a = std::make_any<T &>(object);
+        auto a = std::make_any<T>(object);
         if (!(it->second)(a, parser, coreData))
             return false;
+        object = std::move(std::any_cast<T>(a));
 
         return true;
     }


### PR DESCRIPTION
Oh dear oh dear - how dreadfully embarrassing. This PR adds a single, but critically important, line to the templated `deserialiseObject` routine of `GenericItemDeserialiser`. The transparency gained by implicit conversion managed to hide the fact that the deserialisation was working on _a copy of the templated object, constructed as an `std::any`_. This was not caught by any system tests as the function is only used as a convenience when reading in generic templated objects (typically `Array2D<double>` and friends) that do not have explicit class-local deserialisation routines.

To coin a phrase - "D'oh."

While I remember, this PR also reverts the recent conan-centre changes.
