### PR TITLE
Parallel force calculations

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -7,6 +7,7 @@ dissolve_benchmark(box)
 dissolve_benchmark(histogram)
 dissolve_benchmark(array)
 dissolve_benchmark(energy)
+dissolve_benchmark(forces)
 
 # create a single benchmark executable
 add_executable(benchmarks benchmarks.cpp ${benchmark_files})

--- a/benchmark/forces/forces_benchmark.cpp
+++ b/benchmark/forces/forces_benchmark.cpp
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+#include "benchmark/benchmark.h"
+#include "classes/cell.h"
+#include "classes/forcekernel.h"
+#include "classes/species.h"
+#include "common/problems.h"
+#include "modules/forces/forces.h"
+
+template <ProblemType problem, Population population> ForceKernel createForceKernel(Problem<problem, population> &problemDef)
+{
+
+    auto &procPool = problemDef.dissolve_.worldPool();
+    const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
+    auto *cfg = problemDef.cfg_;
+    ForceKernel kernel(procPool, cfg->box(), potentialMap);
+    return kernel;
+}
+
+template <ProblemType problem, Population population> static void BM_CalculateForces_InterAtomic(benchmark::State &state)
+{
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto forceKernel = createForceKernel(problemDef);
+    const auto &cellArray = problemDef.cfg_->cells();
+    auto *cellI = cellArray.cell(1);
+    for (auto _ : state)
+    {
+        forceKernel.forces(cellI, true, ProcessPool::PoolStrategy, forces);
+    }
+}
+
+template <ProblemType problem, Population population> static void BM_CalculateForces_SpeciesBond(benchmark::State &state)
+{
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto forceKernel = createForceKernel(problemDef);
+    const auto &mol = problemDef.cfg_->molecules().front();
+    const auto &bond = mol->species()->bonds().back();
+
+    for (auto _ : state)
+    {
+        forceKernel.forces(bond, forces);
+    }
+}
+
+template <ProblemType problem, Population population> static void BM_CalculateForces_SpeciesAngle(benchmark::State &state)
+{
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto forceKernel = createForceKernel(problemDef);
+    const auto &mol = problemDef.cfg_->molecules().front();
+    const auto &angle = mol->species()->angles().back();
+    for (auto _ : state)
+    {
+        forceKernel.forces(angle, forces);
+    }
+}
+template <ProblemType problem, Population population> static void BM_CalculateForces_SpeciesTorsion(benchmark::State &state)
+{
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto forceKernel = createForceKernel(problemDef);
+    const auto &mol = problemDef.cfg_->molecules().front();
+    const auto &torsion = mol->species()->torsions().back();
+    for (auto _ : state)
+    {
+        forceKernel.forces(torsion, forces);
+    }
+}
+
+template <ProblemType problem, Population population>
+static void BM_CalculateForces_TotalIntraMolecular(benchmark::State &state)
+{
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto &procPool = problemDef.dissolve_.worldPool();
+    const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
+    for (auto _ : state)
+        ForcesModule::intraMolecularForces(procPool, cfg, potentialMap, forces);
+}
+
+template <ProblemType problem, Population population> static void BM_CalculateForces_TotalInterAtomic(benchmark::State &state)
+{
+
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto &procPool = problemDef.dissolve_.worldPool();
+    const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
+    for (auto _ : state)
+    {
+        std::vector<Vec3<double>> forces(cfg->nAtoms());
+        ForcesModule::interAtomicForces(procPool, cfg, potentialMap, forces);
+    }
+}
+
+template <ProblemType problem, Population population> static void BM_CalculateForces_TotalForces(benchmark::State &state)
+{
+
+    Problem<problem, population> problemDef;
+    auto *cfg = problemDef.cfg_;
+    std::vector<Vec3<double>> forces(cfg->nAtoms());
+    auto &procPool = problemDef.dissolve_.worldPool();
+    const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
+    for (auto _ : state)
+    {
+        std::vector<Vec3<double>> forces(cfg->nAtoms());
+        ForcesModule::totalForces(procPool, cfg, potentialMap, forces);
+    }
+}
+// small molecule benchmarks
+BENCHMARK_TEMPLATE(BM_CalculateForces_InterAtomic, ProblemType::smallMolecule, Population::small)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesBond, ProblemType::smallMolecule, Population::small);
+BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesAngle, ProblemType::smallMolecule, Population::small);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalIntraMolecular, ProblemType::smallMolecule, Population::small)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalInterAtomic, ProblemType::smallMolecule, Population::small)
+    ->Iterations(5)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalForces, ProblemType::smallMolecule, Population::small)
+    ->Iterations(5)
+    ->Unit(benchmark::kMillisecond);
+
+// medium molecule benchmarks
+BENCHMARK_TEMPLATE(BM_CalculateForces_InterAtomic, ProblemType::mediumMolecule, Population::small)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesAngle, ProblemType::mediumMolecule, Population::small);
+BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesBond, ProblemType::mediumMolecule, Population::small);
+BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesTorsion, ProblemType::mediumMolecule, Population::small);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalInterAtomic, ProblemType::mediumMolecule, Population::small)
+    ->Iterations(5)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalIntraMolecular, ProblemType::mediumMolecule, Population::small)
+    ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalForces, ProblemType::mediumMolecule, Population::small)
+    ->Iterations(5)
+    ->Unit(benchmark::kMillisecond);

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -23,9 +23,8 @@ ForceKernel::ForceKernel(ProcessPool &procPool, const Box *box, const PotentialM
  */
 
 // Calculate PairPotential forces between Atoms provided (no minimum image calculation)
-void ForceKernel::forcesWithoutMim(const Atom &i, const Atom &j, std::optional<double> scaleOpt, ForceVector &f) const
+void ForceKernel::forcesWithoutMim(const Atom &i, const Atom &j, ForceVector &f, double scale) const
 {
-    auto scale = scaleOpt.value_or(1.00);
     auto force = j.r() - i.r();
     auto distanceSq = force.magnitudeSq();
     if (distanceSq > cutoffDistanceSquared_)
@@ -38,9 +37,8 @@ void ForceKernel::forcesWithoutMim(const Atom &i, const Atom &j, std::optional<d
 }
 
 // Calculate PairPotential forces between Atoms provided (minimum image calculation)
-void ForceKernel::forcesWithMim(const Atom &i, const Atom &j, std::optional<double> scaleOpt, ForceVector &f) const
+void ForceKernel::forcesWithMim(const Atom &i, const Atom &j, ForceVector &f, double scale) const
 {
-    auto scale = scaleOpt.value_or(1.00);
     auto force = box_->minimumVector(i, j);
     auto distanceSq = force.magnitudeSq();
     if (distanceSq > cutoffDistanceSquared_)
@@ -69,9 +67,9 @@ void ForceKernel::forces(const Atom &i, const Atom &j, bool applyMim, bool exclu
         return;
 
     if (applyMim)
-        forcesWithMim(i, j, std::nullopt, f);
+        forcesWithMim(i, j, f);
     else
-        forcesWithoutMim(i, j, std::nullopt, f);
+        forcesWithoutMim(i, j, f);
 }
 
 // Calculate forces between atoms in supplied cells
@@ -107,12 +105,12 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
 
                 // Check for atoms in the same Molecule
                 if (molI != jj->molecule())
-                    forcesWithMim(*ii, *jj, std::nullopt, f);
+                    forcesWithMim(*ii, *jj, f);
                 else
                 {
                     double scale = ii->scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithMim(*ii, *jj, scale, f);
+                        forcesWithMim(*ii, *jj, f, scale);
                 }
             }
         }
@@ -135,12 +133,12 @@ void ForceKernel::forces(Cell *centralCell, Cell *otherCell, bool applyMim, bool
 
                 // Check for atoms in the same molecule
                 if (molI != jj->molecule())
-                    forcesWithoutMim(*ii, *jj, std::nullopt, f);
+                    forcesWithoutMim(*ii, *jj, f);
                 else
                 {
                     double scale = ii->scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithoutMim(*ii, *jj, scale, f);
+                        forcesWithoutMim(*ii, *jj, f, scale);
                 }
             }
         }
