### PR TITLE
Show all parameters in a single cell

### DIFF
--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -33,6 +33,7 @@ set(models_SRCS
     speciesAtomModel.cpp
     speciesBondModel.cpp
     speciesImproperModel.cpp
+    speciesModelUtils.cpp
     speciesTorsionModel.cpp
 )
 

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -1,5 +1,6 @@
 #include "gui/models/speciesAngleModel.h"
 #include "classes/masterintra.h"
+#include "gui/models/speciesModelUtils.h"
 
 SpeciesAngleModel::SpeciesAngleModel(std::vector<SpeciesAngle> &angles, Dissolve &dissolve)
     : angles_(angles), dissolve_(dissolve)
@@ -15,7 +16,7 @@ int SpeciesAngleModel::rowCount(const QModelIndex &parent) const
 int SpeciesAngleModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return 8;
+    return 5;
 }
 
 QVariant SpeciesAngleModel::data(const QModelIndex &index, int role) const
@@ -42,12 +43,7 @@ QVariant SpeciesAngleModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(angle.masterParameters()->name()))
                        : QString::fromStdString(SpeciesAngle::angleFunctions().keywordFromInt(angle.form()));
         case 4:
-        case 5:
-        case 6:
-        case 7:
-            if (angle.parameters().size() <= index.column() - 4)
-                return 0;
-            return angle.parameter(index.column() - 4);
+            return joinParameters(angle);
         default:
             return QVariant();
     }
@@ -68,13 +64,7 @@ QVariant SpeciesAngleModel::headerData(int section, Qt::Orientation orientation,
         case 3:
             return "Form";
         case 4:
-            return "Parameter 1";
-        case 5:
-            return "Parameter 2";
-        case 6:
-            return "Parameter 3";
-        case 7:
-            return "Parameter 4";
+            return "Parameters";
         default:
             return QVariant();
     }
@@ -123,14 +113,8 @@ bool SpeciesAngleModel::setData(const QModelIndex &index, const QVariant &value,
             }
             break;
         case 4:
-        case 5:
-        case 6:
-        case 7:
-            if (item.masterParameters())
+            if (!splitParameters(value.toString(), item))
                 return false;
-            if (item.parameters().size() <= index.column() - 4)
-                return false;
-            item.setParameter(index.column() - 4, value.toDouble());
             break;
         default:
             return false;

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -43,7 +43,7 @@ QVariant SpeciesAngleModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(angle.masterParameters()->name()))
                        : QString::fromStdString(SpeciesAngle::angleFunctions().keywordFromInt(angle.form()));
         case 4:
-            return joinParameters(angle);
+            return QString::fromStdString(joinStrings(angle.parameters()));
         default:
             return QVariant();
     }

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -1,6 +1,7 @@
 #include "gui/models/speciesAngleModel.h"
 #include "classes/masterintra.h"
 #include "gui/models/speciesModelUtils.h"
+#include "templates/algorithms.h"
 
 SpeciesAngleModel::SpeciesAngleModel(std::vector<SpeciesAngle> &angles, Dissolve &dissolve)
     : angles_(angles), dissolve_(dissolve)

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -1,4 +1,5 @@
 #include "gui/models/speciesBondModel.h"
+#include "gui/models/speciesModelUtils.h"
 
 SpeciesBondModel::SpeciesBondModel(std::vector<SpeciesBond> &bonds, Dissolve &dissolve) : bonds_(bonds), dissolve_(dissolve) {}
 
@@ -34,14 +35,7 @@ QVariant SpeciesBondModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(bond.masterParameters()->name()))
                        : QString::fromStdString(std::string(SpeciesBond::bondFunctions().keywordFromInt(bond.form())));
         case 3:
-            if (bond.parameters().empty())
-                return "";
-            {
-                std::string result = std::to_string(bond.parameters().front());
-                std::for_each(std::next(bond.parameters().begin()), bond.parameters().end(),
-                              [&result](const auto value) { result += "," + std::to_string(value); });
-                return QString::fromStdString(result);
-            }
+            return joinParameters(bond);
         default:
             return QVariant();
     }
@@ -108,19 +102,8 @@ bool SpeciesBondModel::setData(const QModelIndex &index, const QVariant &value, 
             }
             break;
         case 3:
-            if (item.masterParameters())
+            if (!splitParameters(value.toString(), item))
                 return false;
-            if (item.parameters().size() <= index.column() - 3)
-                return false;
-            {
-                auto terms = value.toString().split(",");
-                if (terms.size() != item.parameters().size())
-                    return false;
-                for (int i = 0; i < terms.size(); ++i)
-                {
-                    item.setParameter(i, terms[i].toDouble());
-                }
-            }
             break;
         default:
             return false;

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -35,7 +35,7 @@ QVariant SpeciesBondModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(bond.masterParameters()->name()))
                        : QString::fromStdString(std::string(SpeciesBond::bondFunctions().keywordFromInt(bond.form())));
         case 3:
-            return joinParameters(bond);
+            return QString::fromStdString(joinStrings(bond.parameters()));
         default:
             return QVariant();
     }

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -1,5 +1,6 @@
 #include "gui/models/speciesBondModel.h"
 #include "gui/models/speciesModelUtils.h"
+#include "templates/algorithms.h"
 
 SpeciesBondModel::SpeciesBondModel(std::vector<SpeciesBond> &bonds, Dissolve &dissolve) : bonds_(bonds), dissolve_(dissolve) {}
 

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -1,5 +1,6 @@
 #include "gui/models/speciesImproperModel.h"
 #include "classes/masterintra.h"
+#include "gui/models/speciesModelUtils.h"
 
 SpeciesImproperModel::SpeciesImproperModel(std::vector<SpeciesImproper> &impropers, Dissolve &dissolve)
     : impropers_(impropers), dissolve_(dissolve)
@@ -15,7 +16,7 @@ int SpeciesImproperModel::rowCount(const QModelIndex &parent) const
 int SpeciesImproperModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return 9;
+    return 6;
 }
 
 QVariant SpeciesImproperModel::data(const QModelIndex &index, int role) const
@@ -43,10 +44,7 @@ QVariant SpeciesImproperModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(item.masterParameters()->name()))
                        : QString::fromStdString(SpeciesTorsion::torsionFunctions().keywordFromInt(item.form()));
         case 5:
