### PR TITLE
Box Regions

### DIFF
--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -139,8 +139,8 @@ class Configuration : public ListItem<Configuration>
     const std::vector<std::shared_ptr<Atom>> &atoms() const;
     // Return nth Atom
     std::shared_ptr<Atom> atom(int n);
-    // Scale geometric centres of molecules within box
-    void scaleMoleculeCentres(double factor);
+    // Scale contents of the box by the specified factor
+    void scaleContents(double factor);
 
     /*
      * Periodic Box and Cells

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -64,7 +64,7 @@ void Configuration::applySizeFactor(const PotentialMap &potentialMap)
                              requestedSizeFactor_, appliedSizeFactor_);
 
             // Scale molecule centres of geometry
-            scaleMoleculeCentres(sizeFactorRatio);
+            scaleContents(sizeFactorRatio);
 
             // Now scale the Box and its Cells
             scaleBox(sizeFactorRatio);

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
   collect3d.cpp
   dynamicsite.cpp
   fit1d.cpp
+  generalregion.cpp
   integrate1d.cpp
   node.cpp
   nodereference.cpp
@@ -28,6 +29,7 @@ add_library(
   process1d.cpp
   process2d.cpp
   process3d.cpp
+  regionbase.cpp
   select.cpp
   sequence.cpp
   sum1d.cpp
@@ -43,6 +45,7 @@ add_library(
   collect3d.h
   dynamicsite.h
   fit1d.h
+  generalregion.h
   integrate1d.h
   node.h
   nodereference.h
@@ -60,6 +63,7 @@ add_library(
   process1d.h
   process2d.h
   process3d.h
+  regionbase.h
   select.h
   sequence.h
   sum1d.h

--- a/src/procedure/nodes/addspecies.cpp
+++ b/src/procedure/nodes/addspecies.cpp
@@ -139,8 +139,8 @@ bool AddSpeciesProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
 
         auto scaleFactor = pow(requiredVolume / currentVolume, 1.0 / 3.0);
 
-        // Scale centres of geometry of existing contents
-        cfg->scaleMoleculeCentres(scaleFactor);
+        // Scale existing contents
+        cfg->scaleContents(scaleFactor);
 
         // Scale the current Box so there is enough space for our new species
         cfg->scaleBox(scaleFactor);
@@ -176,8 +176,8 @@ bool AddSpeciesProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
 
         auto scaleFactor = pow(requiredVolume / cfg->box()->volume(), 1.0 / 3.0);
 
-        // Scale centres of geometry of existing contents
-        cfg->scaleMoleculeCentres(scaleFactor);
+        // Scale existing contents
+        cfg->scaleContents(scaleFactor);
 
         // Scale the current Box so there is enough space for our new species
         cfg->scaleBox(scaleFactor);

--- a/src/procedure/nodes/addspecies.h
+++ b/src/procedure/nodes/addspecies.h
@@ -46,7 +46,8 @@ class AddSpeciesProcedureNode : public ProcedureNode
     {
         Central, /* Position the Species at the centre of the Box */
         Current, /* Use current Species coordinates */
-        Random   /* Set position randomly */
+        Random,  /* Set position randomly */
+        Region   /* Set position randomly within a specified region */
     };
     // Return enum option info for PositioningType
     static EnumOptions<PositioningType> positioningTypes();

