### PR TITLE
Add GitHub action for benchmarking

### DIFF
--- a/.github/workflows/benchmark_linux.yml
+++ b/.github/workflows/benchmark_linux.yml
@@ -38,3 +38,6 @@ jobs:
               output-file-path: benchmark_result.json
               github-token: ${{ secrets.GITHUB_TOKEN }}
               auto-push: true
+              comment-on-alert: true
+              alert-threshold: '200%'
+              alert-comment-cc-users: '@disorderedmaterials/dissolve-devs'

--- a/.github/workflows/benchmark_linux.yml
+++ b/.github/workflows/benchmark_linux.yml
@@ -1,0 +1,40 @@
+name: benchmarks_ubuntu
+
+on:
+  # Trigger the workflow on push to the develop branch
+  push:
+    branches:
+      - develop
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v2
+        - name: Install Prerequisites
+          run: |
+            sudo apt-get update -q
+            sudo apt-get install antlr4 ninja-build python3-setuptools uuid uuid-dev
+        - name: Install Conan
+          run: |
+            sudo pip3 install wheel
+            sudo pip3 install conan
+        - name: Build
+          run: |
+            mkdir build
+            cd build
+            conan install ../ -s compiler.libcxx=libstdc++11
+            cmake -G "Ninja" -DBUILD_BENCHMARKS:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ../
+            ninja
+        - name: Run benchmark
+          run: ./build/bin/benchmarks --benchmark_format=json | tee benchmark_result.json
+        - name: Store benchmark result
+          uses: rhysd/github-action-benchmark@v1
+          with:
+              tool: 'googlecpp'
+              output-file-path: benchmark_result.json
+              github-token: ${{ secrets.GITHUB_TOKEN }}
+              auto-push: true


### PR DESCRIPTION
This PR adds a GitHub action to store, plot and visualise the benchmark results.

I tested this locally at : https://stephensmith25.github.io/dissolve/dev/bench/

For this to work we'll need to setup a gh-pages branch, mine was a minimal example: 

https://github.com/StephenSmith25/dissolve/tree/gh-pages

I'm not sure if we already have something setup?

**The only thing you need to look at is the benchmark_linux.yml action**

This is built upon the benchmarking branch - so don't merge before thats in.