-        case 6:
-        case 7:
-        case 8:
-            return item.parameter(index.column() - 5);
+            return joinParameters(item);
         default:
             return QVariant();
     }
@@ -71,13 +69,7 @@ QVariant SpeciesImproperModel::headerData(int section, Qt::Orientation orientati
             return "Form";
 
         case 5:
-            return "Parameter 1";
-        case 6:
-            return "Parameter 2";
-        case 7:
-            return "Parameter 3";
-        case 8:
-            return "Parameter 4";
+            return "Parameters";
 
         default:
             return QVariant();
@@ -129,14 +121,8 @@ bool SpeciesImproperModel::setData(const QModelIndex &index, const QVariant &val
             }
             break;
         case 5:
-        case 6:
-        case 7:
-        case 8:
-            if (item.masterParameters())
+            if (!splitParameters(value.toString(), item))
                 return false;
-            if (item.parameters().size() <= index.column() - 5)
-                return false;
-            item.setParameter(index.column() - 5, value.toDouble());
             break;
         default:
             return false;

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -1,6 +1,7 @@
 #include "gui/models/speciesImproperModel.h"
 #include "classes/masterintra.h"
 #include "gui/models/speciesModelUtils.h"
+#include "templates/algorithms.h"
 
 SpeciesImproperModel::SpeciesImproperModel(std::vector<SpeciesImproper> &impropers, Dissolve &dissolve)
     : impropers_(impropers), dissolve_(dissolve)

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -44,7 +44,7 @@ QVariant SpeciesImproperModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(item.masterParameters()->name()))
                        : QString::fromStdString(SpeciesTorsion::torsionFunctions().keywordFromInt(item.form()));
         case 5:
-            return joinParameters(item);
+            return QString::fromStdString(joinStrings(item.parameters()));
         default:
             return QVariant();
     }

--- a/src/gui/models/speciesModelUtils.cpp
+++ b/src/gui/models/speciesModelUtils.cpp
@@ -1,0 +1,25 @@
+#include "gui/models/speciesModelUtils.h"
+#include <QStringList>
+#include <algorithm>
+#include <vector>
+
+QString joinParameters(const SpeciesIntra &source)
+{
+    std::vector<QString> vec(source.parameters().size());
+    std::transform(source.parameters().begin(), source.parameters().end(), vec.begin(),
+		   [](const double value) { return QString::number(value); });
+    QStringList terms(vec.begin(), vec.end());
+    return terms.join(",");
+}
+
+bool splitParameters(const QString &params, SpeciesIntra &destination)
+{
+    if (destination.masterParameters())
+	return false;
+    auto terms = params.split(",");
+    if (terms.size() != destination.parameters().size())
+	return false;
+    for (int i = 0; i < terms.size(); ++i)
+	destination.setParameter(i, terms[i].toDouble());
+    return true;
+}

--- a/src/gui/models/speciesModelUtils.cpp
+++ b/src/gui/models/speciesModelUtils.cpp
@@ -7,7 +7,7 @@ QString joinParameters(const SpeciesIntra &source)
 {
     std::vector<QString> vec(source.parameters().size());
     std::transform(source.parameters().begin(), source.parameters().end(), vec.begin(),
-		   [](const double value) { return QString::number(value); });
+                   [](const double value) { return QString::number(value); });
     QStringList terms(vec.begin(), vec.end());
     return terms.join(",");
 }
@@ -15,11 +15,11 @@ QString joinParameters(const SpeciesIntra &source)
 bool splitParameters(const QString &params, SpeciesIntra &destination)
 {
     if (destination.masterParameters())
-	return false;
+        return false;
     auto terms = params.split(",");
     if (terms.size() != destination.parameters().size())
-	return false;
+        return false;
     for (int i = 0; i < terms.size(); ++i)
-	destination.setParameter(i, terms[i].toDouble());
+        destination.setParameter(i, terms[i].toDouble());
     return true;
 }

--- a/src/gui/models/speciesModelUtils.cpp
+++ b/src/gui/models/speciesModelUtils.cpp
@@ -1,25 +1,14 @@
 #include "gui/models/speciesModelUtils.h"
-#include <QStringList>
-#include <algorithm>
-#include <vector>
-
-QString joinParameters(const SpeciesIntra &source)
-{
-    std::vector<QString> vec(source.parameters().size());
-    std::transform(source.parameters().begin(), source.parameters().end(), vec.begin(),
-                   [](const double value) { return QString::number(value); });
-    QStringList terms(vec.begin(), vec.end());
-    return terms.join(",");
-}
 
 bool splitParameters(const QString &params, SpeciesIntra &destination)
 {
     if (destination.masterParameters())
         return false;
-    auto terms = params.split(",");
-    if (terms.size() != destination.parameters().size())
+
+    std::vector<std::string> terms(destination.parameters().size());
+    if (splitString(params.toStdString(), terms.begin(), terms.size()) != terms.size())
         return false;
     for (int i = 0; i < terms.size(); ++i)
-        destination.setParameter(i, terms[i].toDouble());
+        destination.setParameter(i, std::stod(terms[i]));
     return true;
 }

--- a/src/gui/models/speciesModelUtils.cpp
+++ b/src/gui/models/speciesModelUtils.cpp
@@ -1,4 +1,5 @@
 #include "gui/models/speciesModelUtils.h"
