### PR TITLE
Improve fallback implementation of counting iterator

### DIFF
--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -569,21 +569,21 @@ double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, Pro
     auto totalEnergy = 0.0;
     Cell *cell;
     auto [begin, end] = chop_range(0, cellArray.nCells(), nChunks, offset);
-    dissolve::counting_iterator<int> countingIterator(begin, end);
 
-    totalEnergy = dissolve::transform_reduce(
-        ParallelPolicies::par, countingIterator.begin(), countingIterator.end(), 0.0, std::plus<double>(), [&](int i) {
-            auto localEnergy = 0.0;
-            auto *cell = cellArray.cell(i);
+    totalEnergy = dissolve::transform_reduce(ParallelPolicies::par, dissolve::counting_iterator<int>(begin),
+                                             dissolve::counting_iterator<int>(end), 0.0, std::plus<double>(), [&](int i) {
+                                                 auto localEnergy = 0.0;
+                                                 auto *cell = cellArray.cell(i);
 
-            // This cell with itself
-            localEnergy += energy(cell, cell, false, true, interMolecular, subStrategy, performSum);
+                                                 // This cell with itself
+                                                 localEnergy +=
+                                                     energy(cell, cell, false, true, interMolecular, subStrategy, performSum);
 
-            // Interatomic interactions between atoms in this cell and its neighbours
-            localEnergy += energy(cell, true, interMolecular, subStrategy, performSum);
+                                                 // Interatomic interactions between atoms in this cell and its neighbours
+                                                 localEnergy += energy(cell, true, interMolecular, subStrategy, performSum);
 
-            return localEnergy;
-        });
+                                                 return localEnergy;
+                                             });
 
     return totalEnergy;
 }

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -178,7 +178,6 @@ bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, Part
         return histograms;
     });
 
-    dissolve::counting_iterator<int> countingIterator(cStart, cEnd);
     auto unaryOp = [&combinableHistograms, cfg, &comb, rdfRange](const auto idx) {
         // auto &histograms = combinableHistograms.local().histograms_;
         auto &histograms = combinableHistograms.local();
@@ -212,7 +211,8 @@ bool RDFModule::calculateGRCells(ProcessPool &procPool, Configuration *cfg, Part
     };
 
     // Execute lambda operator for each cell
-    dissolve::for_each(ParallelPolicies::par, countingIterator.begin(), countingIterator.end(), unaryOp);
+    dissolve::for_each(ParallelPolicies::par, dissolve::counting_iterator<int>(cStart), dissolve::counting_iterator<int>(cEnd),
+                       unaryOp);
     auto histograms = combinableHistograms.finalize();
     addHistogramsToPartialSet(histograms, partialSet);
 

--- a/src/templates/tbb-defs.h
+++ b/src/templates/tbb-defs.h
@@ -5,17 +5,8 @@
 #include "tbb/iterators.h"
 namespace dissolve
 {
-template <typename T> class counting_iterator
-{
-    public:
-    counting_iterator(int N, int M) : N_(N), M_(M) { assert(M > N); }
-    auto begin() { return tbb::counting_iterator<int>(N_); }
-    auto end() { return tbb::counting_iterator<int>(M_); }
 
-    private:
-    int N_;
-    int M_;
-};
+template <typename T> using counting_iterator = tbb::counting_iterator<T>;
 
 template <typename T> using combinable = tbb::combinable<T>;
 


### PR DESCRIPTION
This PR improves the fallback implementation of the counting iterator. Previously it just created a vector and used that for iteration. If we have lots of atoms and therefore lots of combinations, the vector could have millions of elements. 