### PR TITLE
Default to thread build of dissolve and add CI for threading

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -36,22 +36,39 @@ stages:
               PathtoPublish: "build/"
               ArtifactName: 'linux-tests-serial'
             displayName: 'Publish Serial Test Artifacts'
-      - job: 'linux_parallel'
-        displayName: 'Build Linux (Parallel, ubuntu-latest)'
+      - job: 'linux_threadsgui'
+        displayName: 'Build Linux (Serial/Threads/GUI, ubuntu-latest)'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
           - checkout: self
             fetchDepth: 1
           - template: templates/set-short-hash.yml
-          - template: templates/build-linux-parallel.yml
+          - template: templates/build-linux-serial-gui.yml
             parameters:
               extraflags: '-DBUILD_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug'
+              threading: 'ON'
           - task: PublishBuildArtifacts@1
-            inputs:
-              PathtoPublish: "build/"
-              ArtifactName: 'linux-tests-parallel'
-            displayName: 'Publish Parallel Test Artifacts'
+              inputs:
+                PathtoPublish: "build/"
+                ArtifactName: 'linux-tests-serial-threads'
+              displayName: 'Publish Serial/Threaded Test Artifacts'
+        - job: 'linux_parallel'
+          displayName: 'Build Linux (Parallel, ubuntu-latest)'
+          pool:
+            vmImage: 'ubuntu-latest'
+          steps:
+            - checkout: self
+              fetchDepth: 1
+            - template: templates/set-short-hash.yml
+            - template: templates/build-linux-parallel.yml
+              parameters:
+                extraflags: '-DBUILD_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug'
+            - task: PublishBuildArtifacts@1
+              inputs:
+                PathtoPublish: "build/"
+                ArtifactName: 'linux-tests-parallel'
+              displayName: 'Publish Parallel Test Artifacts'
       - job: 'osx_serialgui'
         displayName: 'Build OSX (Serial/GUI, macos-latest)'
         timeoutInMinutes: 120

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -84,6 +84,23 @@ stages:
               PathtoPublish: "packages/"
               ArtifactName: 'windows-artifacts'
             displayName: 'Publish Windows Artifacts'
+      - job: 'windows_threadinggui'
+        displayName: 'Build Windows (Threading/GUI, windows-latest)'
+        timeoutInMinutes: 120
+        pool:
+          vmImage: 'windows-latest'
+        steps:
+          - checkout: self
+            fetchDepth: 1
+          - template: templates/set-short-hash.yml
+          - template: templates/build-windows-serial-gui.yml
+            parameters:
+              threading: 'ON'
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: "build/"
+              ArtifactName: 'windows-threading-artifacts'
+            displayName: 'Publish Windows Threading Artifacts'   
 
   # Run System Tests
   - stage: 'system_tests_serial'

--- a/.azure-pipelines/templates/build-linux-parallel.yml
+++ b/.azure-pipelines/templates/build-linux-parallel.yml
@@ -1,6 +1,8 @@
 parameters:
   - name: extraflags
     default: ''
+  - name: threading
+    default: 'OFF'
 
 steps:
   - bash: |
@@ -18,7 +20,7 @@ steps:
       set -ex
       mkdir build
       cd build
-      conan install ../ -s compiler.libcxx=libstdc++11
-      cmake -G "Ninja" -DPARALLEL:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
+      conan install ../ -s compiler.libcxx=libstdc++11 --build missing
+      cmake -G "Ninja" -DMULTI_THREADING=${{ parameters.threading }} -DPARALLEL:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
       ninja
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-linux-serial-gui.yml
+++ b/.azure-pipelines/templates/build-linux-serial-gui.yml
@@ -5,6 +5,8 @@ parameters:
     default: 'beineri/opt-qt-5.15.2-focal'
   - name: qtver
     default: 515
+  - name: threading
+    default: 'OFF'
 
 steps:
   - bash: |
@@ -29,7 +31,7 @@ steps:
       export LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
       mkdir build
       cd build
-      conan install .. -s compiler.libcxx=libstdc++11
-      cmake -G "Ninja" -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
+      conan install .. -s compiler.libcxx=libstdc++11 --build missing
+      cmake -G "Ninja" -DMULTI_THREADING=${{ parameters.threading }} -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
       ninja
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-osx-serial-gui.yml
+++ b/.azure-pipelines/templates/build-osx-serial-gui.yml
@@ -1,6 +1,8 @@
 parameters:
   - name: extraflags
     default: ''
+  - name: threading
+    default: 'OFF'
 
 steps:
   - bash: |
@@ -29,7 +31,7 @@ steps:
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
       mkdir build
       cd build
-      conan install ..
-      cmake -DGUI:bool=true -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ parameters.extraflags }} ../
+      conan install .. --build missing
+      cmake -DGUI:bool=true -DMULTI_THREADING=${{ parameters.threading }} -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ parameters.extraflags }} ../
       make
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-windows-serial-gui.yml
+++ b/.azure-pipelines/templates/build-windows-serial-gui.yml
@@ -7,6 +7,8 @@ parameters:
     default: git://git.sv.nongnu.org/freetype/freetype2.git
   - name: ftglrepo
     default: https://github.com/frankheckenbach/ftgl.git