@@ -185,12 +183,12 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithMim(i, *jj, std::nullopt, f);
+                    forcesWithMim(i, *jj, f);
                 else
                 {
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithMim(i, *jj, std::nullopt, f);
+                        forcesWithMim(i, *jj, f);
                 }
             }
         else if (flags & KernelFlags::ExcludeIGEJFlag)
@@ -202,12 +200,12 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithMim(i, *jj, std::nullopt, f);
+                    forcesWithMim(i, *jj, f);
                 else
                 {
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithMim(i, *jj, scale, f);
+                        forcesWithMim(i, *jj, f, scale);
                 }
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
@@ -220,7 +218,7 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithMim(i, *jj, std::nullopt, f);
+                    forcesWithMim(i, *jj, f);
                 else
                 {
                     // Check for i >= jj
@@ -229,7 +227,7 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithMim(i, *jj, scale, f);
+                        forcesWithMim(i, *jj, f, scale);
                 }
             }
         }
@@ -243,12 +241,12 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithMim(i, *jj, std::nullopt, f);
+                    forcesWithMim(i, *jj, f);
                 else
                 {
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithMim(i, *jj, scale, f);
+                        forcesWithMim(i, *jj, f, scale);
                 }
             }
         }
@@ -269,12 +267,12 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithoutMim(i, *jj, std::nullopt, f);
+                    forcesWithoutMim(i, *jj, f);
                 else
                 {
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithoutMim(i, *jj, scale, f);
+                        forcesWithoutMim(i, *jj, f, scale);
                 }
             }
         else if (flags & KernelFlags::ExcludeIGEJFlag)
@@ -289,12 +287,12 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithoutMim(i, *jj, std::nullopt, f);
+                    forcesWithoutMim(i, *jj, f);
                 else
                 {
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithoutMim(i, *jj, scale, f);
+                        forcesWithoutMim(i, *jj, f, scale);
                 }
             }
         else if (flags & KernelFlags::ExcludeIntraIGEJFlag)
@@ -305,7 +303,7 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithoutMim(i, *jj, std::nullopt, f);
+                    forcesWithoutMim(i, *jj, f);
                 else
                 {
                     // Pointer comparison for i >= jj
@@ -314,7 +312,7 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithoutMim(i, *jj, scale, f);
+                        forcesWithoutMim(i, *jj, f, scale);
                 }
             }
         else
@@ -325,12 +323,12 @@ void ForceKernel::forces(const Atom &i, Cell *cell, int flags, ProcessPool::Divi
 
                 // Check for atoms in the same species
                 if (moleculeI != jj->molecule())
-                    forcesWithoutMim(i, *jj, std::nullopt, f);
+                    forcesWithoutMim(i, *jj, f);
                 else
                 {
                     double scale = i.scaling(jj);
                     if (scale > 1.0e-3)
-                        forcesWithoutMim(i, *jj, scale, f);
+                        forcesWithoutMim(i, *jj, f, scale);
                 }
             }
     }
@@ -358,53 +356,53 @@ void ForceKernel::forces(const Atom &i, ProcessPool::DivisionStrategy strategy, 
  */
 
 // Add torsion forces for atom 'i' in 'i-j-k-l' into the specified vector index and input vector
-void ForceKernel::addTorsionForceI(double du_dphi, int index, ForceKernel::TorsionParameters &torisionParameters,
+void ForceKernel::addTorsionForceI(double du_dphi, int index, ForceKernel::TorsionParameters &torsionParameters,
                                    ForceVector &f) const
 {
-    auto &dcos_dxpj = torisionParameters.dcos_dxpj_;
+    auto &dcos_dxpj = torsionParameters.dcos_dxpj_;
 
-    f[index].add(du_dphi * torisionParameters.dcos_dxpj_.dp(torisionParameters.dxpj_dij_.columnAsVec3(0)),
-                 du_dphi * torisionParameters.dcos_dxpj_.dp(torisionParameters.dxpj_dij_.columnAsVec3(1)),
-                 du_dphi * dcos_dxpj.dp(torisionParameters.dxpj_dij_.columnAsVec3(2)));
+    f[index].add(du_dphi * torsionParameters.dcos_dxpj_.dp(torsionParameters.dxpj_dij_.columnAsVec3(0)),
+                 du_dphi * torsionParameters.dcos_dxpj_.dp(torsionParameters.dxpj_dij_.columnAsVec3(1)),
+                 du_dphi * dcos_dxpj.dp(torsionParameters.dxpj_dij_.columnAsVec3(2)));
 }
 
 // Add torsion forces for atom 'j' in 'i-j-k-l' into the specified vector index and input vector
-void ForceKernel::addTorsionForceJ(double du_dphi, int index, ForceKernel::TorsionParameters &torisionParameters,
+void ForceKernel::addTorsionForceJ(double du_dphi, int index, ForceKernel::TorsionParameters &torsionParameters,
                                    ForceVector &f) const
 {
-    f[index].add(du_dphi * (torisionParameters.dcos_dxpj_.dp(-torisionParameters.dxpj_dij_.columnAsVec3(0) -
-                                                             torisionParameters.dxpj_dkj_.columnAsVec3(0)) -
-                            torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dkj_.columnAsVec3(0))),
-                 du_dphi * (torisionParameters.dcos_dxpj_.dp(-torisionParameters.dxpj_dij_.columnAsVec3(1) -
-                                                             torisionParameters.dxpj_dkj_.columnAsVec3(1)) -
-                            torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dkj_.columnAsVec3(1))),
-                 du_dphi * (torisionParameters.dcos_dxpj_.dp(-torisionParameters.dxpj_dij_.columnAsVec3(2) -
-                                                             torisionParameters.dxpj_dkj_.columnAsVec3(2)) -
-                            torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dkj_.columnAsVec3(2))));
+    f[index].add(du_dphi * (torsionParameters.dcos_dxpj_.dp(-torsionParameters.dxpj_dij_.columnAsVec3(0) -
+                                                            torsionParameters.dxpj_dkj_.columnAsVec3(0)) -
+                            torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dkj_.columnAsVec3(0))),
+                 du_dphi * (torsionParameters.dcos_dxpj_.dp(-torsionParameters.dxpj_dij_.columnAsVec3(1) -
+                                                            torsionParameters.dxpj_dkj_.columnAsVec3(1)) -
+                            torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dkj_.columnAsVec3(1))),
+                 du_dphi * (torsionParameters.dcos_dxpj_.dp(-torsionParameters.dxpj_dij_.columnAsVec3(2) -
+                                                            torsionParameters.dxpj_dkj_.columnAsVec3(2)) -
+                            torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dkj_.columnAsVec3(2))));
 }
 
 // Add torsion forces for atom 'k' in 'i-j-k-l' into the specified vector index and input vector