+#include "templates/algorithms.h"
 
 bool splitParameters(const QString &params, SpeciesIntra &destination)
 {

--- a/src/gui/models/speciesModelUtils.h
+++ b/src/gui/models/speciesModelUtils.h
@@ -1,0 +1,24 @@
+#include <QAbstractTableModel>
+#include <algorithm>
+
+template <class T> QString joinParameters(const T &source)
+{
+    if (source.parameters().empty())
+	return "";
+    std::string result = std::to_string(source.parameters().front());
+    std::for_each(std::next(source.parameters().begin()), source.parameters().end(),
+		  [&result](const auto value) { result += "," + std::to_string(value); });
+    return QString::fromStdString(result);
+}
+
+template <class T> bool splitParameters(const QString &params, T &destination)
+{
+    if (destination.masterParameters())
+	return false;
+    auto terms = params.split(",");
+    if (terms.size() != destination.parameters().size())
+	return false;
+    for (int i = 0; i < terms.size(); ++i)
+	destination.setParameter(i, terms[i].toDouble());
+    return true;
+}

--- a/src/gui/models/speciesModelUtils.h
+++ b/src/gui/models/speciesModelUtils.h
@@ -1,24 +1,7 @@
-#include <QAbstractTableModel>
-#include <algorithm>
+#include "classes/speciesintra.h"
+#include <QString>
 
-template <class T> QString joinParameters(const T &source)
-{
-    if (source.parameters().empty())
-	return "";
-    std::string result = std::to_string(source.parameters().front());
-    std::for_each(std::next(source.parameters().begin()), source.parameters().end(),
-		  [&result](const auto value) { result += "," + std::to_string(value); });
-    return QString::fromStdString(result);
-}
+// Join the parameters values of a
+QString joinParameters(const SpeciesIntra &source);
 
-template <class T> bool splitParameters(const QString &params, T &destination)
-{
-    if (destination.masterParameters())
-	return false;
-    auto terms = params.split(",");
-    if (terms.size() != destination.parameters().size())
-	return false;
-    for (int i = 0; i < terms.size(); ++i)
-	destination.setParameter(i, terms[i].toDouble());
-    return true;
-}
+bool splitParameters(const QString &params, SpeciesIntra &destination);

--- a/src/gui/models/speciesModelUtils.h
+++ b/src/gui/models/speciesModelUtils.h
@@ -1,8 +1,44 @@
 #include "classes/speciesintra.h"
 #include <QString>
+#include <iostream>
+#include <numeric>
+#include <vector>
 
 // Join the parameters into a comma separated string
-QString joinParameters(const SpeciesIntra &source);
+template <typename Iterator> std::string joinStrings(Iterator begin, Iterator end, std::string delim = ", ")
+{
+    if (begin == end)
+	return std::string();
+    return std::accumulate(std::next(begin), end, fmt::format("{}", *begin),
+			   [&delim](const auto acc, const auto value) { return fmt::format("{}{}{}", acc, delim, value); });
+}
+
+// Join the parameters into a comma separated string
+template <class Class> std::string joinStrings(Class range, std::string delim = ", ")
+{
+    return joinStrings(range.begin(), range.end(), delim);
+}
+
+// Split a string over a delimiter and store the results in an iterator.  Returns the number of elements split, or -1 if the
+// number of elements exceeds the givens size of the container.
+template <class T> int splitString(std::string str, T iterator, int size, std::string delim = " ")
+{
+    int found = 0, index = 0, count = 0;
+    while (true)
+    {
+	found = str.find(delim, index);
+	count += 1;
+	if (count > size)
+	    return -1;
+	if (found == std::string::npos)
+	{
+	    *iterator++ = str.substr(index);
+	    return count;
+	}
+	*iterator++ = str.substr(index, found - index);
+	index = found + delim.size();
+    }
+}
 
 // Populate the parameters of a SpeciesIntra with a comma separated
 // string of values

--- a/src/gui/models/speciesModelUtils.h
+++ b/src/gui/models/speciesModelUtils.h
@@ -4,42 +4,6 @@
 #include <numeric>
 #include <vector>
 
-// Join the parameters into a comma separated string
-template <typename Iterator> std::string joinStrings(Iterator begin, Iterator end, std::string delim = ", ")
-{
-    if (begin == end)
-	return std::string();
-    return std::accumulate(std::next(begin), end, fmt::format("{}", *begin),
-			   [&delim](const auto acc, const auto value) { return fmt::format("{}{}{}", acc, delim, value); });
-}
-
-// Join the parameters into a comma separated string
-template <class Class> std::string joinStrings(Class range, std::string delim = ", ")
-{
-    return joinStrings(range.begin(), range.end(), delim);
-}
-
-// Split a string over a delimiter and store the results in an iterator.  Returns the number of elements split, or -1 if the
-// number of elements exceeds the givens size of the container.
-template <class T> int splitString(std::string str, T iterator, int size, std::string delim = " ")
-{
-    int found = 0, index = 0, count = 0;
-    while (true)
-    {
-	found = str.find(delim, index);
-	count += 1;
-	if (count > size)
-	    return -1;
-	if (found == std::string::npos)
-	{
-	    *iterator++ = str.substr(index);
-	    return count;
-	}
-	*iterator++ = str.substr(index, found - index);
-	index = found + delim.size();
-    }
-}
-
 // Populate the parameters of a SpeciesIntra with a comma separated
 // string of values
 bool splitParameters(const QString &params, SpeciesIntra &destination);

--- a/src/gui/models/speciesModelUtils.h
+++ b/src/gui/models/speciesModelUtils.h
@@ -1,7 +1,9 @@
 #include "classes/speciesintra.h"
 #include <QString>
 
-// Join the parameters values of a
+// Join the parameters into a comma separated string
 QString joinParameters(const SpeciesIntra &source);
 
+// Populate the parameters of a SpeciesIntra with a comma separated
+// string of values
 bool splitParameters(const QString &params, SpeciesIntra &destination);

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -1,5 +1,6 @@
 #include "gui/models/speciesTorsionModel.h"
 #include "classes/masterintra.h"
+#include "gui/models/speciesModelUtils.h"
 #include <algorithm>
 
 SpeciesTorsionModel::SpeciesTorsionModel(std::vector<SpeciesTorsion> &torsions, Dissolve &dissolve)
@@ -16,7 +17,7 @@ int SpeciesTorsionModel::rowCount(const QModelIndex &parent) const
 int SpeciesTorsionModel::columnCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return 9;
+    return 6;
 }
 
 QVariant SpeciesTorsionModel::data(const QModelIndex &index, int role) const
@@ -44,12 +45,7 @@ QVariant SpeciesTorsionModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(item.masterParameters()->name()))
                        : QString::fromStdString(SpeciesTorsion::torsionFunctions().keywordFromInt(item.form()));
         case 5:
-        case 6:
-        case 7:
-        case 8:
-            if (item.nParameters() <= index.column() - 5)
-                return 0;
-            return item.parameter(index.column() - 5);
+            return joinParameters(item);
         default:
             return QVariant();
     }
