### PR TITLE
Bugfix 15/04/21 Various

### DIFF
--- a/.azure-pipelines/templates/build-web.yml
+++ b/.azure-pipelines/templates/build-web.yml
@@ -12,7 +12,6 @@ parameters:
 steps:
   - checkout: self
     submodules: true
-    fetchDepth: 1
   - bash: |
       git submodule update --init --recursive --depth 1
     displayName: 'Init Submodules'

--- a/src/data/ff/kulmala2010/kulmala2010.h
+++ b/src/data/ff/kulmala2010/kulmala2010.h
@@ -13,23 +13,23 @@ class Forcefield_Kulmala2010 : public Forcefield
 {
     public:
     Forcefield_Kulmala2010() = default;
-    ~Forcefield_Kulmala2010() = default;
+    ~Forcefield_Kulmala2010() override = default;
 
     /*
      * Set Up
      */
     public:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 };

--- a/src/data/ff/library.cpp
+++ b/src/data/ff/library.cpp
@@ -17,6 +17,7 @@
 #include "data/ff/pcl2019/anions.h"
 #include "data/ff/pcl2019/cations.h"
 #include "data/ff/spcfw/spcfw.h"
+#include "data/ff/strader2002/dmso.h"
 #include "data/ff/uff/uff.h"
 
 // Static Members
@@ -60,6 +61,7 @@ void ForcefieldLibrary::registerForcefields()
     registerForcefield(std::make_shared<Forcefield_PCL2019_Anions>());
     registerForcefield(std::make_shared<Forcefield_PCL2019_Cations>());
     registerForcefield(std::make_shared<Forcefield_SPCFw>());
+    registerForcefield(std::make_shared<Forcefield_Strader2002>());
     registerForcefield(std::make_shared<Forcefield_UFF>());
 }
 

--- a/src/data/ff/ludwig/ntf2.h
+++ b/src/data/ff/ludwig/ntf2.h
@@ -13,23 +13,23 @@ class Forcefield_Ludwig_NTf2 : public Forcefield
 {
     public:
     Forcefield_Ludwig_NTf2() = default;
-    ~Forcefield_Ludwig_NTf2() = default;
+    ~Forcefield_Ludwig_NTf2() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 };

--- a/src/data/ff/ludwig/py4oh.h
+++ b/src/data/ff/ludwig/py4oh.h
@@ -13,23 +13,23 @@ class Forcefield_Ludwig_Py4OH : public Forcefield
 {
     public:
     Forcefield_Ludwig_Py4OH() = default;
-    ~Forcefield_Ludwig_Py4OH() = default;
+    ~Forcefield_Ludwig_Py4OH() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 };

--- a/src/data/ff/ludwig/py5.h
+++ b/src/data/ff/ludwig/py5.h
@@ -13,23 +13,23 @@ class Forcefield_Ludwig_Py5 : public Forcefield
 {
     public:
     Forcefield_Ludwig_Py5() = default;
-    ~Forcefield_Ludwig_Py5() = default;
+    ~Forcefield_Ludwig_Py5() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 };

