### PR TITLE
Store forces in std::vector

### DIFF
--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -4,6 +4,7 @@
 #include "base/processpool.h"
 #include "base/messenger.h"
 #include "base/sysfunc.h"
+#include "templates/algorithms.h"
 
 // Static Members
 int ProcessPool::nWorldProcesses_ = 1;
@@ -1207,6 +1208,36 @@ bool ProcessPool::allSum(double *source, int count, ProcessPool::CommunicatorTyp
     return true;
 }
 
+// Reduce (sum) vector of Vec3<double> data to all processes
+bool ProcessPool::allSum(std::vector<Vec3<double>> &source, ProcessPool::CommunicatorType commType)
+{
+#ifdef PARALLEL
+    timer_.start();
+    if ((commType == ProcessPool::GroupLeadersCommunicator) && (!groupLeader()))
+        return true;
+
+    // Construct a contiguous POD buffer that we can send via MPI
+    std::vector<double> buffer(source.size());
+    for (auto n = 0; n < 3; ++n)
+    {
+        // Copy elements (x, y, or z) to buffer
+        for (auto &&[buf, val] : zip(buffer, source))
+            buf = val[n];
+
+        // Reduce
+        if (MPI_Allreduce(source, buffer.data(), buffer.size(), MPI_DOUBLE, MPI_SUM, communicator(commType)) != MPI_SUCCESS)
+            return false;
+
+        // Put reduced data aback into source
+        for (auto &&[buf, val] : zip(buffer, source))
+            val[n] = buf;
+    }
+
+    timer_.accumulate();
+#endif
+    return true;
+}
+
 // Reduce (sum) int data to all processes
 bool ProcessPool::allSum(int *source, int count, ProcessPool::CommunicatorType commType)
 {
@@ -1245,7 +1276,7 @@ bool ProcessPool::allSum(long int *source, int count, ProcessPool::CommunicatorT
     return true;
 }
 
-// Reduce (sum) double data over processes relevant to specifeid strategy
+// Reduce (sum) double data over processes relevant to specified strategy
 bool ProcessPool::allSum(double *source, int count, ProcessPool::DivisionStrategy strategy)
 {
 #ifdef PARALLEL

--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -1223,8 +1223,7 @@ bool ProcessPool::allSum(std::vector<Vec3<double>> &source, ProcessPool::Communi
         std::fill(received.begin(), received.end(), 0.0);
 
         // Copy elements (x, y, or z) to buffer
-        for (auto &&[buf, val] : zip(buffer, source))
-            buf = val[n];
+        std::transform(source.begin(), source.end(), buffer.begin(), [n](const auto &val) { return val.get(n); });
 
         // Reduce
         if (MPI_Allreduce(buffer.data(), received.data(), received.size(), MPI_DOUBLE, MPI_SUM, communicator(commType)) !=

--- a/src/base/processpool.h
+++ b/src/base/processpool.h
@@ -302,6 +302,9 @@ class ProcessPool
              ProcessPool::CommunicatorType commType = ProcessPool::PoolProcessesCommunicator);
     // Reduce (sum) double data to all processes
     bool allSum(double *source, int count, ProcessPool::CommunicatorType commType = ProcessPool::PoolProcessesCommunicator);
+    // Reduce (sum) vector of Vec3<double> data to all processes
+    bool allSum(std::vector<Vec3<double>> &source,
+                ProcessPool::CommunicatorType commType = ProcessPool::PoolProcessesCommunicator);
     // Reduce (sum) int data to all processes
     bool allSum(int *source, int count, ProcessPool::CommunicatorType commType = ProcessPool::PoolProcessesCommunicator);
     // Reduce (sum) int data to all processes

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -22,8 +22,8 @@ class SpeciesTorsion;
 class ForceKernel
 {
     public:
-    ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy,
-                Array<double> &fz, double cutoffDistance = -1.0);
+    ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, std::vector<Vec3<double>> &f,
+                double cutoffDistance = -1.0);
     ~ForceKernel() = default;
 
     /*
@@ -36,12 +36,8 @@ class ForceKernel
     const PotentialMap &potentialMap_;
     // Squared cutoff distance to use in calculation
     double cutoffDistanceSquared_;
-    // Force array for x component
-    Array<double> &fx_;
-    // Force array for y component
-    Array<double> &fy_;
-    // Force array for z component
-    Array<double> &fz_;
+    // Force vector
+    std::vector<Vec3<double>> &f_;
 
     /*
      * Internal Force Calculation
@@ -84,6 +80,14 @@ class ForceKernel
     void calculateAngleParameters(Vec3<double> vecji, Vec3<double> vecjk);
     // Calculate torsion force parameters from supplied vectors, storing result in local class variables
     void calculateTorsionParameters(const Vec3<double> vecji, const Vec3<double> vecjk, const Vec3<double> veckl);
+    // Sum torsion forces for atom 'i' in 'i-j-k-l' into the specified vector index
+    void sumTorsionForceI(double du_dphi, int index);
+    // Sum torsion forces for atom 'j' in 'i-j-k-l' into the specified vector index
+    void sumTorsionForceJ(double du_dphi, int index);
+    // Sum torsion forces for atom 'k' in 'i-j-k-l' into the specified vector index
+    void sumTorsionForceK(double du_dphi, int index);
+    // Sum torsion forces for atom 'l' in 'i-j-k-l' into the specified vector index
+    void sumTorsionForceL(double du_dphi, int index);
 
     public:
     // Calculate SpeciesBond forces

--- a/src/genericitems/deserialisers.cpp
+++ b/src/genericitems/deserialisers.cpp
@@ -36,7 +36,7 @@ GenericItemDeserialiser::GenericItemDeserialiser()
         return true;
     });
 
-    // stdlib
+    // Standard Classes / Containers
     registerDeserialiser<std::streampos>([](std::any &a, LineParser &parser, const CoreData &coreData) {
         // NOTE Can't implicit cast streampos into the arg for readArg(), so assume long long int for now.
         long long int pos;
@@ -62,6 +62,20 @@ GenericItemDeserialiser::GenericItemDeserialiser()
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
             n = parser.argd(0);
+        }
+        return true;
+    });
+    registerDeserialiser<std::vector<Vec3<double>>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
+        auto &v = std::any_cast<std::vector<Vec3<double>> &>(a);
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+            return false;
+        v.clear();
+        v.resize(parser.argi(0));
+        for (auto &n : v)
+        {
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            n = parser.arg3d(0);
         }
         return true;
     });

--- a/src/genericitems/producers.cpp
+++ b/src/genericitems/producers.cpp
@@ -22,12 +22,14 @@ GenericItemProducer::GenericItemProducer()
     registerProducer<double>("double");
     registerProducer<int>("int");
 
-    // stdlib
+    // Standard Classes / Containers
     registerProducer<std::string>("std::string");
     registerProducer<std::streampos>("streampos");
     registerProducer<std::vector<double>>("std::vector<double>");
+    registerProducer<std::vector<Vec3<double>>>("std::vector<Vec3<double>>");
 
-    // Custom Classes
+    // Custom Classes / Containers
+    registerProducer<Array<Vec3<double>>>("Array<Vec3<double>>");
     registerProducer<Array<double>>("Array<double>");
     registerProducer<Array<SampledDouble>>("Array<SampledDouble>");
     registerProducer<Array<Vec3<double>>>("Array<Vec3<double>>");

--- a/src/genericitems/serialisers.cpp
+++ b/src/genericitems/serialisers.cpp
@@ -25,7 +25,7 @@ GenericItemSerialiser::GenericItemSerialiser()
     registerSerialiser<int>(
         [](const std::any &a, LineParser &parser) { return parser.writeLineF("{}\n", std::any_cast<int>(a)); });
 
-    // stdlib
+    // Standard Classes / Containers
     registerSerialiser<std::string>(
         [](const std::any &a, LineParser &parser) { return parser.writeLineF("{}\n", std::any_cast<std::string>(a)); });
     registerSerialiser<std::streampos>(
@@ -39,8 +39,17 @@ GenericItemSerialiser::GenericItemSerialiser()
                 return false;
         return true;
     });
+    registerSerialiser<std::vector<Vec3<double>>>([](const std::any &a, LineParser &parser) {
+        const auto &v = std::any_cast<const std::vector<Vec3<double>> &>(a);
+        if (!parser.writeLineF("{}\n", v.size()))
+            return false;
+        for (auto &n : v)
+            if (!parser.writeLineF("{} {} {}\n", n.x, n.y, n.z))
+                return false;
+        return true;
+    });
 
-    // Custom Classes
+    // Custom Classes / Containers
     registerSerialiser<Array<double>>([](const std::any &a, LineParser &parser) {
         const auto &v = std::any_cast<const Array<double> &>(a);
         if (!parser.writeLineF("{}\n", v.nItems()))

--- a/src/io/export/forces.cpp
+++ b/src/io/export/forces.cpp
@@ -46,24 +46,24 @@ ForceExportFileFormat::ForceExportFormat ForceExportFileFormat::forceFormat() co
  */
 
 // Export simple forces
-bool ForceExportFileFormat::exportSimple(LineParser &parser, const Array<double> &fx, const Array<double> &fy,
-                                         const Array<double> &fz)
+bool ForceExportFileFormat::exportSimple(LineParser &parser, const std::vector<Vec3<double>> &f)
 {
     if (!parser.writeLine("# Atom        FX            FY            FZ"))
         return false;
 
-    if (!parser.writeLineF("{}\n", fx.nItems()))
+    if (!parser.writeLineF("{}\n", f.size()))
         return false;
 
-    for (auto n = 0; n < fx.nItems(); ++n)
-        if (!parser.writeLineF("  {:10d}  {:15.8e}  {:15.8e}  {:15.8e}\n", n + 1, fx.at(n), fy.at(n), fz.at(n)))
+    auto count = 1;
+    for (auto &fxyz : f)
+        if (!parser.writeLineF("  {:10d}  {:15.8e}  {:15.8e}  {:15.8e}\n", count++, fxyz.x, fxyz.y, fxyz.z))
             return false;
 
     return true;
 }
 
 // Export forces using current filename and format
-bool ForceExportFileFormat::exportData(const Array<double> &fx, const Array<double> &fy, const Array<double> &fz)
+bool ForceExportFileFormat::exportData(const std::vector<Vec3<double>> &f)
 {
     // Open the file
     LineParser parser;
@@ -76,7 +76,7 @@ bool ForceExportFileFormat::exportData(const Array<double> &fx, const Array<doub
     // Write data
     auto result = false;
     if (forceFormat() == ForceExportFileFormat::SimpleForces)
-        result = exportSimple(parser, fx, fy, fz);
+        result = exportSimple(parser, f);
     else
     {
         Messenger::error("Unrecognised force format.\nKnown formats are:\n");

--- a/src/io/export/forces.h
+++ b/src/io/export/forces.h
@@ -47,9 +47,9 @@ class ForceExportFileFormat : public FileAndFormat
      */
     private:
     // Export supplied forces in simple format
-    bool exportSimple(LineParser &parser, const Array<double> &fx, const Array<double> &fy, const Array<double> &fz);
+    bool exportSimple(LineParser &parser, const std::vector<Vec3<double>> &f);
 
     public:
     // Export supplied forces using current filename and format
-    bool exportData(const Array<double> &fx, const Array<double> &fy, const Array<double> &fz);
+    bool exportData(const std::vector<Vec3<double>> &f);
 };

--- a/src/io/import/forces.cpp
+++ b/src/io/import/forces.cpp
@@ -61,7 +61,7 @@ ForceImportFileFormat::ForceImportFormat ForceImportFileFormat::forceFormat() co
  */
 
 // Read forces using current filename and format
-bool ForceImportFileFormat::importData(Array<double> &fx, Array<double> &fy, Array<double> &fz, ProcessPool *procPool)
+bool ForceImportFileFormat::importData(std::vector<Vec3<double>> &f, ProcessPool *procPool)
 {
     // Open file and check that we're OK to proceed importing from it
     LineParser parser(procPool);
@@ -69,7 +69,7 @@ bool ForceImportFileFormat::importData(Array<double> &fx, Array<double> &fy, Arr
         return Messenger::error("Couldn't open file '{}' for loading forces data.\n", filename_);
 
     // Import the data
-    auto result = importData(parser, fx, fy, fz);
+    auto result = importData(parser, f);
 
     parser.closeFiles();
 
@@ -77,20 +77,20 @@ bool ForceImportFileFormat::importData(Array<double> &fx, Array<double> &fy, Arr
 }
 
 // Import forces using supplied parser and current format
-bool ForceImportFileFormat::importData(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz)
+bool ForceImportFileFormat::importData(LineParser &parser, std::vector<Vec3<double>> &f)
 {
     // Import the data
     auto result = false;
     switch (forceFormat())
     {
         case (ForceImportFileFormat::DLPOLYForces):
-            result = importDLPOLY(parser, fx, fy, fz);
+            result = importDLPOLY(parser, f);
             break;
         case (ForceImportFileFormat::MoscitoForces):
-            result = importMoscito(parser, fx, fy, fz);
+            result = importMoscito(parser, f);
             break;
         case (ForceImportFileFormat::SimpleForces):
-            result = importSimple(parser, fx, fy, fz);
+            result = importSimple(parser, f);
             break;
         default:
             Messenger::error("Don't know how to load forces in format '{}'.\n", formatKeyword(forceFormat()));
@@ -98,9 +98,8 @@ bool ForceImportFileFormat::importData(LineParser &parser, Array<double> &fx, Ar
 
     // Apply factor to data
     auto factor = keywords_.asDouble("Factor");
-    fx *= factor;
-    fy *= factor;
-    fz *= factor;
+std:
+    transform(f.begin(), f.end(), f.begin(), [factor](auto &value) { return value * factor; });
 
     return result;
 }

--- a/src/io/import/forces.h
+++ b/src/io/import/forces.h
@@ -61,15 +61,15 @@ class ForceImportFileFormat : public FileAndFormat
      */
     private:
     // Import DL_POLY forces through specified parser
-    bool importDLPOLY(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    bool importDLPOLY(LineParser &parser, std::vector<Vec3<double>> &f);
     // Import Moscito forces through specified parser
-    bool importMoscito(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    bool importMoscito(LineParser &parser, std::vector<Vec3<double>> &f);
     // Import simple formatted forces through specified parser
-    bool importSimple(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    bool importSimple(LineParser &parser, std::vector<Vec3<double>> &f);
 
     public:
     // Import forces using current filename and format
-    bool importData(Array<double> &fx, Array<double> &fy, Array<double> &fz, ProcessPool *procPool = nullptr);
+    bool importData(std::vector<Vec3<double>> &f, ProcessPool *procPool = nullptr);
     // Import forces using supplied parser and current format
-    bool importData(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    bool importData(LineParser &parser, std::vector<Vec3<double>> &f);
 };

--- a/src/io/import/forces_dlpoly.cpp
+++ b/src/io/import/forces_dlpoly.cpp
@@ -5,7 +5,7 @@
 #include "io/import/forces.h"
 
 // Import DL_POLY forces through specified parser
-bool ForceImportFileFormat::importDLPOLY(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz)
+bool ForceImportFileFormat::importDLPOLY(LineParser &parser, std::vector<Vec3<double>> &f)
 {
     /*
      * Read DL_POLY force information through the specified line parser.
@@ -39,9 +39,8 @@ bool ForceImportFileFormat::importDLPOLY(LineParser &parser, Array<double> &fx, 
         return false;
     }
     Messenger::print(" --> Expecting forces for {} atoms (DLPOLY keytrj={}, imcon={}).\n", nAtoms, keytrj, imcon);
-    fx.initialise(nAtoms);
-    fy.initialise(nAtoms);
-    fz.initialise(nAtoms);
+    f.resize(nAtoms);
+    std::fill(f.begin(), f.end(), Vec3<double>());
 
     // Skip cell information if given
     if (imcon > 0)
@@ -55,9 +54,7 @@ bool ForceImportFileFormat::importDLPOLY(LineParser &parser, Array<double> &fx, 
             return false;
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
-        fx[n] = parser.argd(0);
-        fy[n] = parser.argd(1);
-        fz[n] = parser.argd(2);
+        f[n] = parser.arg3d(0);
     }
 
     return true;

--- a/src/io/import/forces_dlpoly.cpp
+++ b/src/io/import/forces_dlpoly.cpp
@@ -39,8 +39,7 @@ bool ForceImportFileFormat::importDLPOLY(LineParser &parser, std::vector<Vec3<do
         return false;
     }
     Messenger::print(" --> Expecting forces for {} atoms (DLPOLY keytrj={}, imcon={}).\n", nAtoms, keytrj, imcon);
-    f.resize(nAtoms);
-    std::fill(f.begin(), f.end(), Vec3<double>());
+    f.resize(nAtoms, Vec3<double>());
 
     // Skip cell information if given
     if (imcon > 0)

--- a/src/io/import/forces_moscito.cpp
+++ b/src/io/import/forces_moscito.cpp
@@ -5,7 +5,7 @@
 #include "io/import/forces.h"
 
 // Import Moscito forces through specified parser
-bool ForceImportFileFormat::importMoscito(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz)
+bool ForceImportFileFormat::importMoscito(LineParser &parser, std::vector<Vec3<double>> &f)
 {
     /*
      * Import Moscito coordinate information through the specified line parser.
@@ -37,9 +37,7 @@ bool ForceImportFileFormat::importMoscito(LineParser &parser, Array<double> &fx,
     Messenger::print(" --> Structure file contains {} molecules.\n", nMolecules);
 
     // Can't pre-initialise for number of atoms as it is unknown at this point
-    fx.clear();
-    fy.clear();
-    fz.clear();
+    f.clear();
 
     for (auto n = 0; n < nMolecules; ++n)
     {
@@ -77,9 +75,8 @@ bool ForceImportFileFormat::importMoscito(LineParser &parser, Array<double> &fx,
             if (parser.readNextLine(LineParser::Defaults) != LineParser::Success)
                 return false;
             std::string coords{parser.line()};
-            fx.add(std::stof(coords.substr(0, 15)) * 10.0);
-            fy.add(std::stof(coords.substr(15, 15)) * 10.0);
-            fz.add(std::stof(coords.substr(30)) * 10.0);
+            f.emplace_back(std::stof(coords.substr(0, 15)) * 10.0, std::stof(coords.substr(15, 15)) * 10.0,
+                           std::stof(coords.substr(30)) * 10.0);
         }
     }
 

--- a/src/io/import/forces_simple.cpp
+++ b/src/io/import/forces_simple.cpp
@@ -5,7 +5,7 @@
 #include "io/import/forces.h"
 
 // Read simple formatted forces from specified file
-bool ForceImportFileFormat::importSimple(LineParser &parser, Array<double> &fx, Array<double> &fy, Array<double> &fz)
+bool ForceImportFileFormat::importSimple(LineParser &parser, std::vector<Vec3<double>> &f)
 {
     /*
      * Read force information through the specified line parser.
@@ -23,17 +23,14 @@ bool ForceImportFileFormat::importSimple(LineParser &parser, Array<double> &fx, 
         return false;
     auto nAtoms = parser.argi(0);
     Messenger::print(" --> Expecting forces for {} atoms.\n", nAtoms);
-    fx.initialise(nAtoms);
-    fy.initialise(nAtoms);
-    fz.initialise(nAtoms);
+    f.resize(nAtoms);
+    std::fill(f.begin(), f.end(), Vec3<double>());
 
     for (auto n = 0; n < nAtoms; ++n)
     {
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
-        fx[n] = parser.argd(1);
-        fy[n] = parser.argd(2);
-        fz[n] = parser.argd(3);
+        f[n] = parser.arg3d(1);
     }
 
     return true;

--- a/src/io/import/forces_simple.cpp
+++ b/src/io/import/forces_simple.cpp
@@ -23,8 +23,7 @@ bool ForceImportFileFormat::importSimple(LineParser &parser, std::vector<Vec3<do
         return false;
     auto nAtoms = parser.argi(0);
     Messenger::print(" --> Expecting forces for {} atoms.\n", nAtoms);
-    f.resize(nAtoms);
-    std::fill(f.begin(), f.end(), Vec3<double>());
+    f.resize(nAtoms, Vec3<double>());
 
     for (auto n = 0; n < nAtoms; ++n)
     {

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -76,32 +76,31 @@ class ForcesModule : public Module
     public:
     // Calculate interatomic forces within the specified Configuration
     static void interAtomicForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                  Array<double> &fx, Array<double> &fy, Array<double> &fz);
+                                  std::vector<Vec3<double>> &f);
     // Calculate interatomic forces on specified atoms within the specified Configuration
     static void interAtomicForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
-                                  const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+                                  const PotentialMap &potentialMap, std::vector<Vec3<double>> &f);
     // Calculate interatomic forces within the specified Species
-    static void interAtomicForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, Array<double> &fx,
-                                  Array<double> &fy, Array<double> &fz);
+    static void interAtomicForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
+                                  std::vector<Vec3<double>> &f);
     // Calculate total intramolecular forces acting on specific atoms in the Configuration
     static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
-                                     const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+                                     const PotentialMap &potentialMap, std::vector<Vec3<double>> &f);
     // Calculate total intramolecular forces in Configuration
     static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                     Array<double> &fx, Array<double> &fy, Array<double> &fz);
+                                     std::vector<Vec3<double>> &f);
     // Calculate total intramolecular forces in Species
-    static void intraMolecularForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, Array<double> &fx,
-                                     Array<double> &fy, Array<double> &fz);
+    static void intraMolecularForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
+                                     std::vector<Vec3<double>> &f);
     // Calculate total forces within the specified Configuration
-    static void totalForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, Array<double> &fx,
-                            Array<double> &fy, Array<double> &fz);
+    static void totalForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+                            std::vector<Vec3<double>> &f);
     // Calculate forces acting on specific atoms within the specified Configuration (arising from all atoms)
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const Array<int> &targetIndices,
-                            const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+                            const PotentialMap &potentialMap, std::vector<Vec3<double>> &f);
     // Calculate forces acting on specific Molecules within the specified Configuration (arising from all atoms)
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const Array<std::shared_ptr<Molecule>> &targetMolecules,
-                            const PotentialMap &potentialMap, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+                            const PotentialMap &potentialMap, std::vector<Vec3<double>> &f);
     // Calculate total forces within the specified Species
-    static void totalForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, Array<double> &fx,
-                            Array<double> &fy, Array<double> &fz);
+    static void totalForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap, std::vector<Vec3<double>> &f);
 };

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -12,13 +12,13 @@
 // Copy coordinates from supplied Configuration into reference arrays
 template <> void GeometryOptimisationModule::setReferenceCoordinates(Configuration *cfg)
 {
-    std::transform(cfg->atoms().begin(), cfg->atoms().end(), zRef_.begin(), [](const auto i){ return i->r();});
+    std::transform(cfg->atoms().begin(), cfg->atoms().end(), rRef_.begin(), [](const auto i) { return i->r(); });
 }
 
 // Copy coordinates from supplied Species into reference arrays
 template <> void GeometryOptimisationModule::setReferenceCoordinates(Species *sp)
 {
-    std::transform(sp->atoms().begin(), sp->atoms().end(), rRef_.begin(), [](const auto i){ return i.r();});
+    std::transform(sp->atoms().begin(), sp->atoms().end(), rRef_.begin(), [](const auto i) { return i.r(); });
 }
 
 // Revert Configuration to reference coordinates

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -6,70 +6,45 @@
 #include "classes/species.h"
 #include "modules/energy/energy.h"
 #include "modules/geomopt/geomopt.h"
+#include "templates/algorithms.h"
+#include <numeric>
 
 // Copy coordinates from supplied Configuration into reference arrays
 template <> void GeometryOptimisationModule::setReferenceCoordinates(Configuration *cfg)
 {
-    for (auto n = 0; n < cfg->nAtoms(); ++n)
-    {
-        auto r = cfg->atom(n)->r();
-        xRef_[n] = r.x;
-        yRef_[n] = r.y;
-        zRef_[n] = r.z;
-    }
+    for (auto &&[ref, i] : zip(rRef_, cfg->atoms()))
+        ref = i->r();
 }
 
 // Copy coordinates from supplied Species into reference arrays
 template <> void GeometryOptimisationModule::setReferenceCoordinates(Species *sp)
 {
-    for (auto n = 0; n < sp->nAtoms(); ++n)
-    {
-        auto r = sp->atom(n).r();
-        xRef_[n] = r.x;
-        yRef_[n] = r.y;
-        zRef_[n] = r.z;
-    }
+    for (auto &&[ref, i] : zip(rRef_, sp->atoms()))
+        ref = i.r();
 }
 
 // Revert Configuration to reference coordinates
 template <> void GeometryOptimisationModule::revertToReferenceCoordinates(Configuration *cfg)
 {
-    for (auto n = 0; n < cfg->nAtoms(); ++n)
-        cfg->atom(n)->setCoordinates(xRef_[n], yRef_[n], zRef_[n]);
+    for (auto &&[ref, i] : zip(rRef_, cfg->atoms()))
+        i->setCoordinates(ref);
 }
 
 // Revert Species to reference coordinates
 template <> void GeometryOptimisationModule::revertToReferenceCoordinates(Species *sp)
 {
-    for (auto n = 0; n < sp->nAtoms(); ++n)
-        sp->setAtomCoordinates(n, xRef_[n], yRef_[n], zRef_[n]);
+    for (auto &&[ref, i] : zip(rRef_, sp->atoms()))
+        sp->setAtomCoordinates(&i, ref);
 }
 
 // Return current RMS force
 double GeometryOptimisationModule::rmsForce() const
 {
-    auto rmsf = 0.0;
+    auto msf = std::accumulate(f_.begin(), f_.end(), 0.0,
+                               [](auto &acc, const auto &f) { return acc + f.x * f.x + f.y * f.y + f.z * f.z; }) /
+               f_.size();
 
-    for (auto n = 0; n < xForce_.nItems(); ++n)
-        rmsf += xForce_.at(n) * xForce_.at(n) + yForce_.at(n) * yForce_.at(n) + zForce_.at(n) * zForce_.at(n);
-    rmsf /= xForce_.nItems();
-
-    return sqrt(rmsf);
-}
-
-// Determine suitable step size from current forces
-double GeometryOptimisationModule::gradientStepSize()
-{
-    auto fMax = xForce_.maxAbs();
-    auto fTemp = yForce_.maxAbs();
-    if (fTemp > fMax)
-        fMax = fTemp;
-    fTemp = zForce_.maxAbs();
-    if (fTemp > fMax)
-        fMax = fTemp;
-
-    return 1.0e-5;
-    return 1.0 / fMax;
+    return sqrt(msf);
 }
 
 // Sort bounds / energies so that minimum energy is in the central position
@@ -92,9 +67,8 @@ template <>
 double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, Configuration *cfg,
                                                          const PotentialMap &potentialMap, double delta)
 {
-    auto &atoms = cfg->atoms();
-    for (auto n = 0; n < cfg->nAtoms(); ++n)
-        atoms[n]->setCoordinates(xRef_[n] + xForce_[n] * delta, yRef_[n] + yForce_[n] * delta, zRef_[n] + zForce_[n] * delta);
+    for (auto &&[i, r, f] : zip(cfg->atoms(), rRef_, f_))
+        i->setCoordinates(r.x + f.x * delta, r.y + f.y * delta, r.z + f.z * delta);
     cfg->updateCellContents();
 
     return EnergyModule::totalEnergy(procPool, cfg, potentialMap);
@@ -105,8 +79,8 @@ template <>
 double GeometryOptimisationModule::energyAtGradientPoint(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
                                                          double delta)
 {
-    for (auto n = 0; n < sp->nAtoms(); ++n)
-        sp->setAtomCoordinates(n, xRef_[n] + xForce_[n] * delta, yRef_[n] + yForce_[n] * delta, zRef_[n] + zForce_[n] * delta);
+    for (auto &&[i, r, f] : zip(sp->atoms(), rRef_, f_))
+        sp->setAtomCoordinates(&i, Vec3<double>(r.x + f.x * delta, r.y + f.y * delta, r.z + f.z * delta));
 
     return EnergyModule::totalEnergy(procPool, sp, potentialMap);
 }
@@ -130,15 +104,9 @@ bool GeometryOptimisationModule::optimiseSpecies(Dissolve &dissolve, ProcessPool
     Messenger::print("\n");
 
     // Initialise working arrays for coordinates and forces
-    xRef_.initialise(sp->nAtoms());
-    yRef_.initialise(sp->nAtoms());
-    zRef_.initialise(sp->nAtoms());
-    xTemp_.initialise(sp->nAtoms());
-    yTemp_.initialise(sp->nAtoms());
-    zTemp_.initialise(sp->nAtoms());
-    xForce_.initialise(sp->nAtoms());
-    yForce_.initialise(sp->nAtoms());
-    zForce_.initialise(sp->nAtoms());
+    rRef_.resize(sp->nAtoms());
+    rTemp_.resize(sp->nAtoms());
+    f_.resize(sp->nAtoms());
 
     optimise<Species>(dissolve, procPool, sp);
 

--- a/src/modules/geomopt/functions.cpp
+++ b/src/modules/geomopt/functions.cpp
@@ -12,15 +12,13 @@
 // Copy coordinates from supplied Configuration into reference arrays
 template <> void GeometryOptimisationModule::setReferenceCoordinates(Configuration *cfg)
 {
-    for (auto &&[ref, i] : zip(rRef_, cfg->atoms()))
-        ref = i->r();
+    std::transform(cfg->atoms().begin(), cfg->atoms().end(), zRef_.begin(), [](const auto i){ return i->r();});
 }
 
 // Copy coordinates from supplied Species into reference arrays
 template <> void GeometryOptimisationModule::setReferenceCoordinates(Species *sp)
 {
-    for (auto &&[ref, i] : zip(rRef_, sp->atoms()))
-        ref = i.r();
+    std::transform(sp->atoms().begin(), sp->atoms().end(), rRef_.begin(), [](const auto i){ return i.r();});
 }
 
 // Revert Configuration to reference coordinates

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -58,11 +58,11 @@ class GeometryOptimisationModule : public Module
      */
     private:
     // Current (reference) coordinates
-    Array<double> xRef_, yRef_, zRef_;
+    std::vector<Vec3<double>> rRef_;
     // Temporary test coordinates
-    Array<double> xTemp_, yTemp_, zTemp_;
+    std::vector<Vec3<double>> rTemp_;
     // Current forces
-    Array<double> xForce_, yForce_, zForce_;
+    std::vector<Vec3<double>> f_;
     // Control variables (retrieved from keywords)
     int nCycles_;
     double tolerance_;
@@ -75,8 +75,6 @@ class GeometryOptimisationModule : public Module
     template <class T> void revertToReferenceCoordinates(T *target);
     // Return current RMS force
     double rmsForce() const;
-    // Determine suitable step size from current forces
-    double gradientStepSize();
     // Sort bounds / energies so that minimum energy is in the central position
     void sortBoundsAndEnergies(std::array<double, 3> &bounds, std::array<double, 3> &energies);
     // Return energy of adjusted coordinates, following the force vectors by the supplied amount
@@ -233,7 +231,7 @@ class GeometryOptimisationModule : public Module
 
         // Get the initial energy and forces of the Configuration
         auto oldEnergy = EnergyModule::totalEnergy(procPool, target, dissolve.potentialMap());
-        ForcesModule::totalForces(procPool, target, dissolve.potentialMap(), xForce_, yForce_, zForce_);
+        ForcesModule::totalForces(procPool, target, dissolve.potentialMap(), f_);
         auto oldRMSForce = rmsForce();
 
         // Set initial step size - the line minimiser will modify this as we proceed
@@ -255,7 +253,7 @@ class GeometryOptimisationModule : public Module
 
             // Get new forces and RMS for the adjusted coordinates (now stored in the Configuration) and determine
             // new step size
-            ForcesModule::totalForces(procPool, target, dissolve.potentialMap(), xForce_, yForce_, zForce_);
+            ForcesModule::totalForces(procPool, target, dissolve.potentialMap(), f_);
             auto newRMSForce = rmsForce();
 
             // Calculate deltas

--- a/src/modules/geomopt/process.cpp
+++ b/src/modules/geomopt/process.cpp
@@ -35,15 +35,9 @@ bool GeometryOptimisationModule::process(Dissolve &dissolve, ProcessPool &procPo
         procPool.assignProcessesToGroups(cfg->processPool());
 
         // Initialise working arrays for coordinates and forces
-        xRef_.initialise(cfg->nAtoms());
-        yRef_.initialise(cfg->nAtoms());
-        zRef_.initialise(cfg->nAtoms());
-        xTemp_.initialise(cfg->nAtoms());
-        yTemp_.initialise(cfg->nAtoms());
-        zTemp_.initialise(cfg->nAtoms());
-        xForce_.initialise(cfg->nAtoms());
-        yForce_.initialise(cfg->nAtoms());
-        zForce_.initialise(cfg->nAtoms());
+        rRef_.resize(cfg->nAtoms(), 0.0);
+        rTemp_.resize(cfg->nAtoms(), 0.0);
+        f_.resize(cfg->nAtoms(), 0.0);
 
         optimise<Configuration>(dissolve, procPool, cfg);
     }

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -28,7 +28,7 @@ int MDModule::capForces(double maxForce, std::vector<Vec3<double>> &f)
 // Determine timestep based on maximal force component
 double MDModule::determineTimeStep(const std::vector<Vec3<double>> &f)
 {
-    auto fMax = *std::max_element(f.begin(), f.end(), [](auto & left, auto& right){ return left.absMax() < right.absMax(););
+    auto fMax = *std::max_element(f.begin(), f.end(), [](auto &left, auto &right) { return left.absMax() < right.absMax(); });
 
-    return 1.0 / fMax;
+    return 1.0 / fMax.absMax();
 }

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -28,13 +28,7 @@ int MDModule::capForces(double maxForce, std::vector<Vec3<double>> &f)
 // Determine timestep based on maximal force component
 double MDModule::determineTimeStep(const std::vector<Vec3<double>> &f)
 {
-    auto fMax = 0.0;
-    for (auto &fxyz : f)
-    {
-        auto m = fxyz.absMax();
-        if (m > fMax)
-            fMax = m;
-    }
+    auto fMax = *std::max_element(f.begin(), f.end(), [](auto & left, auto& right){ return left.absMax() < right.absMax(););
 
     return 1.0 / fMax;
 }

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -5,21 +5,19 @@
 #include "modules/md/md.h"
 
 // Cap forces in Configuration
-int MDModule::capForces(Configuration *cfg, double maxForce, Array<double> &fx, Array<double> &fy, Array<double> &fz)
+int MDModule::capForces(double maxForce, std::vector<Vec3<double>> &f)
 {
     double fMag;
     const auto maxForceSq = maxForce * maxForce;
     auto nCapped = 0;
-    for (auto n = 0; n < cfg->nAtoms(); ++n)
+    for (auto &fxyz : f)
     {
-        fMag = fx[n] * fx[n] + fy[n] * fy[n] + fz[n] * fz[n];
+        fMag = fxyz.magnitudeSq();
         if (fMag < maxForceSq)
             continue;
 
         fMag = maxForce / sqrt(fMag);
-        fx[n] *= fMag;
-        fy[n] *= fMag;
-        fz[n] *= fMag;
+        fxyz *= fMag;
 
         ++nCapped;
     }
@@ -28,15 +26,15 @@ int MDModule::capForces(Configuration *cfg, double maxForce, Array<double> &fx, 
 }
 
 // Determine timestep based on maximal force component
-double MDModule::determineTimeStep(const Array<double> &fx, const Array<double> &fy, const Array<double> &fz)
+double MDModule::determineTimeStep(const std::vector<Vec3<double>> &f)
 {
-    double fMax = fx.maxAbs();
-    double fTemp = fy.maxAbs();
-    if (fTemp > fMax)
-        fMax = fTemp;
-    fTemp = fz.maxAbs();
-    if (fTemp > fMax)
-        fMax = fTemp;
+    auto fMax = 0.0;
+    for (auto &fxyz : f)
+    {
+        auto m = fxyz.absMax();
+        if (m > fMax)
+            fMax = m;
+    }
 
     return 1.0 / fMax;
 }

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -62,7 +62,7 @@ class MDModule : public Module
      */
     private:
     // Cap forces in Configuration
-    int capForces(Configuration *cfg, double maxForceSq, Array<double> &fx, Array<double> &fy, Array<double> &fz);
+    int capForces(double maxForceSq, std::vector<Vec3<double>> &f);
     // Determine timestep based on maximal force component
-    double determineTimeStep(const Array<double> &fx, const Array<double> &fy, const Array<double> &fz);
+    double determineTimeStep(const std::vector<Vec3<double>> &f);
 };

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -108,8 +108,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         const auto temperature = cfg->temperature();
 
         // Create arrays
-        std::vector<double> mass;
-        mass.resize(cfg->nAtoms(), 0.0);
+        std::vector<double> mass(cfg->nAtoms(), 0.0);
         std::vector<Vec3<double>> forces(cfg->nAtoms()), accelerations(cfg->nAtoms());
 
         // Variables
@@ -129,7 +128,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (status == GenericItem::ItemStatus::Created)
         {
             randomVelocities = true;
-            velocities.resize(cfg->nAtoms());
+            velocities.resize(cfg->nAtoms(), Vec3<double>());
         }
         if (randomVelocities)
             Messenger::print("Random initial velocities will be assigned.\n");

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -166,8 +166,8 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // If ke is in units of [g mol-1 Angstroms2 ps-2] then must use kb in units of 10 J mol-1 K-1 (= 0.8314462)
         const auto kb = 0.8314462;
         ke = 0.0;
-        ke = std::transform_reduce(momentum.begin(), momentum.end(), velocity.begin(), 0.0, std::plus<>, 
-                                                    [](const auto &m, const auto &v) { return 0.5 * m * v.dp(v); });
+        for (auto &&[m, v] : zip(mass, velocities))
+            ke += 0.5 * m * v.dp(v);
         tInstant = ke * 2.0 / (3.0 * atoms.size() * kb);
 
         // Rescale velocities for desired temperature

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -12,6 +12,7 @@
 #include "modules/energy/energy.h"
 #include "modules/forces/forces.h"
 #include "modules/md/md.h"
+#include "templates/algorithms.h"
 
 // Run main processing
 bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
@@ -106,15 +107,16 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Get temperature from Configuration
         const auto temperature = cfg->temperature();
 
-        // Create force arrays as simple double arrays (easier to sum with MPI) - others are Vec3<double> arrays
-        Array<double> mass(cfg->nAtoms()), fx(cfg->nAtoms()), fy(cfg->nAtoms()), fz(cfg->nAtoms());
-        Array<Vec3<double>> a(cfg->nAtoms());
+        // Create arrays
+        std::vector<double> mass;
+        mass.resize(cfg->nAtoms(), 0.0);
+        std::vector<Vec3<double>> forces(cfg->nAtoms()), accelerations(cfg->nAtoms());
 
         // Variables
-        int n, nCapped = 0;
+        auto nCapped = 0;
         auto &atoms = cfg->atoms();
         double tInstant, ke, tScale, peInter, peIntra;
-        double deltaTSq = deltaT * deltaT;
+        auto deltaTSq = deltaT * deltaT;
 
         /*
          * Calculation Begins
@@ -122,12 +124,12 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
         // Read in or assign random velocities
         // Realise the velocity array from the moduleData
-        auto [v, status] = dissolve.processingModuleData().realiseIf<Array<Vec3<double>>>(
+        auto [velocities, status] = dissolve.processingModuleData().realiseIf<std::vector<Vec3<double>>>(
             fmt::format("{}//Velocities", cfg->niceName()), uniqueName(), GenericItem::NoFlags);
         if (status == GenericItem::ItemStatus::Created)
         {
             randomVelocities = true;
-            v.initialise(cfg->nAtoms());
+            velocities.resize(cfg->nAtoms());
         }
         if (randomVelocities)
             Messenger::print("Random initial velocities will be assigned.\n");
@@ -138,41 +140,40 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         procPool.initialiseRandomBuffer(ProcessPool::PoolProcessesCommunicator);
 
         Vec3<double> vCom;
-        double massSum = 0.0;
-        for (n = 0; n < cfg->nAtoms(); ++n)
+        auto massSum = 0.0;
+        for (auto &&[i, v, m] : zip(atoms, velocities, mass))
         {
             if (randomVelocities)
             {
-                v[n].x = exp(procPool.random() - 0.5) / sqrt(TWOPI);
-                v[n].y = exp(procPool.random() - 0.5) / sqrt(TWOPI);
-                v[n].z = exp(procPool.random() - 0.5) / sqrt(TWOPI);
+                v.x = exp(procPool.random() - 0.5) / sqrt(TWOPI);
+                v.y = exp(procPool.random() - 0.5) / sqrt(TWOPI);
+                v.z = exp(procPool.random() - 0.5) / sqrt(TWOPI);
             }
 
             // Grab atom mass for future use
-            mass[n] = AtomicMass::mass(atoms[n]->speciesAtom()->Z());
+            m = AtomicMass::mass(i->speciesAtom()->Z());
 
             // Calculate total velocity and mass over all atoms
-            vCom += v[n] * mass[n];
-            massSum += mass[n];
+            vCom += v * m;
+            massSum += m;
         }
 
         // Remove any velocity shift
         vCom /= massSum;
-        v -= vCom;
+        std::transform(velocities.begin(), velocities.end(), velocities.begin(), [vCom](auto vel) { return vel - vCom; });
 
         // Calculate instantaneous temperature
         // J = kg m2 s-2  -->   10 J = g Ang2 ps-2
         // If ke is in units of [g mol-1 Angstroms2 ps-2] then must use kb in units of 10 J mol-1 K-1 (= 0.8314462)
         const auto kb = 0.8314462;
         ke = 0.0;
-        for (n = 0; n < cfg->nAtoms(); ++n)
-            ke += 0.5 * mass[n] * v[n].dp(v[n]);
-        tInstant = ke * 2.0 / (3.0 * cfg->nAtoms() * kb);
+        for (auto &&[m, v] : zip(mass, velocities))
+            ke += 0.5 * m * v.dp(v);
+        tInstant = ke * 2.0 / (3.0 * atoms.size() * kb);
 
         // Rescale velocities for desired temperature
         tScale = sqrt(temperature / tInstant);
-        for (n = 0; n < cfg->nAtoms(); ++n)
-            v[n] *= tScale;
+        std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto v) { return v * tScale; });
 
         // Open trajectory file (if requested)
         LineParser trajParser;
@@ -210,14 +211,12 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         if (variableTimestep)
         {
             if (restrictToSpecies_.nItems() > 0)
-                ForcesModule::totalForces(procPool, cfg, targetMolecules, dissolve.potentialMap(), fx, fy, fz);
+                ForcesModule::totalForces(procPool, cfg, targetMolecules, dissolve.potentialMap(), forces);
             else
-                ForcesModule::totalForces(procPool, cfg, dissolve.potentialMap(), fx, fy, fz);
+                ForcesModule::totalForces(procPool, cfg, dissolve.potentialMap(), forces);
 
             // Must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
-            fx *= 100.0;
-            fy *= 100.0;
-            fz *= 100.0;
+            std::transform(forces.begin(), forces.end(), forces.begin(), [](auto f) { return f * 100.0; });
         }
 
         // Ready to do MD propagation of system
@@ -225,40 +224,35 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         {
             // Variable timestep?
             if (variableTimestep)
-                deltaT = determineTimeStep(fx, fy, fz);
+                deltaT = determineTimeStep(forces);
 
             // Velocity Verlet first stage (A)
             // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
             // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
             // B:  a(t+dt) = F(t+dt)/m
             // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
-            for (n = 0; n < cfg->nAtoms(); ++n)
+            for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
             {
                 // Propagate positions (by whole step)...
-                atoms[n]->translateCoordinates(v[n] * deltaT + a[n] * 0.5 * deltaTSq);
+                i->translateCoordinates(v * deltaT + a * 0.5 * deltaTSq);
 
                 // ...velocities (by half step)...
-                v[n] += a[n] * 0.5 * deltaT;
+                v += a * 0.5 * deltaT;
             }
 
             // Update Cell contents / Atom locations
             cfg->updateCellContents();
 
             // Calculate forces - must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
-            fx = 0.0;
-            fy = 0.0;
-            fz = 0.0;
             if (restrictToSpecies_.nItems() > 0)
-                ForcesModule::totalForces(procPool, cfg, targetMolecules, dissolve.potentialMap(), fx, fy, fz);
+                ForcesModule::totalForces(procPool, cfg, targetMolecules, dissolve.potentialMap(), forces);
             else
-                ForcesModule::totalForces(procPool, cfg, dissolve.potentialMap(), fx, fy, fz);
-            fx *= 100.0;
-            fy *= 100.0;
-            fz *= 100.0;
+                ForcesModule::totalForces(procPool, cfg, dissolve.potentialMap(), forces);
+            std::transform(forces.begin(), forces.end(), forces.begin(), [](auto &f) { return f * 100.0; });
 
             // Cap forces
             if (capForce)
-                nCapped = capForces(cfg, maxForce, fx, fy, fz);
+                nCapped = capForces(maxForce, forces);
 
             // Velocity Verlet second stage (B) and velocity scaling
             // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
@@ -266,27 +260,21 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
             // B:  a(t+dt) = F(t+dt)/m
             // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
             ke = 0.0;
-            for (n = 0; n < cfg->nAtoms(); ++n)
+            for (auto &&[f, v, a, m] : zip(forces, velocities, accelerations, mass))
             {
                 // Determine new accelerations
-                a[n].set(fx[n], fy[n], fz[n]);
-                a[n] /= mass[n];
+                a = f / m;
 
                 // ..and finally velocities again (by second half-step)
-                v[n] += a[n] * 0.5 * deltaT;
+                v += a * 0.5 * deltaT;
 
-                ke += 0.5 * mass[n] * v[n].dp(v[n]);
+                ke += 0.5 * m * v.dp(v);
             }
 
             // Rescale velocities for desired temperature
             tInstant = ke * 2.0 / (3.0 * cfg->nAtoms() * kb);
             tScale = sqrt(temperature / tInstant);
-            for (n = 0; n < cfg->nAtoms(); ++n)
-            {
-                v[n].x *= tScale;
-                v[n].y *= tScale;
-                v[n].z *= tScale;
-            }
+            std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto &v) { return v * tScale; });
 
             // Convert ke from 10J/mol to kJ/mol
             ke *= 0.01;

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -166,8 +166,8 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // If ke is in units of [g mol-1 Angstroms2 ps-2] then must use kb in units of 10 J mol-1 K-1 (= 0.8314462)
         const auto kb = 0.8314462;
         ke = 0.0;
-        for (auto &&[m, v] : zip(mass, velocities))
-            ke += 0.5 * m * v.dp(v);
+        ke = std::transform_reduce(momentum.begin(), momentum.end(), velocity.begin(), 0.0, std::plus<>, 
+                                                    [](const auto &m, const auto &v) { return 0.5 * m * v.dp(v); });
         tInstant = ke * 2.0 / (3.0 * atoms.size() * kb);
 
         // Rescale velocities for desired temperature


### PR DESCRIPTION
Here we tidy up storage of force arrays in multiple places in the code. Previously each component (x, y, and z) of the forces for all atoms were stored in separate `Array<double>` which is convenient for MPI broadcast but annoying for almost everything else.

This PR moves force storage to `std::vector<Vec3<double>>`, and added new broadcast, produce, serialise, and deserialise functions accordingly.