@@ -74,13 +70,7 @@ QVariant SpeciesTorsionModel::headerData(int section, Qt::Orientation orientatio
             return "Form";
 
         case 5:
-            return "Parameter 1";
-        case 6:
-            return "Parameter 2";
-        case 7:
-            return "Parameter 3";
-        case 8:
-            return "Parameter 4";
+            return "Parameters";
 
         default:
             return QVariant();
@@ -132,14 +122,8 @@ bool SpeciesTorsionModel::setData(const QModelIndex &index, const QVariant &valu
             }
             break;
         case 5:
-        case 6:
-        case 7:
-        case 8:
-            if (item.masterParameters())
+            if (!splitParameters(value.toString(), item))
                 return false;
-            if (item.parameters().size() <= index.column() - 5)
-                return false;
-            item.setParameter(index.column() - 5, value.toDouble());
             break;
         default:
             return false;

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -1,7 +1,7 @@
 #include "gui/models/speciesTorsionModel.h"
 #include "classes/masterintra.h"
 #include "gui/models/speciesModelUtils.h"
-#include <algorithm>
+#include "templates/algorithms.h"
 
 SpeciesTorsionModel::SpeciesTorsionModel(std::vector<SpeciesTorsion> &torsions, Dissolve &dissolve)
     : torsions_(torsions), dissolve_(dissolve)

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -45,7 +45,7 @@ QVariant SpeciesTorsionModel::data(const QModelIndex &index, int role) const
                        ? QString::fromStdString("@" + std::string(item.masterParameters()->name()))
                        : QString::fromStdString(SpeciesTorsion::torsionFunctions().keywordFromInt(item.form()));
         case 5:
-            return joinParameters(item);
+            return QString::fromStdString(joinStrings(item.parameters()));
         default:
             return QVariant();
     }

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "templates/parallel_defs.h"
+#include <fmt/format.h>
 #include <functional>
 #include <optional>
 #include <tuple>
@@ -222,3 +223,40 @@ void for_each(ParallelPolicy, Iter begin, Iter end, UnaryOp unaryOp)
     dissolve::for_each(begin, end, unaryOp);
 }
 } // namespace dissolve
+
+// Join the parameters into a comma separated string
+template <typename Iterator> std::string joinStrings(Iterator begin, Iterator end, std::string delim = ", ")
+{
+    // TODO: Rework this to not be O(n²) in string length
+    if (begin == end)
+        return std::string();
+    return std::accumulate(std::next(begin), end, fmt::format("{}", *begin),
+                           [&delim](const auto acc, const auto value) { return fmt::format("{}{}{}", acc, delim, value); });
+}
+
+// Join the parameters into a comma separated string
+template <class Class> std::string joinStrings(Class range, std::string delim = ", ")
+{
+    return joinStrings(range.begin(), range.end(), delim);
+}
+
+// Split a string over a delimiter and store the results in an iterator.  Returns the number of elements split, or -1 if the
+// number of elements exceeds the givens size of the container.
+template <class T> int splitString(std::string str, T iterator, int size, std::string delim = " ")
+{
+    int found = 0, index = 0, count = 0;
+    while (true)
+    {
+        found = str.find(delim, index);
+        count += 1;
+        if (count > size)
+            return -1;
+        if (found == std::string::npos)
+        {
+            *iterator++ = str.substr(index);
+            return count;
+        }
+        *iterator++ = str.substr(index, found - index);
+        index = found + delim.size();
+    }
+}

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 #include <functional>
 #include <optional>
+#include <sstream>
 #include <tuple>
 #include <utility>
 
@@ -227,11 +228,12 @@ void for_each(ParallelPolicy, Iter begin, Iter end, UnaryOp unaryOp)
 // Join the parameters into a comma separated string
 template <typename Iterator> std::string joinStrings(Iterator begin, Iterator end, std::string delim = ", ")
 {
-    // TODO: Rework this to not be O(n²) in string length
     if (begin == end)
         return std::string();
-    return std::accumulate(std::next(begin), end, fmt::format("{}", *begin),
-                           [&delim](const auto acc, const auto value) { return fmt::format("{}{}{}", acc, delim, value); });
+    std::stringstream stream;
+    stream << fmt::format("{}", *begin);
+    std::for_each(std::next(begin), end, [&stream, &delim](const auto value) { stream << delim << fmt::format("{}", value); });
+    return stream.str();
 }
 
 // Join the parameters into a comma separated string

--- a/unit/gui/test_speciestab.cpp
+++ b/unit/gui/test_speciestab.cpp
@@ -165,7 +165,7 @@ TEST_F(SpeciesTabTest, Torsions)
     SpeciesTorsionModel torsion(species->torsions(), dissolve);
 
     // Test Torsions
-    EXPECT_EQ(torsion.columnCount(), 9);
+    EXPECT_EQ(torsion.columnCount(), 6);
     EXPECT_EQ(torsion.rowCount(), 24);
     for (auto role : roles)
     {
@@ -174,10 +174,7 @@ TEST_F(SpeciesTabTest, Torsions)
         EXPECT_EQ(torsion.data(torsion.index(3, 2), role).toInt(), 2);
         EXPECT_EQ(torsion.data(torsion.index(3, 3), role).toInt(), 3);
         EXPECT_EQ(torsion.data(torsion.index(3, 4), role).toString().toStdString(), "@CA-CA-CA-CA");
-        EXPECT_EQ(torsion.data(torsion.index(3, 5), role).toDouble(), 0);
-        EXPECT_DOUBLE_EQ(torsion.data(torsion.index(3, 6), role).toDouble(), 30.334);
-        EXPECT_EQ(torsion.data(torsion.index(3, 7), role).toDouble(), 0);
-        EXPECT_EQ(torsion.data(torsion.index(3, 8), role).toDouble(), 0);
+        EXPECT_EQ(torsion.data(torsion.index(3, 5), role).toString().toStdString(), "0.000000,30.334000,0.000000");
     }
 
     // Mutate torsion
@@ -185,23 +182,20 @@ TEST_F(SpeciesTabTest, Torsions)
     EXPECT_FALSE(torsion.setData(torsion.index(3, 1), 6));
     EXPECT_FALSE(torsion.setData(torsion.index(3, 2), 7));
     EXPECT_FALSE(torsion.setData(torsion.index(3, 3), 8));
-    for (auto i = 5; i < 9; ++i)
-        EXPECT_FALSE(torsion.setData(torsion.index(3, i), 6));
+
+    EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0,5.0,6.0"));
 
     EXPECT_FALSE(torsion.setData(torsion.index(3, 4), "Undefined"));
     EXPECT_TRUE(torsion.setData(torsion.index(3, 4), "Cos3"));
