### PR TITLE
Periodic Species

### DIFF
--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -10,30 +10,9 @@
 
 Box::Box()
 {
-    type_ = Box::CubicBoxType;
+    type_ = Box::BoxType::Cubic;
     periodic_.set(true, true, true);
     volume_ = 0.0;
-}
-
-// Virtual Destructor
-Box::~Box() = default;
-
-void Box::operator=(const Box &source)
-{
-    // Basic Definition
-    type_ = source.type_;
-    a_ = source.a_;
-    b_ = source.b_;
-    c_ = source.c_;
-    ra_ = source.ra_;
-    rb_ = source.rb_;
-    rc_ = source.rc_;
-    alpha_ = source.alpha_;
-    beta_ = source.beta_;
-    gamma_ = source.gamma_;
-    axes_ = source.axes_;
-    inverseAxes_ = source.inverseAxes_;
-    periodic_ = source.periodic_;
 }
 
 /*
@@ -43,11 +22,11 @@ void Box::operator=(const Box &source)
 // Return enum options for BoxType
 EnumOptions<Box::BoxType> Box::boxTypes()
 {
-    return EnumOptions<Box::BoxType>("BoxType", {{Box::NonPeriodicBoxType, "NonPeriodic"},
-                                                 {Box::CubicBoxType, "Cubic"},
-                                                 {Box::OrthorhombicBoxType, "Orthorhombic"},
-                                                 {Box::MonoclinicBoxType, "Monoclinic"},
-                                                 {Box::TriclinicBoxType, "Triclinic"}});
+    return EnumOptions<Box::BoxType>("BoxType", {{Box::BoxType::NonPeriodic, "NonPeriodic"},
+                                                 {Box::BoxType::Cubic, "Cubic"},
+                                                 {Box::BoxType::Orthorhombic, "Orthorhombic"},
+                                                 {Box::BoxType::Monoclinic, "Monoclinic"},
+                                                 {Box::BoxType::Triclinic, "Triclinic"}});
 }
 
 // Return Box type

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -147,8 +147,8 @@ void Box::scale(double factor)
  * Utility Routines
  */
 
