### PR TITLE
Bugfix 18/05/21 Benchmarks and Const

### DIFF
--- a/benchmark/energy/energy_benchmark.cpp
+++ b/benchmark/energy/energy_benchmark.cpp
@@ -34,8 +34,8 @@ static void BM_CalculateEnergy_SpeciesInterAtomicEnergy(benchmark::State &state)
 {
     Problem<problem, population> problemDef;
     auto &mol = problemDef.cfg_->molecules().front();
-    auto &usedSpecies = problemDef.cfg_->usedSpecies();
-    auto *species = usedSpecies.back().species();
+    auto &usedSpecies = problemDef.cfg_->speciesPopulations();
+    auto *species = usedSpecies.back().first;
     auto &procPool = problemDef.dissolve_.worldPool();
     const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
     for (auto _ : state)

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -126,6 +126,7 @@ class Configuration : public ListItem<Configuration>
     int nMolecules() const;
     // Return array of Molecules
     std::deque<std::shared_ptr<Molecule>> &molecules();
+    const std::deque<std::shared_ptr<Molecule>> &molecules() const;
     // Return nth Molecule
     std::shared_ptr<Molecule> molecule(int n);
     // Add new Atom to Configuration

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -119,6 +119,7 @@ int Configuration::nMolecules() const { return molecules_.size(); }
 
 // Return array of Molecules
 std::deque<std::shared_ptr<Molecule>> &Configuration::molecules() { return molecules_; }
+const std::deque<std::shared_ptr<Molecule>> &Configuration::molecules() const { return molecules_; }
 
 // Return nth Molecule
 std::shared_ptr<Molecule> Configuration::molecule(int n) { return molecules_[n]; }

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -11,8 +11,9 @@
 #include "templates/algorithms.h"
 #include <iterator>
 
-EnergyKernel::EnergyKernel(ProcessPool &procPool, Configuration *config, const PotentialMap &potentialMap, double energyCutoff)
-    : configuration_(config), cells_(config->cells()), potentialMap_(potentialMap), processPool_(procPool)
+EnergyKernel::EnergyKernel(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap,
+                           double energyCutoff)
+    : configuration_(cfg), cells_(cfg->cells()), potentialMap_(potentialMap), processPool_(procPool)
 {
     box_ = configuration_->box();
     cutoffDistanceSquared_ = (energyCutoff < 0.0 ? potentialMap_.range() * potentialMap_.range() : energyCutoff * energyCutoff);

--- a/src/classes/energykernel.h
+++ b/src/classes/energykernel.h
@@ -24,7 +24,8 @@ class SpeciesTorsion;
 class EnergyKernel
 {
     public:
-    EnergyKernel(ProcessPool &procPool, Configuration *config, const PotentialMap &potentialMap, double energyCutoff = -1.0);
+    EnergyKernel(ProcessPool &procPool, const Configuration *config, const PotentialMap &potentialMap,
+                 double energyCutoff = -1.0);
     ~EnergyKernel() = default;
     // Clear all data
     void clear();

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -69,27 +69,28 @@ class EnergyModule : public Module
         EnergyUnstable = 1
     };
     // Return total interatomic energy of Configuration
-    static double interAtomicEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    static double interAtomicEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
     // Return total interatomic energy of Species
-    static double interAtomicEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap);
+    static double interAtomicEnergy(ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap);
     // Return total intermolecular energy
-    static double interMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    static double interMolecularEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
     // Return total intramolecular energy of Configuration
-    static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    static double intraMolecularEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
     // Return total intramolecular energy of Configuration, storing components in provided variables
-    static double intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+    static double intraMolecularEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap,
                                        double &bondEnergy, double &angleEnergy, double &torsionEnergy, double &improperEnergy);
     // Return total intramolecular energy of Species
-    static double intraMolecularEnergy(ProcessPool &procPool, Species *sp);
+    static double intraMolecularEnergy(ProcessPool &procPool, const Species *sp);
     // Return total energy (interatomic and intramolecular)
-    static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap);
+    static double totalEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
     // Return total energy (interatomic and intramolecular) of Configuration, storing components in provided variables
-    static double totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap, double &interEnergy,
-                              double &bondEnergy, double &angleEnergy, double &torsionEnergy, double &improperEnergy);
+    static double totalEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap,
+                              double &interEnergy, double &bondEnergy, double &angleEnergy, double &torsionEnergy,
+                              double &improperEnergy);
     // Return total energy (interatomic and intramolecular) of Species
-    static double totalEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap);
+    static double totalEnergy(ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap);
     // Check energy stability of specified Configuration