-    for (auto i = 5; i < 8; ++i)
-    {
-        EXPECT_TRUE(torsion.setData(torsion.index(3, i), i));
-        EXPECT_DOUBLE_EQ(torsion.data(torsion.index(3, i)).toDouble(), i);
-    }
+
+    EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0,5.0"));
+    EXPECT_TRUE(torsion.setData(torsion.index(3, 5), "4.0,5.0,6.0"));
+    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "4.000000,5.000000,6.000000");
+
     EXPECT_FALSE(torsion.setData(torsion.index(3, 8), 8));
     EXPECT_EQ(torsion.data(torsion.index(3, 8)).toDouble(), 0);
     EXPECT_TRUE(torsion.setData(torsion.index(3, 4), "@CA-CA-CA-CA"));
-    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toDouble(), 0);
-    EXPECT_DOUBLE_EQ(torsion.data(torsion.index(3, 6)).toDouble(), 30.334);
-    EXPECT_EQ(torsion.data(torsion.index(3, 7)).toDouble(), 0);
-    EXPECT_EQ(torsion.data(torsion.index(3, 8)).toDouble(), 0);
+    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "0.000000,30.334000,0.000000");
 }
 
 TEST_F(SpeciesTabTest, Impropers)

--- a/unit/gui/test_speciestab.cpp
+++ b/unit/gui/test_speciestab.cpp
@@ -85,7 +85,7 @@ TEST_F(SpeciesTabTest, Bonds)
     SpeciesBondModel bond(species->bonds(), dissolve);
 
     // Test Bonds
-    EXPECT_EQ(bond.columnCount(), 7);
+    EXPECT_EQ(bond.columnCount(), 4);
     EXPECT_EQ(bond.rowCount(), 12);
 
     for (auto role : roles)
@@ -93,34 +93,23 @@ TEST_F(SpeciesTabTest, Bonds)
         EXPECT_EQ(bond.data(bond.index(3, 0), role).toInt(), 4);
         EXPECT_EQ(bond.data(bond.index(3, 1), role).toInt(), 5);
         EXPECT_EQ(bond.data(bond.index(3, 2), role).toString().toStdString(), "@CA-CA");
-        EXPECT_DOUBLE_EQ(bond.data(bond.index(3, 3), role).toDouble(), 3924.59);
-        EXPECT_DOUBLE_EQ(bond.data(bond.index(3, 4), role).toDouble(), 1.4);
-        EXPECT_EQ(bond.data(bond.index(3, 5), role).toDouble(), 0);
-        EXPECT_EQ(bond.data(bond.index(3, 6), role).toDouble(), 0);
+        EXPECT_EQ(bond.data(bond.index(3, 3), role).toString().toStdString(), "3924.590000,1.400000");
     }
 
     // Mutate bond
     EXPECT_FALSE(bond.setData(bond.index(3, 0), 5));
     EXPECT_FALSE(bond.setData(bond.index(3, 1), 6));
-    for (auto i = 3; i < 7; ++i)
-        EXPECT_FALSE(bond.setData(bond.index(3, i), 6));
+
+    EXPECT_FALSE(bond.setData(bond.index(3, 3), 6));
+
     EXPECT_FALSE(bond.setData(bond.index(3, 2), "Undefined"));
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "Harmonic"));
-    for (auto i = 3; i < 5; ++i)
-    {
-        EXPECT_TRUE(bond.setData(bond.index(3, i), i));
-        EXPECT_DOUBLE_EQ(bond.data(bond.index(3, i)).toDouble(), i);
-    }
-    for (auto i = 5; i < 7; ++i)
-    {
-        EXPECT_FALSE(bond.setData(bond.index(3, i), i));
-        EXPECT_EQ(bond.data(bond.index(3, i)).toDouble(), 0);
-    }
+
+    EXPECT_TRUE(bond.setData(bond.index(3, 3), "4.0,5.0"));
+    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "4.000000,5.000000");
+
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "@CA-CA"));
-    EXPECT_DOUBLE_EQ(bond.data(bond.index(3, 3)).toDouble(), 3924.59);
-    EXPECT_DOUBLE_EQ(bond.data(bond.index(3, 4)).toDouble(), 1.4);
-    EXPECT_NEAR(bond.data(bond.index(3, 5)).toDouble(), 0, 1e-100);
-    EXPECT_NEAR(bond.data(bond.index(3, 6)).toDouble(), 0, 1e-100);
+    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "3924.590000,1.400000");
 }
 
 TEST_F(SpeciesTabTest, Angles)

--- a/unit/gui/test_speciestab.cpp
+++ b/unit/gui/test_speciestab.cpp
@@ -93,23 +93,23 @@ TEST_F(SpeciesTabTest, Bonds)
         EXPECT_EQ(bond.data(bond.index(3, 0), role).toInt(), 4);
         EXPECT_EQ(bond.data(bond.index(3, 1), role).toInt(), 5);
         EXPECT_EQ(bond.data(bond.index(3, 2), role).toString().toStdString(), "@CA-CA");
-        EXPECT_EQ(bond.data(bond.index(3, 3), role).toString().toStdString(), "3924.590000,1.400000");
+        EXPECT_EQ(bond.data(bond.index(3, 3), role).toString().toStdString(), "3924.59,1.4");
     }
 
     // Mutate bond
     EXPECT_FALSE(bond.setData(bond.index(3, 0), 5));
     EXPECT_FALSE(bond.setData(bond.index(3, 1), 6));
 
-    EXPECT_FALSE(bond.setData(bond.index(3, 3), "4.000000,5.000000"));
+    EXPECT_FALSE(bond.setData(bond.index(3, 3), "4,5"));
 
     EXPECT_FALSE(bond.setData(bond.index(3, 2), "Undefined"));
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "Harmonic"));
 
     EXPECT_TRUE(bond.setData(bond.index(3, 3), "4.0,5.0"));
-    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "4.000000,5.000000");
+    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "4,5");
 
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "@CA-CA"));
-    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "3924.590000,1.400000");
+    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "3924.59,1.4");
 }
 
 TEST_F(SpeciesTabTest, Angles)