--- a/src/procedure/nodes/generalregion.cpp
+++ b/src/procedure/nodes/generalregion.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "procedure/nodes/generalregion.h"
+#include "classes/configuration.h"
+#include "keywords/double.h"
+
+GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBase(ProcedureNode::NodeType::GeneralRegion)
+{
+    keywords_.add("Control", new DoubleKeyword(2.0), "Tolerance",
+                  "Distance threshold for avoiding existing atoms in the configuration");
+}
+
+/*
+ * Region Data
+ */
+
+// Return whether voxel centred at supplied real coordinates is valid
+bool GeneralRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &vCentre) const
+{
+    const Box *box = cfg->box();
+
+    // If any atom in the Configuration is less than some tolerance value to this coordinate, invalidate the voxel
+    return !std::any_of(cfg->atoms().begin(), cfg->atoms().end(),
+                        [&](const auto &i) { return box->minimumDistanceSquared(i, vCentre) <= toleranceSquared_; });
+}
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool GeneralRegionProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+{
+    // Retrieve keyword values
+    toleranceSquared_ = keywords_.asDouble("Tolerance");
+    toleranceSquared_ *= toleranceSquared_;
+
+    return true;
+}

--- a/src/procedure/nodes/generalregion.h
+++ b/src/procedure/nodes/generalregion.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/regionbase.h"
+
+// General Region
+class GeneralRegionProcedureNode : public RegionProcedureNodeBase
+{
+    public:
+    GeneralRegionProcedureNode();
+    ~GeneralRegionProcedureNode() override = default;
+
+    /*
+     * Control
+     */
+    private:
+    // Distance tolerance (threshold) for avoiding existing atoms (retrieved from keywords)
+    double toleranceSquared_;
+
+    /*
+     * Region Data
+     */
+    public:
+    // Return whether voxel centred at supplied real coordinates is valid
+    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &vCentre) const;
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+};

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -16,7 +16,8 @@ EnumOptions<ProcedureNode::NodeClass> ProcedureNode::nodeClasses()
 {
     return EnumOptions<ProcedureNode::NodeClass>("NodeClass", {{ProcedureNode::NodeClass::None, "None"},
                                                                {ProcedureNode::NodeClass::Calculate, "Calculate"},
-                                                               {ProcedureNode::NodeClass::Operate, "Operate"}});
+                                                               {ProcedureNode::NodeClass::Operate, "Operate"},
+                                                               {ProcedureNode::NodeClass::Region, "Region"}});
 }
 
 // Return enum option info for NodeType
@@ -34,6 +35,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Collect3D, "Collect3D"},
                      {ProcedureNode::NodeType::DynamicSite, "DynamicSite"},
                      {ProcedureNode::NodeType::Fit1D, "Fit1D"},