-void ForceKernel::addTorsionForceK(double du_dphi, int index, ForceKernel::TorsionParameters &torisionParameters,
+void ForceKernel::addTorsionForceK(double du_dphi, int index, ForceKernel::TorsionParameters &torsionParameters,
                                    ForceVector &f) const
 {
-    f[index].add(du_dphi * (torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dkj_.columnAsVec3(0) -
-                                                             torisionParameters.dxpk_dlk_.columnAsVec3(0)) +
-                            torisionParameters.dcos_dxpj_.dp(torisionParameters.dxpj_dkj_.columnAsVec3(0))),
-                 du_dphi * (torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dkj_.columnAsVec3(1) -
-                                                             torisionParameters.dxpk_dlk_.columnAsVec3(1)) +
-                            torisionParameters.dcos_dxpj_.dp(torisionParameters.dxpj_dkj_.columnAsVec3(1))),
-                 du_dphi * (torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dkj_.columnAsVec3(2) -
-                                                             torisionParameters.dxpk_dlk_.columnAsVec3(2)) +
-                            torisionParameters.dcos_dxpj_.dp(torisionParameters.dxpj_dkj_.columnAsVec3(2))));
+    f[index].add(du_dphi * (torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dkj_.columnAsVec3(0) -
+                                                            torsionParameters.dxpk_dlk_.columnAsVec3(0)) +
+                            torsionParameters.dcos_dxpj_.dp(torsionParameters.dxpj_dkj_.columnAsVec3(0))),
+                 du_dphi * (torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dkj_.columnAsVec3(1) -
+                                                            torsionParameters.dxpk_dlk_.columnAsVec3(1)) +
+                            torsionParameters.dcos_dxpj_.dp(torsionParameters.dxpj_dkj_.columnAsVec3(1))),
+                 du_dphi * (torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dkj_.columnAsVec3(2) -
+                                                            torsionParameters.dxpk_dlk_.columnAsVec3(2)) +
+                            torsionParameters.dcos_dxpj_.dp(torsionParameters.dxpj_dkj_.columnAsVec3(2))));
 }
 
 // Add torsion forces for atom 'l' in 'i-j-k-l' into the specified vector index and input vector
-void ForceKernel::addTorsionForceL(double du_dphi, int index, ForceKernel::TorsionParameters &torisionParameters,
+void ForceKernel::addTorsionForceL(double du_dphi, int index, ForceKernel::TorsionParameters &torsionParameters,
                                    ForceVector &f) const
 {
-    f[index].add(du_dphi * torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dlk_.columnAsVec3(0)),
-                 du_dphi * torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dlk_.columnAsVec3(1)),
-                 du_dphi * torisionParameters.dcos_dxpk_.dp(torisionParameters.dxpk_dlk_.columnAsVec3(2)));
+    f[index].add(du_dphi * torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dlk_.columnAsVec3(0)),
+                 du_dphi * torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dlk_.columnAsVec3(1)),
+                 du_dphi * torsionParameters.dcos_dxpk_.dp(torsionParameters.dxpk_dlk_.columnAsVec3(2)));
 }
 
 // Calculate SpeciesBond forces
@@ -647,18 +645,18 @@ void ForceKernel::forces(const Atom &onlyThis, const SpeciesTorsion &torsion, co
     else
         veckl = k.r() - l.r();
 
-    auto torisionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
-    const auto du_dphi = torsion.force(torisionParameters.phi_ * DEGRAD);
+    auto torsionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
+    const auto du_dphi = torsion.force(torsionParameters.phi_ * DEGRAD);
 
     // Sum forces for specified atom
     if (&onlyThis == &i)
-        addTorsionForceI(du_dphi, onlyThis.arrayIndex(), torisionParameters, f);
+        addTorsionForceI(du_dphi, onlyThis.arrayIndex(), torsionParameters, f);
     else if (&onlyThis == &j)
-        addTorsionForceJ(du_dphi, onlyThis.arrayIndex(), torisionParameters, f);
+        addTorsionForceJ(du_dphi, onlyThis.arrayIndex(), torsionParameters, f);
     else if (&onlyThis == &k)
-        addTorsionForceK(du_dphi, onlyThis.arrayIndex(), torisionParameters, f);
+        addTorsionForceK(du_dphi, onlyThis.arrayIndex(), torsionParameters, f);
     else
-        addTorsionForceL(du_dphi, onlyThis.arrayIndex(), torisionParameters, f);
+        addTorsionForceL(du_dphi, onlyThis.arrayIndex(), torsionParameters, f);
 }
 
 // Calculate SpeciesTorsion forces
@@ -668,14 +666,14 @@ void ForceKernel::forces(const SpeciesTorsion &torsion, ForceVector &f) const
     const Vec3<double> vecji = torsion.j()->r() - torsion.i()->r(), vecjk = torsion.j()->r() - torsion.k()->r(),
                        veckl = torsion.k()->r() - torsion.l()->r();
 
-    auto torisionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
-    const auto du_dphi = torsion.force(torisionParameters.phi_ * DEGRAD);
+    auto torsionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
+    const auto du_dphi = torsion.force(torsionParameters.phi_ * DEGRAD);
 
     // Sum forces on atoms
-    addTorsionForceI(du_dphi, torsion.i()->index(), torisionParameters, f);
-    addTorsionForceJ(du_dphi, torsion.j()->index(), torisionParameters, f);
-    addTorsionForceK(du_dphi, torsion.k()->index(), torisionParameters, f);
-    addTorsionForceL(du_dphi, torsion.l()->index(), torisionParameters, f);
+    addTorsionForceI(du_dphi, torsion.i()->index(), torsionParameters, f);
+    addTorsionForceJ(du_dphi, torsion.j()->index(), torsionParameters, f);
+    addTorsionForceK(du_dphi, torsion.k()->index(), torsionParameters, f);
+    addTorsionForceL(du_dphi, torsion.l()->index(), torsionParameters, f);
 }
 
 // Calculate SpeciesImproper forces