@@ -133,7 +133,7 @@ TEST_F(SpeciesTabTest, Angles)
         EXPECT_EQ(angle.data(angle.index(3, 1), role).toInt(), 5);
         EXPECT_EQ(angle.data(angle.index(3, 2), role).toInt(), 6);
         EXPECT_EQ(angle.data(angle.index(3, 3), role).toString().toStdString(), "@CA-CA-CA");
-        EXPECT_EQ(angle.data(angle.index(3, 4), role).toString().toStdString(), "527.184000,120.000000");
+        EXPECT_EQ(angle.data(angle.index(3, 4), role).toString().toStdString(), "527.184,120");
     }
 
     // Mutate angle
@@ -146,10 +146,10 @@ TEST_F(SpeciesTabTest, Angles)
     EXPECT_TRUE(angle.setData(angle.index(3, 3), "Harmonic"));
 
     EXPECT_TRUE(angle.setData(angle.index(3, 4), "4.0,5.0"));
-    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "4.000000,5.000000");
+    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "4,5");
 
     EXPECT_TRUE(angle.setData(angle.index(3, 3), "@CA-CA-CA"));
-    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "527.184000,120.000000");
+    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "527.184,120");
 }
 
 TEST_F(SpeciesTabTest, Torsions)
@@ -174,7 +174,7 @@ TEST_F(SpeciesTabTest, Torsions)
         EXPECT_EQ(torsion.data(torsion.index(3, 2), role).toInt(), 2);
         EXPECT_EQ(torsion.data(torsion.index(3, 3), role).toInt(), 3);
         EXPECT_EQ(torsion.data(torsion.index(3, 4), role).toString().toStdString(), "@CA-CA-CA-CA");
-        EXPECT_EQ(torsion.data(torsion.index(3, 5), role).toString().toStdString(), "0.000000,30.334000,0.000000");
+        EXPECT_EQ(torsion.data(torsion.index(3, 5), role).toString().toStdString(), "0,30.334,0");
     }
 
     // Mutate torsion
@@ -190,12 +190,12 @@ TEST_F(SpeciesTabTest, Torsions)
 
     EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0,5.0"));
     EXPECT_TRUE(torsion.setData(torsion.index(3, 5), "4.0,5.0,6.0"));
-    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "4.000000,5.000000,6.000000");
+    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "4,5,6");
 
     EXPECT_FALSE(torsion.setData(torsion.index(3, 8), 8));
     EXPECT_EQ(torsion.data(torsion.index(3, 8)).toDouble(), 0);
     EXPECT_TRUE(torsion.setData(torsion.index(3, 4), "@CA-CA-CA-CA"));
-    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "0.000000,30.334000,0.000000");
+    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "0,30.334,0");
 }
 
 TEST_F(SpeciesTabTest, Impropers)
@@ -220,7 +220,7 @@ TEST_F(SpeciesTabTest, Impropers)
         EXPECT_EQ(improper.data(improper.index(3, 2), role).toInt(), 5);
         EXPECT_EQ(improper.data(improper.index(3, 3), role).toInt(), 9);
         EXPECT_EQ(improper.data(improper.index(3, 4), role).toString().toStdString(), "@impgeneral");
-        EXPECT_EQ(improper.data(improper.index(3, 5), role).toString().toStdString(), "4.606000,2.000000,180.000000,1.000000");
+        EXPECT_EQ(improper.data(improper.index(3, 5), role).toString().toStdString(), "4.606,2,180,1");
     }
 
     // Mutate improper
@@ -236,10 +236,10 @@ TEST_F(SpeciesTabTest, Impropers)
 
     EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0"));
     EXPECT_TRUE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0,6.0"));
-    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "3.000000,4.000000,5.000000,6.000000");
+    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "3,4,5,6");
 
     EXPECT_TRUE(improper.setData(improper.index(3, 4), "@impgeneral"));
-    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "4.606000,2.000000,180.000000,1.000000");
+    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "4.606,2,180,1");
 }
 
 } // namespace UnitTest

--- a/unit/gui/test_speciestab.cpp
+++ b/unit/gui/test_speciestab.cpp
@@ -211,7 +211,7 @@ TEST_F(SpeciesTabTest, Impropers)
     SpeciesImproperModel improper(species->impropers(), dissolve);
 
     // Test Torsions
-    EXPECT_EQ(improper.columnCount(), 9);
+    EXPECT_EQ(improper.columnCount(), 6);
     EXPECT_EQ(improper.rowCount(), 6);
     for (auto role : roles)
     {
@@ -220,10 +220,7 @@ TEST_F(SpeciesTabTest, Impropers)
         EXPECT_EQ(improper.data(improper.index(3, 2), role).toInt(), 5);
         EXPECT_EQ(improper.data(improper.index(3, 3), role).toInt(), 9);
         EXPECT_EQ(improper.data(improper.index(3, 4), role).toString().toStdString(), "@impgeneral");
-        EXPECT_EQ(improper.data(improper.index(3, 5), role).toDouble(), 4.606);
-        EXPECT_DOUBLE_EQ(improper.data(improper.index(3, 6), role).toDouble(), 2.0);
-        EXPECT_DOUBLE_EQ(improper.data(improper.index(3, 7), role).toDouble(), 180.0);
-        EXPECT_DOUBLE_EQ(improper.data(improper.index(3, 8), role).toDouble(), 1.00);
+        EXPECT_EQ(improper.data(improper.index(3, 5), role).toString().toStdString(), "4.606000,2.000000,180.000000,1.000000");
     }
 
     // Mutate improper
@@ -231,21 +228,18 @@ TEST_F(SpeciesTabTest, Impropers)
     EXPECT_FALSE(improper.setData(improper.index(3, 1), 6));
     EXPECT_FALSE(improper.setData(improper.index(3, 2), 7));
     EXPECT_FALSE(improper.setData(improper.index(3, 3), 8));
-    for (auto i = 5; i < 9; ++i)
-        EXPECT_FALSE(improper.setData(improper.index(3, i), 6));
+
+    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0,6.0"));
 
     EXPECT_FALSE(improper.setData(improper.index(3, 4), "Undefined"));
     EXPECT_TRUE(improper.setData(improper.index(3, 4), "Cos3"));