+  - name: threading
+    default: 'OFF'
 
 steps:
   - task: UsePythonVersion@0
@@ -55,8 +57,8 @@ steps:
       $env:LIB += "$(Build.BinariesDirectory)\ftgl-install\lib;"
       mkdir build
       cd build
-      conan install ..
-      cmake ../ -G "Visual Studio 16 2019" -A "x64" -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DBUILD_ANTLR_LINK_LIB:string="dist\Release\antlr4-runtime.lib" -DCMAKE_BUILD_TYPE:STRING="Release" ${{ parameters.extraflags }}
+      conan install .. --build missing
+      cmake ../ -G "Visual Studio 16 2019" -A "x64" -DMULTI_THREADING=${{ parameters.threading }} -DGUI:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DBUILD_ANTLR_LINK_LIB:string="dist\Release\antlr4-runtime.lib" -DCMAKE_BUILD_TYPE:STRING="Release" ${{ parameters.extraflags }}
       cmake --build . --config Release --target keywordwidgets
       cmake --build . --config Release
     displayName: 'Build'

--- a/.azure-pipelines/templates/system-tests.yml
+++ b/.azure-pipelines/templates/system-tests.yml
@@ -34,6 +34,32 @@ jobs:
           ctest -j2 --output-on-failure
         displayName: 'Run Serial System Tests'
   - job:
+    condition: eq('${{ parameters.parallel }}', false)
+    displayName: 'System Tests (Serial/Threads)'
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - checkout: self
+        fetchDepth: 1
+      - bash: |
+          set -ex
+          sudo add-apt-repository ppa:${{ parameters.ppa }} -y
+          sudo apt-get install qt${{ parameters.qtver }}base
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          specificBuildWithTriggering: true
+          downloadType: 'single'
+          artifactName: 'linux-tests-serial-threads'
+        displayName: 'Download Serial/Threads Test Artifacts'
+      - bash: |
+          set -ex
+          mkdir build && cd build
+          mv $(System.ArtifactsDirectory)/linux-tests-serial-threads/* ./
+          chmod +x bin/*
+          ctest -j2 --output-on-failure
+        displayName: 'Run Serial System Tests'
+  - job:
     condition: eq('${{ parameters.parallel }}', true)
     displayName: 'System Tests (Parallel)'
     pool:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,13 @@ if(PARALLEL)
   set(EXTRA_LINK_LIBS ${EXTRA_LINK_LIBS} ${MPI_LIBRARIES})
 endif(PARALLEL)
 
-if(MULTI_THREADING)
+
+option(DISSOLVE_MULTI_THREADING "Enable threading using tbb" ON)
+
+if(DISSOLVE_MULTI_THREADING)
   add_definitions("-DMULTITHREADING")
   set(THREADING_LINK_LIBS ${THREADING_LINK_LIBS} CONAN_PKG::tbb)
-endif(MULTI_THREADING)
+endif(DISSOLVE_MULTI_THREADING)
 
 # Add local Modules dir to cmake search path
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,12 @@ if(PARALLEL)
   set(EXTRA_LINK_LIBS ${EXTRA_LINK_LIBS} ${MPI_LIBRARIES})
 endif(PARALLEL)
 
-
-option(DISSOLVE_MULTI_THREADING "Enable threading using tbb" ON)
-
-if(DISSOLVE_MULTI_THREADING)
+# Build with threads
+option(MULTI_THREADING "Enable threading using tbb" ON)
+if(MULTI_THREADING)
   add_definitions("-DMULTITHREADING")
   set(THREADING_LINK_LIBS ${THREADING_LINK_LIBS} CONAN_PKG::tbb)
-endif(DISSOLVE_MULTI_THREADING)
+endif(MULTI_THREADING)
 
 # Add local Modules dir to cmake search path
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -12,3 +12,4 @@ cmake
 [options]
 fmt:header_only=True
 pugixml:header_only=False
+tbb:shared=False

--- a/web/content/docs/startingout/compilation.md
+++ b/web/content/docs/startingout/compilation.md
@@ -205,3 +205,11 @@ Requests that the parallel version of Dissolve be built. This option is mutually
 Usage: `-DPARALLEL:bool=true`
 
 Default: `false`
+
+#### `MULTI_THREADING`
+
+Requests that the multithreaded version of Dissolve be built. Intel thread building blocks (tbb) must be present on the path. By default this option is enabled.
+
+Usage: `-DMULTI_THREADING=ON`
+
+Default: `ON`


### PR DESCRIPTION
This PR defaults dissolve to build with threads. With regards to the CI, it adds a threading flag, which is defaulted off for the time being. I guess we could have / should in the future let everything build with threads, but while threading is still a WIP this may be the best option for now. 