@@ -697,14 +695,14 @@ void ForceKernel::forces(const SpeciesImproper &improper, const Atom &i, const A
     else
         veckl = k.r() - l.r();
 
-    auto torisionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
-    const auto du_dphi = improper.force(torisionParameters.phi_ * DEGRAD);
+    auto torsionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
+    const auto du_dphi = improper.force(torsionParameters.phi_ * DEGRAD);
 
     // Sum forces on atoms
-    addTorsionForceI(du_dphi, i.arrayIndex(), torisionParameters, f);
-    addTorsionForceJ(du_dphi, j.arrayIndex(), torisionParameters, f);
-    addTorsionForceK(du_dphi, k.arrayIndex(), torisionParameters, f);
-    addTorsionForceL(du_dphi, l.arrayIndex(), torisionParameters, f);
+    addTorsionForceI(du_dphi, i.arrayIndex(), torsionParameters, f);
+    addTorsionForceJ(du_dphi, j.arrayIndex(), torsionParameters, f);
+    addTorsionForceK(du_dphi, k.arrayIndex(), torsionParameters, f);
+    addTorsionForceL(du_dphi, l.arrayIndex(), torsionParameters, f);
 }
 
 // Calculate SpeciesImproper forces for specified Atom only

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -26,6 +26,7 @@ class ForceKernel
     ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, double cutoffDistance = -1.0);
     ~ForceKernel() = default;
 
+    // alias for force storage vector
     using ForceVector = std::vector<Vec3<double>>;
     /*
      * Source Data
@@ -120,8 +121,7 @@ class ForceKernel
                 ForceVector &f) const;
 
     // Torsion terms
-    // Calculate SpeciesTorsionforces for given atoms
-
+    // Calculate SpeciesTorsion forces for given atoms
     void forces(const SpeciesTorsion &torsion, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
                 ForceVector &f) const;
     // Calculate SpeciesTorsion forces

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -44,9 +44,9 @@ class ForceKernel
      */
     private:
     // Calculate inter-particle forces between Atoms provided (no minimum image calculation)
-    void forcesWithoutMim(const Atom &i, const Atom &j, std::optional<double>, ForceVector &f) const;
+    void forcesWithoutMim(const Atom &i, const Atom &j, ForceVector &f, double scale = 1.00) const;
     // Calculate inter-particle forces between Atoms provided (minimum image calculation)
-    void forcesWithMim(const Atom &i, const Atom &j, std::optional<double>, ForceVector &f) const;
+    void forcesWithMim(const Atom &i, const Atom &j, ForceVector &f, double scale = 1.00) const;
 
     /*
      * PairPotential Terms
@@ -94,13 +94,13 @@ class ForceKernel
      */
     private:
     // Add torsion forces for atom 'i' in 'i-j-k-l' into the specified vector index