-    for (auto i = 5; i < 9; ++i)
-    {
-        EXPECT_TRUE(improper.setData(improper.index(3, i), i));
-        EXPECT_DOUBLE_EQ(improper.data(improper.index(3, i)).toDouble(), i);
-    }
+
+    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0"));
+    EXPECT_TRUE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0,6.0"));
+    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "3.000000,4.000000,5.000000,6.000000");
+
     EXPECT_TRUE(improper.setData(improper.index(3, 4), "@impgeneral"));
-    EXPECT_EQ(improper.data(improper.index(3, 5)).toDouble(), 4.606);
-    EXPECT_DOUBLE_EQ(improper.data(improper.index(3, 6)).toDouble(), 2.0);
-    EXPECT_DOUBLE_EQ(improper.data(improper.index(3, 7)).toDouble(), 180.0);
-    EXPECT_DOUBLE_EQ(improper.data(improper.index(3, 8)).toDouble(), 1.00);
+    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "4.606000,2.000000,180.000000,1.000000");
 }
 
 } // namespace UnitTest

--- a/unit/gui/test_speciestab.cpp
+++ b/unit/gui/test_speciestab.cpp
@@ -100,7 +100,7 @@ TEST_F(SpeciesTabTest, Bonds)
     EXPECT_FALSE(bond.setData(bond.index(3, 0), 5));
     EXPECT_FALSE(bond.setData(bond.index(3, 1), 6));
 
-    EXPECT_FALSE(bond.setData(bond.index(3, 3), 6));
+    EXPECT_FALSE(bond.setData(bond.index(3, 3), "4.000000,5.000000"));
 
     EXPECT_FALSE(bond.setData(bond.index(3, 2), "Undefined"));
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "Harmonic"));
@@ -125,7 +125,7 @@ TEST_F(SpeciesTabTest, Angles)
     SpeciesAngleModel angle(species->angles(), dissolve);
 
     // Test Angles
-    EXPECT_EQ(angle.columnCount(), 8);
+    EXPECT_EQ(angle.columnCount(), 5);
     EXPECT_EQ(angle.rowCount(), 18);
     for (auto role : roles)
     {
@@ -133,36 +133,23 @@ TEST_F(SpeciesTabTest, Angles)
         EXPECT_EQ(angle.data(angle.index(3, 1), role).toInt(), 5);
         EXPECT_EQ(angle.data(angle.index(3, 2), role).toInt(), 6);
         EXPECT_EQ(angle.data(angle.index(3, 3), role).toString().toStdString(), "@CA-CA-CA");
-        EXPECT_DOUBLE_EQ(angle.data(angle.index(3, 4), role).toDouble(), 527.184);
-        EXPECT_DOUBLE_EQ(angle.data(angle.index(3, 5), role).toDouble(), 120);
-        EXPECT_EQ(angle.data(angle.index(3, 6), role).toDouble(), 0);
-        EXPECT_EQ(angle.data(angle.index(3, 7), role).toDouble(), 0);
+        EXPECT_EQ(angle.data(angle.index(3, 4), role).toString().toStdString(), "527.184000,120.000000");
     }
 
     // Mutate angle
     EXPECT_FALSE(angle.setData(angle.index(3, 0), 5));
     EXPECT_FALSE(angle.setData(angle.index(3, 1), 6));
     EXPECT_FALSE(angle.setData(angle.index(3, 2), 7));
-    for (auto i = 4; i < 6; ++i)
-        EXPECT_FALSE(angle.setData(angle.index(3, i), 6));
+    EXPECT_FALSE(angle.setData(angle.index(3, 4), 6));
 
     EXPECT_FALSE(angle.setData(angle.index(3, 3), "Undefined"));
     EXPECT_TRUE(angle.setData(angle.index(3, 3), "Harmonic"));
-    for (auto i = 4; i < 6; ++i)
-    {
-        EXPECT_TRUE(angle.setData(angle.index(3, i), i));
-        EXPECT_DOUBLE_EQ(angle.data(angle.index(3, i)).toDouble(), i);
-    }
-    for (auto i = 6; i < 8; ++i)
-    {
-        EXPECT_FALSE(angle.setData(angle.index(3, i), i));
-        EXPECT_EQ(angle.data(angle.index(3, i)).toDouble(), 0);
-    }
+
+    EXPECT_TRUE(angle.setData(angle.index(3, 4), "4.0,5.0"));
+    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "4.000000,5.000000");
+
     EXPECT_TRUE(angle.setData(angle.index(3, 3), "@CA-CA-CA"));
-    EXPECT_DOUBLE_EQ(angle.data(angle.index(3, 4)).toDouble(), 527.184);
-    EXPECT_DOUBLE_EQ(angle.data(angle.index(3, 5)).toDouble(), 120);
-    EXPECT_EQ(angle.data(angle.index(3, 6)).toDouble(), 0);
-    EXPECT_EQ(angle.data(angle.index(3, 7)).toDouble(), 0);
+    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "527.184000,120.000000");
 }
 
 TEST_F(SpeciesTabTest, Torsions)

--- a/unit/gui/test_speciestab.cpp
+++ b/unit/gui/test_speciestab.cpp
@@ -93,23 +93,23 @@ TEST_F(SpeciesTabTest, Bonds)
         EXPECT_EQ(bond.data(bond.index(3, 0), role).toInt(), 4);
         EXPECT_EQ(bond.data(bond.index(3, 1), role).toInt(), 5);
         EXPECT_EQ(bond.data(bond.index(3, 2), role).toString().toStdString(), "@CA-CA");
-        EXPECT_EQ(bond.data(bond.index(3, 3), role).toString().toStdString(), "3924.59,1.4");
+        EXPECT_EQ(bond.data(bond.index(3, 3), role).toString().toStdString(), "3924.59, 1.4");
     }
 
     // Mutate bond
     EXPECT_FALSE(bond.setData(bond.index(3, 0), 5));
     EXPECT_FALSE(bond.setData(bond.index(3, 1), 6));
 
-    EXPECT_FALSE(bond.setData(bond.index(3, 3), "4,5"));
+    EXPECT_FALSE(bond.setData(bond.index(3, 3), "4, 5"));
 
     EXPECT_FALSE(bond.setData(bond.index(3, 2), "Undefined"));
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "Harmonic"));
 
-    EXPECT_TRUE(bond.setData(bond.index(3, 3), "4.0,5.0"));
-    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "4,5");
+    EXPECT_TRUE(bond.setData(bond.index(3, 3), "4.0, 5.0"));
+    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "4.0, 5.0");
 
     EXPECT_TRUE(bond.setData(bond.index(3, 2), "@CA-CA"));