-    static EnergyStability checkStability(GenericList &processingData, Configuration *cfg);
+    static EnergyStability checkStability(GenericList &processingData, const Configuration *cfg);
     // Check energy stability of specified Configurations, returning the number that are unstable
     static int nUnstable(GenericList &processingData, const RefList<Configuration> &configurations);
 

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -161,9 +161,9 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, const Configura
     auto start = procPool.interleavedLoopStart(strategy);
     auto stride = procPool.interleavedLoopStride(strategy);
 
-    std::deque<std::shared_ptr<Molecule>> molecules = cfg->molecules();
+    const auto &molecules = cfg->molecules();
     std::shared_ptr<const Molecule> mol;
-    auto [begin, end] = chop_range(cfg->molecules().begin(), cfg->molecules().end(), stride, start);
+    auto [begin, end] = chop_range(molecules.begin(), molecules.end(), stride, start);
 
     auto unaryOp = [&](const auto &mol) -> Energies {
         Energies localEnergies{0.0, 0.0, 0.0, 0.0};

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -32,7 +32,7 @@ struct Energies
 } // namespace
 
 // Return total interatomic energy of Configuration
-double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap)
+double EnergyModule::interAtomicEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap)
 {
     /*
      * Calculates the total interatomic energy of the system, i.e. the energy contributions from PairPotential
@@ -62,7 +62,7 @@ double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Configuration *cfg
 }
 
 // Return total interatomic energy of Species
-double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap)
+double EnergyModule::interAtomicEnergy(ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap)
 {
     const auto cutoff = potentialMap.range();
 
@@ -98,7 +98,7 @@ double EnergyModule::interAtomicEnergy(ProcessPool &procPool, Species *sp, const
 }
 
 // Return total intermolecular energy of Configuration
-double EnergyModule::interMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap)
+double EnergyModule::interMolecularEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap)
 {
     /*
      * Calculates the total intermolecular energy of the system, i.e. the energy contributions from PairPotential
@@ -128,7 +128,7 @@ double EnergyModule::interMolecularEnergy(ProcessPool &procPool, Configuration *
 }
 
 // Return total intramolecular energy of Configuration
-double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap)
+double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap)
 {
     double bondEnergy, angleEnergy, torsionEnergy, improperEnergy;
 
@@ -136,7 +136,7 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *
 }
 
 // Return total intramolecular energy of Configuration, storing components in provided variables
-double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap,
                                           double &bondEnergy, double &angleEnergy, double &torsionEnergy,
                                           double &improperEnergy)
 {
@@ -234,7 +234,7 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Configuration *
 }
 
 // Return total intramolecular energy of Species
-double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Species *sp)
+double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, const Species *sp)
 {
     auto energy = 0.0;
 
@@ -258,13 +258,13 @@ double EnergyModule::intraMolecularEnergy(ProcessPool &procPool, Species *sp)
 }
 
 // Return total energy (interatomic and intramolecular) of Configuration
-double EnergyModule::totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap)
+double EnergyModule::totalEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap)
 {
     return (interAtomicEnergy(procPool, cfg, potentialMap) + intraMolecularEnergy(procPool, cfg, potentialMap));
 }
 
 // Return total energy (interatomic and intramolecular) of Configuration, storing components in provided variables
-double EnergyModule::totalEnergy(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+double EnergyModule::totalEnergy(ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap,
                                  double &interEnergy, double &bondEnergy, double &angleEnergy, double &torsionEnergy,
                                  double &improperEnergy)
 {
@@ -275,13 +275,13 @@ double EnergyModule::totalEnergy(ProcessPool &procPool, Configuration *cfg, cons
 }
 
 // Return total energy (interatomic and intramolecular) of Species
-double EnergyModule::totalEnergy(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap)
+double EnergyModule::totalEnergy(ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap)
 {
     return (interAtomicEnergy(procPool, sp, potentialMap) + intraMolecularEnergy(procPool, sp));
 }
 
 // Check energy stability of specified Configuration
-EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processingData, Configuration *cfg)
+EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processingData, const Configuration *cfg)
 {
     // First, check if the Configuration is targetted by an EnergyModule
     if (!processingData.valueOr<bool>("IsEnergyModuleTarget", cfg->niceName(), false))


### PR DESCRIPTION
Quick bugfix PR to address a broken benchmark arising from merging #684.

Some `const`-ness is liberally applied to functions within the `EnergyKernel`, and a small bug in `EnergyModule::intraMolecularEnergy()` fixed.