-    void addTorsionForceI(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
+    void addTorsionForceI(double du_dphi, int index, TorsionParameters &torsionParameters, ForceVector &f) const;
     // Sum torsion forces for atom 'j' in 'i-j-k-l' into the specified vector index
-    void addTorsionForceJ(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
+    void addTorsionForceJ(double du_dphi, int index, TorsionParameters &torsionParameters, ForceVector &f) const;
     // Sum torsion forces for atom 'k' in 'i-j-k-l' into the specified vector index
-    void addTorsionForceK(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
+    void addTorsionForceK(double du_dphi, int index, TorsionParameters &torsionParameters, ForceVector &f) const;
     // Sum torsion forces for atom 'l' in 'i-j-k-l' into the specified vector index
-    void addTorsionForceL(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
+    void addTorsionForceL(double du_dphi, int index, TorsionParameters &torsionParameters, ForceVector &f) const;
 
     public:
     // Bond terms

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -6,6 +6,7 @@
 #include "base/processpool.h"
 #include "classes/cellarray.h"
 #include "classes/kernelflags.h"
+#include <optional>
 
 // Forward Declarations
 class Atom;
@@ -22,10 +23,10 @@ class SpeciesTorsion;
 class ForceKernel
 {
     public:
-    ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, std::vector<Vec3<double>> &f,
-                double cutoffDistance = -1.0);
+    ForceKernel(ProcessPool &procPool, const Box *box, const PotentialMap &potentialMap, double cutoffDistance = -1.0);
     ~ForceKernel() = default;
 
+    using ForceVector = std::vector<Vec3<double>>;
     /*
      * Source Data
      */
@@ -36,98 +37,108 @@ class ForceKernel
     const PotentialMap &potentialMap_;
     // Squared cutoff distance to use in calculation
     double cutoffDistanceSquared_;
-    // Force vector
-    std::vector<Vec3<double>> &f_;
 
     /*
      * Internal Force Calculation
      */
     private:
     // Calculate inter-particle forces between Atoms provided (no minimum image calculation)
-    void forcesWithoutMim(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double scale = 1.0);
+    void forcesWithoutMim(const Atom &i, const Atom &j, std::optional<double>, ForceVector &f) const;
     // Calculate inter-particle forces between Atoms provided (minimum image calculation)
-    void forcesWithMim(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double scale = 1.0);
+    void forcesWithMim(const Atom &i, const Atom &j, std::optional<double>, ForceVector &f) const;
 
     /*
      * PairPotential Terms
      */
     public:
     // Calculate forces between atoms provided
-    void forces(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, bool applyMim, bool excludeIgeJ);
+    void forces(const Atom &i, const Atom &j, bool applyMim, bool excludeIgeJ, ForceVector &f) const;
     // Calculate forces between two cells
-    void forces(Cell *cell, Cell *otherCell, bool applyMim, bool excludeIgeJ, ProcessPool::DivisionStrategy strategy);
+    void forces(Cell *cell, Cell *otherCell, bool applyMim, bool excludeIgeJ, ProcessPool::DivisionStrategy strategy,
+                ForceVector &f) const;
     // Calculate forces between Cell and its neighbours
-    void forces(Cell *cell, bool excludeIgeJ, ProcessPool::DivisionStrategy strategy);
+    void forces(Cell *cell, bool excludeIgeJ, ProcessPool::DivisionStrategy strategy, ForceVector &f) const;
     // Calculate forces between Atom and Cell
-    void forces(const std::shared_ptr<Atom> i, Cell *cell, int flags, ProcessPool::DivisionStrategy strategy);
+    void forces(const Atom &i, Cell *cell, int flags, ProcessPool::DivisionStrategy strategy, ForceVector &f) const;
     // Calculate forces between atom and world
-    void forces(const std::shared_ptr<Atom> i, ProcessPool::DivisionStrategy strategy);
+    void forces(const Atom &i, ProcessPool::DivisionStrategy strategy, ForceVector &f) const;
+
+    struct TorsionParameters
+    {
+        TorsionParameters() = default;
+        double phi_;
+        Matrix3 dxpj_dij_;
+        Matrix3 dxpj_dkj_;
+        Matrix3 dxpk_dkj_;
+        Matrix3 dxpk_dlk_;
+        Vec3<double> dcos_dxpj_;
+        Vec3<double> dcos_dxpk_;
+    };
+
+    struct AngleParameters
+    {
+        AngleParameters() = default;
+        double theta_;
+        Vec3<double> dfi_dtheta_;
+        Vec3<double> dfk_dtheta_;
+    };
+    // Calculate angle force parameters from supplied vectors
+    static AngleParameters calculateAngleParameters(Vec3<double> vecji, Vec3<double> vecjk);
+    // Calculate torsion force parameters from supplied vectors
+    static TorsionParameters calculateTorsionParameters(const Vec3<double> &vecji, const Vec3<double> &vecjk,
+                                                        const Vec3<double> &veckl);
 
     /*
      * Intramolecular Terms
      */
     private:
-    // Local calculated angle parameters
-    double theta_;
-    Vec3<double> dfi_dtheta_, dfk_dtheta_;
-    // Local calculated torsion parameters
-    double phi_;
-    Matrix3 dxpj_dij_, dxpj_dkj_, dxpk_dkj_, dxpk_dlk_;
-    Vec3<double> dcos_dxpj_, dcos_dxpk_;
-
-    private:
-    // Calculate angle force parameters from supplied vectors, storing result in local class variables
-    void calculateAngleParameters(Vec3<double> vecji, Vec3<double> vecjk);
-    // Calculate torsion force parameters from supplied vectors, storing result in local class variables
-    void calculateTorsionParameters(const Vec3<double> vecji, const Vec3<double> vecjk, const Vec3<double> veckl);
-    // Sum torsion forces for atom 'i' in 'i-j-k-l' into the specified vector index
-    void sumTorsionForceI(double du_dphi, int index);
+    // Add torsion forces for atom 'i' in 'i-j-k-l' into the specified vector index
+    void addTorsionForceI(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
     // Sum torsion forces for atom 'j' in 'i-j-k-l' into the specified vector index
-    void sumTorsionForceJ(double du_dphi, int index);
+    void addTorsionForceJ(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
     // Sum torsion forces for atom 'k' in 'i-j-k-l' into the specified vector index
-    void sumTorsionForceK(double du_dphi, int index);
+    void addTorsionForceK(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
     // Sum torsion forces for atom 'l' in 'i-j-k-l' into the specified vector index
-    void sumTorsionForceL(double du_dphi, int index);
+    void addTorsionForceL(double du_dphi, int index, TorsionParameters &torisionParameters, ForceVector &f) const;
 
     public:
+    // Bond terms
+    // Calculate SpeciesBond forces for given atoms
+    void forces(const SpeciesBond &bond, const Atom &i, const Atom &j, ForceVector &f) const;
     // Calculate SpeciesBond forces
-    void forces(const SpeciesBond &bond, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j);
-    // Calculate SpeciesBond forces
-    void forces(const SpeciesBond &bond);
+    void forces(const SpeciesBond &bond, ForceVector &f) const;
     // Calculate SpeciesBond forces for specified Atom only
-    void forces(const std::shared_ptr<Atom> onlyThis, const SpeciesBond &bond, const std::shared_ptr<Atom> i,
-                const std::shared_ptr<Atom> j);
-    // Calculate angle force parameters from supplied vectors, storing results in supplied variables
-    static void calculateAngleParameters(Vec3<double> vecji, Vec3<double> vecjk, double &theta, Vec3<double> &dfi_dtheta,
-                                         Vec3<double> &dfk_dtheta);
+    void forces(const Atom &onlyThis, const SpeciesBond &bond, const Atom &i, const Atom &j, ForceVector &f) const;
+
+    // Angle terms
+    // Calculate SpeciesAngle forces for given atoms
+    void forces(const SpeciesAngle &angle, const Atom &i, const Atom &j, const Atom &k, ForceVector &f) const;
     // Calculate SpeciesAngle forces
-    void forces(const SpeciesAngle &angle, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j,
-                const std::shared_ptr<Atom> k);
-    // Calculate SpeciesAngle forces
-    void forces(const SpeciesAngle &angle);
+    void forces(const SpeciesAngle &angle, ForceVector &f) const;
     // Calculate SpeciesAngle forces for specified Atom only
-    void forces(const std::shared_ptr<Atom> onlyThis, const SpeciesAngle &angle, const std::shared_ptr<Atom> i,
-                const std::shared_ptr<Atom> j, const std::shared_ptr<Atom> k);
-    // Calculate torsion force parameters from supplied vectors, storing results in supplied variables
-    static void calculateTorsionParameters(const Vec3<double> vecji, const Vec3<double> vecjk, const Vec3<double> veckl,
-                                           double &phi, Matrix3 &dxpj_dij, Matrix3 &dxpj_dkj, Matrix3 &dxpk_dkj,
-                                           Matrix3 &dxpk_dlk, Vec3<double> &dcos_dxpj, Vec3<double> &dcos_dxpk);
+    void forces(const Atom &onlyThis, const SpeciesAngle &angle, const Atom &i, const Atom &j, const Atom &k,
+                ForceVector &f) const;
+
+    // Torsion terms
+    // Calculate SpeciesTorsionforces for given atoms
+
+    void forces(const SpeciesTorsion &torsion, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
+                ForceVector &f) const;
     // Calculate SpeciesTorsion forces
-    void forces(const SpeciesTorsion &torsion, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j,
-                const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l);
-    // Calculate SpeciesTorsion forces
-    void forces(const SpeciesTorsion &torsion);
+    void forces(const SpeciesTorsion &torsion, ForceVector &f) const;
     // Calculate SpeciesTorsion forces for specified Atom only
-    void forces(const std::shared_ptr<Atom> onlyThis, const SpeciesTorsion &torsion, const std::shared_ptr<Atom> i,
-                const std::shared_ptr<Atom> j, const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l);
+    void forces(const Atom &onlyThis, const SpeciesTorsion &torsion, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
+                ForceVector &f) const;
+
+    // Improper Terms
+    // Calculate SpeciesImproper forces for given atoms
+    void forces(const SpeciesImproper &improper, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
+                ForceVector &f) const;
     // Calculate SpeciesImproper forces
-    void forces(const SpeciesImproper &torsion, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j,
-                const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l);
-    // Calculate SpeciesImproper forces
-    void forces(const SpeciesImproper &torsion);
+    void forces(const SpeciesImproper &improper, ForceVector &f) const;
     // Calculate SpeciesImproper forces for specified Atom only
-    void forces(const std::shared_ptr<Atom> onlyThis, const SpeciesImproper &torsion, const std::shared_ptr<Atom> i,
-                const std::shared_ptr<Atom> j, const std::shared_ptr<Atom> k, const std::shared_ptr<Atom> l);
+    void forces(const Atom &onlyThis, const SpeciesImproper &improper, const Atom &i, const Atom &j, const Atom &k,
+                const Atom &l, ForceVector &f) const;
 
     /*
      * Parallel Comms

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -114,20 +114,6 @@ double PotentialMap::analyticEnergy(const std::shared_ptr<Atom> i, const std::sh
 }
 
 // Return force between Atoms at distance specified
-double PotentialMap::force(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const
-{
-    assert(r >= 0.0);
-    assert(i && j);
-    assert(i->speciesAtom() && j->speciesAtom());
-
-    // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
-    // interpolated potential
-    auto *pp = potentialMatrix_[{i->masterTypeIndex(), j->masterTypeIndex()}];
-    return pp->includeCoulomb()
-               ? pp->force(r)
-               : pp->force(r) + pp->analyticCoulombForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
-}
-// Return force between Atoms at distance specified
 double PotentialMap::force(const Atom &i, const Atom &j, double r) const
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
@@ -148,15 +134,6 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r)
     // interpolated potential
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return pp->includeCoulomb() ? pp->force(r) : pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r);
-}
-
-// Return force between SpeciesAtoms at distance specified
-double PotentialMap::force(const SpeciesAtom &i, const SpeciesAtom &j, double r) const
-{
-    // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
-    // interpolated potential
-    auto *pp = potentialMatrix_[{i.atomType()->index(), j.atomType()->index()}];
-    return pp->includeCoulomb() ? pp->force(r) : pp->force(r) + pp->analyticCoulombForce(i.charge() * j.charge(), r);
 }
 
 // Return analytic force between Atom types at distance specified

--- a/src/classes/potentialmap.cpp
+++ b/src/classes/potentialmap.cpp
@@ -127,6 +127,16 @@ double PotentialMap::force(const std::shared_ptr<Atom> i, const std::shared_ptr<
                ? pp->force(r)
                : pp->force(r) + pp->analyticCoulombForce(i->speciesAtom()->charge() * j->speciesAtom()->charge(), r);
 }
+// Return force between Atoms at distance specified
+double PotentialMap::force(const Atom &i, const Atom &j, double r) const
+{
+    // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
+    // interpolated potential
+    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    return pp->includeCoulomb()
+               ? pp->force(r)
+               : pp->force(r) + pp->analyticCoulombForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r);
+}
 
 // Return force between SpeciesAtoms at distance specified
 double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r) const
@@ -138,6 +148,15 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r)
     // interpolated potential
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return pp->includeCoulomb() ? pp->force(r) : pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r);
+}
+
+// Return force between SpeciesAtoms at distance specified
+double PotentialMap::force(const SpeciesAtom &i, const SpeciesAtom &j, double r) const
+{
+    // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
+    // interpolated potential
+    auto *pp = potentialMatrix_[{i.atomType()->index(), j.atomType()->index()}];
+    return pp->includeCoulomb() ? pp->force(r) : pp->force(r) + pp->analyticCoulombForce(i.charge() * j.charge(), r);
 }
 
 // Return analytic force between Atom types at distance specified

--- a/src/classes/potentialmap.h
+++ b/src/classes/potentialmap.h
@@ -51,8 +51,12 @@ class PotentialMap
     double analyticEnergy(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const;
     // Return force between Atoms at distance specified
     double force(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const;
+    // Return force between Atoms at distance specified
+    double force(const Atom &i, const Atom &j, double r) const;
     // Return force between SpeciesAtoms at distance specified
     double force(const SpeciesAtom *i, const SpeciesAtom *j, double r) const;
+    // Return force between species atoms at distance specified
+    double force(const SpeciesAtom &i, const SpeciesAtom &j, double r) const;
     // Return analytic force between Atom types at distance specified
     double analyticForce(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const;
 };

--- a/src/classes/potentialmap.h
+++ b/src/classes/potentialmap.h
@@ -50,13 +50,9 @@ class PotentialMap
     // Return analytic energy between Atom types at distance specified
     double analyticEnergy(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const;
     // Return force between Atoms at distance specified
-    double force(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const;
-    // Return force between Atoms at distance specified
     double force(const Atom &i, const Atom &j, double r) const;
     // Return force between SpeciesAtoms at distance specified
     double force(const SpeciesAtom *i, const SpeciesAtom *j, double r) const;
-    // Return force between species atoms at distance specified
-    double force(const SpeciesAtom &i, const SpeciesAtom &j, double r) const;
     // Return analytic force between Atom types at distance specified
     double analyticForce(const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j, double r) const;
 };

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -82,9 +82,8 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
             double magjisq, magji, magjk, dp, force, r;
             std::shared_ptr<Atom> i, j, k, l;
             Vec3<double> vecji, vecjk, veckl, forcei, forcek;
-            Vec3<double> xpj, xpk, dcos_dxpj, dcos_dxpk, temp;
-            Matrix3 dxpj_dij, dxpj_dkj, dxpk_dkj, dxpk_dlk;
-            double phi, du_dphi;
+            Vec3<double> xpj, xpk, temp;
+            double du_dphi;
             std::shared_ptr<Molecule> molN, molM;
             const auto *box = cfg->box();
             double scale;
@@ -229,9 +228,14 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                         veckl = box->minimumVector(l, k);
 
                         // Calculate torsion force parameters
-                        ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl, phi, dxpj_dij, dxpj_dkj, dxpk_dkj,
-                                                                dxpk_dlk, dcos_dxpj, dcos_dxpk);
-                        du_dphi = torsion.force(phi * DEGRAD);
+                        auto torisionParameters = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
+                        auto dxpj_dij = torisionParameters.dxpj_dij_;
+                        auto dxpj_dkj = torisionParameters.dxpj_dkj_;
+                        auto dxpk_dkj = torisionParameters.dxpk_dkj_;
+                        auto dxpk_dlk = torisionParameters.dxpk_dlk_;
+                        auto dcos_dxpj = torisionParameters.dcos_dxpj_;
+                        auto dcos_dxpk = torisionParameters.dcos_dxpk_;
+                        du_dphi = torsion.force(torisionParameters.phi_ * DEGRAD);
 
                         // Sum forces on Atoms
                         fIntra[i->arrayIndex()].add(du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(0)),
@@ -274,9 +278,14 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                         veckl = box->minimumVector(l, k);
 
                         // Calculate improper force parameters
-                        ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl, phi, dxpj_dij, dxpj_dkj, dxpk_dkj,
-                                                                dxpk_dlk, dcos_dxpj, dcos_dxpk);
-                        du_dphi = imp.force(phi * DEGRAD);
+                        auto torisionParameters = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
+                        auto dxpj_dij = torisionParameters.dxpj_dij_;
+                        auto dxpj_dkj = torisionParameters.dxpj_dkj_;
+                        auto dxpk_dkj = torisionParameters.dxpk_dkj_;
+                        auto dxpk_dlk = torisionParameters.dxpk_dlk_;
+                        auto dcos_dxpj = torisionParameters.dcos_dxpj_;
+                        auto dcos_dxpk = torisionParameters.dcos_dxpk_;
+                        du_dphi = imp.force(torisionParameters.phi_ * DEGRAD);
 
                         // Sum forces on Atoms
                         fIntra[i->arrayIndex()].add(du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(0)),

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -128,7 +128,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                             if (testAnalytic)
                                 vecji *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r) * scale;
                             else
-                                vecji *= potentialMap.force(molN->atom(ii), molN->atom(jj), r) * scale;
+                                vecji *= potentialMap.force(*molN->atom(ii), *molN->atom(jj), r) * scale;
                             fInter[i->arrayIndex()] += vecji;
                             fInter[j->arrayIndex()] -= vecji;
                         }
@@ -160,7 +160,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                                 if (testAnalytic)
                                     vecji *= potentialMap.analyticForce(i, j, r);
                                 else
-                                    vecji *= potentialMap.force(i, j, r);
+                                    vecji *= potentialMap.force(*i, *j, r);
 
                                 fInter[i->arrayIndex()] += vecji;
                                 fInter[j->arrayIndex()] -= vecji;
@@ -228,39 +228,33 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                         veckl = box->minimumVector(l, k);
 
                         // Calculate torsion force parameters
-                        auto torisionParameters = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
-                        auto dxpj_dij = torisionParameters.dxpj_dij_;
-                        auto dxpj_dkj = torisionParameters.dxpj_dkj_;
-                        auto dxpk_dkj = torisionParameters.dxpk_dkj_;
-                        auto dxpk_dlk = torisionParameters.dxpk_dlk_;
-                        auto dcos_dxpj = torisionParameters.dcos_dxpj_;
-                        auto dcos_dxpk = torisionParameters.dcos_dxpk_;
-                        du_dphi = torsion.force(torisionParameters.phi_ * DEGRAD);
+                        auto tp = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
+                        du_dphi = torsion.force(tp.phi_ * DEGRAD);
 
                         // Sum forces on Atoms
-                        fIntra[i->arrayIndex()].add(du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(0)),
-                                                    du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(1)),
-                                                    du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(2)));
+                        fIntra[i->arrayIndex()].add(du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(0)),
+                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(1)),
+                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(2)));
 
                         fIntra[j->arrayIndex()].add(
-                            du_dphi * (dcos_dxpj.dp(-dxpj_dij.columnAsVec3(0) - dxpj_dkj.columnAsVec3(0)) -
-                                       dcos_dxpk.dp(dxpk_dkj.columnAsVec3(0))),
-                            du_dphi * (dcos_dxpj.dp(-dxpj_dij.columnAsVec3(1) - dxpj_dkj.columnAsVec3(1)) -
-                                       dcos_dxpk.dp(dxpk_dkj.columnAsVec3(1))),
-                            du_dphi * (dcos_dxpj.dp(-dxpj_dij.columnAsVec3(2) - dxpj_dkj.columnAsVec3(2)) -
-                                       dcos_dxpk.dp(dxpk_dkj.columnAsVec3(2))));
+                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(0) - tp.dxpj_dkj_.columnAsVec3(0)) -
+                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0))),
+                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(1) - tp.dxpj_dkj_.columnAsVec3(1)) -
+                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1))),
+                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(2) - tp.dxpj_dkj_.columnAsVec3(2)) -
+                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2))));
 
                         fIntra[k->arrayIndex()].add(
-                            du_dphi * (dcos_dxpk.dp(dxpk_dkj.columnAsVec3(0) - dxpk_dlk.columnAsVec3(0)) +
-                                       dcos_dxpj.dp(dxpj_dkj.columnAsVec3(0))),
-                            du_dphi * (dcos_dxpk.dp(dxpk_dkj.columnAsVec3(1) - dxpk_dlk.columnAsVec3(1)) +
-                                       dcos_dxpj.dp(dxpj_dkj.columnAsVec3(1))),
-                            du_dphi * (dcos_dxpk.dp(dxpk_dkj.columnAsVec3(2) - dxpk_dlk.columnAsVec3(2)) +
-                                       dcos_dxpj.dp(dxpj_dkj.columnAsVec3(2))));
+                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0) - tp.dxpk_dlk_.columnAsVec3(0)) +
+                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(0))),
+                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1) - tp.dxpk_dlk_.columnAsVec3(1)) +
+                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(1))),
+                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2) - tp.dxpk_dlk_.columnAsVec3(2)) +
+                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(2))));
 
-                        fIntra[l->arrayIndex()].add(du_dphi * dcos_dxpk.dp(dxpk_dlk.columnAsVec3(0)),
-                                                    du_dphi * dcos_dxpk.dp(dxpk_dlk.columnAsVec3(1)),
-                                                    du_dphi * dcos_dxpk.dp(dxpk_dlk.columnAsVec3(2)));
+                        fIntra[l->arrayIndex()].add(du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(0)),
+                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(1)),
+                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(2)));
                     }
 
                     // Improper forces
@@ -278,39 +272,33 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                         veckl = box->minimumVector(l, k);
 
                         // Calculate improper force parameters
-                        auto torisionParameters = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
-                        auto dxpj_dij = torisionParameters.dxpj_dij_;
-                        auto dxpj_dkj = torisionParameters.dxpj_dkj_;
-                        auto dxpk_dkj = torisionParameters.dxpk_dkj_;
-                        auto dxpk_dlk = torisionParameters.dxpk_dlk_;
-                        auto dcos_dxpj = torisionParameters.dcos_dxpj_;
-                        auto dcos_dxpk = torisionParameters.dcos_dxpk_;
-                        du_dphi = imp.force(torisionParameters.phi_ * DEGRAD);
+                        auto tp = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
+                        du_dphi = imp.force(tp.phi_ * DEGRAD);
 
                         // Sum forces on Atoms
-                        fIntra[i->arrayIndex()].add(du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(0)),
-                                                    du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(1)),
-                                                    du_dphi * dcos_dxpj.dp(dxpj_dij.columnAsVec3(2)));
+                        fIntra[i->arrayIndex()].add(du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(0)),
+                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(1)),
+                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(2)));
 
                         fIntra[j->arrayIndex()].add(
-                            du_dphi * (dcos_dxpj.dp(-dxpj_dij.columnAsVec3(0) - dxpj_dkj.columnAsVec3(0)) -
-                                       dcos_dxpk.dp(dxpk_dkj.columnAsVec3(0))),
-                            du_dphi * (dcos_dxpj.dp(-dxpj_dij.columnAsVec3(1) - dxpj_dkj.columnAsVec3(1)) -
-                                       dcos_dxpk.dp(dxpk_dkj.columnAsVec3(1))),
-                            du_dphi * (dcos_dxpj.dp(-dxpj_dij.columnAsVec3(2) - dxpj_dkj.columnAsVec3(2)) -
-                                       dcos_dxpk.dp(dxpk_dkj.columnAsVec3(2))));
+                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(0) - tp.dxpj_dkj_.columnAsVec3(0)) -
+                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0))),
+                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(1) - tp.dxpj_dkj_.columnAsVec3(1)) -
+                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1))),
+                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(2) - tp.dxpj_dkj_.columnAsVec3(2)) -
+                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2))));
 
                         fIntra[k->arrayIndex()].add(
-                            du_dphi * (dcos_dxpk.dp(dxpk_dkj.columnAsVec3(0) - dxpk_dlk.columnAsVec3(0)) +
-                                       dcos_dxpj.dp(dxpj_dkj.columnAsVec3(0))),
-                            du_dphi * (dcos_dxpk.dp(dxpk_dkj.columnAsVec3(1) - dxpk_dlk.columnAsVec3(1)) +
-                                       dcos_dxpj.dp(dxpj_dkj.columnAsVec3(1))),
-                            du_dphi * (dcos_dxpk.dp(dxpk_dkj.columnAsVec3(2) - dxpk_dlk.columnAsVec3(2)) +
-                                       dcos_dxpj.dp(dxpj_dkj.columnAsVec3(2))));
+                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0) - tp.dxpk_dlk_.columnAsVec3(0)) +
+                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(0))),
+                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1) - tp.dxpk_dlk_.columnAsVec3(1)) +
+                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(1))),
+                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2) - tp.dxpk_dlk_.columnAsVec3(2)) +
+                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(2))));
 
-                        fIntra[l->arrayIndex()].add(du_dphi * dcos_dxpk.dp(dxpk_dlk.columnAsVec3(0)),
-                                                    du_dphi * dcos_dxpk.dp(dxpk_dlk.columnAsVec3(1)),
-                                                    du_dphi * dcos_dxpk.dp(dxpk_dlk.columnAsVec3(2)));
+                        fIntra[l->arrayIndex()].add(du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(0)),
+                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(1)),
+                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(2)));
                     }
                 }
             }

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -196,4 +196,28 @@ T transform_reduce(ParallelPolicy, Iter begin, Iter end, T initialVal, BinaryOp 
 {
     return dissolve::transform_reduce(begin, end, initialVal, binaryOp, unaryOp);
 }
+
+// For each algorithm
+// unaryOp applies to each element in the range
+// Base for_each, no parallel policy
+template <class Iter, class UnaryOp> void for_each(Iter begin, Iter end, UnaryOp unaryOp)
+{
+    std::for_each(begin, end, unaryOp);
+}
+// Only enabled if parallelpolicies are fully defined i.e. we have compiled with multithreading enabled
+template <typename ParallelPolicy, class Iter, class UnaryOp,
+          std::enable_if_t<dissolve::internal::is_execution_policy<ParallelPolicy>::value, bool> = true>
+void for_each(ParallelPolicy policy, Iter begin, Iter end, UnaryOp unaryOp)
+{
+    std::for_each(policy, begin, end, unaryOp);
+}
+
+// Enabled if parallelpolicy is not a real execution policy, i.e. we haven't compiled with multithreading but attempted to set a
+// parallel policy
+template <typename ParallelPolicy, class Iter, class UnaryOp,
+          std::enable_if_t<std::is_same_v<ParallelPolicy, FakeParallelPolicy>, bool> = true>
+void for_each(ParallelPolicy, Iter begin, Iter end, UnaryOp unaryOp)
+{
+    dissolve::for_each(begin, end, unaryOp);
+}
 } // namespace dissolve

--- a/src/templates/combinable.h
+++ b/src/templates/combinable.h
@@ -15,7 +15,7 @@ namespace dissolve
 // - Capture the combinable by reference in the lambda operator of the parallel operation
 // - Within the lambda operator call local() to access a thread local version of the container
 // - After the parallel operation call finaliize to accumulate into the parent container.
-template <class Container> struct CombinableContainer
+template <class Container> class CombinableContainer
 {
     public:
     template <typename Lambda>

--- a/src/templates/combinable.h
+++ b/src/templates/combinable.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+#include "parallel_defs.h"
+
+namespace dissolve
+{
+// A combinable container used in multithreading operations
+// The local method retrives a thread local object during the multithreading computations
+// We then use finalize to combine each thread local storage instance into the parent container
+// using std::transform
+
+// Usage:
+// - Create an instance by passing in the parent container and a lambda initializer which specifies how to create local
+// instances of the container
+// - Capture the combinable by reference in the lambda operator of the parallel operation
+// - Within the lambda operator call local() to access a thread local version of the container
+// - After the parallel operation call finaliize to accumulate into the parent container.
+template <class Container> struct CombinableContainer
+{
+    public:
+    template <typename Lambda>
+    CombinableContainer(Container &parent, Lambda initializer) : parent_(parent), combinable_(initializer)
+    {
+    }
+    void finalize()
+    {
+        auto combineOp = [this](const auto &localContainer) {
+            std::transform(parent_.begin(), parent_.end(), localContainer.begin(), parent_.begin(), std::plus<>{});
+        };
+        combinable_.combine_each(combineOp);
+    }
+
+    Container &local() { return combinable_.local(); }
+
+    private:
+    Container &parent_;
+    dissolve::combinable<Container> combinable_;
+};
+} // namespace dissolve

--- a/src/templates/parallel_tbb.h
+++ b/src/templates/parallel_tbb.h
@@ -11,12 +11,6 @@ namespace dissolve
 // returns a tbb iteration range between begin and end
 inline auto blocked_range(int begin, int end) { return tbb::blocked_range<int>(begin, end); }
 
-// creates a tbb combinable type which acts as thread local storage for the tbb parallel algorithms
-template <typename Type, typename Lambda> inline auto combinable(Lambda &&lambda)
-{
-    return tbb::combinable<Type>(std::forward<Lambda>(lambda));
-}
-
 // runs the tbb parallel_for algorithm
 template <typename... Args> void parallel_for(Args &&... args) { tbb::parallel_for(std::forward<Args>(args)...); }
 

--- a/src/templates/tbb-defs.h
+++ b/src/templates/tbb-defs.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 #pragma once
+#include "tbb/combinable.h"
 #include "tbb/iterators.h"
 namespace dissolve
 {
@@ -15,5 +16,7 @@ template <typename T> class counting_iterator
     int N_;
     int M_;
 };
+
+template <typename T> using combinable = tbb::combinable<T>;
 
 } // namespace dissolve

--- a/src/templates/tbb-fallbacks.h
+++ b/src/templates/tbb-fallbacks.h
@@ -24,4 +24,16 @@ template <typename T> class counting_iterator
     std::vector<T> indices_;
 };
 
+template <typename T> class combinable
+{
+    public:
+    template <typename Lambda> combinable(Lambda init) { data_ = init(); }
+    T &local() { return data_; }
+    template <typename Lambda> T combine(Lambda) { return data_; }
+    template <typename Lambda> void combine_each(Lambda unaryOp) { return unaryOp(data_); }
+
+    private:
+    T data_;
+};
+
 } // namespace dissolve


### PR DESCRIPTION
This PR adds parallel force calculations and benchmarks. Performance look good, just comparing three of the macro benchmarks:

On my macbook pro quad core.
 |  Benchmark  |  Single threaded  |  Multithreaded | 
 |  ------------ |  ----------------- |  ------------- | 
 | BM_CalculateForces_TotalInterAtomic |  1524ms |  341ms
 | BM_CalculateForces_TotalIntraMolecular  |   42.4ms | 9.27ms
 | BM_CalculateForces_TotalForces |  1605 ms |  355ms

This PR also restructed the force kernel:

- References instead of shared ptr
- Extract force vector from class, now we can create a thread local force vector and combine at the end of parallel computations
- Remove storage of torision and angle parameters -> makes it easier to parallelize
- Most methods are now const -> implying some degree of thread safety