-    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "3924.59,1.4");
+    EXPECT_EQ(bond.data(bond.index(3, 3)).toString().toStdString(), "3924.59, 1.4");
 }
 
 TEST_F(SpeciesTabTest, Angles)
@@ -133,7 +133,7 @@ TEST_F(SpeciesTabTest, Angles)
         EXPECT_EQ(angle.data(angle.index(3, 1), role).toInt(), 5);
         EXPECT_EQ(angle.data(angle.index(3, 2), role).toInt(), 6);
         EXPECT_EQ(angle.data(angle.index(3, 3), role).toString().toStdString(), "@CA-CA-CA");
-        EXPECT_EQ(angle.data(angle.index(3, 4), role).toString().toStdString(), "527.184,120");
+        EXPECT_EQ(angle.data(angle.index(3, 4), role).toString().toStdString(), "527.184, 120.0");
     }
 
     // Mutate angle
@@ -145,11 +145,11 @@ TEST_F(SpeciesTabTest, Angles)
     EXPECT_FALSE(angle.setData(angle.index(3, 3), "Undefined"));
     EXPECT_TRUE(angle.setData(angle.index(3, 3), "Harmonic"));
 
-    EXPECT_TRUE(angle.setData(angle.index(3, 4), "4.0,5.0"));
-    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "4,5");
+    EXPECT_TRUE(angle.setData(angle.index(3, 4), "4.0, 5.0"));
+    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "4.0, 5.0");
 
     EXPECT_TRUE(angle.setData(angle.index(3, 3), "@CA-CA-CA"));
-    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "527.184,120");
+    EXPECT_EQ(angle.data(angle.index(3, 4)).toString().toStdString(), "527.184, 120.0");
 }
 
 TEST_F(SpeciesTabTest, Torsions)
@@ -174,7 +174,7 @@ TEST_F(SpeciesTabTest, Torsions)
         EXPECT_EQ(torsion.data(torsion.index(3, 2), role).toInt(), 2);
         EXPECT_EQ(torsion.data(torsion.index(3, 3), role).toInt(), 3);
         EXPECT_EQ(torsion.data(torsion.index(3, 4), role).toString().toStdString(), "@CA-CA-CA-CA");
-        EXPECT_EQ(torsion.data(torsion.index(3, 5), role).toString().toStdString(), "0,30.334,0");
+        EXPECT_EQ(torsion.data(torsion.index(3, 5), role).toString().toStdString(), "0.0, 30.334, 0.0");
     }
 
     // Mutate torsion
@@ -183,19 +183,19 @@ TEST_F(SpeciesTabTest, Torsions)
     EXPECT_FALSE(torsion.setData(torsion.index(3, 2), 7));
     EXPECT_FALSE(torsion.setData(torsion.index(3, 3), 8));
 
-    EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0,5.0,6.0"));
+    EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0, 5.0, 6.0"));
 
     EXPECT_FALSE(torsion.setData(torsion.index(3, 4), "Undefined"));
     EXPECT_TRUE(torsion.setData(torsion.index(3, 4), "Cos3"));
 
-    EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0,5.0"));
-    EXPECT_TRUE(torsion.setData(torsion.index(3, 5), "4.0,5.0,6.0"));
-    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "4,5,6");
+    EXPECT_FALSE(torsion.setData(torsion.index(3, 5), "4.0, 5.0"));
+    EXPECT_TRUE(torsion.setData(torsion.index(3, 5), "4.0, 5.0, 6.0"));
+    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "4.0, 5.0, 6.0");
 
     EXPECT_FALSE(torsion.setData(torsion.index(3, 8), 8));
     EXPECT_EQ(torsion.data(torsion.index(3, 8)).toDouble(), 0);
     EXPECT_TRUE(torsion.setData(torsion.index(3, 4), "@CA-CA-CA-CA"));
-    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "0,30.334,0");
+    EXPECT_EQ(torsion.data(torsion.index(3, 5)).toString().toStdString(), "0.0, 30.334, 0.0");
 }
 
 TEST_F(SpeciesTabTest, Impropers)
@@ -220,7 +220,7 @@ TEST_F(SpeciesTabTest, Impropers)
         EXPECT_EQ(improper.data(improper.index(3, 2), role).toInt(), 5);
         EXPECT_EQ(improper.data(improper.index(3, 3), role).toInt(), 9);
         EXPECT_EQ(improper.data(improper.index(3, 4), role).toString().toStdString(), "@impgeneral");
-        EXPECT_EQ(improper.data(improper.index(3, 5), role).toString().toStdString(), "4.606,2,180,1");
+        EXPECT_EQ(improper.data(improper.index(3, 5), role).toString().toStdString(), "4.606, 2.0, 180.0, 1.0");
     }
 
     // Mutate improper
@@ -229,17 +229,18 @@ TEST_F(SpeciesTabTest, Impropers)
     EXPECT_FALSE(improper.setData(improper.index(3, 2), 7));
     EXPECT_FALSE(improper.setData(improper.index(3, 3), 8));
 
-    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0,6.0"));
+    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0, 4.0, 5.0, 6.0"));
 
     EXPECT_FALSE(improper.setData(improper.index(3, 4), "Undefined"));
     EXPECT_TRUE(improper.setData(improper.index(3, 4), "Cos3"));
 
-    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0"));
-    EXPECT_TRUE(improper.setData(improper.index(3, 5), "3.0,4.0,5.0,6.0"));
-    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "3,4,5,6");
+    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0, 4.0, 5.0"));
+    EXPECT_FALSE(improper.setData(improper.index(3, 5), "3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.0"));
+    EXPECT_TRUE(improper.setData(improper.index(3, 5), "3.0, 4.0, 5.0, 6.0"));
+    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "3.0, 4.0, 5.0, 6.0");
 
     EXPECT_TRUE(improper.setData(improper.index(3, 4), "@impgeneral"));
-    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "4.606,2,180,1");
+    EXPECT_EQ(improper.data(improper.index(3, 5)).toString().toStdString(), "4.606, 2.0, 180.0, 1.0");
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
Instead of having four parameters displayed for each row, we display a single cell that has a comma separated list of the parameter values.  Eventually we'll want the parameters to be labelled, but that's a larger issue than the immediate interface one.

This closes #597.