### PR TITLE
Remove List Dependency from Tabs

### DIFF
--- a/src/gui/configurationtab.h
+++ b/src/gui/configurationtab.h
@@ -12,7 +12,7 @@ class Configuration;
 class SpeciesInfo;
 
 // Configuration Tab
-class ConfigurationTab : public QWidget, public ListItem<ConfigurationTab>, public MainTab
+class ConfigurationTab : public QWidget, public MainTab
 {
     // All Qt declarations derived from QObject must include this macro
     Q_OBJECT

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -16,7 +16,7 @@
 
 ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent,
                                    const QString title, Configuration *cfg)
-    : ListItem<ConfigurationTab>(), MainTab(dissolveWindow, dissolve, parent, QString("Configuration: %1").arg(title), this)
+    : MainTab(dissolveWindow, dissolve, parent, QString("Configuration: %1").arg(title), this)
 {
     ui_.setupUi(this);
 

--- a/src/gui/gettabnamedialog.h
+++ b/src/gui/gettabnamedialog.h
@@ -17,14 +17,14 @@ class GetTabNameDialog : public QDialog
     Q_OBJECT
 
     public:
-    GetTabNameDialog(QWidget *parent, RefList<const MainTab> currentTabs);
+    GetTabNameDialog(QWidget *parent, const std::vector<std::shared_ptr<MainTab>> &currentTabs);
     ~GetTabNameDialog();
 
     private:
     // Main form declaration
     Ui::GetTabNameDialog ui_;
     // RefList of current tabs
-    RefList<const MainTab> currentTabs_;
+    const std::vector<std::shared_ptr<MainTab>> &currentTabs_;
     // Current tab that we are renaming
     const MainTab *currentTab_;
 

--- a/src/gui/gettabnamedialog_funcs.cpp
+++ b/src/gui/gettabnamedialog_funcs.cpp
@@ -43,7 +43,7 @@ void GetTabNameDialog::on_NameEdit_textChanged(const QString text)
         nameValid = false;
     else
     {
-        for (const MainTab *tab : currentTabs_)
+        for (const auto tab : currentTabs_)
         {
             if (currentTab_ == tab)
                 continue;

--- a/src/gui/gettabnamedialog_funcs.cpp
+++ b/src/gui/gettabnamedialog_funcs.cpp
@@ -5,11 +5,10 @@
 #include "gui/gettabnamedialog.h"
 #include "gui/maintab.h"
 
-GetTabNameDialog::GetTabNameDialog(QWidget *parent, RefList<const MainTab> currentTabs)
+GetTabNameDialog::GetTabNameDialog(QWidget *parent, const std::vector<std::shared_ptr<MainTab>> &currentTabs)
+    : currentTabs_(currentTabs)
 {
     ui_.setupUi(this);
-
-    currentTabs_ = currentTabs;
 }
 
 GetTabNameDialog::~GetTabNameDialog() {}
@@ -45,7 +44,7 @@ void GetTabNameDialog::on_NameEdit_textChanged(const QString text)
     {
         for (const auto tab : currentTabs_)
         {
-            if (currentTab_ == tab)
+            if (currentTab_ == tab.get())
                 continue;
 
             if (tab->title() == text)

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -284,7 +284,7 @@ class DissolveWindow : public QMainWindow
 
     public:
     // Return list of all current tabs
-    RefList<const MainTab> allTabs() const;
+    const std::vector<std::shared_ptr<MainTab>> allTabs() const;
 
     /*
      * 'Simulation' Stack Page - Messages

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -311,7 +311,7 @@ void DissolveWindow::updateControlsFrame()
 // Update menus
 void DissolveWindow::updateMenus()
 {
-    MainTab *activeTab = ui_.MainTabs->currentTab();
+    auto activeTab = ui_.MainTabs->currentTab();
     if (!activeTab)
         return;
 

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -112,7 +112,7 @@ void DissolveWindow::on_MainTabs_currentChanged(int index)
 }
 
 // Return list of all current tabs
-RefList<const MainTab> DissolveWindow::allTabs() const { return ui_.MainTabs->allTabs(); }
+const std::vector<std::shared_ptr<MainTab>> DissolveWindow::allTabs() const { return ui_.MainTabs->allTabs(); }
 
 /*
  * Messages

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -11,7 +11,7 @@ class ModuleChart;
 class ModulePalette;
 
 // Layer Tab
-class LayerTab : public QWidget, public ListItem<LayerTab>, public MainTab
+class LayerTab : public QWidget, public MainTab
 {
     // All Qt declarations derived from QObject must include this macro
     Q_OBJECT

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -11,7 +11,7 @@
 
 LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                    ModuleLayer *layer)
-    : ListItem<LayerTab>(), MainTab(dissolveWindow, dissolve, parent, QString("Layer: %1").arg(title), this)
+    : MainTab(dissolveWindow, dissolve, parent, QString("Layer: %1").arg(title), this)
 {
     ui_.setupUi(this);
 

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -50,7 +50,7 @@ class MainTabsWidget : public QTabWidget
     // List of processing layer tabs
     std::vector<std::shared_ptr<LayerTab>> processingLayerTabs_;
     // List of Workspace tabs
-    List<WorkspaceTab> workspaceTabs_;
+    std::vector<std::shared_ptr<WorkspaceTab>> workspaceTabs_;
 
     public:
     // Return reference list of all current tabs
@@ -68,7 +68,7 @@ class MainTabsWidget : public QTabWidget
     // Find LayerTab containing specified page widget
     std::shared_ptr<LayerTab> processingLayerTab(QWidget *page);
     // Find WorkspaceTab containing specified page widget
-    WorkspaceTab *workspaceTab(QWidget *page);
+    std::shared_ptr<WorkspaceTab> workspaceTab(QWidget *page);
     // Find tab with title specified
     MainTab *findTab(const QString title);
     // Find tab with specified page widget

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -11,6 +11,8 @@
 #include "templates/list.h"
 #include "templates/reflist.h"
 #include <QTabWidget>
+#include <memory>
+#include <vector>
 
 // Forward declarations
 class Dissolve;
@@ -42,7 +44,7 @@ class MainTabsWidget : public QTabWidget
     // Pointer to Forcefield tab
     ForcefieldTab *forcefieldTab_;
     // List of Species tabs
-    List<SpeciesTab> speciesTabs_;
+    std::vector<std::shared_ptr<SpeciesTab>> speciesTabs_;
     // List of Configuration tabs
     List<ConfigurationTab> configurationTabs_;
     // List of processing layer tabs
@@ -60,7 +62,7 @@ class MainTabsWidget : public QTabWidget
     // Return currently-selected ModuleLayer (if a LayerTab is the current one)
     ModuleLayer *currentLayer() const;
     // Find SpeciesTab containing specified page widget
-    SpeciesTab *speciesTab(QWidget *page);
+    std::shared_ptr<SpeciesTab> speciesTab(QWidget *page);
     // Find ConfigurationTab containing specified page widget
     ConfigurationTab *configurationTab(QWidget *page);
     // Find LayerTab containing specified page widget

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -40,9 +40,9 @@ class MainTabsWidget : public QTabWidget
      */
     private:
     // Reference list of all available tabs
-    RefList<MainTab> allTabs_;
+    std::vector<std::shared_ptr<MainTab>> allTabs_;
     // Pointer to Forcefield tab
-    ForcefieldTab *forcefieldTab_;
+    std::shared_ptr<ForcefieldTab> forcefieldTab_;
     // List of Species tabs
     std::vector<std::shared_ptr<SpeciesTab>> speciesTabs_;
     // List of Configuration tabs
@@ -54,7 +54,7 @@ class MainTabsWidget : public QTabWidget
 
     public:
     // Return reference list of all current tabs
-    RefList<const MainTab> allTabs() const;
+    const std::vector<std::shared_ptr<MainTab>> &allTabs() const;
     // Return currently-selected Species (if a SpeciesTab is the current one)
     Species *currentSpecies() const;
     // Return currently-selected Configuration (if a ConfigurationTab is the current one)
@@ -70,9 +70,9 @@ class MainTabsWidget : public QTabWidget
     // Find WorkspaceTab containing specified page widget
     std::shared_ptr<WorkspaceTab> workspaceTab(QWidget *page);
     // Find tab with title specified
-    MainTab *findTab(const QString title);
+    std::shared_ptr<MainTab> findTab(const QString title);
     // Find tab with specified page widget
-    MainTab *findTab(QWidget *page);
+    std::shared_ptr<MainTab> findTab(QWidget *page);
     // Generate unique tab name with base name provided
     const QString uniqueTabName(const QString base);
 
@@ -89,16 +89,16 @@ class MainTabsWidget : public QTabWidget
     // Remove tab containing the specified page widget
     void removeByPage(QWidget *page);
     // Add on a new workspace tab
-    MainTab *addWorkspaceTab(DissolveWindow *dissolveWindow, const QString title);
+    std::shared_ptr<MainTab> addWorkspaceTab(DissolveWindow *dissolveWindow, const QString title);
 
     /*
      * Display
      */
     public:
     // Return current tab
-    MainTab *currentTab() const;
+    std::shared_ptr<MainTab> currentTab() const;
     // Make specified tab the current one
-    void setCurrentTab(MainTab *tab);
+    void setCurrentTab(std::shared_ptr<MainTab> tab);
     // Make specified tab the current one (by index)
     void setCurrentTab(int tabIndex);
     // Make specified Species tab the current one

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -137,7 +137,7 @@ class MainTabsWidget : public QTabWidget
      */
     private:
     // List of close buttons and their associated pageWidgets
-    RefDataList<QToolButton, QWidget *> closeButtons_;
+    std::vector<std::tuple<QToolButton *, QWidget *>> closeButtons_;
     // Overload insertTab for shared_ptr
     int insertTab(int index, std::shared_ptr<QWidget> widget, const QString &title);
 

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -46,7 +46,7 @@ class MainTabsWidget : public QTabWidget
     // List of Species tabs
     std::vector<std::shared_ptr<SpeciesTab>> speciesTabs_;
     // List of Configuration tabs
-    List<ConfigurationTab> configurationTabs_;
+    std::vector<std::shared_ptr<ConfigurationTab>> configurationTabs_;
     // List of processing layer tabs
     std::vector<std::shared_ptr<LayerTab>> processingLayerTabs_;
     // List of Workspace tabs
@@ -64,7 +64,7 @@ class MainTabsWidget : public QTabWidget
     // Find SpeciesTab containing specified page widget
     std::shared_ptr<SpeciesTab> speciesTab(QWidget *page);
     // Find ConfigurationTab containing specified page widget
-    ConfigurationTab *configurationTab(QWidget *page);
+    std::shared_ptr<ConfigurationTab> configurationTab(QWidget *page);
     // Find LayerTab containing specified page widget
     std::shared_ptr<LayerTab> processingLayerTab(QWidget *page);
     // Find WorkspaceTab containing specified page widget

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -138,6 +138,8 @@ class MainTabsWidget : public QTabWidget
     private:
     // List of close buttons and their associated pageWidgets
     RefDataList<QToolButton, QWidget *> closeButtons_;
+    // Overload insertTab for shared_ptr
+    int insertTab(int index, std::shared_ptr<QWidget> widget, const QString &title);
 
     private slots:
     // Tab close button clicked

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -48,7 +48,7 @@ class MainTabsWidget : public QTabWidget
     // List of Configuration tabs
     List<ConfigurationTab> configurationTabs_;
     // List of processing layer tabs
-    List<LayerTab> processingLayerTabs_;
+    std::vector<std::shared_ptr<LayerTab>> processingLayerTabs_;
     // List of Workspace tabs
     List<WorkspaceTab> workspaceTabs_;
 
@@ -66,7 +66,7 @@ class MainTabsWidget : public QTabWidget
     // Find ConfigurationTab containing specified page widget
     ConfigurationTab *configurationTab(QWidget *page);
     // Find LayerTab containing specified page widget
-    LayerTab *processingLayerTab(QWidget *page);
+    std::shared_ptr<LayerTab> processingLayerTab(QWidget *page);
     // Find WorkspaceTab containing specified page widget
     WorkspaceTab *workspaceTab(QWidget *page);
     // Find tab with title specified

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -226,7 +226,7 @@ void MainTabsWidget::reconcileTabs(DissolveWindow *dissolveWindow)
 
             auto newTab = speciesTabs_.back();
             allTabs_.append(newTab.get());
-            insertTab(baseIndex + currentTabIndex, newTab.get(), tabTitle);
+            insertTab(baseIndex + currentTabIndex, newTab, tabTitle);
             addTabCloseButton(newTab->page());
             setTabTextColour(newTab->page(), QColor(0, 81, 0));
             setTabIcon(newTab->page(), QIcon(":/tabs/icons/tabs_species.svg"));
@@ -262,7 +262,7 @@ void MainTabsWidget::reconcileTabs(DissolveWindow *dissolveWindow)
             auto newTab = std::make_shared<ConfigurationTab>(dissolveWindow, dissolve, this, tabTitle, cfg);
             configurationTabs_.push_back(newTab);
             allTabs_.append(newTab.get());
-            insertTab(baseIndex + currentTabIndex, newTab.get(), tabTitle);
+            insertTab(baseIndex + currentTabIndex, newTab, tabTitle);
             addTabCloseButton(newTab->page());
             setTabTextColour(newTab->page(), QColor(0, 81, 0));
             setTabIcon(newTab->page(), QIcon(":/tabs/icons/tabs_configuration.svg"));
@@ -299,7 +299,7 @@ void MainTabsWidget::reconcileTabs(DissolveWindow *dissolveWindow)
             auto newTab = std::make_shared<LayerTab>(dissolveWindow, dissolve, this, tabTitle, layer);
             processingLayerTabs_.push_back(newTab);
             allTabs_.append(newTab.get());
-            insertTab(baseIndex + currentTabIndex, newTab.get(), tabTitle);
+            insertTab(baseIndex + currentTabIndex, newTab, tabTitle);
             addTabCloseButton(newTab->page());
             setTabTextColour(newTab->page(), QColor(0, 81, 0));
             if (layer->enabled())
@@ -603,4 +603,9 @@ void MainTabsWidget::tabBarDoubleClicked(int index)
 
     // Call the rename function in the tab
     tab->rename();
+}
+
+int MainTabsWidget::insertTab(int index, std::shared_ptr<QWidget> widget, const QString &title)
+{
+    return QTabWidget::insertTab(index, dynamic_cast<QWidget *>(widget.get()), title);
 }

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -51,7 +51,7 @@ RefList<const MainTab> MainTabsWidget::allTabs() const
 Species *MainTabsWidget::currentSpecies() const
 {
     // Get the currently-selected tab, and make sure it's a SpeciesTab
-    MainTab *tab = currentTab();
+    auto tab = currentTab();
     if (tab->type() != MainTab::SpeciesTabType)
         return nullptr;
 
@@ -63,7 +63,7 @@ Species *MainTabsWidget::currentSpecies() const
 Configuration *MainTabsWidget::currentConfiguration() const
 {
     // Get the currently-selected tab, and make sure it's a SpeciesTab
-    MainTab *tab = currentTab();
+    auto tab = currentTab();
     if (tab->type() != MainTab::ConfigurationTabType)
         return nullptr;
 
@@ -75,7 +75,7 @@ Configuration *MainTabsWidget::currentConfiguration() const
 ModuleLayer *MainTabsWidget::currentLayer() const
 {
     // Get the currently-selected tab, and make sure it's a SpeciesTab
-    MainTab *tab = currentTab();
+    auto tab = currentTab();
     if (tab->type() != MainTab::LayerTabType)
         return nullptr;
 
@@ -359,7 +359,7 @@ void MainTabsWidget::removeByPage(QWidget *page)
 MainTab *MainTabsWidget::addWorkspaceTab(DissolveWindow *dissolveWindow, const QString title)
 {
     // Check that a tab with this title doesn't already exist
-    MainTab *tab = findTab(title);
+    auto tab = findTab(title);
     if (!tab)
     {
         auto newWorkspace = std::make_shared<WorkspaceTab>(dissolveWindow, dissolveWindow->dissolve(), this, title);
@@ -462,7 +462,7 @@ void MainTabsWidget::setCurrentTab(ModuleLayer *layer)
 // Update all tabs
 void MainTabsWidget::updateAllTabs()
 {
-    for (MainTab *tab : allTabs_)
+    for (auto tab : allTabs_)
         tab->updateControls();
 }
 
@@ -476,7 +476,7 @@ void MainTabsWidget::updateSpeciesTabs()
 // Disable sensitive controls in all tabs
 void MainTabsWidget::disableSensitiveControls()
 {
-    for (MainTab *tab : allTabs_)
+    for (auto tab : allTabs_)
         tab->disableSensitiveControls();
 
     // Disable tab close buttons
@@ -488,7 +488,7 @@ void MainTabsWidget::disableSensitiveControls()
 // Enable sensitive controls in all tabs
 void MainTabsWidget::enableSensitiveControls()
 {
-    for (MainTab *tab : allTabs_)
+    for (auto tab : allTabs_)
         tab->enableSensitiveControls();
 
     // Enable tab close buttons

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -196,7 +196,7 @@ void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
         return;
 
     // Cast up the tab to a ConfigurationTab so we can get the ModuleLayer pointer
-    auto *cfgTab = dynamic_cast<ConfigurationTab *>(tab);
+    auto cfgTab = std::dynamic_pointer_cast<ConfigurationTab>(tab);
     if (!cfgTab)
         return;
 

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -182,7 +182,7 @@ void DissolveWindow::on_ConfigurationCreateFrameworkAdsorbatesAction_triggered(b
 void DissolveWindow::on_ConfigurationRenameAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a ConfigurationTab, then call its rename() function
-    auto *tab = ui_.MainTabs->currentTab();
+    auto tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::ConfigurationTabType))
         return;
     tab->rename();
@@ -191,7 +191,7 @@ void DissolveWindow::on_ConfigurationRenameAction_triggered(bool checked)
 void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a ConfigurationTab
-    auto *tab = ui_.MainTabs->currentTab();
+    auto tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::ConfigurationTabType))
         return;
 

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -307,7 +307,7 @@ void DissolveWindow::on_LayerDeleteAction_triggered(bool checked)
         return;
 
     // Cast up the tab to a ConfigurationTab so we can get the ModuleLayer pointer
-    LayerTab *layerTab = dynamic_cast<LayerTab *>(tab);
+    auto layerTab = std::dynamic_pointer_cast<LayerTab>(tab);
     if (!layerTab)
         return;
 

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -293,7 +293,7 @@ void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked
 void DissolveWindow::on_LayerRenameAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a LayerTab, then call its rename() function
-    MainTab *tab = ui_.MainTabs->currentTab();
+    auto tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::LayerTabType))
         return;
     tab->rename();
@@ -302,7 +302,7 @@ void DissolveWindow::on_LayerRenameAction_triggered(bool checked)
 void DissolveWindow::on_LayerDeleteAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a ConfigurationTab
-    MainTab *tab = ui_.MainTabs->currentTab();
+    auto tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::ConfigurationTabType))
         return;
 

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -109,7 +109,7 @@ void DissolveWindow::on_SpeciesImportLigParGenAction_triggered(bool checked)
 void DissolveWindow::on_SpeciesRenameAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a SpeciesTab, then call its rename() function
-    auto *tab = ui_.MainTabs->currentTab();
+    auto tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::SpeciesTabType))
         return;
     tab->rename();
@@ -118,7 +118,7 @@ void DissolveWindow::on_SpeciesRenameAction_triggered(bool checked)
 void DissolveWindow::on_SpeciesAddForcefieldTermsAction_triggered(bool checked)
 {
     // Get the current Species (if a SpeciesTab is selected)
-    auto *species = ui_.MainTabs->currentSpecies();
+    auto species = ui_.MainTabs->currentSpecies();
     if (!species)
         return;
 
@@ -135,7 +135,7 @@ void DissolveWindow::on_SpeciesAddForcefieldTermsAction_triggered(bool checked)
 void DissolveWindow::on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked)
 {
     // Get the current Species (if a SpeciesTab is selected)
-    auto *species = ui_.MainTabs->currentSpecies();
+    auto species = ui_.MainTabs->currentSpecies();
     if (!species)
         return;
 
@@ -192,7 +192,7 @@ void DissolveWindow::on_SpeciesReduceToMasterTermsAction_triggered(bool checked)
 void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a SpeciesTab
-    auto *tab = ui_.MainTabs->currentTab();
+    auto tab = ui_.MainTabs->currentTab();
     if ((!tab) || (tab->type() != MainTab::SpeciesTabType))
         return;
 

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -197,7 +197,7 @@ void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
         return;
 
     // Cast up the tab to a SpeciesTab
-    auto *spTab = dynamic_cast<SpeciesTab *>(tab);
+    auto spTab = std::dynamic_pointer_cast<SpeciesTab>(tab);
     if (!spTab)
         return;
 

--- a/src/gui/menu_workspace.cpp
+++ b/src/gui/menu_workspace.cpp
@@ -11,7 +11,7 @@
 
 void DissolveWindow::on_WorkspaceCreateEmptyAction_triggered(bool checked)
 {
-    MainTab *workspaceTab = ui_.MainTabs->addWorkspaceTab(this, "New Workspace");
+    auto workspaceTab = ui_.MainTabs->addWorkspaceTab(this, "New Workspace");
 
     ui_.MainTabs->setCurrentTab(workspaceTab);
 }

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -22,7 +22,7 @@ class Isotopologue;
 class Species;
 
 // Species Tab
-class SpeciesTab : public QWidget, public ListItem<SpeciesTab>, public MainTab
+class SpeciesTab : public QWidget, public MainTab
 {
     // All Qt declarations derived from QObject must include this macro
     Q_OBJECT

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -17,9 +17,9 @@
 
 SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                        Species *species)
-    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this),
-      atoms_(species->atoms(), dissolve), angles_(species->angles(), dissolve), bonds_(species->bonds(), dissolve),
-      torsions_(species->torsions(), dissolve), impropers_(species->impropers(), dissolve), isos_(*species)
+    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this), atoms_(species->atoms(), dissolve),
+      angles_(species->angles(), dissolve), bonds_(species->bonds(), dissolve), torsions_(species->torsions(), dissolve),
+      impropers_(species->impropers(), dissolve), isos_(*species)
 {
     ui_.setupUi(this);
 

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -17,7 +17,7 @@
 
 SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                        Species *species)
-    : ListItem<SpeciesTab>(), MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this),
+    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this),
       atoms_(species->atoms(), dissolve), angles_(species->angles(), dissolve), bonds_(species->bonds(), dissolve),
       torsions_(species->torsions(), dissolve), impropers_(species->impropers(), dissolve), isos_(*species)
 {

--- a/src/gui/wizard_funcs.cpp
+++ b/src/gui/wizard_funcs.cpp
@@ -3,6 +3,7 @@
 
 #include "gui/wizard.hui"
 #include <fmt/core.h>
+#include <stdexcept>
 
 WizardDialog::WizardDialog(QWidget *parent)
     : QDialog(parent), headerAvailable_(false), closeButtonAvailable_(true), footerAvailable_(false),

--- a/src/gui/workspacetab.h
+++ b/src/gui/workspacetab.h
@@ -12,7 +12,7 @@ class TMdiArea;
 class QMenu;
 
 // Workspace Tab
-class WorkspaceTab : public QWidget, public ListItem<WorkspaceTab>, public MainTab
+class WorkspaceTab : public QWidget, public MainTab
 {
     // All Qt declarations derived from QObject must include this macro
     Q_OBJECT

--- a/src/gui/workspacetab_funcs.cpp
+++ b/src/gui/workspacetab_funcs.cpp
@@ -15,7 +15,7 @@
 #include <QMenu>
 
 WorkspaceTab::WorkspaceTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title)
-    : ListItem<WorkspaceTab>(), MainTab(dissolveWindow, dissolve, parent, title, this)
+    : MainTab(dissolveWindow, dissolve, parent, title, this)
 {
     ui.setupUi(this);
 


### PR DESCRIPTION
This PR remove all uses of the custom List container from the MainTabsWidget.  The eliminates four more instance of subclasses of ListItem