--- a/src/data/ff/oplsaa2005/alcohols.h
+++ b/src/data/ff/oplsaa2005/alcohols.h
@@ -13,21 +13,21 @@ class Forcefield_OPLSAA2005_Alcohols : public Forcefield_OPLSAA2005_Alkanes
 {
     public:
     Forcefield_OPLSAA2005_Alcohols() = default;
-    ~Forcefield_OPLSAA2005_Alcohols() = default;
+    ~Forcefield_OPLSAA2005_Alcohols() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/oplsaa2005/alkanes.h
+++ b/src/data/ff/oplsaa2005/alkanes.h
@@ -13,21 +13,21 @@ class Forcefield_OPLSAA2005_Alkanes : public OPLSAA2005BaseForcefield
 {
     public:
     Forcefield_OPLSAA2005_Alkanes() = default;
-    ~Forcefield_OPLSAA2005_Alkanes() = default;
+    ~Forcefield_OPLSAA2005_Alkanes() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/oplsaa2005/alkenes.h
+++ b/src/data/ff/oplsaa2005/alkenes.h
@@ -13,21 +13,21 @@ class Forcefield_OPLSAA2005_Alkenes : public Forcefield_OPLSAA2005_Alkanes
 {
     public:
     Forcefield_OPLSAA2005_Alkenes() = default;
-    ~Forcefield_OPLSAA2005_Alkenes() = default;
+    ~Forcefield_OPLSAA2005_Alkenes() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/oplsaa2005/aromatics.h
+++ b/src/data/ff/oplsaa2005/aromatics.h
@@ -13,21 +13,21 @@ class Forcefield_OPLSAA2005_Aromatics : public OPLSAA2005BaseForcefield
 {
     public:
     Forcefield_OPLSAA2005_Aromatics() = default;
-    ~Forcefield_OPLSAA2005_Aromatics() = default;
+    ~Forcefield_OPLSAA2005_Aromatics() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -23,7 +23,7 @@ class OPLSAA2005BaseForcefield : public Forcefield
     // Return formatted publication references
     std::string_view publicationReferences() const;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 
     /*
      * Atom Type Data

--- a/src/data/ff/oplsaa2005/diols.h
+++ b/src/data/ff/oplsaa2005/diols.h
@@ -13,21 +13,21 @@ class Forcefield_OPLSAA2005_Diols : public Forcefield_OPLSAA2005_Alkanes
 {
     public:
     Forcefield_OPLSAA2005_Diols() = default;
-    ~Forcefield_OPLSAA2005_Diols() = default;
+    ~Forcefield_OPLSAA2005_Diols() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/oplsaa2005/noblegases.h
+++ b/src/data/ff/oplsaa2005/noblegases.h
@@ -19,21 +19,21 @@ class Forcefield_OPLSAA2005_NobleGases : public OPLSAA2005BaseForcefield
 {
     public:
     Forcefield_OPLSAA2005_NobleGases() = default;
-    ~Forcefield_OPLSAA2005_NobleGases() = default;
+    ~Forcefield_OPLSAA2005_NobleGases() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/oplsaa2005/triols.h
+++ b/src/data/ff/oplsaa2005/triols.h
@@ -13,21 +13,21 @@ class Forcefield_OPLSAA2005_Triols : public Forcefield_OPLSAA2005_Alkanes
 {
     public:
     Forcefield_OPLSAA2005_Triols() = default;
-    ~Forcefield_OPLSAA2005_Triols() = default;
+    ~Forcefield_OPLSAA2005_Triols() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/pcl2019/anions.h
+++ b/src/data/ff/pcl2019/anions.h
@@ -13,21 +13,21 @@ class Forcefield_PCL2019_Anions : public PCL2019BaseForcefield
 {
     public:
     Forcefield_PCL2019_Anions() = default;
-    ~Forcefield_PCL2019_Anions() = default;
+    ~Forcefield_PCL2019_Anions() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/pcl2019/base.h
+++ b/src/data/ff/pcl2019/base.h
@@ -23,7 +23,7 @@ class PCL2019BaseForcefield : public Forcefield
     // Return formatted publication references
     std::string_view publicationReferences() const;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 
     /*
      * Atom Type Data

--- a/src/data/ff/pcl2019/cations.h
+++ b/src/data/ff/pcl2019/cations.h
@@ -13,21 +13,21 @@ class Forcefield_PCL2019_Cations : public PCL2019BaseForcefield
 {
     public:
     Forcefield_PCL2019_Cations() = default;
-    ~Forcefield_PCL2019_Cations() = default;
+    ~Forcefield_PCL2019_Cations() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
 };

--- a/src/data/ff/spcfw/spcfw.h
+++ b/src/data/ff/spcfw/spcfw.h
@@ -13,23 +13,23 @@ class Forcefield_SPCFw : public Forcefield
 {
     public:
     Forcefield_SPCFw() = default;
-    ~Forcefield_SPCFw() = default;
+    ~Forcefield_SPCFw() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 };

--- a/src/data/ff/strader2002/CMakeLists.txt
+++ b/src/data/ff/strader2002/CMakeLists.txt
@@ -1,0 +1,1 @@
+dissolve_add_forcefield(strader2002)

--- a/src/data/ff/strader2002/dmso.cpp
+++ b/src/data/ff/strader2002/dmso.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "data/ff/strader2002/dmso.h"
+#include "base/sysfunc.h"
+#include "classes/atomtype.h"
+#include "classes/speciesatom.h"
+
+/*
+ * Implements "A Flexible All-Atom Model of Dimethyl Sulfoxide"
+ * Matthew L. Strader and Scott E. Feller
+ * J. Phys. Chem A 106 1074-1080 (2002)
+ * http://dx.doi.org/10.1021/jp013658n
+ *
+ * Notes:
+ * Any inconsistencies between the forcefield as implemented here and the original work are the sole responsibility of JB.
+ * All energy values are in kJ/mol.
+ */
+
+/*
+ * Set Up
+ */
+
+// Set up / create all forcefield terms
+bool Forcefield_Strader2002::setUp()
+{
+    // Atom types
+    addAtomType(Elements::C, 1, "CD", "-S,-H(n=3)", "DMSO carbon", -0.148, {0.3265, 3.6349});
+    addAtomType(Elements::S, 2, "SD", "nbonds=3,-O,-C(n=2)", "DMSO sulfur", 0.312, {1.4651, 3.5636});
+    addAtomType(Elements::O, 3, "OD", "-&2", "DMSO oxygen", -0.556, {0.50232, 3.0291});
+    addAtomType(Elements::H, 4, "HD", "-C", "DMSO hydrogen", 0.090, {0.10046, 2.3876});
+
+    // Bond terms
+    addBondTerm("CD", "SD", SpeciesBond::HarmonicForm, {2009.28, 1.80});
+    addBondTerm("SD", "OD", SpeciesBond::HarmonicForm, {4520.88, 1.53});
+    addBondTerm("CD", "HD", SpeciesBond::HarmonicForm, {2695.78, 1.11});
+
+    // Angle terms
+    addAngleTerm("CD", "SD", "CD", SpeciesAngle::HarmonicForm, {284.65, 95.0});
+    addAngleTerm("CD", "SD", "OD", SpeciesAngle::HarmonicForm, {661.39, 106.75});
+    addAngleTerm("HD", "CD", "SD", SpeciesAngle::HarmonicForm, {385.94, 111.30});
+    addAngleTerm("HD", "CD", "HD", SpeciesAngle::HarmonicForm, {297.21, 108.40});
+
+    // Dihedral terms
+    addTorsionTerm("HD", "CD", "SD", "OD", SpeciesTorsion::CosineForm, {0.8372, 3.0, 0.0, 1});
+    addTorsionTerm("HD", "CD", "SD", "CD", SpeciesTorsion::CosineForm, {0.8372, 3.0, 0.0, 1});
+
+    return true;
+}
+
+/*
+ * Definition
+ */
+
+// Return name of Forcefield
+std::string_view Forcefield_Strader2002::name() const { return "Strader2002"; }
+
+// Return description for Forcefield
+std::string_view Forcefield_Strader2002::description() const
+{
+    return "Implements Matthew L. Strader and Scott E. Feller, 'A Flexible All-Atom Model of Dimethyl Sulfoxide for Molecular "
+           "Dynamics Simulations'"
+           ", <i>J. Phys. Chem A</i> "
+           "<b>106</b> "
+           "1074-1080 (2002), http://dx.doi.org/10.1021/jp013658n";
+}
+
+// Return short-range interaction style for AtomTypes
+Forcefield::ShortRangeType Forcefield_Strader2002::shortRangeType() const { return Forcefield::LennardJonesType; }

--- a/src/data/ff/strader2002/dmso.h
+++ b/src/data/ff/strader2002/dmso.h
@@ -10,14 +10,14 @@ class Forcefield_Strader2002 : public Forcefield
 {
     public:
     Forcefield_Strader2002() = default;
-    ~Forcefield_Strader2002() = default;
+    ~Forcefield_Strader2002() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition

--- a/src/data/ff/strader2002/dmso.h
+++ b/src/data/ff/strader2002/dmso.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "data/ff/ff.h"
+
+// DMSO Forcefield
+class Forcefield_Strader2002 : public Forcefield
+{
+    public:
+    Forcefield_Strader2002() = default;
+    ~Forcefield_Strader2002() = default;
+
+    /*
+     * Set Up
+     */
+    protected:
+    // Set up / create all forcefield terms
+    bool setUp();
+
+    /*
+     * Definition
+     */
+    public:
+    // Return name of Forcefield
+    std::string_view name() const override;
+    // Return description for Forcefield
+    std::string_view description() const override;
+    // Return short-range interaction style for AtomTypes
+    Forcefield::ShortRangeType shortRangeType() const override;
+};

--- a/src/data/ff/uff/uff.h
+++ b/src/data/ff/uff/uff.h
@@ -21,25 +21,25 @@ class Forcefield_UFF : public Forcefield
 {
     public:
     Forcefield_UFF() = default;
-    ~Forcefield_UFF() = default;
+    ~Forcefield_UFF() override = default;
 
     /*
      * Set Up
      */
     protected:
     // Set up / create all forcefield terms
-    bool setUp();
+    bool setUp() override;
 
     /*
      * Definition
      */
     public:
     // Return name of Forcefield
-    std::string_view name() const;
+    std::string_view name() const override;
     // Return description for Forcefield
-    std::string_view description() const;
+    std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const;
+    Forcefield::ShortRangeType shortRangeType() const override;
 
     /*
      * Atom Type Data

--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -84,14 +84,14 @@ int main(int args, char **argv)
             dissolve.setRestartFileFrequency(options.restartFileFrequency());
 
         // Iterate before launching the GUI?
-        if (options.nIterations())
+        if (options.nIterations() > 0)
         {
             // Prepare for run
             if (!dissolve.prepare())
                 return 1;
 
             // Run main simulation
-            auto result = dissolve.iterate(options.nIterations().value());
+            auto result = dissolve.iterate(options.nIterations());
             if (!result)
                 return 1;
         }

--- a/src/gui/menu_file.cpp
+++ b/src/gui/menu_file.cpp
@@ -197,5 +197,5 @@ void DissolveWindow::on_FileQuitAction_triggered(bool checked)
     if (!checkSaveCurrentInput())
         return;
 
-    QCoreApplication::quit();
+    close();
 }

--- a/src/gui/menu_help.cpp
+++ b/src/gui/menu_help.cpp
@@ -6,10 +6,10 @@
 
 void DissolveWindow::on_HelpOnlineManualAction_triggered(bool checked)
 {
-    QDesktopServices::openUrl(QUrl("https://www.projectdissolve.com/docs/userguide/"));
+    QDesktopServices::openUrl(QUrl("https://www.projectdissolve.com/docs/"));
 }
 
 void DissolveWindow::on_HelpOnlineTutorialsAction_triggered(bool checked)
 {
-    QDesktopServices::openUrl(QUrl("https://www.projectdissolve.com/docs/examples/"));
+    QDesktopServices::openUrl(QUrl("https://www.projectdissolve.com/examples/"));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,7 @@ int main(int args, char **argv)
 #endif
 
     // Run main simulation?
-    auto result = dissolve.iterate(options.nIterations().value());
+    auto result = dissolve.iterate(options.nIterations());
 
     // Print timing information
     dissolve.printTiming();

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -9,8 +9,7 @@
 #include <CLI/Formatter.hpp>
 
 CLIOptions::CLIOptions()
-    : nIterations_(std::nullopt), restartFileFrequency_(10), ignoreRestartFile_(false), ignoreStateFile_(false),
-      writeNoFiles_(false)
+    : nIterations_(0), restartFileFrequency_(10), ignoreRestartFile_(false), ignoreStateFile_(false), writeNoFiles_(false)
 {
 }
 
@@ -28,7 +27,7 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
     auto inputFileOption = app.add_option("inputFile", inputFile_, "Input file to load");
 
     // Basic Control
-    app.add_option("-n,--iterations", nIterations_, "Number of iterations to run (default = 5)")->group("Basic Control");
+    app.add_option("-n,--iterations", nIterations_, "Number of iterations to run (default = 0)")->group("Basic Control");
     app.add_flag_callback("-q,--quiet", []() { Messenger::setQuiet(true); },
                           "Be quiet - don't output any messages whatsoever (output files are still written)")
         ->group("Basic Control");
@@ -85,7 +84,7 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
 std::optional<std::string> CLIOptions::inputFile() const { return inputFile_; }
 
 // Return number of iterations to perform
-std::optional<int> CLIOptions::nIterations() const { return nIterations_; }
+int CLIOptions::nIterations() const { return nIterations_; }
 
 // Return frequency at which to write restart file
 int CLIOptions::restartFileFrequency() const { return restartFileFrequency_; }

--- a/src/main/cli.h
+++ b/src/main/cli.h
@@ -20,7 +20,7 @@ class CLIOptions
     // Input file to load
     std::optional<std::string> inputFile_;
     // Number of iterations to perform
-    std::optional<int> nIterations_;
+    int nIterations_;
     // Frequency at which to write restart file
     int restartFileFrequency_;
     // Redirection basename (for per-process output)
@@ -47,7 +47,7 @@ class CLIOptions
     // Return input file to load
     std::optional<std::string> inputFile() const;
     // Return number of iterations to perform
-    std::optional<int> nIterations() const;
+    int nIterations() const;
     // Return frequency at which to write restart file
     int restartFileFrequency() const;
     // Return redirection basename (for per-process output)

--- a/web/config.toml
+++ b/web/config.toml
@@ -22,6 +22,7 @@ latexDashes = true
     [markup.goldmark.renderer]
       unsafe = true
 
+## Menu Definition
 [menu]
   [[menu.main]]
     name = "Home"
@@ -48,6 +49,7 @@ latexDashes = true
     url = "https://forum.projectdissolve.com"
     weight = 5
 
+# General Parameters
 [params]
 copyright = "Copyright (c) 2021 Team Dissolve and contributors. Built using Hugo/Docsy."
 releaseVersion = "0.7.5"
@@ -66,7 +68,7 @@ sidebar_menu_compact = true
 # Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar
 navbar_logo = true
 
-# Link Configuration
+# Link Definitions
 [params.links]
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
  [[params.links.developer]]


### PR DESCRIPTION
Bugfix PR addressing a small number of minor issues.

Fixes random display of `FLOAT` as the option type for `-n` in the CLI help. There appears to be a bug in `CLI11` when passing a `std::optional` as the target variable, although this is allowed according to the manual. The `std::optional` has thus been removed.
Closes #638.

The GUI would close correctly by closing the window, but not through the File->Quit option.
Closes #450.

Links to online resource (documentation and examples) in the GUI referred to old locations.
Closes #635.

The CI pipeline to build Hugo documentation only did a shallow (depth == 1) copy of the repo, meaning modification data for all pages were set from the hash of the last commit.
Closes #549.

This PR also brings in the Strader 2002 DMSO forcefield that was added to the release version (0.7.5).

Edit - Now also marks overrides on `Forcefield` base class functions.