+                     {ProcedureNode::NodeType::GeneralRegion, "GeneralRegion"},
                      {ProcedureNode::NodeType::Integrate1D, "Integrate1D"},
                      {ProcedureNode::NodeType::OperateDivide, "OperateDivide"},
                      {ProcedureNode::NodeType::OperateExpression, "OperateExpression"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -29,7 +29,8 @@ class ProcedureNode : public ListItem<ProcedureNode>
     {
         None,
         Calculate,
-        Operate
+        Operate,
+        Region
 
     };
     // Return enum option info for NodeClass
@@ -48,6 +49,7 @@ class ProcedureNode : public ListItem<ProcedureNode>
         Collect3D,
         DynamicSite,
         Fit1D,
+        GeneralRegion,
         Integrate1D,
         OperateDivide,
         OperateExpression,

--- a/src/procedure/nodes/nodes.h
+++ b/src/procedure/nodes/nodes.h
@@ -17,6 +17,7 @@
 #include "procedure/nodes/collect3d.h"
 #include "procedure/nodes/dynamicsite.h"
 #include "procedure/nodes/fit1d.h"
+#include "procedure/nodes/generalregion.h"
 #include "procedure/nodes/integrate1d.h"
 #include "procedure/nodes/operatedivide.h"
 #include "procedure/nodes/operateexpression.h"

--- a/src/procedure/nodes/regionbase.cpp
+++ b/src/procedure/nodes/regionbase.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "procedure/nodes/regionbase.h"
+#include "classes/box.h"
+#include "classes/configuration.h"
+
+constexpr double voxelSize = 2.0;
+
+RegionProcedureNodeBase::RegionProcedureNodeBase(ProcedureNode::NodeType nodeType)
+    : ProcedureNode(nodeType, ProcedureNode::NodeClass::Region)
+{
+}
+
+/*
+ * Identity
+ */
+
+// Return whether specified context is relevant for this node type
+bool RegionProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext context)
+{
+    return (context == ProcedureNode::GenerationContext);
+}
+
+// Return whether a name for the node must be provided
+bool RegionProcedureNodeBase::mustBeNamed() const { return true; }
+
+/*
+ * Region Data
+ */
+
+// Return random fractional coordinate inside region
+Vec3<double> RegionProcedureNodeBase::randomFractionalCoordinate() const
+{
+    // Select a random voxel
+    auto &voxel = freeVoxels_[DissolveMath::randomi(freeVoxels_.size())];
+
+    // Generate random point in fractional coordinates within the voxel
+    return Vec3<double>((voxel.first.x + DissolveMath::random()) * voxelSizeFrac_.x,
+                        (voxel.first.y + DissolveMath::random()) * voxelSizeFrac_.y,
+                        (voxel.first.z + DissolveMath::random()) * voxelSizeFrac_.z);
+}
+
+// Return whether specified fractional coordinate is inside a valid cell of the region
+bool RegionProcedureNodeBase::validFractionalCoordinate(const Vec3<double> &rFrac) const
+{
+    return voxelMap_[{rFrac.x / voxelSizeFrac_.x, rFrac.y / voxelSizeFrac_.y, rFrac.z / voxelSizeFrac_.z}].second;
+}
+
+/*
+ * Execute
+ */
+
+// Execute node, targetting the supplied Configuration
+bool RegionProcedureNodeBase::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
+                                      GenericList &targetList)
+{
+    // Copy Box pointer from Configuration
+    box_ = cfg->box();
+
+    // Determine number of divisions along each cell axis, and set fractional voxel size
+    for (auto n = 0; n < 3; ++n)
+        nVoxels_.set(n, cfg->box()->axisLength(n) / voxelSize);
+    voxelSizeFrac_.set(1.0 / nVoxels_.x, 1.0 / nVoxels_.y, 1.0 / nVoxels_.z);
+
+    // Initialise 3D map and determine valid voxels
+    voxelMap_.initialise(nVoxels_.x, nVoxels_.y, nVoxels_.z);
+    for (auto x = 0; x < nVoxels_.x; ++x)
+        for (auto y = 0; y < nVoxels_.y; ++y)
+            for (auto z = 0; z < nVoxels_.z; ++z)
+                voxelMap_[{x, y, z}] = {
+                    {x, y, z},
+                    isVoxelValid(cfg, box_->fracToReal({(x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
+                                                        (z + 0.5) * voxelSizeFrac_.z}))};
+
+    // Create linear array of all available voxels
+    auto nFreeVoxels = std::count_if(voxelMap_.begin(), voxelMap_.end(), [](const auto &voxel) { return voxel.second; });
+    freeVoxels_.clear();
+    freeVoxels_.resize(nFreeVoxels);
+    std::copy_if(voxelMap_.begin(), voxelMap_.end(), freeVoxels_.begin(), [](const auto &voxel) { return voxel.second; });
+
+    return nFreeVoxels > 0;
+}

--- a/src/procedure/nodes/regionbase.h
+++ b/src/procedure/nodes/regionbase.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "math/matrix3.h"
+#include "procedure/nodes/node.h"
+#include "templates/array3d.h"
+#include <random>
+
+// Forward Declarations
+class Box;
+
+// Region Node Base
+class RegionProcedureNodeBase : public ProcedureNode
+{
+    public:
+    RegionProcedureNodeBase(ProcedureNode::NodeType nodeType);
+    ~RegionProcedureNodeBase() override = default;
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether specified context is relevant for this node type
+    bool isContextRelevant(ProcedureNode::NodeContext context) override;
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const;
+
+    /*
+     * Region Data
+     */
+    private:
+    // Box of target Configuration
+    const Box *box_;
+    // 3D map of available voxels
+    Array3D<std::pair<Vec3<int>, bool>> voxelMap_;
+    // Number of voxels along each cell axis
+    Vec3<int> nVoxels_;
+    // Fractional voxel size
+    Vec3<double> voxelSizeFrac_;
+    // Lower-left corner voxel indices of free regions
+    std::vector<std::pair<Vec3<int>, bool>> freeVoxels_;
+
+    protected:
+    // Return whether voxel centred at supplied real coordinates is valid
+    virtual bool isVoxelValid(const Configuration *cfg, const Vec3<double> &vCentre) const = 0;
+
+    public:
+    // Return random fractional coordinate inside region
+    Vec3<double> randomFractionalCoordinate() const;
+    // Return whether specified coordinate is inside a valid voxel of the region
+    bool validFractionalCoordinate(const Vec3<double> &rFrac) const;
+
+    /*
+     * Execute
+     */
+    public:
+    // Execute node, targetting the supplied Configuration
+    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+};

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -436,6 +436,9 @@ bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &core
             case (ProcedureNode::NodeType::Fit1D):
                 newNode = new Fit1DProcedureNode();
                 break;
+            case (ProcedureNode::NodeType::GeneralRegion):
+                newNode = new GeneralRegionProcedureNode();
+                break;
             case (ProcedureNode::NodeType::OperateDivide):
                 newNode = new OperateDivideProcedureNode();
                 break;

--- a/web/content/docs/procedures/nodes/addspeciesnode.md
+++ b/web/content/docs/procedures/nodes/addspeciesnode.md
@@ -16,13 +16,16 @@ description: Insert a species into a box
 
 The `AddSpecies` node is a core component of nearly all configuration generators requiring the initial construction of a suitable starting point. It adds a number of copies of a given target species to the current box, either at specific or random coordinates. By default, the box is resized to accommodate the new population of molecules based on a supplied density.
 
+If the species is periodic, the box associated with that species can be copied to the model as part of the `AddSpecies` process. In that case, an initial [`Box`]({{< ref boxnode >}}) node is not necessary in the procedure.
+
 ## Description
 
-When adding molecules of the target species to the current box, there are several possible behaviours:
+When adding molecules of the target species to the current configuration, there are several possible actions on the periodic box for that configuration:
 
 1. No resizing of the box is performed ([`BoxAction`]({{< ref "boxactionstyle" >}}) = `None`) - The box retains its original geometry regardless of the number of added molecules. This is useful if an explicit box geometry has already been set by a [`Box`]({{< ref "boxnode" >}}) node, or it has existing contents that should not be resized (e.g. a crystal).
 2. The box volume is increased to accommodate the new molecules ([`BoxAction`]({{< ref "boxactionstyle" >}}) = `AddVolume`) - Additional volume is added to the box based on the density and population of the target species. Existing molecules within the box have their centres of geometry scaled as well.
 3. The box volume is scaled to give the supplied density ([`BoxAction`]({{< ref "boxactionstyle" >}}) = `ScaleVolume`) - The box volume is scaled to give the requested density, taking into account the existing box contents and the new population of molecules requested. Existing molecules within the box have their centres of geometry scaled as well.
+4. The box is set ([`BoxAction`]({{< ref "boxactionstyle" >}}) = `Set`) from a definition on the species itself (if it is periodic). This is typically used when the species is a framework-type model (e.g. a metal organic framework) and it is to be used as the main basis for a configuration.
 
 ## Configuration
 
@@ -34,5 +37,6 @@ When adding molecules of the target species to the current box, there are severa
 |`Density`|[`expr`]({{< ref "expressions" >}})<br/>[`DensityUnit`]({{< ref "densityunit" >}})|`0.1 atoms/A3`|Density at which to add the target species. Note that the use of this value differs according to the selected `BoxAction` (see above).|
 |`Population`|[`expr`]({{< ref "expressions" >}})|`0`|Population of the target species to add.|
 |`Positioning`|[`PositioningType`]({{< ref "positioningtype" >}})|`Random`|Positioning type for individual molecules.|
+|`Region`|`name`|--|Region node controlling the location of inserted species into the configuration.|
 |`Rotate`|`true|false`|`true`|Whether to randomly rotate molecules on insertion.|
 |`Species`|`name`|--|{{< required-label >}} Target species to add.|

--- a/web/content/docs/procedures/nodes/generalregion.md
+++ b/web/content/docs/procedures/nodes/generalregion.md
@@ -1,0 +1,29 @@
+---
+title: GeneralRegion (Node)
+linkTitle: GeneralRegion
+description: Constructs a general region
+---
+
+{{< htable >}}
+| | |
+|-|-|
+|Context|Generation|
+|Name Required?|Yes|
+|Branches|--|
+{{< /htable >}}
+
+## Overview
+
+The `GeneralRegion` node generates a region suitable for the insertion of new molecules by an [`AddSpecies`]({{< ref "addspeciesnode" >}}) node.
+
+## Description
+
+The `GeneralRegion` node assesses the current contents of a configuration and locates "free volume" into which molecules can be added. Volume is excluded based on the proximity of existing atoms in the configuration - a volume element is excluded if any atom is within the tolerance distance specified of its coordinate centre.
+
+## Configuration
+
+### Control Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Tolerance`|`distance`|`2.0`|Minimum distance at which an existing atom may reside next to a voxel's central coordinate. If an atom exists at a shorter distance, that voxel is excluded.|

--- a/web/content/docs/reference/positioningtype.md
+++ b/web/content/docs/reference/positioningtype.md
@@ -5,8 +5,9 @@ description: Positioning type for inserted species
 
 Positioning types for inserted species, as used by the [`AddSpecies`]({{< ref "addspeciesnode" >}}) procedure node.
 
-|Keyword|Parameters|Description|
-|:---:|:--------:|-----------|
-|`Central`|--|On insertion, the species is shifted so that its centre of geometry is at the centre of the box.|
-|`Current`|--|No modification to the species coordinates are made on insertion.|
-|`Random`|--|On insertion, the species is translated to a random position within the box.|
+|Keyword|Description|
+|:-----:|-----------|
+|`Central`|On insertion, the species is shifted so that its centre of geometry is at the centre of the box.|
+|`Current`|No modification to the species coordinates are made on insertion.|
+|`Random`|On insertion, the species is translated to a random position within the box.|
+|`Region`|Use a specified region to control the locations into which species can be inserted.|


### PR DESCRIPTION
This PR introduces "region" nodes for controlling the locations of molecules inserted in to a box when generating configurations. Regions partition the space within a configuration's box into voxels, and then assess by some means which voxels are empty / free / available. The only node available at present is `GeneralRegion` which locates voxels that are a specified distance away from all atoms in the configuration, making it suitable for adding species into periodic frameworks such as MOFs.

It also makes size factor scaling aware of periodic species - rather than scaling by the geometric centre, the absolute positions of atoms are scaled.

Closes #667.

Example configuration generator:

```
  Generator
    AddSpecies
      Species  'MOF5'
      Population  '1'
      BoxAction  Set
      Density  '1.000000e-01'  atoms/A3
      Rotate  False
      Positioning  Current
    EndAddSpecies
    GeneralRegion  'cell'
      Tolerance   2.00000e+00
    EndGeneralRegion
    Parameters
      Parameter  populationA  100
      Parameter  ratioB  1
    EndParameters
    AddSpecies
      Species  'Water'
      Population  'populationA'
      BoxAction  None
      Density  '1.000000e-01'  atoms/A3
      Rotate  True
      Positioning  Region
      Region  'cell'
    EndAddSpecies
  EndGenerator
```