-// Generate a suitable Box given the supplied relative lengths, angles, and volume
-Box *Box::generate(Vec3<double> lengths, Vec3<double> angles)
+// Generate a suitable Box given the supplied relative lengths, angles
+std::unique_ptr<Box> Box::generate(Vec3<double> lengths, Vec3<double> angles)
 {
     // Determine box type from supplied lengths / angles
     auto rightAlpha = (fabs(angles.x - 90.0) < 0.001);
@@ -157,24 +157,17 @@ Box *Box::generate(Vec3<double> lengths, Vec3<double> angles)
 
     if (rightAlpha && rightBeta && rightGamma)
     {
-        // Cubic or orthorhombic
         auto abSame = (fabs(lengths.x - lengths.y) < 0.0001);
         auto acSame = (fabs(lengths.x - lengths.z) < 0.0001);
         if (abSame && acSame)
-            return new CubicBox(lengths.x);
+            return std::make_unique<CubicBox>(lengths.x);
         else
-            return new OrthorhombicBox(lengths);
+            return std::make_unique<OrthorhombicBox>(lengths);
     }
     else if (rightAlpha && (!rightBeta) && rightGamma)
-    {
-        // Monoclinic
-        return new MonoclinicBox(lengths, angles.y);
-    }
+        return std::make_unique<MonoclinicBox>(lengths, angles.y);
     else
-    {
-        // Triclinic
-        return new TriclinicBox(lengths, angles);
-    }
+        return std::make_unique<TriclinicBox>(lengths, angles);
 }
 
 // Return radius of largest possible inscribed sphere for box

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -17,22 +17,21 @@ class Box
 {
     public:
     Box();
-    // Virtual Destructor
-    virtual ~Box();
-    void operator=(const Box &source);
+    virtual ~Box() = default;
+    Box &operator=(const Box &source) = default;
 
     /*
      * Basic Definition
      */
     public:
     // Box Type Enum
-    enum BoxType
+    enum class BoxType
     {
-        NonPeriodicBoxType,  /* Non-periodic system - cubic box, but no minimum image calculation */
-        CubicBoxType,        /* Cubic box with equivalent cell lengths, and right-angles */
-        OrthorhombicBoxType, /* Orthorhombic box with inequivalent cell lengths, and right-angles */
-        MonoclinicBoxType,   /* Monoclinic box with cell angles a != 90, and b == c == 90 */
-        TriclinicBoxType     /* Triclinic box with cell angles a != b != c != 90 */
+        NonPeriodic,  /* Non-periodic system - cubic box, but no minimum image calculation */
+        Cubic,        /* Cubic box with A == B == C, alphe == beta == gamma == 90 */
+        Orthorhombic, /* Orthorhombic box with A != B != C, alphe == beta == gamma = 90 */
+        Monoclinic,   /* Monoclinic box with A != B != C, alpha != 90, and beta == gamma == 90 */
+        Triclinic     /* Triclinic box with A != B != C, alpha != beta != gamma != 90 */
     };
     // Return enum options for BoxType
     static EnumOptions<BoxType> boxTypes();
@@ -179,8 +178,8 @@ class Box
 class NonPeriodicBox : public Box
 {
     public:
-    NonPeriodicBox(double length);
-    ~NonPeriodicBox() override;
+    NonPeriodicBox(double length = 1.0);
+    ~NonPeriodicBox() override = default;
 
     /*
      * Minimum Image Routines (Virtual Implementations)
@@ -236,7 +235,7 @@ class CubicBox : public Box
 {
     public:
     CubicBox(double length);
-    ~CubicBox() override;
+    ~CubicBox() override = default;
 
     /*
      * Minimum Image Routines (Virtual Implementations)
@@ -292,7 +291,7 @@ class OrthorhombicBox : public Box
 {
     public:
     OrthorhombicBox(const Vec3<double> lengths);
-    ~OrthorhombicBox() override;
+    ~OrthorhombicBox() override = default;
 
     /*
      * Minimum Image Routines (Virtual Implementations)
@@ -348,7 +347,7 @@ class MonoclinicBox : public Box
 {
     public:
     MonoclinicBox(const Vec3<double> lengths, double beta);
-    ~MonoclinicBox() override;
+    ~MonoclinicBox() override = default;
 
     /*
      * Minimum Image Routines (Virtual Implementations)
@@ -404,7 +403,7 @@ class TriclinicBox : public Box
 {
     public:
     TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles);
-    ~TriclinicBox() override;
+    ~TriclinicBox() override = default;
 
     /*
      * Minimum Image Routines (Virtual Implementations)

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -126,7 +126,7 @@ class Box
      */
     public:
     // Generate a suitable Box given the supplied relative lengths, angles, and volume
-    static Box *generate(Vec3<double> lengths, Vec3<double> angles);
+    static std::unique_ptr<Box> generate(Vec3<double> lengths, Vec3<double> angles);
     // Return radius of largest possible inscribed sphere for box
     double inscribedSphereRadius() const;
     // Calculate the RDF normalisation for the Box

--- a/src/classes/box_cubic.cpp
+++ b/src/classes/box_cubic.cpp
@@ -7,7 +7,7 @@
 
 CubicBox::CubicBox(double length) : Box()
 {
-    type_ = Box::CubicBoxType;
+    type_ = Box::BoxType::Cubic;
 
     // Construct axes_
     axes_.setColumn(0, length, 0.0, 0.0);
@@ -21,8 +21,6 @@ CubicBox::CubicBox(double length) : Box()
     // Finalise associated data
     finalise();
 }
-
-CubicBox::~CubicBox() = default;
 
 /*
  * Minimum Image Routines (virtual implementations)

--- a/src/classes/box_monoclinic.cpp
+++ b/src/classes/box_monoclinic.cpp
@@ -7,7 +7,7 @@
 
 MonoclinicBox::MonoclinicBox(const Vec3<double> lengths, double beta) : Box()
 {
-    type_ = Box::MonoclinicBoxType;
+    type_ = Box::BoxType::Monoclinic;
 
     // Construct axes
     alpha_ = 90.0;
@@ -33,8 +33,6 @@ MonoclinicBox::MonoclinicBox(const Vec3<double> lengths, double beta) : Box()
     // Finalise associated data
     finalise();
 }
-
-MonoclinicBox::~MonoclinicBox() = default;
 
 /*
  * Minimum Image Routines (virtual implementations)

--- a/src/classes/box_nonperiodic.cpp
+++ b/src/classes/box_nonperiodic.cpp
@@ -8,7 +8,7 @@
 
 NonPeriodicBox::NonPeriodicBox(double length) : Box()
 {
-    type_ = Box::NonPeriodicBoxType;
+    type_ = Box::BoxType::NonPeriodic;
     periodic_.set(false, false, false);
 
     // Construct axes_
@@ -23,8 +23,6 @@ NonPeriodicBox::NonPeriodicBox(double length) : Box()
     // Finalise associated data
     finalise();
 }
-
-NonPeriodicBox::~NonPeriodicBox() = default;
 
 /*
  * Minimum Image Routines (virtual implementations)

--- a/src/classes/box_orthorhombic.cpp
+++ b/src/classes/box_orthorhombic.cpp
@@ -7,7 +7,7 @@
 
 OrthorhombicBox::OrthorhombicBox(const Vec3<double> lengths) : Box()
 {
-    type_ = Box::OrthorhombicBoxType;
+    type_ = Box::BoxType::Orthorhombic;
 
     // Construct axes_
     axes_.setColumn(0, lengths.x, 0.0, 0.0);
@@ -25,8 +25,6 @@ OrthorhombicBox::OrthorhombicBox(const Vec3<double> lengths) : Box()
     // Finalise associated data
     finalise();
 }
-
-OrthorhombicBox::~OrthorhombicBox() = default;
 
 /*
  * Minimum Image Routines (virtual implementations)

--- a/src/classes/box_triclinic.cpp
+++ b/src/classes/box_triclinic.cpp
@@ -7,7 +7,7 @@
 
 TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles) : Box()
 {
-    type_ = Box::TriclinicBoxType;
+    type_ = Box::BoxType::Triclinic;
 
     // Construct axes_
     alpha_ = angles.x;
@@ -39,8 +39,6 @@ TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles
     // Finalise associated data
     finalise();
 }
-
-TriclinicBox::~TriclinicBox() = default;
 
 /*
  * Minimum Image Routines (virtual implementations)

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -255,7 +255,7 @@ bool CellArray::generate(const Box *box, double cellSize, double pairPotentialRa
         {
             // Retrieve Cell pointer
             nbr = this->cell(gridRef.x + nbrIndices.x, gridRef.y + nbrIndices.y, gridRef.z + nbrIndices.z);
-            if (box_->type() == Box::NonPeriodicBoxType)
+            if (box_->type() == Box::BoxType::NonPeriodic)
                 nearNeighbours.emplace_back(nbr);
             else if (minimumImageRequired(cell.get(), nbr, pairPotentialRange))
                 mimNeighbours.emplace_back(nbr);

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -82,7 +82,7 @@ bool Configuration::generate(ProcessPool &procPool, double pairPotentialRange)
 
     // Set-up Cells for the Box
     if (cells_.nCells() == 0)
-        cells_.generate(box_, requestedCellDivisionLength_, pairPotentialRange);
+        cells_.generate(box_.get(), requestedCellDivisionLength_, pairPotentialRange);
 
     // Make sure Cell contents / Atom locations are up-to-date
     updateCellContents();

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -6,6 +6,7 @@
 #include "base/version.h"
 #include "classes/atom.h"
 #include "classes/atomtypelist.h"
+#include "classes/box.h"
 #include "classes/cellarray.h"
 #include "classes/molecule.h"
 #include "classes/sitestack.h"
@@ -22,7 +23,6 @@
 #include <memory>
 
 // Forward Declarations
-class Box;
 class Cell;
 class PotentialMap;
 class ProcessPool;
@@ -149,8 +149,8 @@ class Configuration : public ListItem<Configuration>
     double requestedSizeFactor_;
     // Size factor currently applied to Box / Cells
     double appliedSizeFactor_;
-    // Periodic Box definition for the Configuration
-    Box *box_;
+    // Periodic Box
+    std::unique_ptr<Box> box_;
     // Requested side length for individual Cell
     double requestedCellDivisionLength_;
     // Cell array
@@ -158,7 +158,7 @@ class Configuration : public ListItem<Configuration>
 
     public:
     // Create Box definition with specified lengths and angles
-    bool createBox(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic = false);
+    void createBox(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic = false);
     // Return Box
     const Box *box() const;
     // Scale Box (and associated Cells) by specified factor

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -6,27 +6,14 @@
 #include "classes/configuration.h"
 #include "modules/energy/energy.h"
 
-// Create Box definition with  specifeid lengths and angles
-bool Configuration::createBox(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic)
+// Create Box definition with specified lengths and angles
+void Configuration::createBox(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic)
 {
-    // Remove old box if present
-    if (box_ != nullptr)
-    {
-        Messenger::printVerbose("Removing existing Box definition for Configuration '{}'...\n", niceName());
-        delete box_;
-        box_ = nullptr;
-    }
-
-    if (nonPeriodic)
-        box_ = new NonPeriodicBox(1.0);
-    else
-        box_ = Box::generate(lengths, angles);
-
-    return true;
+    box_ = nonPeriodic ? std::make_unique<NonPeriodicBox>() : Box::generate(lengths, angles);
 }
 
 // Return Box
-const Box *Configuration::box() const { return box_; }
+const Box *Configuration::box() const { return box_.get(); }
 
 // Scale Box lengths (and associated Cells) by specified factor
 void Configuration::scaleBox(double factor)

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -14,9 +14,7 @@ void Configuration::empty()
     molecules_.clear();
     atoms_.clear();
     usedAtomTypes_.clear();
-    if (box_ != nullptr)
-        delete box_;
-    box_ = new CubicBox(1.0);
+    box_ = std::make_unique<CubicBox>(1.0);
     cells_.clear();
     appliedSizeFactor_ = 1.0;
     requestedSizeFactor_ = 1.0;

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -18,7 +18,7 @@ bool Configuration::serialise(LineParser &parser) const
     const auto lengths = box()->axisLengths();
     const auto angles = box()->axisAngles();
     if (!parser.writeLineF("{:12e} {:12e} {:12e}  {}  {}  {}\n", lengths.x, lengths.y, lengths.z, appliedSizeFactor_,
-                           requestedSizeFactor_, DissolveSys::btoa(box()->type() == Box::NonPeriodicBoxType)))
+                           requestedSizeFactor_, DissolveSys::btoa(box()->type() == Box::BoxType::NonPeriodic)))
         return false;
     if (!parser.writeLineF("{:12e} {:12e} {:12e}\n", angles.x, angles.y, angles.z))
         return false;

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -89,8 +89,7 @@ bool Configuration::read(LineParser &parser, const std::vector<std::unique_ptr<S
         return false;
     const auto angles = parser.arg3d(0);
 
-    if (!createBox(lengths, angles, nonPeriodic))
-        return false;
+    createBox(lengths, angles, nonPeriodic);
 
     // Read total number of Molecules to expect
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -141,7 +140,7 @@ bool Configuration::read(LineParser &parser, const std::vector<std::unique_ptr<S
     usedAtomTypes_.finalise();
 
     // Set-up Cells for the Box
-    cells_.generate(box_, requestedCellDivisionLength_, pairPotentialRange);
+    cells_.generate(box_.get(), requestedCellDivisionLength_, pairPotentialRange);
 
     // Scale box and cells according to the applied size factor
     scaleBox(appliedSizeFactor_);

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -5,10 +5,9 @@
 #include "classes/atomtype.h"
 #include "data/isotopes.h"
 
-Species::Species()
+Species::Species() : attachedAtomListsGenerated_(false), forcefield_(nullptr)
 {
-    forcefield_ = nullptr;
-    attachedAtomListsGenerated_ = false;
+    box_ = std::make_unique<NonPeriodicBox>();
 
     // Set up natural Isotopologue
     naturalIsotopologue_.setName("Natural");

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "classes/atomtypelist.h"
+#include "classes/box.h"
 #include "classes/isotopologue.h"
 #include "classes/speciesangle.h"
 #include "classes/speciesatom.h"
@@ -14,9 +15,9 @@
 #include "io/import/coordinates.h"
 #include <list>
 #include <memory>
+#include <variant>
 
 // Forward Declarations
-class Box;
 class Forcefield;
 
 // Species Definition
@@ -217,6 +218,17 @@ class Species
     void detachFromMasterTerms();
 
     /*
+     * Box Definition (if any)
+     */
+    private:
+    // Periodic Box
+    std::unique_ptr<Box> box_;
+
+    public:
+    // Return periodic box
+    const Box *box() const;
+
+    /*
      * Source Forcefield (if any)
      */
     private:
@@ -334,20 +346,22 @@ class Species
      */
     public:
     // Species Block Keyword Enum
-    enum SpeciesKeyword
+    enum class SpeciesKeyword
     {
-        AngleKeyword,          /* 'Angle' - Defines an Angle joining three atoms */
-        AtomKeyword,           /* 'Atom' - Specifies an Atom in the Species */
-        BondKeyword,           /* 'Bond' - Defines a Bond joining two atoms */
-        BondTypeKeyword,       /* 'BondType' - Sets the type of a specific bond */
-        ChargeKeyword,         /* 'Charge' - Specifies the atomic charge for an individual atom */
-        CoordinateSetsKeyword, /* 'CoordinateSets' - File and format for any associated coordinate sets */
-        EndSpeciesKeyword,     /* 'EndSpecies' - Signals the end of the current Species */
-        ForcefieldKeyword,     /* 'Forcefield' - Sets the Forcefield from which to (re)generate or set terms */
-        ImproperKeyword,       /* 'Improper' - Define an Improper interaction between four atoms */
-        IsotopologueKeyword,   /* 'Isotopologue' - Add an isotopologue to the Species */
-        SiteKeyword,           /* 'Site' - Define an analysis site within the Species */
-        TorsionKeyword         /* 'Torsion' - Define a Torsion interaction between four atoms */
+        Angle,          /* 'Angle' - Defines an Angle joining three atoms */
+        Atom,           /* 'Atom' - Specifies an Atom in the Species */
+        Bond,           /* 'Bond' - Defines a Bond joining two atoms */
+        BondType,       /* 'BondType' - Sets the type of a specific bond */
+        BoxAngles,      /* 'BoxAngles' - Specify unit cell angles for the species */
+        BoxLengths,     /* 'BoxLengths' - Specify unit cell lengths for the species */
+        Charge,         /* 'Charge' - Specifies the atomic charge for an individual atom */
+        CoordinateSets, /* 'CoordinateSets' - File and format for any associated coordinate sets */
+        EndSpecies,     /* 'EndSpecies' - Signals the end of the current Species */
+        Forcefield,     /* 'Forcefield' - Sets the Forcefield from which to (re)generate or set terms */
+        Improper,       /* 'Improper' - Define an Improper interaction between four atoms */
+        Isotopologue,   /* 'Isotopologue' - Add an isotopologue to the Species */
+        Site,           /* 'Site' - Define an analysis site within the Species */
+        Torsion         /* 'Torsion' - Define a Torsion interaction between four atoms */
     };
     // Return enum option info for SpeciesKeyword
     static EnumOptions<Species::SpeciesKeyword> keywords();

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -544,3 +544,6 @@ void Species::detachFromMasterTerms()
     for (auto &improper : impropers_)
         improper.detachFromMasterIntra();
 }
+
+// Return periodic box
+const Box *Species::box() const { return box_.get(); }

--- a/src/data/elementcolours.cpp
+++ b/src/data/elementcolours.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "data/elementcolours.h"
+#include <array>
 
 namespace ElementColours
 {

--- a/src/data/elementcolours.cpp
+++ b/src/data/elementcolours.cpp
@@ -6,15 +6,7 @@
 namespace ElementColours
 {
 
-struct color
-{
-    float red;
-    float green;
-    float blue;
-    float alpha;
-};
-
-constexpr color const colours_[] = {
+constexpr std::array<float, 4> const colours_[] = {
     // R	G	B	A
     {0.5, 0.5, 0.5, 1.0},       // XX
     {0.87, 0.87, 0.87, 1.0},    // H
@@ -137,6 +129,6 @@ constexpr color const colours_[] = {
     {1.0, 1.0, 1.0, 1.0}        // OG
 };
 
-const float *colour(Elements::Element Z) { return reinterpret_cast<const float *>(&colours_[Z]); }
+const std::array<float, 4> &colour(Elements::Element Z) { return colours_[Z]; }
 
 } // namespace ElementColours

--- a/src/data/elementcolours.h
+++ b/src/data/elementcolours.h
@@ -10,6 +10,6 @@ namespace ElementColours
 {
 
 // Return colour for specified element
-const float *colour(Elements::Element Z);
+const std::array<float, 4> &colour(Elements::Element Z);
 
 } // namespace ElementColours

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -172,6 +172,8 @@ class DissolveWindow : public QMainWindow
     void on_ConfigurationCreateEmptyAction_triggered(bool checked);
     void on_ConfigurationCreateSimpleRandomMixAction_triggered(bool checked);
     void on_ConfigurationCreateRelativeRandomMixAction_triggered(bool checked);
+    void on_ConfigurationCreateEmptyFrameworkAction_triggered(bool checked);
+    void on_ConfigurationCreateFrameworkAdsorbatesAction_triggered(bool checked);
     void on_ConfigurationRenameAction_triggered(bool checked);
     void on_ConfigurationDeleteAction_triggered(bool checked);
     void on_ConfigurationExportToXYZAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -1138,10 +1138,10 @@
     <widget class="QMenu" name="ConfigurationCreateMenu">
      <property name="geometry">
       <rect>
-       <x>642</x>
-       <y>140</y>
-       <width>176</width>
-       <height>135</height>
+       <x>749</x>
+       <y>600</y>
+       <width>218</width>
+       <height>195</height>
       </rect>
      </property>
      <property name="font">
@@ -1160,6 +1160,9 @@
      <addaction name="separator"/>
      <addaction name="ConfigurationCreateSimpleRandomMixAction"/>
      <addaction name="ConfigurationCreateRelativeRandomMixAction"/>
+     <addaction name="separator"/>
+     <addaction name="ConfigurationCreateEmptyFrameworkAction"/>
+     <addaction name="ConfigurationCreateFrameworkAdsorbatesAction"/>
     </widget>
     <widget class="QMenu" name="ConfigurationExportToMenu">
      <property name="font">
@@ -1709,6 +1712,16 @@
    </property>
    <property name="toolTip">
     <string>Regenerate angle and torsion lists from current connectivity</string>
+   </property>
+  </action>
+  <action name="ConfigurationCreateEmptyFrameworkAction">
+   <property name="text">
+    <string>&amp;Empty framework</string>
+   </property>
+  </action>
+  <action name="ConfigurationCreateFrameworkAdsorbatesAction">
+   <property name="text">
+    <string>&amp;Framework with adsorbates</string>
    </property>
   </action>
  </widget>

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -27,7 +27,7 @@ void DissolveWindow::on_ConfigurationCreateSimpleRandomMixAction_triggered(bool 
     SelectSpeciesDialog speciesSelectDialog(this, dissolve_.coreData(), "Select species to mix");
 
     auto mixSpecies = speciesSelectDialog.selectSpecies(1, -1);
-    if (mixSpecies.nItems() == 0)
+    if (mixSpecies.empty())
         return;
 
     // Create the Configuration and a suitable generator
@@ -37,10 +37,8 @@ void DissolveWindow::on_ConfigurationCreateSimpleRandomMixAction_triggered(bool 
     paramsNode->addParameter("rho", 0.1);
     generator.addRootSequenceNode(paramsNode);
     generator.addRootSequenceNode(new BoxProcedureNode);
-    for (auto sp : mixSpecies)
-    {
+    for (const auto *sp : mixSpecies)
         generator.addRootSequenceNode(new AddSpeciesProcedureNode(sp, 100, NodeValue("rho", paramsNode->parameters())));
-    }
 
     // Run the generator
     newConfiguration->generate(dissolve_.worldPool(), dissolve_.pairPotentialRange());
@@ -55,8 +53,8 @@ void DissolveWindow::on_ConfigurationCreateRelativeRandomMixAction_triggered(boo
     // Create a SpeciesSelectDialog and use it to get the Species to add to the mix
     SelectSpeciesDialog speciesSelectDialog(this, dissolve_.coreData(), "Select species to mix");
 
-    RefList<Species> mixSpecies = speciesSelectDialog.selectSpecies(1, -1);
-    if (mixSpecies.nItems() == 0)
+    auto mixSpecies = speciesSelectDialog.selectSpecies(1, -1);
+    if (mixSpecies.empty())
         return;
 
     // Create the Configuration and a suitable generator

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -3,6 +3,8 @@ set(models_MOC_HDRS
     braggReflectionModel.h
     dataManagerReferencePointModel.h
     dataManagerSimulationModel.h
+    speciesFilterProxy.h
+    speciesModel.h
     xmlAngleModel.h
     xmlAtomModel.h
     xmlBondModel.h
@@ -18,6 +20,8 @@ set(models_SRCS
     braggReflectionModel.cpp
     dataManagerReferencePointModel.cpp
     dataManagerSimulationModel.cpp
+    speciesFilterProxy.cpp
+    speciesModel.cpp
     xmlAngleModel.cpp
     xmlAtomModel.cpp
     xmlBondModel.cpp
@@ -31,6 +35,7 @@ qt_wrap_cpp(
   braggReflectionModel.h
   dataManagerReferencePointModel.h
   dataManagerSimulationModel.h
+  speciesModel.h
   xmlAngleModel.h
   xmlAtomModel.h
   xmlBondModel.h

--- a/src/gui/models/speciesFilterProxy.cpp
+++ b/src/gui/models/speciesFilterProxy.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/models/speciesFilterProxy.h"
+#include "classes/species.h"
+
+Q_DECLARE_METATYPE(const Species *);
+
+SpeciesFilterProxy::SpeciesFilterProxy(int flags) : filterFlags_(flags) {}
+
+// Set filter flags
+void SpeciesFilterProxy::setFlags(int flags)
+{
+    filterFlags_ = flags;
+    invalidateFilter();
+}
+
+/*
+ * QSortFilterProxyModel overrides
+ */
+
+bool SpeciesFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent) const
+{
+    if (filterFlags_ == SpeciesFilterProxy::None)
+        return true;
+
+    const auto *sp = sourceModel()->data(sourceModel()->index(row, 0, parent), Qt::UserRole).value<const Species *>();
+
+    if (filterFlags_ & SpeciesFilterProxy::HasPeriodicBox && sp->box()->type() == Box::BoxType::NonPeriodic)
+        return false;
+    else if (filterFlags_ & SpeciesFilterProxy::NoPeriodicBox && sp->box()->type() != Box::BoxType::NonPeriodic)
+        return false;
+
+    return true;
+}

--- a/src/gui/models/speciesFilterProxy.h
+++ b/src/gui/models/speciesFilterProxy.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include <QSortFilterProxyModel>
+
+// Forward Declarations
+class QModelIndex;
+
+class SpeciesFilterProxy : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+    public:
+    SpeciesFilterProxy(int flags = SpeciesFilterProxy::None);
+
+    public:
+    // Filter flags
+    enum FilterFlags
+    {
+        None = 0,
+        HasPeriodicBox = 1,
+        NoPeriodicBox = 2
+    };
+    // Current filter flags
+    int filterFlags_;
+    // Set filter flags
+    void setFlags(int flags);
+
+    /*
+     * QSortFilterProxyModel overrides
+     */
+    private:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const;
+};

--- a/src/gui/models/speciesModel.cpp
+++ b/src/gui/models/speciesModel.cpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/models/speciesModel.h"
+
+Q_DECLARE_METATYPE(const Species *);
+
+// Set source Species data
+void SpeciesModel::setData(const std::vector<std::unique_ptr<Species>> &species)
+{
+    beginResetModel();
+    species_ = species;
+    endResetModel();
+}
+
+const Species *SpeciesModel::rawData(const QModelIndex &index) const
+{
+    assert(species_);
+    return species_->get()[index.row()].get();
+}
+
+/*
+ * QAbstractItemModel overrides
+ */
+
+int SpeciesModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return species_ ? species_->get().size() : 0;
+}
+
+QVariant SpeciesModel::data(const QModelIndex &index, int role) const
+{
+    if (role == Qt::DisplayRole)
+        return QString::fromStdString(std::string(rawData(index)->name()));
+    else if (role == Qt::UserRole)
+        return QVariant::fromValue(rawData(index));
+
+    return QVariant();
+}
+
+QVariant SpeciesModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole)
+        return QVariant();
+
+    if (orientation == Qt::Horizontal)
+        switch (section)
+        {
+            case 0:
+                return "Name";
+            default:
+                return QVariant();
+        }
+
+    return QVariant();
+}

--- a/src/gui/models/speciesModel.h
+++ b/src/gui/models/speciesModel.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/species.h"
+#include "templates/optionalref.h"
+#include <QAbstractTableModel>
+#include <QModelIndex>
+
+#include <vector>
+
+class SpeciesModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    private:
+    // Source Species data
+    OptionalReferenceWrapper<const std::vector<std::unique_ptr<Species>>> species_;
+
+    public:
+    // Set source Species data
+    void setData(const std::vector<std::unique_ptr<Species>> &species);
+    // Return object represented by specified model index
+    const Species *rawData(const QModelIndex &index) const;
+
+    /*
+     * QAbstractItemModel overrides
+     */
+    public:
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+};

--- a/src/gui/render/primitiveassembly.cpp
+++ b/src/gui/render/primitiveassembly.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "gui/render/primitiveassembly.h"
+#include <array>
 
 PrimitiveAssembly::PrimitiveAssembly() : ListItem<PrimitiveAssembly>() {}
 

--- a/src/gui/render/primitiveassembly.cpp
+++ b/src/gui/render/primitiveassembly.cpp
@@ -23,7 +23,7 @@ void PrimitiveAssembly::add(Primitive *primitive, const Matrix4 &matrix)
 }
 
 // Add Primitive with colour to the assembly
-void PrimitiveAssembly::add(Primitive *primitive, const Matrix4 &matrix, const GLfloat *rgba)
+void PrimitiveAssembly::add(Primitive *primitive, const Matrix4 &matrix, const std::array<float, 4> &rgba)
 {
     ColouredPrimitiveInfo *pi = colouredPrimitiveFactory_.produce();
     (*pi) = ColouredPrimitiveInfo(primitive, matrix, rgba[0], rgba[1], rgba[2], rgba[3]);
@@ -52,6 +52,52 @@ void PrimitiveAssembly::add(LineStyle lineStyle)
     LineStylePrimitiveInfo *pi = lineStylePrimitiveFactory_.produce();
     (*pi) = LineStylePrimitiveInfo(lineStyle);
     assembly_.add(pi);
+}
+
+/*
+ * Object
+ */
+
+// Create cylinder bond between supplied atoms in specified assembly
+void PrimitiveAssembly::createCylinderBond(Primitive *bondPrimitive, Vec3<double> rI, Vec3<double> rJ, Vec3<double> vij,
+                                           const std::array<float, 4> &colI, const std::array<float, 4> &colJ,
+                                           bool drawFromAtoms, double radialScaling)
+{
+    Matrix4 A;
+    auto unit = vij;
+    const auto mag = unit.magAndNormalise();
+
+    // Create rotation matrix for Bond
+    A.setColumn(2, unit.x, unit.y, unit.z, 0.0);
+    A.setColumn(0, unit.orthogonal(), 0.0);
+    A.setColumn(1, unit * A.columnAsVec3(0), 0.0);
+    A.columnMultiply(2, 0.5 * mag);
+    A.applyScaling(radialScaling, radialScaling, 1.0);
+
+    // If drawing from individual Atoms, locate on each Atom and draw the bond halves from there. If not, locate to the bond
+    // centre.
+    if (drawFromAtoms)
+    {
+        // Render half of Bond in colour of Atom j
+        A.setTranslation(rI);
+        add(bondPrimitive, A, colJ);
+
+        // Render half of Bond in colour of Atom i
+        A.setTranslation(rJ);
+        A.columnMultiply(2, -1.0);
+        add(bondPrimitive, A, colI);
+    }
+    else
+    {
+        A.setTranslation(rI + vij * 0.5);
+
+        // Render half of Bond in colour of Atom j
+        add(bondPrimitive, A, colJ);
+
+        // Render half of Bond in colour of Atom i
+        A.columnMultiply(2, -1.0);
+        add(bondPrimitive, A, colI);
+    }
 }
 
 /*

--- a/src/gui/render/primitiveassembly.h
+++ b/src/gui/render/primitiveassembly.h
@@ -41,13 +41,22 @@ class PrimitiveAssembly : public ListItem<PrimitiveAssembly>
     // Add Primitive to the assembly
     void add(Primitive *primitive, const Matrix4 &matrix);
     // Add Primitive with colour to the assembly
-    void add(Primitive *primitive, const Matrix4 &matrix, const GLfloat *rgba);
+    void add(Primitive *primitive, const Matrix4 &matrix, const std::array<float, 4> &rgba);
     // Add Primitive with colour to the assembly
     void add(Primitive *primitive, const Matrix4 &matrix, GLfloat r, GLfloat g, GLfloat b, GLfloat a);
     // Add styling information
     void add(bool lighting, GLenum polygonFillMode);
     // Add line styling information
     void add(LineStyle lineStyle);
+
+    /*
+     * Objects
+     */
+    public:
+    // Create cylinder bond between supplied atoms in specified assembly
+    void createCylinderBond(Primitive *bondPrimitive, Vec3<double> rI, Vec3<double> rJ, Vec3<double> vij,
+                            const std::array<float, 4> &colI, const std::array<float, 4> &colJ, bool drawFromAtoms,
+                            double radialScaling);
 
     /*
      * GL

--- a/src/gui/render/renderableconfiguration.h
+++ b/src/gui/render/renderableconfiguration.h
@@ -45,11 +45,6 @@ class RenderableConfiguration : public Renderable
     // Main assemblies
     PrimitiveAssembly configurationAssembly_, interactionAssembly_, unitCellAssembly_;
 
-    private:
-    // Create cylinder bond between supplied atoms in specified assembly
-    void createCylinderBond(PrimitiveAssembly &assembly, const std::shared_ptr<Atom> i, const std::shared_ptr<Atom> j,
-                            const Vec3<double> vij, bool drawFromAtoms, double radialScaling);
-
     protected:
     // Recreate necessary primitives / primitive assemblies for the data
     void recreatePrimitives(const View &view, const ColourDefinition &colourDefinition);

--- a/src/gui/render/renderablespecies.h
+++ b/src/gui/render/renderablespecies.h
@@ -39,17 +39,13 @@ class RenderableSpecies : public Renderable
      */
     private:
     // Basic primitives
-    Primitive *atomPrimitive_, *selectedAtomPrimitive_, *crossBoxPrimitive_, *bondPrimitive_;
+    Primitive *atomPrimitive_, *selectedAtomPrimitive_, *crossBoxPrimitive_, *bondPrimitive_, *unitCellPrimitive_;
     // Main primitives
     Primitive *lineSpeciesPrimitive_, *lineSelectionPrimitive_, *lineInteractionPrimitive_;
     // Main assemblies
-    PrimitiveAssembly speciesAssembly_, selectionAssembly_, interactionAssembly_;
+    PrimitiveAssembly speciesAssembly_, selectionAssembly_, interactionAssembly_, unitCellAssembly_;
     // Version at which selection primitive was created, relative to selection version
     int selectionPrimitiveVersion_;
-
-    private:
-    // Create cylinder bond between supplied atoms in specified assembly
-    void createCylinderBond(PrimitiveAssembly &assembly, const SpeciesAtom *i, const SpeciesAtom *j, double radialScaling);
 
     protected:
     // Recreate necessary primitives / primitive assemblies for the data

--- a/src/gui/selectspeciesdialog.h
+++ b/src/gui/selectspeciesdialog.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "gui/models/speciesFilterProxy.h"
 #include "gui/ui_selectspeciesdialog.h"
 #include "templates/list.h"
 #include <QDialog>
@@ -19,7 +20,7 @@ class SelectSpeciesDialog : public QDialog
 
     public:
     SelectSpeciesDialog(QWidget *parent, const CoreData &coreData, QString dialogTitle);
-    ~SelectSpeciesDialog();
+    ~SelectSpeciesDialog() = default;
 
     private:
     // Main form declaration
@@ -33,7 +34,8 @@ class SelectSpeciesDialog : public QDialog
 
     public:
     // Run the dialog, returning a single selected Species
-    Species *selectSpecies();
+    const Species *selectSingleSpecies(int filterProxyFlags = SpeciesFilterProxy::None);
     // Run the dialog, returning a list of selected Species
-    RefList<Species> selectSpecies(int minSpecies, int maxSpecies);
+    std::vector<const Species *> selectSpecies(int filterProxyFlags = SpeciesFilterProxy::None, int minSpecies = 1,
+                                               std::optional<int> maxSpecies = std::nullopt);
 };

--- a/src/gui/selectspeciesdialog_funcs.cpp
+++ b/src/gui/selectspeciesdialog_funcs.cpp
@@ -13,17 +13,15 @@ SelectSpeciesDialog::SelectSpeciesDialog(QWidget *parent, const CoreData &coreDa
 
     setWindowTitle(dialogTitle);
 
-    ui_.SpeciesWidget->setCoreData(&coreData);
+    ui_.SpeciesWidget->setSpecies(coreData.species());
 }
-
-SelectSpeciesDialog::~SelectSpeciesDialog() {}
 
 void SelectSpeciesDialog::on_SpeciesWidget_speciesSelectionChanged(bool isValid) { ui_.SelectButton->setEnabled(isValid); }
 
 void SelectSpeciesDialog::on_SpeciesWidget_speciesDoubleClicked()
 {
     // Check current selection size for validity
-    if (ui_.SpeciesWidget->currentSpecies().nItems() != 1)
+    if (ui_.SpeciesWidget->currentSpecies().size() != 1)
         return;
 
     accept();
@@ -34,27 +32,30 @@ void SelectSpeciesDialog::on_SelectButton_clicked(bool checked) { accept(); }
 void SelectSpeciesDialog::on_CancelButton_clicked(bool checked) { reject(); }
 
 // Run the dialog, returning a single selected Species
-Species *SelectSpeciesDialog::selectSpecies()
+const Species *SelectSpeciesDialog::selectSingleSpecies(int filterProxyFlags)
 {
-    ui_.SpeciesWidget->reset(1, 1);
+    ui_.SpeciesWidget->reset(1);
+    ui_.SpeciesWidget->setFilterProxyFlags(filterProxyFlags);
 
     show();
 
     if (exec() == QDialog::Accepted)
-        return ui_.SpeciesWidget->currentSpecies().firstItem();
+        return ui_.SpeciesWidget->currentSpecies().front();
     else
         return nullptr;
 }
 
 // Run the dialog, returning a list of selected Species
-RefList<Species> SelectSpeciesDialog::selectSpecies(int minSpecies, int maxSpecies)
+std::vector<const Species *> SelectSpeciesDialog::selectSpecies(int filterProxyFlags, int minSpecies,
+                                                                std::optional<int> maxSpecies)
 {
     ui_.SpeciesWidget->reset(minSpecies, maxSpecies);
+    ui_.SpeciesWidget->setFilterProxyFlags(filterProxyFlags);
 
     show();
 
     if (exec() == QDialog::Accepted)
         return ui_.SpeciesWidget->currentSpecies();
     else
-        return RefList<Species>();
+        return {};
 }

--- a/src/gui/selectspecieswidget.h
+++ b/src/gui/selectspecieswidget.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "data/ff/library.h"
+#include "gui/models/speciesFilterProxy.h"
+#include "gui/models/speciesModel.h"
 #include "gui/ui_selectspecieswidget.h"
 #include "templates/list.h"
 #include <QWidget>
@@ -19,7 +21,7 @@ class SelectSpeciesWidget : public QWidget
 
     public:
     SelectSpeciesWidget(QWidget *parent);
-    ~SelectSpeciesWidget();
+    ~SelectSpeciesWidget() override = default;
 
     /*
      * UI
@@ -29,39 +31,36 @@ class SelectSpeciesWidget : public QWidget
     Ui::SelectSpeciesWidget ui_;
     // Whether the widget is refreshing
     bool refreshing_;
+    // Model for the Species list
+    SpeciesModel speciesModel_;
+    // Filter proxy for the Species model
+    SpeciesFilterProxy speciesFilterProxy_;
 
     /*
      * Data
      */
     private:
-    // CoreData containing available Species
-    const CoreData *coreData_;
     // Minimum number of Species in a valid selection
     int minimumSelectionSize_;
-    // Maximum number of Species in a valid selection (-1 for no limit)
-    int maximumSelectionSize_;
+    // Maximum number of Species in a valid selection (if specified)
+    std::optional<int> maximumSelectionSize_;
 
     public:
-    // Set CoreData containing available Species
-    void setCoreData(const CoreData *coreData);
+    // Set flags for the filter proxy
+    void setFilterProxyFlags(int flags);
+    // Set target Species data
+    void setSpecies(const std::vector<std::unique_ptr<Species>> &species);
     // Reset widget, applying specified min and max limits to selection
-    void reset(int minSize, int maxSize);
-
-    /*
-     * Update
-     */
-    private:
-    // Update the list of Species
-    void updateSpeciesList();
+    void reset(int minSize, std::optional<int> maxSize = std::nullopt);
 
     /*
      * Signals / Slots
      */
     private slots:
+    void selectionChanged(const QItemSelection &, const QItemSelection &);
     void on_SelectNoneButton_clicked(bool checked);
     void on_SelectAllButton_clicked(bool checked);
-    void on_SpeciesList_itemSelectionChanged();
-    void on_SpeciesList_itemDoubleClicked(QListWidgetItem *item);
+    void on_SpeciesList_doubleClicked(const QModelIndex &index);
 
     signals:
     void speciesSelectionChanged(bool isValid);
@@ -75,5 +74,5 @@ class SelectSpeciesWidget : public QWidget
     // Return number of species currently selected
     int nSelected() const;
     // Return the currently-selected Species
-    RefList<Species> currentSpecies() const;
+    std::vector<const Species *> currentSpecies() const;
 };

--- a/src/gui/selectspecieswidget.ui
+++ b/src/gui/selectspecieswidget.ui
@@ -107,7 +107,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QListWidget" name="SpeciesList">
+       <widget class="QListView" name="SpeciesList">
         <property name="maximumSize">
          <size>
           <width>16777215</width>

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -75,17 +75,17 @@ bool CoordinateExportFileFormat::exportDLPOLY(LineParser &parser, Configuration 
         return false;
 
     // Export keytrj and imcon
-    if (cfg->box()->type() == Box::NonPeriodicBoxType)
+    if (cfg->box()->type() == Box::BoxType::NonPeriodic)
     {
         if (!parser.writeLineF("{:10d}{:10d}\n", 0, 0))
             return false;
     }
-    else if (cfg->box()->type() == Box::CubicBoxType)
+    else if (cfg->box()->type() == Box::BoxType::Cubic)
     {
         if (!parser.writeLineF("{:10d}{:10d}\n", 0, 1))
             return false;
     }
-    else if (cfg->box()->type() == Box::OrthorhombicBoxType)
+    else if (cfg->box()->type() == Box::BoxType::Orthorhombic)
     {
         if (!parser.writeLineF("{:10d}{:10d}\n", 0, 2))
             return false;
@@ -94,7 +94,7 @@ bool CoordinateExportFileFormat::exportDLPOLY(LineParser &parser, Configuration 
         parser.writeLineF("{:10d}{:10d}\n", 0, 3);
 
     // Export Cell
-    if (cfg->box()->type() != Box::NonPeriodicBoxType)
+    if (cfg->box()->type() != Box::BoxType::NonPeriodic)
     {
         Matrix3 axes = cfg->box()->axes();
         if (!parser.writeLineF("{:20.12f}{:20.12f}{:20.12f}\n", axes[0], axes[1], axes[2]))

--- a/src/procedure/nodes/addspecies.h
+++ b/src/procedure/nodes/addspecies.h
@@ -34,9 +34,10 @@ class AddSpeciesProcedureNode : public ProcedureNode
     // Box Action Style
     enum class BoxActionStyle
     {
-        None,       /* Box geometry / volume will remain unchanged */
-        AddVolume,  /* Increase Box volume to accommodate new species, according to supplied density */
-        ScaleVolume /* Scale current Box volume to give, after addition of the current species, the supplied density */
+        None,        /* Box geometry / volume will remain unchanged */
+        AddVolume,   /* Increase Box volume to accommodate new species, according to supplied density */
+        ScaleVolume, /* Scale current Box volume to give, after addition of the current species, the supplied density */
+        Set          /* Set the Box geometry to that specified in the Species */
     };
     // Return enum option info for BoxActionStyle
     static EnumOptions<BoxActionStyle> boxActionStyles();

--- a/src/procedure/nodes/box.cpp
+++ b/src/procedure/nodes/box.cpp
@@ -45,8 +45,7 @@ bool BoxProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::s
     auto nonPeriodic = keywords_.asBool("NonPeriodic");
 
     // Create a Box in the target Configuration with our lengths and angles
-    if (!cfg->createBox(lengths, angles, nonPeriodic))
-        return false;
+    cfg->createBox(lengths, angles, nonPeriodic);
 
     Messenger::print("[Box] Volume is {} cubic Angstroms (reciprocal volume = {:e})\n", cfg->box()->volume(),
                      cfg->box()->reciprocalVolume());


### PR DESCRIPTION
This PR introduces the ability to store periodic box information (cell lengths and angles) in a Species definition, although until periodic model import (e.g. CIFs) is implemented this information can only be provided by editing the input file by hand.

An option to set the peiodic box of a configuration from the information stored in the species has been added, and thus allows a configuration to be seeded from a periodic species (e.g. a MOF).  We also add a Qt model for the display of Speices in a QListView, generalise some rendering (since Species and Configuration are now very similar), and add new configuration generation options from the main menu.
