### PR TITLE
Tidying FileAndFormat

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   base
+  enumoptionsbase.cpp
   geometry.cpp
   lineparser.cpp
   lock.cpp

--- a/src/base/enumoptions.h
+++ b/src/base/enumoptions.h
@@ -16,15 +16,28 @@ template <class E> class EnumOptions : public EnumOptionsBase
 {
     public:
     EnumOptions() = default;
-    EnumOptions(std::string_view name, std::vector<EnumOption<E>> options) : name_(name), options_(std::move(options))
+    EnumOptions(std::string_view name, std::vector<EnumOption<E>> options) : name_(name), options_(options)
     {
         currentOption_ = options_.cbegin();
+    }
+    EnumOptions(std::string_view name, std::vector<EnumOption<E>> options, E currentOption) : name_(name), options_(options)
+    {
+        currentOption_ = std::find_if(options_.cbegin(), options_.cend(),
+                                      [currentOption](const auto &optData) { return optData.enumeration() == currentOption; });
     }
     EnumOptions(const EnumOptions<E> &source)
     {
         name_ = source.name_;
         options_ = source.options_;
-        currentOption_ = options_.cbegin() + source.index();
+        currentOption_ = options_.cbegin() + (source.currentOption_ - source.options_.cbegin());
+    }
+    EnumOptions<E> &operator=(const EnumOptions<E> &source)
+    {
+        name_ = source.name_;
+        options_ = source.options_;
+        currentOption_ = options_.cbegin() + (source.currentOption_ - source.options_.cbegin());
+
+        return *this;
     }
     EnumOptions<E> &operator=(E value)
     {

--- a/src/base/enumoptionsbase.cpp
+++ b/src/base/enumoptionsbase.cpp
@@ -2,6 +2,18 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "base/enumoptionsbase.h"
-#include "base/messenger.h"
 #include "base/sysfunc.h"
-#include <stddef.h>
+
+/*
+ * Search
+ */
+
+// Return index of matching keyword, if it exists
+std::optional<int> EnumOptionsBase::keywordIndex(std::string_view keyword) const
+{
+    for (auto n = 0; n < nOptions(); ++n)
+        if (DissolveSys::sameString(keywordByIndex(n), keyword))
+            return n;
+
+    return std::nullopt;
+}

--- a/src/base/enumoptionsbase.h
+++ b/src/base/enumoptionsbase.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <optional>
+#include <string>
 
 // Enum Options Base
 class EnumOptionsBase
@@ -18,8 +19,6 @@ class EnumOptionsBase
     public:
     // Return name of options (e.g. from source enumeration)
     virtual std::string name() const = 0;
-
-    public:
     // Return number of options available
     virtual int nOptions() const = 0;
     // Return nth keyword in the list
@@ -32,8 +31,9 @@ class EnumOptionsBase
     virtual void setIndex(int index) = 0;
 
     /*
-     * Operators
+     * Search
      */
     public:
-    EnumOptionsBase &operator=(int index);
+    // Return index of matching keyword, if it exists
+    std::optional<int> keywordIndex(std::string_view keyword) const;
 };

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -19,11 +19,6 @@ Configuration::Configuration() : ListItem<Configuration>(), generator_(Procedure
 
 Configuration::~Configuration() { clear(); }
 
-void Configuration::operator=(Configuration &source)
-{
-    Messenger::error("XXX CONFIGURATION COPY (via ASSIGNMENT OPERATOR) IS NOT YET IMPLEMENTED.\n");
-}
-
 // Clear all data
 void Configuration::clear()
 {

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -66,8 +66,6 @@ class Configuration : public ListItem<Configuration>
     bool generate(ProcessPool &procPool, double pairPotentialRange);
     // Return import coordinates file / format
     CoordinateImportFileFormat &inputCoordinates();
-    // Load coordinates from specified parser
-    bool loadCoordinates(LineParser &parser, CoordinateImportFileFormat::CoordinateImportFormat format);
     // Initialise (generate or load) the basic contents of the Configuration
     bool initialiseContent(ProcessPool &procPool, double pairPotentialRange, bool emptyCurrentContent = false);
     // Set configuration temperature

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -34,7 +34,9 @@ class Configuration : public ListItem<Configuration>
     public:
     Configuration();
     ~Configuration();
-    void operator=(Configuration &source);
+    Configuration(const Configuration &source) = delete;
+    Configuration(Configuration &&source) = delete;
+    void operator=(Configuration &source) = delete;
     // Clear all data
     void clear();
 

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -6,6 +6,7 @@
 #include "data/elements.h"
 #include "data/isotopes.h"
 #include "templates/list.h"
+#include "templates/listitem.h"
 #include "templates/refdatalist.h"
 #include <memory>
 #include <tuple>

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -804,7 +804,7 @@ bool Species::write(LineParser &parser, std::string_view prefix)
     }
 
     // Input Coordinates
-    if (coordinateSetInputCoordinates_.hasValidFileAndFormat())
+    if (coordinateSetInputCoordinates_.hasFilename())
     {
         if (!coordinateSetInputCoordinates_.writeFilenameAndFormat(
                 parser, fmt::format("\n{}{}  ", newPrefix, keywords().keyword(Species::SpeciesKeyword::CoordinateSets))))

--- a/src/data/elementcolours.h
+++ b/src/data/elementcolours.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "data/elements.h"
+#include <array>
 
 // Element Colours
 namespace ElementColours

--- a/src/data/elements.h
+++ b/src/data/elements.h
@@ -3,9 +3,7 @@
 
 #pragma once
 
-#include "templates/array.h"
-#include "templates/list.h"
-#include "templates/reflist.h"
+#include <string>
 
 namespace Elements
 {
@@ -174,18 +172,5 @@ std::string_view name(Element Z);
 std::string_view symbol(Element Z);
 // Return group for element with specified Z
 int group(Element Z);
-
-// Create array of Lists, with array size equal to number of elements defined
-template <class T> void createElementListArray(Array<List<T>> &listArray)
-{
-    /*
-     * Create the array, and set all Lists to only disown their items on destruction, rather than deleting them.
-     * Need to do this otherwise each datum will be destructed twice - once from the List<T> destructor, and once
-     * again from the destruction of the static array.
-     */
-    listArray.initialise(Elements::nElements);
-    for (auto n = 0; n < Elements::nElements; ++n)
-        listArray[n].setDisownOnDestruction(true);
-}
 
 }; // namespace Elements

--- a/src/data/formfactors_wk1995.cpp
+++ b/src/data/formfactors_wk1995.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#define _USE_MATH_DEFINES
 #include "data/formfactors_wk1995.h"
 #include "data/formfactors.h"
 #include <algorithm>
 #include <functional>
+#include <math.h>
 #include <utility>
 #include <vector>
 
@@ -37,7 +39,7 @@ double FormFactorData_WK1995::magnitude(double Q) const
      * So, remove factor of 4Pi implicit in our Q value before squaring.
      */
 
-    const auto k = Q / (4 * PI);
+    const auto k = Q / (4 * M_PI);
     const auto k2 = k * k;
     auto mag = c_;
     for (auto n = 0; n < 5; ++n)

--- a/src/data/isotopes.cpp
+++ b/src/data/isotopes.cpp
@@ -2,6 +2,9 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "data/isotopes.h"
+#include <algorithm>
+#include <fmt/core.h>
+#include <stdexcept>
 
 namespace Sears91
 {

--- a/src/data/isotopes.h
+++ b/src/data/isotopes.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "data/elements.h"
+#include <vector>
 
 // Sears '91 Isotope Data
 namespace Sears91

--- a/src/gui/configurationtab.h
+++ b/src/gui/configurationtab.h
@@ -5,6 +5,7 @@
 
 #include "base/units.h"
 #include "gui/maintab.h"
+#include "gui/models/enumOptionsModel.h"
 #include "gui/ui_configurationtab.h"
 
 // Forward Declarations
@@ -28,6 +29,8 @@ class ConfigurationTab : public QWidget, public MainTab
     private:
     // Main form declaration
     Ui::ConfigurationTab ui_;
+    // Model for import file format
+    EnumOptionsModel importEnumOptionsModel_;
 
     /*
      * MainTab Reimplementations

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -24,9 +24,9 @@ ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dis
 
     configuration_ = cfg;
 
-    // Populate coordinates file format combo
-    for (auto n = 0; n < cfg->inputCoordinates().nFormats(); ++n)
-        ui_.CoordinatesFileFormatCombo->addItem(QString::fromStdString(std::string(cfg->inputCoordinates().formatKeyword(n))));
+    // Set model for input file coordinates
+    importEnumOptionsModel_.setData(cfg->inputCoordinates().formats());
+    ui_.CoordinatesFileFormatCombo->setModel(&importEnumOptionsModel_);
 
     // Populate density units combo
     ComboEnumOptionsPopulator(ui_.DensityUnitsCombo, Units::densityUnits());
@@ -137,7 +137,7 @@ void ConfigurationTab::updateControls()
 
     // Input Coordinates
     ui_.CoordinatesFileEdit->setText(QString::fromStdString(std::string(configuration_->inputCoordinates().filename())));
-    ui_.CoordinatesFileFormatCombo->setCurrentIndex(configuration_->inputCoordinates().formatIndex());
+    ui_.CoordinatesFileFormatCombo->setCurrentIndex(configuration_->inputCoordinates().formats().index());
 
     // Size Factor
     ui_.RequestedSizeFactorSpin->setValue(configuration_->requestedSizeFactor());

--- a/src/gui/keywordwidgets/fileandformat.h
+++ b/src/gui/keywordwidgets/fileandformat.h
@@ -5,12 +5,9 @@
 
 #include "gui/keywordwidgets/base.h"
 #include "gui/keywordwidgets/ui_fileandformat.h"
+#include "gui/models/enumOptionsModel.h"
 #include "keywords/fileandformat.h"
 #include <QWidget>
-
-// Forward Declarations
-class Dissolve;
-class QComboBox;
 
 class FileAndFormatKeywordWidget : public QWidget, public KeywordWidgetBase
 {
@@ -33,6 +30,8 @@ class FileAndFormatKeywordWidget : public QWidget, public KeywordWidgetBase
     private:
     // Main form declaration
     Ui::FileAndFormatWidget ui_;
+    // Model for enum options
+    EnumOptionsModel enumOptionsModel_;
 
     private slots:
     void on_FileEdit_editingFinished();

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -223,7 +223,7 @@ void DissolveWindow::on_ConfigurationExportToXYZAction_triggered(bool checked)
     if (exportFile.isEmpty())
         return;
 
-    CoordinateExportFileFormat fileAndFormat(qPrintable(exportFile), CoordinateExportFileFormat::XYZCoordinates);
+    CoordinateExportFileFormat fileAndFormat(qPrintable(exportFile), CoordinateExportFileFormat::CoordinateExportFormat::XYZ);
     if (!fileAndFormat.exportData(cfg))
         QMessageBox::warning(this, "Error", "Failed to export the configuration. Check the messages for details.",
                              QMessageBox::Ok, QMessageBox::Ok);

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -31,6 +31,7 @@ set(models_SRCS
     braggReflectionModel.cpp
     dataManagerReferencePointModel.cpp
     dataManagerSimulationModel.cpp
+    enumOptionsModel.cpp
     masterTermModel.cpp
     procedureNodeModel.cpp
     speciesFilterProxy.cpp
@@ -56,6 +57,7 @@ qt_wrap_cpp(
   braggReflectionModel.h
   dataManagerReferencePointModel.h
   dataManagerSimulationModel.h
+  enumOptionsModel.h
   speciesModel.h
   xmlAngleModel.h
   xmlAtomModel.h

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -4,6 +4,7 @@ set(models_MOC_HDRS
     braggReflectionModel.h
     dataManagerReferencePointModel.h
     dataManagerSimulationModel.h
+    enumOptionsModel.h
     procedureNodeModel.h
     masterTermModel.h
     speciesFilterProxy.h

--- a/src/gui/models/enumOptionsModel.cpp
+++ b/src/gui/models/enumOptionsModel.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/models/enumOptionsModel.h"
+#include "base/enumoptionsbase.h"
+
+// Set source AtomType data
+void EnumOptionsModel::setData(EnumOptionsBase &options)
+{
+    beginResetModel();
+    enumOptions_ = options;
+    endResetModel();
+}
+
+/*
+ * QAbstractItemModel overrides
+ */
+
+int EnumOptionsModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return enumOptions_ ? enumOptions_->get().nOptions() : 0;
+}
+
+QVariant EnumOptionsModel::data(const QModelIndex &index, int role) const
+{
+    if (role != Qt::DisplayRole || index.column() != 0)
+        return QVariant();
+
+    return QString::fromStdString(enumOptions_->get().keywordByIndex(index.row()));
+}
+
+Qt::ItemFlags EnumOptionsModel::flags(const QModelIndex &index) const
+{
+    return index.column() == 1 ? Qt::ItemIsSelectable | Qt::ItemIsEnabled
+                               : Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled;
+}
+
+QVariant EnumOptionsModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole || orientation != Qt::Horizontal)
+        return QVariant();
+
+    if (section == 0)
+        return "Option";
+
+    return QVariant();
+}

--- a/src/gui/models/enumOptionsModel.h
+++ b/src/gui/models/enumOptionsModel.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "templates/optionalref.h"
+#include <QAbstractListModel>
+#include <QModelIndex>
+#include <vector>
+
+// Forward Declarations
+class EnumOptionsBase;
+
+class EnumOptionsModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+    private:
+    // Source EnumOptions data
+    OptionalReferenceWrapper<EnumOptionsBase> enumOptions_;
+
+    public:
+    // Set source EnumOptions data
+    void setData(EnumOptionsBase &options);
+
+    /*
+     * QAbstractItemModel overrides
+     */
+    public:
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+};

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -11,38 +11,13 @@
 #include "data/atomicmasses.h"
 
 CoordinateExportFileFormat::CoordinateExportFileFormat(std::string_view filename, CoordinateExportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
-}
-
-/*
- * Format Access
- */
-
-// Return enum options for CoordinateExportFormat
-EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> CoordinateExportFileFormat::coordinateExportFormats()
-{
-    return EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat>(
-        "CoordinateExportFileFormat", {{CoordinateExportFileFormat::XYZCoordinates, "xyz", "Simple XYZ Coordinates"},
-                                       {CoordinateExportFileFormat::DLPOLYCoordinates, "dlpoly", "DL_POLY CONFIG File"}});
-}
-
-// Return number of available formats
-int CoordinateExportFileFormat::nFormats() const { return CoordinateExportFileFormat::nCoordinateExportFormats; }
-
-// Return format keyword for supplied index
-std::string CoordinateExportFileFormat::formatKeyword(int id) const { return coordinateExportFormats().keywordByIndex(id); }
-
-// Return description string for supplied index
-std::string CoordinateExportFileFormat::formatDescription(int id) const
-{
-    return coordinateExportFormats().descriptionByIndex(id);
-}
-
-// Return current format as CoordinateExportFormat
-CoordinateExportFileFormat::CoordinateExportFormat CoordinateExportFileFormat::coordinateFormat() const
-{
-    return (CoordinateExportFileFormat::CoordinateExportFormat)format_;
+    formats_ = EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat>(
+        "CoordinateExportFileFormat",
+        {{CoordinateExportFileFormat::XYZCoordinates, "xyz", "Simple XYZ Coordinates"},
+         {CoordinateExportFileFormat::DLPOLYCoordinates, "dlpoly", "DL_POLY CONFIG File"}},
+        format);
 }
 
 /*
@@ -129,14 +104,17 @@ bool CoordinateExportFileFormat::exportData(Configuration *cfg)
 
     // Write data
     auto result = false;
-    if (coordinateFormat() == CoordinateExportFileFormat::XYZCoordinates)
-        result = exportXYZ(parser, cfg);
-    else if (coordinateFormat() == CoordinateExportFileFormat::DLPOLYCoordinates)
-        result = exportDLPOLY(parser, cfg);
-    else
+    switch (formats_.enumeration())
     {
-        Messenger::error("Unrecognised coordinate format.\nKnown formats are:\n");
-        printAvailableFormats();
+        case (CoordinateExportFileFormat::XYZCoordinates):
+            result = exportXYZ(parser, cfg);
+            break;
+        case (CoordinateExportFileFormat::DLPOLYCoordinates):
+            result = exportDLPOLY(parser, cfg);
+            break;
+        default:
+            throw(std::runtime_error(
+                fmt::format("Coordinates format '{}' export has not been implemented.\n", formats_.keyword())));
     }
 
     return result;

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -15,8 +15,8 @@ CoordinateExportFileFormat::CoordinateExportFileFormat(std::string_view filename
 {
     formats_ = EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat>(
         "CoordinateExportFileFormat",
-        {{CoordinateExportFileFormat::XYZCoordinates, "xyz", "Simple XYZ Coordinates"},
-         {CoordinateExportFileFormat::DLPOLYCoordinates, "dlpoly", "DL_POLY CONFIG File"}},
+        {{CoordinateExportFormat::XYZ, "xyz", "Simple XYZ Coordinates"},
+         {CoordinateExportFormat::DLPOLY, "dlpoly", "DL_POLY CONFIG File"}},
         format);
 }
 
@@ -106,10 +106,10 @@ bool CoordinateExportFileFormat::exportData(Configuration *cfg)
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (CoordinateExportFileFormat::XYZCoordinates):
+        case (CoordinateExportFormat::XYZ):
             result = exportXYZ(parser, cfg);
             break;
-        case (CoordinateExportFileFormat::DLPOLYCoordinates):
+        case (CoordinateExportFormat::DLPOLY):
             result = exportDLPOLY(parser, cfg);
             break;
         default:

--- a/src/io/export/coordinates.h
+++ b/src/io/export/coordinates.h
@@ -13,13 +13,12 @@ class CoordinateExportFileFormat : public FileAndFormat
 {
     public:
     // Available coordinate formats
-    enum CoordinateExportFormat
+    enum class CoordinateExportFormat
     {
-        XYZCoordinates,
-        DLPOLYCoordinates,
-        nCoordinateExportFormats
+        XYZ,
+        DLPOLY
     };
-    CoordinateExportFileFormat(std::string_view filename = "", CoordinateExportFormat format = XYZCoordinates);
+    CoordinateExportFileFormat(std::string_view filename = "", CoordinateExportFormat format = CoordinateExportFormat::XYZ);
     ~CoordinateExportFileFormat() override = default;
 
     /*

--- a/src/io/export/coordinates.h
+++ b/src/io/export/coordinates.h
@@ -20,6 +20,7 @@ class CoordinateExportFileFormat : public FileAndFormat
         nCoordinateExportFormats
     };
     CoordinateExportFileFormat(std::string_view filename = "", CoordinateExportFormat format = XYZCoordinates);
+    ~CoordinateExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/coordinates.h
+++ b/src/io/export/coordinates.h
@@ -22,19 +22,11 @@ class CoordinateExportFileFormat : public FileAndFormat
     CoordinateExportFileFormat(std::string_view filename = "", CoordinateExportFormat format = XYZCoordinates);
 
     /*
-     * Format Access
+     * Formats
      */
-    public:
-    // Return enum options for CoordinateExportFormat
-    static EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> coordinateExportFormats();
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as CoordinateExportFormat
-    CoordinateExportFormat coordinateFormat() const;
+    private:
+    // Format enum options
+    EnumOptions<CoordinateExportFileFormat::CoordinateExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/data1d.cpp
+++ b/src/io/export/data1d.cpp
@@ -9,34 +9,10 @@
 #include "templates/algorithms.h"
 
 Data1DExportFileFormat::Data1DExportFileFormat(std::string_view filename, Data1DExportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
-}
-
-/*
- * Format Access
- */
-
-// Return enum options for Data1DExportFormat
-EnumOptions<Data1DExportFileFormat::Data1DExportFormat> Data1DExportFileFormat::data1DExportFormats()
-{
-    return EnumOptions<Data1DExportFileFormat::Data1DExportFormat>(
-        "Data1DExportFileFormat", {{Data1DExportFileFormat::XYData1D, "xy", "Simple XY data (x = bin centres)"}});
-}
-
-// Return number of available formats
-int Data1DExportFileFormat::nFormats() const { return Data1DExportFileFormat::nData1DExportFormats; }
-
-// Return format keyword for supplied index
-std::string Data1DExportFileFormat::formatKeyword(int id) const { return data1DExportFormats().keywordByIndex(id); }
-
-// Return description string for supplied index
-std::string Data1DExportFileFormat::formatDescription(int id) const { return data1DExportFormats().descriptionByIndex(id); }
-
-// Return current format as CoordinateExportFormat
-Data1DExportFileFormat::Data1DExportFormat Data1DExportFileFormat::data1DFormat() const
-{
-    return (Data1DExportFileFormat::Data1DExportFormat)format_;
+    formats_ = EnumOptions<Data1DExportFileFormat::Data1DExportFormat>(
+        "Data1DExportFileFormat", {{Data1DExportFileFormat::XYData1D, "xy", "Simple XY data (x = bin centres)"}}, format);
 }
 
 /*
@@ -74,17 +50,16 @@ bool Data1DExportFileFormat::exportData(const Data1DBase &data)
 
     // Write data
     auto result = false;
-    if (data1DFormat() == Data1DExportFileFormat::XYData1D)
+    switch (formats_.enumeration())
     {
-        if (data.valuesHaveErrors())
-            result = exportXY(parser, data.xAxis(), data.values(), data.errors());
-        else
-            result = exportXY(parser, data.xAxis(), data.values());
-    }
-    else
-    {
-        Messenger::error("Unrecognised Data1D format.\nKnown formats are:\n");
-        printAvailableFormats();
+        case (Data1DExportFileFormat::XYData1D):
+            if (data.valuesHaveErrors())
+                result = exportXY(parser, data.xAxis(), data.values(), data.errors());
+            else
+                result = exportXY(parser, data.xAxis(), data.values());
+            break;
+        default:
+            throw(std::runtime_error(fmt::format("Data1D format '{}' export has not been implemented.\n", formats_.keyword())));
     }
 
     return result;

--- a/src/io/export/data1d.cpp
+++ b/src/io/export/data1d.cpp
@@ -12,7 +12,7 @@ Data1DExportFileFormat::Data1DExportFileFormat(std::string_view filename, Data1D
     : FileAndFormat(formats_, filename)
 {
     formats_ = EnumOptions<Data1DExportFileFormat::Data1DExportFormat>(
-        "Data1DExportFileFormat", {{Data1DExportFileFormat::XYData1D, "xy", "Simple XY data (x = bin centres)"}}, format);
+        "Data1DExportFileFormat", {{Data1DExportFormat::XY, "xy", "Simple XY data (x = bin centres)"}}, format);
 }
 
 /*
@@ -52,7 +52,7 @@ bool Data1DExportFileFormat::exportData(const Data1DBase &data)
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (Data1DExportFileFormat::XYData1D):
+        case (Data1DExportFormat::XY):
             if (data.valuesHaveErrors())
                 result = exportXY(parser, data.xAxis(), data.values(), data.errors());
             else

--- a/src/io/export/data1d.h
+++ b/src/io/export/data1d.h
@@ -21,6 +21,7 @@ class Data1DExportFileFormat : public FileAndFormat
         nData1DExportFormats
     };
     Data1DExportFileFormat(std::string_view filename = "", Data1DExportFormat format = Data1DExportFileFormat::XYData1D);
+    ~Data1DExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/data1d.h
+++ b/src/io/export/data1d.h
@@ -15,12 +15,11 @@ class Data1DExportFileFormat : public FileAndFormat
 {
     public:
     // Available data formats
-    enum Data1DExportFormat
+    enum class Data1DExportFormat
     {
-        XYData1D,
-        nData1DExportFormats
+        XY
     };
-    Data1DExportFileFormat(std::string_view filename = "", Data1DExportFormat format = Data1DExportFileFormat::XYData1D);
+    Data1DExportFileFormat(std::string_view filename = "", Data1DExportFormat format = Data1DExportFormat::XY);
     ~Data1DExportFileFormat() override = default;
 
     /*

--- a/src/io/export/data1d.h
+++ b/src/io/export/data1d.h
@@ -23,21 +23,11 @@ class Data1DExportFileFormat : public FileAndFormat
     Data1DExportFileFormat(std::string_view filename = "", Data1DExportFormat format = Data1DExportFileFormat::XYData1D);
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for Data1DExportFormat
-    static EnumOptions<Data1DExportFileFormat::Data1DExportFormat> data1DExportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as Data1DExportFormat
-    Data1DExportFormat data1DFormat() const;
+    // Format enum options
+    EnumOptions<Data1DExportFileFormat::Data1DExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/data2d.cpp
+++ b/src/io/export/data2d.cpp
@@ -11,8 +11,8 @@ Data2DExportFileFormat::Data2DExportFileFormat(std::string_view filename, Data2D
 {
     formats_ = EnumOptions<Data2DExportFileFormat::Data2DExportFormat>(
         "Data2DExportFileFormat",
-        {{Data2DExportFileFormat::BlockData2D, "block", "Block Data"},
-         {Data2DExportFileFormat::CartesianData2D, "cartesian", "Cartesian (x,y,value) Data"}},
+        {{Data2DExportFormat::Block, "block", "Block Data"},
+         {Data2DExportFormat::Cartesian, "cartesian", "Cartesian (x,y,value) Data"}},
         format);
 }
 
@@ -74,10 +74,10 @@ bool Data2DExportFileFormat::exportData(const Data2DBase &data)
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (Data2DExportFileFormat::BlockData2D):
+        case (Data2DExportFormat::Block):
             result = exportBlock(parser, data.xAxis(), data.yAxis(), data.values());
             break;
-        case (Data2DExportFileFormat::CartesianData2D):
+        case (Data2DExportFormat::Cartesian):
             result = exportCartesian(parser, data.xAxis(), data.yAxis(), data.values());
             break;
         default:

--- a/src/io/export/data2d.h
+++ b/src/io/export/data2d.h
@@ -14,13 +14,12 @@ class Data2DExportFileFormat : public FileAndFormat
 {
     public:
     // Available data formats
-    enum Data2DExportFormat
+    enum class Data2DExportFormat
     {
-        BlockData2D,
-        CartesianData2D,
-        nData2DExportFormats
+        Block,
+        Cartesian
     };
-    Data2DExportFileFormat(std::string_view filename = "", Data2DExportFormat format = Data2DExportFileFormat::BlockData2D);
+    Data2DExportFileFormat(std::string_view filename = "", Data2DExportFormat format = Data2DExportFormat::Block);
     ~Data2DExportFileFormat() override = default;
 
     /*

--- a/src/io/export/data2d.h
+++ b/src/io/export/data2d.h
@@ -23,21 +23,11 @@ class Data2DExportFileFormat : public FileAndFormat
     Data2DExportFileFormat(std::string_view filename = "", Data2DExportFormat format = Data2DExportFileFormat::BlockData2D);
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for Data2DExportFormat
-    static EnumOptions<Data2DExportFileFormat::Data2DExportFormat> data2DExportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as Data2DExportFormat
-    Data2DExportFormat data2DFormat() const;
+    // Format enum options
+    EnumOptions<Data2DExportFileFormat::Data2DExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/data2d.h
+++ b/src/io/export/data2d.h
@@ -21,6 +21,7 @@ class Data2DExportFileFormat : public FileAndFormat
         nData2DExportFormats
     };
     Data2DExportFileFormat(std::string_view filename = "", Data2DExportFormat format = Data2DExportFileFormat::BlockData2D);
+    ~Data2DExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -7,36 +7,14 @@
 #include "math/data3d.h"
 
 Data3DExportFileFormat::Data3DExportFileFormat(std::string_view filename, Data3DExportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
-}
-
-/*
- * Format Access
- */
-
-// Return enum options for Data3DExportFormat
-EnumOptions<Data3DExportFileFormat::Data3DExportFormat> Data3DExportFileFormat::data3DExportFormats()
-{
-    return EnumOptions<Data3DExportFileFormat::Data3DExportFormat>(
-        "Data3DExportFileFormat", {{Data3DExportFileFormat::BlockData3D, "block", "Block Data"},
-                                   {Data3DExportFileFormat::CartesianData3D, "cartesian", "Cartesian (x,y,z,value) Data"},
-                                   {Data3DExportFileFormat::PDensData3D, "pdens", "DLPutils PDens Data"}});
-}
-
-// Return number of available formats
-int Data3DExportFileFormat::nFormats() const { return Data3DExportFileFormat::nData3DExportFormats; }
-
-// Return format keyword for supplied index
-std::string Data3DExportFileFormat::formatKeyword(int id) const { return data3DExportFormats().keywordByIndex(id); }
-
-// Return description string for supplied index
-std::string Data3DExportFileFormat::formatDescription(int id) const { return data3DExportFormats().descriptionByIndex(id); }
-
-// Return current format as CoordinateExportFormat
-Data3DExportFileFormat::Data3DExportFormat Data3DExportFileFormat::data3DFormat() const
-{
-    return (Data3DExportFileFormat::Data3DExportFormat)format_;
+    formats_ = EnumOptions<Data3DExportFileFormat::Data3DExportFormat>(
+        "Data3DExportFileFormat",
+        {{Data3DExportFileFormat::BlockData3D, "block", "Block Data"},
+         {Data3DExportFileFormat::CartesianData3D, "cartesian", "Cartesian (x,y,z,value) Data"},
+         {Data3DExportFileFormat::PDensData3D, "pdens", "DLPutils PDens Data"}},
+        format);
 }
 
 /*
@@ -148,16 +126,19 @@ bool Data3DExportFileFormat::exportData(const Data3DBase &data)
 
     // Write data
     auto result = false;
-    if (data3DFormat() == Data3DExportFileFormat::BlockData3D)
-        result = exportBlock(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
-    else if (data3DFormat() == Data3DExportFileFormat::CartesianData3D)
-        result = exportCartesian(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
-    else if (data3DFormat() == Data3DExportFileFormat::PDensData3D)
-        result = exportPDens(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
-    else
+    switch (formats_.enumeration())
     {
-        Messenger::error("Unrecognised Data3D format.\nKnown formats are:\n");
-        printAvailableFormats();
+        case (Data3DExportFileFormat::BlockData3D):
+            result = exportBlock(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
+            break;
+        case (Data3DExportFileFormat::CartesianData3D):
+            result = exportCartesian(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
+            break;
+        case (Data3DExportFileFormat::PDensData3D):
+            result = exportPDens(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
+            break;
+        default:
+            throw(std::runtime_error(fmt::format("Data3D format '{}' export has not been implemented.\n", formats_.keyword())));
     }
 
     return result;

--- a/src/io/export/data3d.cpp
+++ b/src/io/export/data3d.cpp
@@ -11,9 +11,9 @@ Data3DExportFileFormat::Data3DExportFileFormat(std::string_view filename, Data3D
 {
     formats_ = EnumOptions<Data3DExportFileFormat::Data3DExportFormat>(
         "Data3DExportFileFormat",
-        {{Data3DExportFileFormat::BlockData3D, "block", "Block Data"},
-         {Data3DExportFileFormat::CartesianData3D, "cartesian", "Cartesian (x,y,z,value) Data"},
-         {Data3DExportFileFormat::PDensData3D, "pdens", "DLPutils PDens Data"}},
+        {{Data3DExportFormat::Block, "block", "Block Data"},
+         {Data3DExportFormat::Cartesian, "cartesian", "Cartesian (x,y,z,value) Data"},
+         {Data3DExportFormat::PDens, "pdens", "DLPutils PDens Data"}},
         format);
 }
 
@@ -128,13 +128,13 @@ bool Data3DExportFileFormat::exportData(const Data3DBase &data)
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (Data3DExportFileFormat::BlockData3D):
+        case (Data3DExportFormat::Block):
             result = exportBlock(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
             break;
-        case (Data3DExportFileFormat::CartesianData3D):
+        case (Data3DExportFormat::Cartesian):
             result = exportCartesian(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
             break;
-        case (Data3DExportFileFormat::PDensData3D):
+        case (Data3DExportFormat::PDens):
             result = exportPDens(parser, data.xAxis(), data.yAxis(), data.zAxis(), data.values());
             break;
         default:

--- a/src/io/export/data3d.h
+++ b/src/io/export/data3d.h
@@ -15,14 +15,13 @@ class Data3DExportFileFormat : public FileAndFormat
 {
     public:
     // Available data formats
-    enum Data3DExportFormat
+    enum class Data3DExportFormat
     {
-        BlockData3D,
-        CartesianData3D,
-        PDensData3D,
-        nData3DExportFormats
+        Block,
+        Cartesian,
+        PDens
     };
-    Data3DExportFileFormat(std::string_view filename = "", Data3DExportFormat format = Data3DExportFileFormat::BlockData3D);
+    Data3DExportFileFormat(std::string_view filename = "", Data3DExportFormat format = Data3DExportFormat::Block);
     ~Data3DExportFileFormat() override = default;
 
     /*

--- a/src/io/export/data3d.h
+++ b/src/io/export/data3d.h
@@ -23,6 +23,7 @@ class Data3DExportFileFormat : public FileAndFormat
         nData3DExportFormats
     };
     Data3DExportFileFormat(std::string_view filename = "", Data3DExportFormat format = Data3DExportFileFormat::BlockData3D);
+    ~Data3DExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/data3d.h
+++ b/src/io/export/data3d.h
@@ -25,21 +25,11 @@ class Data3DExportFileFormat : public FileAndFormat
     Data3DExportFileFormat(std::string_view filename = "", Data3DExportFormat format = Data3DExportFileFormat::BlockData3D);
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for Data3DExportFormat
-    static EnumOptions<Data3DExportFileFormat::Data3DExportFormat> data3DExportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as Data3DExportFormat
-    Data3DExportFormat data3DFormat() const;
+    // Format enum options
+    EnumOptions<Data3DExportFileFormat::Data3DExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/forces.cpp
+++ b/src/io/export/forces.cpp
@@ -14,7 +14,7 @@ ForceExportFileFormat::ForceExportFileFormat(std::string_view filename, ForceExp
     : FileAndFormat(formats_, filename)
 {
     formats_ = EnumOptions<ForceExportFileFormat::ForceExportFormat>(
-        "ForceExportFileFormat", {{ForceExportFileFormat::SimpleForces, "simple", "Simple Free-Formatted Forces"}}, format);
+        "ForceExportFileFormat", {{ForceExportFormat::Simple, "simple", "Simple Free-Formatted Forces"}}, format);
 }
 
 /*
@@ -51,7 +51,7 @@ bool ForceExportFileFormat::exportData(const std::vector<Vec3<double>> &f)
 
     // Write data
     auto result = false;
-    if (formats_.enumeration() == ForceExportFileFormat::SimpleForces)
+    if (formats_.enumeration() == ForceExportFormat::Simple)
         result = exportSimple(parser, f);
     else
     {

--- a/src/io/export/forces.cpp
+++ b/src/io/export/forces.cpp
@@ -11,34 +11,10 @@
 #include "data/atomicmasses.h"
 
 ForceExportFileFormat::ForceExportFileFormat(std::string_view filename, ForceExportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
-}
-
-/*
- * Format Access
- */
-
-// Return enum options for ForceExportFormat
-EnumOptions<ForceExportFileFormat::ForceExportFormat> ForceExportFileFormat::forceExportFormats()
-{
-    return EnumOptions<ForceExportFileFormat::ForceExportFormat>(
-        "ForceExportFileFormat", {{ForceExportFileFormat::SimpleForces, "simple", "Simple Free-Formatted Forces"}});
-}
-
-// Return number of available formats
-int ForceExportFileFormat::nFormats() const { return ForceExportFileFormat::nForceExportFormats; }
-
-// Return format keyword for supplied index
-std::string ForceExportFileFormat::formatKeyword(int id) const { return forceExportFormats().keywordByIndex(id); }
-
-// Return description string for supplied index
-std::string ForceExportFileFormat::formatDescription(int id) const { return forceExportFormats().descriptionByIndex(id); }
-
-// Return current format as ForceExportFormat
-ForceExportFileFormat::ForceExportFormat ForceExportFileFormat::forceFormat() const
-{
-    return (ForceExportFileFormat::ForceExportFormat)format_;
+    formats_ = EnumOptions<ForceExportFileFormat::ForceExportFormat>(
+        "ForceExportFileFormat", {{ForceExportFileFormat::SimpleForces, "simple", "Simple Free-Formatted Forces"}}, format);
 }
 
 /*
@@ -75,7 +51,7 @@ bool ForceExportFileFormat::exportData(const std::vector<Vec3<double>> &f)
 
     // Write data
     auto result = false;
-    if (forceFormat() == ForceExportFileFormat::SimpleForces)
+    if (formats_.enumeration() == ForceExportFileFormat::SimpleForces)
         result = exportSimple(parser, f);
     else
     {

--- a/src/io/export/forces.h
+++ b/src/io/export/forces.h
@@ -13,12 +13,11 @@ class ForceExportFileFormat : public FileAndFormat
 {
     public:
     // Available force formats
-    enum ForceExportFormat
+    enum class ForceExportFormat
     {
-        SimpleForces,
-        nForceExportFormats
+        Simple
     };
-    ForceExportFileFormat(std::string_view filename = "", ForceExportFormat format = SimpleForces);
+    ForceExportFileFormat(std::string_view filename = "", ForceExportFormat format = ForceExportFormat::Simple);
     ~ForceExportFileFormat() override = default;
 
     /*

--- a/src/io/export/forces.h
+++ b/src/io/export/forces.h
@@ -21,19 +21,11 @@ class ForceExportFileFormat : public FileAndFormat
     ForceExportFileFormat(std::string_view filename = "", ForceExportFormat format = SimpleForces);
 
     /*
-     * Format Access
+     * Formats
      */
-    public:
-    // Return enum options for ForceExportFormat
-    static EnumOptions<ForceExportFileFormat::ForceExportFormat> forceExportFormats();
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as ForceExportFormat
-    ForceExportFormat forceFormat() const;
+    private:
+    // Format enum options
+    EnumOptions<ForceExportFileFormat::ForceExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/forces.h
+++ b/src/io/export/forces.h
@@ -19,6 +19,7 @@ class ForceExportFileFormat : public FileAndFormat
         nForceExportFormats
     };
     ForceExportFileFormat(std::string_view filename = "", ForceExportFormat format = SimpleForces);
+    ~ForceExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -8,43 +8,13 @@
 #include "math/data1d.h"
 
 PairPotentialExportFileFormat::PairPotentialExportFileFormat(std::string_view filename, PairPotentialExportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
-}
-
-/*
- * Format Access
- */
-
-// Return enum options for PairPotentialExportFormat
-EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat>
-PairPotentialExportFileFormat::pairPotentialExportFormats()
-{
-    return EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat>(
+    formats_ = EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat>(
         "PairPotentialExportFileFormat",
         {{PairPotentialExportFileFormat::BlockPairPotential, "block", "Block Data"},
-         {PairPotentialExportFileFormat::DLPOLYTABLEPairPotential, "table", "DL_POLY TABLE File"}});
-}
-
-// Return number of available formats
-int PairPotentialExportFileFormat::nFormats() const { return PairPotentialExportFileFormat::nPairPotentialExportFormats; }
-
-// Return format keyword for supplied index
-std::string PairPotentialExportFileFormat::formatKeyword(int id) const
-{
-    return pairPotentialExportFormats().keywordByIndex(id);
-}
-
-// Return description string for supplied index
-std::string PairPotentialExportFileFormat::formatDescription(int id) const
-{
-    return pairPotentialExportFormats().descriptionByIndex(id);
-}
-
-// Return current format as PairPotentialExportFormat
-PairPotentialExportFileFormat::PairPotentialExportFormat PairPotentialExportFileFormat::pairPotentialFormat() const
-{
-    return (PairPotentialExportFileFormat::PairPotentialExportFormat)format_;
+         {PairPotentialExportFileFormat::DLPOLYTABLEPairPotential, "table", "DL_POLY TABLE File"}},
+        format);
 }
 
 /*
@@ -138,9 +108,9 @@ bool PairPotentialExportFileFormat::exportData(PairPotential *pp)
 
     // Write data
     auto result = false;
-    if (pairPotentialFormat() == PairPotentialExportFileFormat::BlockPairPotential)
+    if (formats_.enumeration() == PairPotentialExportFileFormat::BlockPairPotential)
         result = exportBlock(parser, pp);
-    else if (pairPotentialFormat() == PairPotentialExportFileFormat::DLPOLYTABLEPairPotential)
+    else if (formats_.enumeration() == PairPotentialExportFileFormat::DLPOLYTABLEPairPotential)
         result = exportDLPOLY(parser, pp);
     else
     {

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -12,8 +12,8 @@ PairPotentialExportFileFormat::PairPotentialExportFileFormat(std::string_view fi
 {
     formats_ = EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat>(
         "PairPotentialExportFileFormat",
-        {{PairPotentialExportFileFormat::BlockPairPotential, "block", "Block Data"},
-         {PairPotentialExportFileFormat::DLPOLYTABLEPairPotential, "table", "DL_POLY TABLE File"}},
+        {{PairPotentialExportFormat::Block, "block", "Block Data"},
+         {PairPotentialExportFormat::DLPOLYTABLE, "table", "DL_POLY TABLE File"}},
         format);
 }
 
@@ -108,9 +108,9 @@ bool PairPotentialExportFileFormat::exportData(PairPotential *pp)
 
     // Write data
     auto result = false;
-    if (formats_.enumeration() == PairPotentialExportFileFormat::BlockPairPotential)
+    if (formats_.enumeration() == PairPotentialExportFormat::Block)
         result = exportBlock(parser, pp);
-    else if (formats_.enumeration() == PairPotentialExportFileFormat::DLPOLYTABLEPairPotential)
+    else if (formats_.enumeration() == PairPotentialExportFormat::DLPOLYTABLE)
         result = exportDLPOLY(parser, pp);
     else
     {

--- a/src/io/export/pairpotential.h
+++ b/src/io/export/pairpotential.h
@@ -20,6 +20,7 @@ class PairPotentialExportFileFormat : public FileAndFormat
         nPairPotentialExportFormats
     };
     PairPotentialExportFileFormat(std::string_view filename = "", PairPotentialExportFormat format = BlockPairPotential);
+    ~PairPotentialExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/pairpotential.h
+++ b/src/io/export/pairpotential.h
@@ -13,13 +13,13 @@ class PairPotentialExportFileFormat : public FileAndFormat
 {
     public:
     // Available data formats
-    enum PairPotentialExportFormat
+    enum class PairPotentialExportFormat
     {
-        BlockPairPotential,
-        DLPOLYTABLEPairPotential,
-        nPairPotentialExportFormats
+        Block,
+        DLPOLYTABLE
     };
-    PairPotentialExportFileFormat(std::string_view filename = "", PairPotentialExportFormat format = BlockPairPotential);
+    PairPotentialExportFileFormat(std::string_view filename = "",
+                                  PairPotentialExportFormat format = PairPotentialExportFormat::Block);
     ~PairPotentialExportFileFormat() override = default;
 
     /*

--- a/src/io/export/pairpotential.h
+++ b/src/io/export/pairpotential.h
@@ -22,21 +22,11 @@ class PairPotentialExportFileFormat : public FileAndFormat
     PairPotentialExportFileFormat(std::string_view filename = "", PairPotentialExportFormat format = BlockPairPotential);
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for PairPotentialExportFormat
-    static EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat> pairPotentialExportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as PairPotentialExportFormat
-    PairPotentialExportFormat pairPotentialFormat() const;
+    // Format enum options
+    EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -12,7 +12,7 @@ TrajectoryExportFileFormat::TrajectoryExportFileFormat(std::string_view filename
     : FileAndFormat(formats_, filename)
 {
     formats_ = EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat>(
-        "TrajectoryExportFileFormat", {{TrajectoryExportFileFormat::XYZTrajectory, "xyz", "XYZ Trajectory"}}, format);
+        "TrajectoryExportFileFormat", {{TrajectoryExportFormat::XYZ, "xyz", "XYZ Trajectory"}}, format);
 }
 
 /*
@@ -56,7 +56,7 @@ bool TrajectoryExportFileFormat::exportData(Configuration *cfg)
     {
         auto headerResult = false;
 
-        if (formats_.enumeration() == XYZTrajectory)
+        if (formats_.enumeration() == TrajectoryExportFormat::XYZ)
             headerResult = true;
         else
             headerResult = Messenger::error("Unrecognised trajectory format so can't write header.\nKnown formats are:\n");
@@ -70,7 +70,7 @@ bool TrajectoryExportFileFormat::exportData(Configuration *cfg)
     auto frameResult = false;
     switch (formats_.enumeration())
     {
-        case (TrajectoryExportFileFormat::XYZTrajectory):
+        case (TrajectoryExportFormat::XYZ):
             frameResult = exportXYZ(parser, cfg);
             break;
         default:

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -19,6 +19,7 @@ class TrajectoryExportFileFormat : public FileAndFormat
         nTrajectoryExportFormats
     };
     TrajectoryExportFileFormat(std::string_view filename = "", TrajectoryExportFormat format = XYZTrajectory);
+    ~TrajectoryExportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -21,21 +21,11 @@ class TrajectoryExportFileFormat : public FileAndFormat
     TrajectoryExportFileFormat(std::string_view filename = "", TrajectoryExportFormat format = XYZTrajectory);
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for TrajectoryExportFormat
-    static EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat> trajectoryExportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as TrajectoryExportFormat
-    TrajectoryExportFormat trajectoryFormat() const;
+    // Format enum options
+    EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -13,12 +13,11 @@ class TrajectoryExportFileFormat : public FileAndFormat
 {
     public:
     // Trajectory Export Formats
-    enum TrajectoryExportFormat
+    enum class TrajectoryExportFormat
     {
-        XYZTrajectory,
-        nTrajectoryExportFormats
+        XYZ
     };
-    TrajectoryExportFileFormat(std::string_view filename = "", TrajectoryExportFormat format = XYZTrajectory);
+    TrajectoryExportFileFormat(std::string_view filename = "", TrajectoryExportFormat format = TrajectoryExportFormat::XYZ);
     ~TrajectoryExportFileFormat() override = default;
 
     /*

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "keywords/list.h"
-#include "templates/list.h"
 
 // Forward Declarations
 class CoreData;
@@ -14,34 +13,23 @@ class LineParser;
 class FileAndFormat
 {
     public:
-    FileAndFormat(int format = 0);
-    FileAndFormat(std::string_view filename = "", int format = 0);
+    FileAndFormat(EnumOptionsBase &formats, std::string_view filename = "");
     virtual ~FileAndFormat() = default;
     operator std::string_view() const;
 
     /*
-     * Available Formats
+     * File and Format
      */
     protected:
-    // Format of associated file
-    int format_;
+    // Formats enum as the base object
+    EnumOptionsBase &formats_;
 
     public:
-    // Return number of available formats
-    virtual int nFormats() const = 0;
-    // Return format keyword for supplied index
-    virtual std::string formatKeyword(int id) const = 0;
-    // Return description string for supplied index
-    virtual std::string formatDescription(int id) const = 0;
-    // Convert text string to format index
-    int format(std::string_view fmtString) const;
-    // Set format index
-    void setFormatIndex(int id);
-    // Return format index
-    int formatIndex() const;
-    // Return format string
+    // Return formats enum as the base object
+    EnumOptionsBase &formats();
+    // Return current format keyword
     std::string format() const;
-    // Return description string
+    // Return current format description
     std::string description() const;
     // Print available formats
     void printAvailableFormats() const;
@@ -69,8 +57,6 @@ class FileAndFormat
     public:
     // Return whether a filename has been set
     bool hasFilename() const;
-    // Return whether a filename and format have been set
-    bool hasValidFileAndFormat() const;
 
     /*
      * Additional Options

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -14,10 +14,10 @@ CoordinateImportFileFormat::CoordinateImportFileFormat(std::string_view filename
 {
     formats_ = EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat>(
         "CoordinateImportFileFormat",
-        {{CoordinateImportFileFormat::DLPOLYCoordinates, "dlpoly", "DL_POLY CONFIG"},
-         {CoordinateImportFileFormat::EPSRCoordinates, "epsr", "EPSR ATO"},
-         {CoordinateImportFileFormat::MoscitoCoordinates, "moscito", "Moscito structure file"},
-         {CoordinateImportFileFormat::XYZCoordinates, "xyz", "Simple XYZ"}},
+        {{CoordinateImportFormat::DLPOLY, "dlpoly", "DL_POLY CONFIG"},
+         {CoordinateImportFormat::EPSR, "epsr", "EPSR ATO"},
+         {CoordinateImportFormat::Moscito, "moscito", "Moscito structure file"},
+         {CoordinateImportFormat::XYZ, "xyz", "Simple XYZ"}},
         format);
     setUpKeywords();
 }
@@ -72,16 +72,16 @@ bool CoordinateImportFileFormat::importData(LineParser &parser, std::vector<Vec3
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (CoordinateImportFileFormat::DLPOLYCoordinates):
+        case (CoordinateImportFormat::DLPOLY):
             result = importDLPOLY(parser, r);
             break;
-        case (CoordinateImportFileFormat::EPSRCoordinates):
+        case (CoordinateImportFormat::EPSR):
             result = importEPSR(parser, r);
             break;
-        case (CoordinateImportFileFormat::MoscitoCoordinates):
+        case (CoordinateImportFormat::Moscito):
             result = importMoscito(parser, r);
             break;
-        case (CoordinateImportFileFormat::XYZCoordinates):
+        case (CoordinateImportFormat::XYZ):
             result = importXYZ(parser, r);
             break;
         default:

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -8,18 +8,6 @@
 #include "classes/configuration.h"
 #include "templates/algorithms.h"
 
-CoordinateImportFileFormat::CoordinateImportFileFormat(CoordinateImportFileFormat::CoordinateImportFormat format)
-    : FileAndFormat(formats_)
-{
-    formats_ = EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat>(
-        "CoordinateImportFileFormat",
-        {{CoordinateImportFileFormat::DLPOLYCoordinates, "dlpoly", "DL_POLY CONFIG"},
-         {CoordinateImportFileFormat::EPSRCoordinates, "epsr", "EPSR ATO"},
-         {CoordinateImportFileFormat::MoscitoCoordinates, "moscito", "Moscito structure file"},
-         {CoordinateImportFileFormat::XYZCoordinates, "xyz", "Simple XYZ"}},
-        format);
-    setUpKeywords();
-}
 CoordinateImportFileFormat::CoordinateImportFileFormat(std::string_view filename,
                                                        CoordinateImportFileFormat::CoordinateImportFormat format)
     : FileAndFormat(formats_, filename)
@@ -33,8 +21,6 @@ CoordinateImportFileFormat::CoordinateImportFileFormat(std::string_view filename
         format);
     setUpKeywords();
 }
-
-CoordinateImportFileFormat::~CoordinateImportFileFormat() = default;
 
 /*
  * Keyword Options

--- a/src/io/import/coordinates.h
+++ b/src/io/import/coordinates.h
@@ -22,9 +22,8 @@ class CoordinateImportFileFormat : public FileAndFormat
         XYZCoordinates,
         nCoordinateImportFormats
     };
-    CoordinateImportFileFormat(CoordinateImportFormat format = XYZCoordinates);
-    CoordinateImportFileFormat(std::string_view filename, CoordinateImportFormat format = XYZCoordinates);
-    ~CoordinateImportFileFormat() override;
+    explicit CoordinateImportFileFormat(std::string_view filename = "", CoordinateImportFormat format = XYZCoordinates);
+    ~CoordinateImportFileFormat() override = default;
 
     /*
      * Keyword Options

--- a/src/io/import/coordinates.h
+++ b/src/io/import/coordinates.h
@@ -14,15 +14,15 @@ class CoordinateImportFileFormat : public FileAndFormat
 {
     public:
     // Coordinate Import Formats
-    enum CoordinateImportFormat
+    enum class CoordinateImportFormat
     {
-        DLPOLYCoordinates,
-        EPSRCoordinates,
-        MoscitoCoordinates,
-        XYZCoordinates,
-        nCoordinateImportFormats
+        DLPOLY,
+        EPSR,
+        Moscito,
+        XYZ
     };
-    explicit CoordinateImportFileFormat(std::string_view filename = "", CoordinateImportFormat format = XYZCoordinates);
+    explicit CoordinateImportFileFormat(std::string_view filename = "",
+                                        CoordinateImportFormat format = CoordinateImportFormat::XYZ);
     ~CoordinateImportFileFormat() override = default;
 
     /*

--- a/src/io/import/coordinates.h
+++ b/src/io/import/coordinates.h
@@ -34,21 +34,11 @@ class CoordinateImportFileFormat : public FileAndFormat
     void setUpKeywords();
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for CoordinateImportFormat
-    static EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> coordinateImportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as CoordinateImportFormat
-    CoordinateImportFormat coordinateFormat() const;
+    // Format enum options
+    EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> formats_;
 
     /*
      * Filename / Basename
@@ -73,6 +63,10 @@ class CoordinateImportFileFormat : public FileAndFormat
     public:
     // Import coordinates using current filename and format
     bool importData(std::vector<Vec3<double>> &r, ProcessPool *procPool = nullptr);
+    // Import coordinates direct to configuration using current filename and format
+    bool importData(Configuration *cfg, ProcessPool *procPool = nullptr);
     // Import coordinates using supplied parser and current format
     bool importData(LineParser &parser, std::vector<Vec3<double>> &r);
+    // Import coordinates direct to configuration using supplied parser and current format
+    bool importData(LineParser &parser, Configuration *cfg);
 };

--- a/src/io/import/data1d.cpp
+++ b/src/io/import/data1d.cpp
@@ -11,9 +11,9 @@ Data1DImportFileFormat::Data1DImportFileFormat(std::string_view filename, Data1D
 {
     formats_ = EnumOptions<Data1DImportFileFormat::Data1DImportFormat>(
         "Data1DImportFileFormat",
-        {{Data1DImportFileFormat::XYData1D, "xy", "Simple XY data (x = bin centres)"},
-         {Data1DImportFileFormat::HistogramData1D, "histogram", "Histogrammed Data (x = bin left-boundaries)"},
-         {Data1DImportFileFormat::GudrunMintData1D, "mint", "Gudrun output (mint01)"}},
+        {{Data1DImportFormat::XY, "xy", "Simple XY data (x = bin centres)"},
+         {Data1DImportFormat::Histogram, "histogram", "Histogrammed Data (x = bin left-boundaries)"},
+         {Data1DImportFormat::GudrunMint, "mint", "Gudrun output (mint01)"}},
         format);
     setUpKeywords();
 }
@@ -63,13 +63,13 @@ bool Data1DImportFileFormat::importData(LineParser &parser, Data1D &data)
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (Data1DImportFileFormat::XYData1D):
+        case (Data1DImportFormat::XY):
             result = importXY(parser, data);
             break;
-        case (Data1DImportFileFormat::HistogramData1D):
+        case (Data1DImportFormat::Histogram):
             result = importHistogram(parser, data);
             break;
-        case (Data1DImportFileFormat::GudrunMintData1D):
+        case (Data1DImportFormat::GudrunMint):
             result = importGudrunMint(parser, data);
             break;
         default:

--- a/src/io/import/data1d.cpp
+++ b/src/io/import/data1d.cpp
@@ -6,16 +6,6 @@
 #include "base/sysfunc.h"
 #include "math/filters.h"
 
-Data1DImportFileFormat::Data1DImportFileFormat(Data1DImportFileFormat::Data1DImportFormat format) : FileAndFormat(formats_)
-{
-    formats_ = EnumOptions<Data1DImportFileFormat::Data1DImportFormat>(
-        "Data1DImportFileFormat",
-        {{Data1DImportFileFormat::XYData1D, "xy", "Simple XY data (x = bin centres)"},
-         {Data1DImportFileFormat::HistogramData1D, "histogram", "Histogrammed Data (x = bin left-boundaries)"},
-         {Data1DImportFileFormat::GudrunMintData1D, "mint", "Gudrun output (mint01)"}},
-        format);
-    setUpKeywords();
-}
 Data1DImportFileFormat::Data1DImportFileFormat(std::string_view filename, Data1DImportFileFormat::Data1DImportFormat format)
     : FileAndFormat(formats_, filename)
 {
@@ -27,8 +17,6 @@ Data1DImportFileFormat::Data1DImportFileFormat(std::string_view filename, Data1D
         format);
     setUpKeywords();
 }
-
-Data1DImportFileFormat::~Data1DImportFileFormat() = default;
 
 /*
  * Keyword Options

--- a/src/io/import/data1d.h
+++ b/src/io/import/data1d.h
@@ -34,21 +34,11 @@ class Data1DImportFileFormat : public FileAndFormat
     void setUpKeywords();
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for Data1DImportFormat
-    static EnumOptions<Data1DImportFileFormat::Data1DImportFormat> data1DImportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as Data1DImportFormat
-    Data1DImportFormat data1DFormat() const;
+    // Format enum options
+    EnumOptions<Data1DImportFileFormat::Data1DImportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/import/data1d.h
+++ b/src/io/import/data1d.h
@@ -15,14 +15,13 @@ class Data1DImportFileFormat : public FileAndFormat
 {
     public:
     // Data1D Formats
-    enum Data1DImportFormat
+    enum class Data1DImportFormat
     {
-        XYData1D,
-        HistogramData1D,
-        GudrunMintData1D,
-        nData1DImportFormats
+        XY,
+        Histogram,
+        GudrunMint
     };
-    explicit Data1DImportFileFormat(std::string_view filename = "", Data1DImportFormat format = XYData1D);
+    explicit Data1DImportFileFormat(std::string_view filename = "", Data1DImportFormat format = Data1DImportFormat::XY);
     ~Data1DImportFileFormat() override = default;
 
     /*

--- a/src/io/import/data1d.h
+++ b/src/io/import/data1d.h
@@ -22,9 +22,8 @@ class Data1DImportFileFormat : public FileAndFormat
         GudrunMintData1D,
         nData1DImportFormats
     };
-    Data1DImportFileFormat(Data1DImportFormat format = XYData1D);
-    Data1DImportFileFormat(std::string_view filename, Data1DImportFormat format = XYData1D);
-    ~Data1DImportFileFormat() override;
+    explicit Data1DImportFileFormat(std::string_view filename = "", Data1DImportFormat format = XYData1D);
+    ~Data1DImportFileFormat() override = default;
 
     /*
      * Keyword Options

--- a/src/io/import/data2d.cpp
+++ b/src/io/import/data2d.cpp
@@ -10,8 +10,7 @@ Data2DImportFileFormat::Data2DImportFileFormat(std::string_view filename, Data2D
     : FileAndFormat(formats_, filename)
 {
     formats_ = EnumOptions<Data2DImportFileFormat::Data2DImportFormat>(
-        "Data2DImportFileFormat", {{Data2DImportFileFormat::CartesianData2D, "cartesian", "Cartesian X,Y,f(X,Y) data"}},
-        format);
+        "Data2DImportFileFormat", {{Data2DImportFormat::Cartesian, "cartesian", "Cartesian X,Y,f(X,Y) data"}}, format);
     setUpKeywords();
 }
 
@@ -55,7 +54,7 @@ bool Data2DImportFileFormat::importData(LineParser &parser, Data2D &data)
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (Data2DImportFileFormat::CartesianData2D):
+        case (Data2DImportFormat::Cartesian):
             result = importCartesian(parser, data);
             break;
         default:

--- a/src/io/import/data2d.cpp
+++ b/src/io/import/data2d.cpp
@@ -6,13 +6,19 @@
 #include "base/sysfunc.h"
 #include "keywords/types.h"
 
-Data2DImportFileFormat::Data2DImportFileFormat(Data2DImportFileFormat::Data2DImportFormat format) : FileAndFormat(format)
+Data2DImportFileFormat::Data2DImportFileFormat(Data2DImportFileFormat::Data2DImportFormat format) : FileAndFormat(formats_)
 {
+    formats_ = EnumOptions<Data2DImportFileFormat::Data2DImportFormat>(
+        "Data2DImportFileFormat", {{Data2DImportFileFormat::CartesianData2D, "cartesian", "Cartesian X,Y,f(X,Y) data"}},
+        format);
     setUpKeywords();
 }
 Data2DImportFileFormat::Data2DImportFileFormat(std::string_view filename, Data2DImportFileFormat::Data2DImportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
+    formats_ = EnumOptions<Data2DImportFileFormat::Data2DImportFormat>(
+        "Data2DImportFileFormat", {{Data2DImportFileFormat::CartesianData2D, "cartesian", "Cartesian X,Y,f(X,Y) data"}},
+        format);
     setUpKeywords();
 }
 
@@ -29,32 +35,6 @@ void Data2DImportFileFormat::setUpKeywords()
                   "Min, max, and delta to assume for x axis");
     keywords_.add("Ranges", new Vec3DoubleKeyword(Vec3<double>(0.0, 0.0, 0.0)), "YAxis",
                   "Min, max, and delta to assume for y axis");
-}
-
-/*
- * Format Access
- */
-
-// Return enum options for Data2DImportFormat
-EnumOptions<Data2DImportFileFormat::Data2DImportFormat> Data2DImportFileFormat::data2DImportFormats()
-{
-    return EnumOptions<Data2DImportFileFormat::Data2DImportFormat>(
-        "Data2DImportFileFormat", {{Data2DImportFileFormat::CartesianData2D, "cartesian", "Cartesian X,Y,f(X,Y) data"}});
-}
-
-// Return number of available formats
-int Data2DImportFileFormat::nFormats() const { return Data2DImportFileFormat::nData2DImportFormats; }
-
-// Return format keyword for supplied index
-std::string Data2DImportFileFormat::formatKeyword(int id) const { return data2DImportFormats().keywordByIndex(id); }
-
-// Return description string for supplied index
-std::string Data2DImportFileFormat::formatDescription(int id) const { return data2DImportFormats().descriptionByIndex(id); }
-
-// Return current format as Data2DImportFormat
-Data2DImportFileFormat::Data2DImportFormat Data2DImportFileFormat::data2DFormat() const
-{
-    return (Data2DImportFileFormat::Data2DImportFormat)format_;
 }
 
 /*
@@ -82,13 +62,13 @@ bool Data2DImportFileFormat::importData(LineParser &parser, Data2D &data)
 {
     // Import the data
     auto result = false;
-    switch (data2DFormat())
+    switch (formats_.enumeration())
     {
         case (Data2DImportFileFormat::CartesianData2D):
             result = importCartesian(parser, data);
             break;
         default:
-            Messenger::error("Don't know how to load Data2D of format '{}'.\n", formatKeyword(data2DFormat()));
+            throw(std::runtime_error(fmt::format("Data2D format '{}' import has not been implemented.\n", formats_.keyword())));
     }
 
     return result;

--- a/src/io/import/data2d.cpp
+++ b/src/io/import/data2d.cpp
@@ -6,13 +6,6 @@
 #include "base/sysfunc.h"
 #include "keywords/types.h"
 
-Data2DImportFileFormat::Data2DImportFileFormat(Data2DImportFileFormat::Data2DImportFormat format) : FileAndFormat(formats_)
-{
-    formats_ = EnumOptions<Data2DImportFileFormat::Data2DImportFormat>(
-        "Data2DImportFileFormat", {{Data2DImportFileFormat::CartesianData2D, "cartesian", "Cartesian X,Y,f(X,Y) data"}},
-        format);
-    setUpKeywords();
-}
 Data2DImportFileFormat::Data2DImportFileFormat(std::string_view filename, Data2DImportFileFormat::Data2DImportFormat format)
     : FileAndFormat(formats_, filename)
 {
@@ -21,8 +14,6 @@ Data2DImportFileFormat::Data2DImportFileFormat(std::string_view filename, Data2D
         format);
     setUpKeywords();
 }
-
-Data2DImportFileFormat::~Data2DImportFileFormat() = default;
 
 /*
  * Keyword Options

--- a/src/io/import/data2d.h
+++ b/src/io/import/data2d.h
@@ -17,12 +17,11 @@ class Data2DImportFileFormat : public FileAndFormat
 {
     public:
     // Available Data2D formats
-    enum Data2DImportFormat
+    enum class Data2DImportFormat
     {
-        CartesianData2D,
-        nData2DImportFormats
+        Cartesian
     };
-    explicit Data2DImportFileFormat(std::string_view filename = "", Data2DImportFormat format = CartesianData2D);
+    explicit Data2DImportFileFormat(std::string_view filename = "", Data2DImportFormat format = Data2DImportFormat::Cartesian);
     ~Data2DImportFileFormat() override = default;
 
     /*

--- a/src/io/import/data2d.h
+++ b/src/io/import/data2d.h
@@ -34,21 +34,11 @@ class Data2DImportFileFormat : public FileAndFormat
     void setUpKeywords();
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for Data2DImportFormat
-    static EnumOptions<Data2DImportFileFormat::Data2DImportFormat> data2DImportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as Data2DImportFormat
-    Data2DImportFormat data2DFormat() const;
+    // Format enum options
+    EnumOptions<Data2DImportFileFormat::Data2DImportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/import/data2d.h
+++ b/src/io/import/data2d.h
@@ -22,9 +22,8 @@ class Data2DImportFileFormat : public FileAndFormat
         CartesianData2D,
         nData2DImportFormats
     };
-    Data2DImportFileFormat(Data2DImportFormat format = CartesianData2D);
-    Data2DImportFileFormat(std::string_view filename, Data2DImportFormat format = CartesianData2D);
-    ~Data2DImportFileFormat() override;
+    explicit Data2DImportFileFormat(std::string_view filename = "", Data2DImportFormat format = CartesianData2D);
+    ~Data2DImportFileFormat() override = default;
 
     /*
      * Keyword Options

--- a/src/io/import/data3d.cpp
+++ b/src/io/import/data3d.cpp
@@ -5,13 +5,19 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-Data3DImportFileFormat::Data3DImportFileFormat(Data3DImportFileFormat::Data3DImportFormat format) : FileAndFormat(format)
+Data3DImportFileFormat::Data3DImportFileFormat(Data3DImportFileFormat::Data3DImportFormat format) : FileAndFormat(formats_)
 {
+    formats_ = EnumOptions<Data3DImportFileFormat::Data3DImportFormat>(
+        "Data3DImportFileFormat", {{Data3DImportFileFormat::CartesianData3D, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}},
+        format);
     setUpKeywords();
 }
 Data3DImportFileFormat::Data3DImportFileFormat(std::string_view filename, Data3DImportFileFormat::Data3DImportFormat format)
-    : FileAndFormat(filename, format)
+    : FileAndFormat(formats_, filename)
 {
+    formats_ = EnumOptions<Data3DImportFileFormat::Data3DImportFormat>(
+        "Data3DImportFileFormat", {{Data3DImportFileFormat::CartesianData3D, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}},
+        format);
     setUpKeywords();
 }
 
@@ -23,65 +29,6 @@ Data3DImportFileFormat::~Data3DImportFileFormat() = default;
 
 // Set up keywords for the format
 void Data3DImportFileFormat::setUpKeywords() {}
-
-/*
- * Format Access
- */
-
-// Return enum options for Data3DImportFormat
-EnumOptions<Data3DImportFileFormat::Data3DImportFormat> Data3DImportFileFormat::data3DImportFormats()
-{
-    return EnumOptions<Data3DImportFileFormat::Data3DImportFormat>(
-        "Data3DImportFileFormat", {{Data3DImportFileFormat::CartesianData3D, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}});
-}
-
-// Return number of available formats
-int Data3DImportFileFormat::nFormats() const { return Data3DImportFileFormat::nData3DImportFormats; }
-
-// Return format keyword for supplied index
-std::string Data3DImportFileFormat::formatKeyword(int id) const { return data3DImportFormats().keywordByIndex(id); }
-
-// Return description string for supplied index
-std::string Data3DImportFileFormat::formatDescription(int id) const { return data3DImportFormats().descriptionByIndex(id); }
-
-// Return current format as Data3DImportFormat
-Data3DImportFileFormat::Data3DImportFormat Data3DImportFileFormat::data3DFormat() const
-{
-    return (Data3DImportFileFormat::Data3DImportFormat)format_;
-}
-
-/*
- * Import / Write
- */
-
-// Parse additional argument
-bool Data3DImportFileFormat::parseArgument(std::string_view arg)
-{
-    // Split arg into parts before and after the '='
-    std::string_view key = DissolveSys::beforeChar(arg, '=');
-    std::string_view value = DissolveSys::afterChar(arg, '=');
-    if (key == "template")
-        templateSourceObjectTag_ = value;
-    else
-        return false;
-
-    return true;
-}
-
-// Return whether this file/format has any additional arguments to write
-bool Data3DImportFileFormat::hasAdditionalArguments() const { return true; }
-
-// Return additional arguments as string
-std::string Data3DImportFileFormat::additionalArguments() const
-{
-    std::string args;
-
-    args.clear();
-    if (!templateSourceObjectTag_.empty())
-        args += fmt::format("template='{}'", templateSourceObjectTag_);
-
-    return args;
-}
 
 /*
  * Import Functions
@@ -108,10 +55,10 @@ bool Data3DImportFileFormat::importData(LineParser &parser, Data3D &data)
 {
     // Import the data
     auto result = false;
-    switch (data3DFormat())
+    switch (formats_.enumeration())
     {
         default:
-            Messenger::error("Don't know how to load Data3D in format '{}'.\n", formatKeyword(data3DFormat()));
+            throw(std::runtime_error(fmt::format("Data3D format '{}' import has not been implemented.\n", formats_.keyword())));
     }
 
     return result;

--- a/src/io/import/data3d.cpp
+++ b/src/io/import/data3d.cpp
@@ -5,13 +5,6 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-Data3DImportFileFormat::Data3DImportFileFormat(Data3DImportFileFormat::Data3DImportFormat format) : FileAndFormat(formats_)
-{
-    formats_ = EnumOptions<Data3DImportFileFormat::Data3DImportFormat>(
-        "Data3DImportFileFormat", {{Data3DImportFileFormat::CartesianData3D, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}},
-        format);
-    setUpKeywords();
-}
 Data3DImportFileFormat::Data3DImportFileFormat(std::string_view filename, Data3DImportFileFormat::Data3DImportFormat format)
     : FileAndFormat(formats_, filename)
 {
@@ -20,8 +13,6 @@ Data3DImportFileFormat::Data3DImportFileFormat(std::string_view filename, Data3D
         format);
     setUpKeywords();
 }
-
-Data3DImportFileFormat::~Data3DImportFileFormat() = default;
 
 /*
  * Keyword Options

--- a/src/io/import/data3d.cpp
+++ b/src/io/import/data3d.cpp
@@ -9,8 +9,7 @@ Data3DImportFileFormat::Data3DImportFileFormat(std::string_view filename, Data3D
     : FileAndFormat(formats_, filename)
 {
     formats_ = EnumOptions<Data3DImportFileFormat::Data3DImportFormat>(
-        "Data3DImportFileFormat", {{Data3DImportFileFormat::CartesianData3D, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}},
-        format);
+        "Data3DImportFileFormat", {{Data3DImportFormat::Cartesian, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}}, format);
     setUpKeywords();
 }
 

--- a/src/io/import/data3d.h
+++ b/src/io/import/data3d.h
@@ -14,12 +14,11 @@ class Data3DImportFileFormat : public FileAndFormat
 {
     public:
     // Available Data3D formats
-    enum Data3DImportFormat
+    enum class Data3DImportFormat
     {
-        CartesianData3D,
-        nData3DImportFormats
+        Cartesian
     };
-    explicit Data3DImportFileFormat(std::string_view filename = "", Data3DImportFormat format = CartesianData3D);
+    explicit Data3DImportFileFormat(std::string_view filename = "", Data3DImportFormat format = Data3DImportFormat::Cartesian);
     ~Data3DImportFileFormat() override = default;
 
     /*

--- a/src/io/import/data3d.h
+++ b/src/io/import/data3d.h
@@ -19,11 +19,8 @@ class Data3DImportFileFormat : public FileAndFormat
         CartesianData3D,
         nData3DImportFormats
     };
-    Data3DImportFileFormat(Data3DImportFormat format = CartesianData3D);
-    Data3DImportFileFormat(std::string_view filename, Data3DImportFormat format = CartesianData3D);
-    ~Data3DImportFileFormat() override;
-    Data3DImportFileFormat(const Data3DImportFileFormat &source);
-    void operator=(const Data3DImportFileFormat &source);
+    explicit Data3DImportFileFormat(std::string_view filename = "", Data3DImportFormat format = CartesianData3D);
+    ~Data3DImportFileFormat() override = default;
 
     /*
      * Keyword Options

--- a/src/io/import/data3d.h
+++ b/src/io/import/data3d.h
@@ -33,28 +33,11 @@ class Data3DImportFileFormat : public FileAndFormat
     void setUpKeywords();
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for Data3DImportFormat
-    static EnumOptions<Data3DImportFileFormat::Data3DImportFormat> data3DImportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as Data3DImportFormat
-    Data3DImportFormat data3DFormat() const;
-
-    /*
-     * Templating
-     */
-    private:
-    // Object tag of Data3D upon which to template arrays before importing
-    std::string templateSourceObjectTag_;
+    // Format enum options
+    EnumOptions<Data3DImportFileFormat::Data3DImportFormat> formats_;
 
     /*
      * Filename / Basename
@@ -62,17 +45,6 @@ class Data3DImportFileFormat : public FileAndFormat
     public:
     // Return whether the file must exist
     bool fileMustExist() const override { return true; }
-
-    /*
-     * Import / Write
-     */
-    protected:
-    // Parse additional argument
-    bool parseArgument(std::string_view arg);
-    // Return whether this file/format has any additional arguments to write
-    bool hasAdditionalArguments() const;
-    // Return additional arguments as string
-    std::string additionalArguments() const;
 
     /*
      * Data Import

--- a/src/io/import/forces.cpp
+++ b/src/io/import/forces.cpp
@@ -11,9 +11,9 @@ ForceImportFileFormat::ForceImportFileFormat(std::string_view filename, ForceImp
 {
     formats_ = EnumOptions<ForceImportFileFormat::ForceImportFormat>(
         "ForceImportFileFormat",
-        {{ForceImportFileFormat::DLPOLYForces, "dlpoly", "DL_POLY Config File Forces"},
-         {ForceImportFileFormat::MoscitoForces, "moscito", "Moscito Structure File Forces"},
-         {ForceImportFileFormat::SimpleForces, "simple", "Simple Free-Formatted Forces"}},
+        {{ForceImportFormat::DLPOLY, "dlpoly", "DL_POLY Config File Forces"},
+         {ForceImportFormat::Moscito, "moscito", "Moscito Structure File Forces"},
+         {ForceImportFormat::Simple, "simple", "Simple Free-Formatted Forces"}},
         format);
     setUpKeywords();
 }
@@ -55,13 +55,13 @@ bool ForceImportFileFormat::importData(LineParser &parser, std::vector<Vec3<doub
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (ForceImportFileFormat::DLPOLYForces):
+        case (ForceImportFormat::DLPOLY):
             result = importDLPOLY(parser, f);
             break;
-        case (ForceImportFileFormat::MoscitoForces):
+        case (ForceImportFormat::Moscito):
             result = importMoscito(parser, f);
             break;
-        case (ForceImportFileFormat::SimpleForces):
+        case (ForceImportFormat::Simple):
             result = importSimple(parser, f);
             break;
         default:

--- a/src/io/import/forces.cpp
+++ b/src/io/import/forces.cpp
@@ -6,16 +6,6 @@
 #include "base/sysfunc.h"
 #include "keywords/double.h"
 
-ForceImportFileFormat::ForceImportFileFormat(ForceImportFileFormat::ForceImportFormat format) : FileAndFormat(formats_)
-{
-    formats_ = EnumOptions<ForceImportFileFormat::ForceImportFormat>(
-        "ForceImportFileFormat",
-        {{ForceImportFileFormat::DLPOLYForces, "dlpoly", "DL_POLY Config File Forces"},
-         {ForceImportFileFormat::MoscitoForces, "moscito", "Moscito Structure File Forces"},
-         {ForceImportFileFormat::SimpleForces, "simple", "Simple Free-Formatted Forces"}},
-        format);
-    setUpKeywords();
-}
 ForceImportFileFormat::ForceImportFileFormat(std::string_view filename, ForceImportFileFormat::ForceImportFormat format)
     : FileAndFormat(formats_, filename)
 {
@@ -27,8 +17,6 @@ ForceImportFileFormat::ForceImportFileFormat(std::string_view filename, ForceImp
         format);
     setUpKeywords();
 }
-
-ForceImportFileFormat::~ForceImportFileFormat() = default;
 
 /*
  * Keyword Options

--- a/src/io/import/forces.h
+++ b/src/io/import/forces.h
@@ -14,14 +14,13 @@ class ForceImportFileFormat : public FileAndFormat
 {
     public:
     // Forces Formats
-    enum ForceImportFormat
+    enum class ForceImportFormat
     {
-        DLPOLYForces,
-        MoscitoForces,
-        SimpleForces,
-        nForceImportFormats
+        DLPOLY,
+        Moscito,
+        Simple
     };
-    explicit ForceImportFileFormat(std::string_view filename = "", ForceImportFormat format = SimpleForces);
+    explicit ForceImportFileFormat(std::string_view filename = "", ForceImportFormat format = ForceImportFormat::Simple);
     ~ForceImportFileFormat() override = default;
 
     /*

--- a/src/io/import/forces.h
+++ b/src/io/import/forces.h
@@ -21,9 +21,8 @@ class ForceImportFileFormat : public FileAndFormat
         SimpleForces,
         nForceImportFormats
     };
-    ForceImportFileFormat(ForceImportFormat format = SimpleForces);
-    ForceImportFileFormat(std::string_view filename, ForceImportFormat format = SimpleForces);
-    ~ForceImportFileFormat() override;
+    explicit ForceImportFileFormat(std::string_view filename = "", ForceImportFormat format = SimpleForces);
+    ~ForceImportFileFormat() override = default;
 
     /*
      * Keyword Options

--- a/src/io/import/forces.h
+++ b/src/io/import/forces.h
@@ -33,21 +33,11 @@ class ForceImportFileFormat : public FileAndFormat
     void setUpKeywords();
 
     /*
-     * Format Access
+     * Formats
      */
     private:
-    // Return enum options for ForceImportFormat
-    static EnumOptions<ForceImportFileFormat::ForceImportFormat> forceImportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as ForceImportFormat
-    ForceImportFormat forceFormat() const;
+    // Format enum options
+    EnumOptions<ForceImportFileFormat::ForceImportFormat> formats_;
 
     /*
      * Filename / Basename

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -11,7 +11,7 @@ TrajectoryImportFileFormat::TrajectoryImportFileFormat(std::string_view filename
     : FileAndFormat(formats_, filename)
 {
     formats_ = EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>(
-        "TrajectoryImportFileFormat", {{TrajectoryImportFileFormat::XYZTrajectory, "xyz", "XYZ Trajectory"}}, format);
+        "TrajectoryImportFileFormat", {{TrajectoryImportFormat::XYZ, "xyz", "XYZ Trajectory"}}, format);
 }
 
 /*
@@ -25,8 +25,9 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
     auto result = false;
     switch (formats_.enumeration())
     {
-        case (TrajectoryImportFileFormat::XYZTrajectory):
-            result = CoordinateImportFileFormat("", CoordinateImportFileFormat::XYZCoordinates).importData(parser, cfg);
+        case (TrajectoryImportFormat::XYZ):
+            result =
+                CoordinateImportFileFormat("", CoordinateImportFileFormat::CoordinateImportFormat::XYZ).importData(parser, cfg);
             break;
         default:
             throw(std::runtime_error(

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -6,12 +6,6 @@
 #include "base/sysfunc.h"
 #include "io/import/coordinates.h"
 
-TrajectoryImportFileFormat::TrajectoryImportFileFormat(TrajectoryImportFileFormat::TrajectoryImportFormat format)
-    : FileAndFormat(formats_)
-{
-    formats_ = EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>(
-        "TrajectoryImportFileFormat", {{TrajectoryImportFileFormat::XYZTrajectory, "xyz", "XYZ Trajectory"}}, format);
-}
 TrajectoryImportFileFormat::TrajectoryImportFileFormat(std::string_view filename,
                                                        TrajectoryImportFileFormat::TrajectoryImportFormat format)
     : FileAndFormat(formats_, filename)
@@ -19,8 +13,6 @@ TrajectoryImportFileFormat::TrajectoryImportFileFormat(std::string_view filename
     formats_ = EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>(
         "TrajectoryImportFileFormat", {{TrajectoryImportFileFormat::XYZTrajectory, "xyz", "XYZ Trajectory"}}, format);
 }
-
-TrajectoryImportFileFormat::~TrajectoryImportFileFormat() = default;
 
 /*
  * Import Functions
@@ -34,7 +26,7 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
     switch (formats_.enumeration())
     {
         case (TrajectoryImportFileFormat::XYZTrajectory):
-            result = CoordinateImportFileFormat(CoordinateImportFileFormat::XYZCoordinates).importData(parser, cfg);
+            result = CoordinateImportFileFormat("", CoordinateImportFileFormat::XYZCoordinates).importData(parser, cfg);
             break;
         default:
             throw(std::runtime_error(

--- a/src/io/import/trajectory.h
+++ b/src/io/import/trajectory.h
@@ -14,13 +14,13 @@ class TrajectoryImportFileFormat : public FileAndFormat
 {
     public:
     // Available trajectory formats
-    enum TrajectoryImportFormat
+    enum class TrajectoryImportFormat
     {
-        XYZTrajectory,
-        nTrajectoryImportFormats
+        XYZ
     };
 
-    explicit TrajectoryImportFileFormat(std::string_view filename = "", TrajectoryImportFormat format = XYZTrajectory);
+    explicit TrajectoryImportFileFormat(std::string_view filename = "",
+                                        TrajectoryImportFormat format = TrajectoryImportFormat::XYZ);
     ~TrajectoryImportFileFormat() override = default;
 
     /*

--- a/src/io/import/trajectory.h
+++ b/src/io/import/trajectory.h
@@ -6,7 +6,8 @@
 #include "io/fileandformat.h"
 
 // Forward Declarations
-/* none */
+class Configuration;
+class ProcessPool;
 
 // Trajectory Import Formats
 class TrajectoryImportFileFormat : public FileAndFormat
@@ -23,28 +24,11 @@ class TrajectoryImportFileFormat : public FileAndFormat
     ~TrajectoryImportFileFormat() override;
 
     /*
-     * Keyword Options
+     * Formats
      */
     private:
-    // Set up keywords for the format
-    void setUpKeywords();
-
-    /*
-     * Format Access
-     */
-    private:
-    // Return enum options for TrajectoryImportFileFormat
-    static EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> trajectoryImportFormats();
-
-    public:
-    // Return number of available formats
-    int nFormats() const override;
-    // Return format keyword for supplied index
-    std::string formatKeyword(int id) const override;
-    // Return description string for supplied index
-    std::string formatDescription(int id) const override;
-    // Return current format as TrajectoryImportFormat
-    TrajectoryImportFormat trajectoryFormat() const;
+    // Format enum options
+    EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> formats_;
 
     /*
      * Filename / Basename
@@ -52,4 +36,11 @@ class TrajectoryImportFileFormat : public FileAndFormat
     public:
     // Return whether the file must exist
     bool fileMustExist() const override { return true; }
+
+    /*
+     * Import Functions
+     */
+    public:
+    // Import trajectory using supplied parser and current format
+    bool importData(LineParser &parser, Configuration *cfg);
 };

--- a/src/io/import/trajectory.h
+++ b/src/io/import/trajectory.h
@@ -19,9 +19,9 @@ class TrajectoryImportFileFormat : public FileAndFormat
         XYZTrajectory,
         nTrajectoryImportFormats
     };
-    TrajectoryImportFileFormat(TrajectoryImportFormat format = XYZTrajectory);
-    TrajectoryImportFileFormat(std::string_view filename, TrajectoryImportFormat format = XYZTrajectory);
-    ~TrajectoryImportFileFormat() override;
+
+    explicit TrajectoryImportFileFormat(std::string_view filename = "", TrajectoryImportFormat format = XYZTrajectory);
+    ~TrajectoryImportFileFormat() override = default;
 
     /*
      * Formats

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -299,7 +299,7 @@ bool Dissolve::saveInput(std::string_view filename)
             return false;
 
         // Input Coordinates
-        if (cfg->inputCoordinates().hasValidFileAndFormat())
+        if (cfg->inputCoordinates().hasFilename())
         {
             if (!cfg->inputCoordinates().writeFilenameAndFormat(
                     parser,

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -194,7 +194,7 @@ void BenchmarkModule::printTimingResult(std::string_view testFile, std::string_v
     // Open the existing timings file if it exists
     Data1D existingTimings;
     existingTimings.addErrors();
-    Data1DImportFileFormat importer(testFile, Data1DImportFileFormat::XYData1D);
+    Data1DImportFileFormat importer(testFile, Data1DImportFileFormat::Data1DImportFormat::XY);
     if (importer.fileExists())
     {
         importer.keywords().set("Error", 3);
@@ -220,7 +220,7 @@ void BenchmarkModule::printTimingResult(std::string_view testFile, std::string_v
     {
         existingTimings.addPoint(existingTimings.nValues() + 1, timing.value(), timing.stDev());
 
-        Data1DExportFileFormat exporter(testFile, Data1DExportFileFormat::XYData1D);
+        Data1DExportFileFormat exporter(testFile, Data1DExportFileFormat::Data1DExportFormat::XY);
         exporter.exportData(existingTimings);
     }
 }

--- a/src/modules/calculate_sdf/process.cpp
+++ b/src/modules/calculate_sdf/process.cpp
@@ -38,7 +38,7 @@ bool CalculateSDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         return Messenger::error("CalculateSDF experienced problems with its analysis.\n");
 
     // Save data?
-    if (sdfFileAndFormat_.hasValidFileAndFormat())
+    if (sdfFileAndFormat_.hasFilename())
     {
         if (procPool.isMaster())
         {

--- a/src/modules/export_pairpotentials/process.cpp
+++ b/src/modules/export_pairpotentials/process.cpp
@@ -12,7 +12,7 @@
 // Run main processing
 bool ExportPairPotentialsModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    if (!pairPotentialFormat_.hasValidFileAndFormat())
+    if (!pairPotentialFormat_.hasFilename())
         return Messenger::error("No valid file/format set for pair potential export.\n");
 
     // Only the pool master saves the data

--- a/src/modules/export_trajectory/process.cpp
+++ b/src/modules/export_trajectory/process.cpp
@@ -12,7 +12,7 @@
 // Run main processing
 bool ExportTrajectoryModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    if (!trajectoryFormat_.hasValidFileAndFormat())
+    if (!trajectoryFormat_.hasFilename())
         Messenger::error("No valid file/format set for trajectory export.\n");
 
     // Check for zero Configuration targets

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -13,7 +13,7 @@
 // Run set-up stage
 bool ForcesModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
 {
-    if (referenceForces_.hasValidFileAndFormat())
+    if (referenceForces_.hasFilename())
     {
         Messenger::print("Reading test reference forces.\n");
 
@@ -51,7 +51,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
         procPool.assignProcessesToGroups(cfg->processPool());
 
         // Retrieve control parameters
-        const auto saveData = exportedForces_.hasValidFileAndFormat();
+        const auto saveData = exportedForces_.hasFilename();
         const auto testMode = keywords_.asBool("Test");
         const auto testAnalytic = keywords_.asBool("TestAnalytic");
         const auto testInter = keywords_.asBool("TestInter");

--- a/src/modules/import_trajectory/process.cpp
+++ b/src/modules/import_trajectory/process.cpp
@@ -37,18 +37,9 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, ProcessPool &procPool)
     }
 
     // Read the frame
-    switch (trajectoryFormat_.trajectoryFormat())
-    {
-        case (TrajectoryImportFileFormat::XYZTrajectory):
-            if (!cfg->loadCoordinates(parser, CoordinateImportFileFormat::XYZCoordinates))
-                return false;
-            cfg->incrementContentsVersion();
-            break;
-        default:
-            return Messenger::error("Bad TGAY - he hasn't implemented reading of trajectory frames of format {}.\n",
-                                    trajectoryFormat_.trajectoryFormat());
-            break;
-    }
+    if (!trajectoryFormat_.importData(parser, cfg))
+        return Messenger::error("Failed to read trajectory frame data.\n");
+    cfg->incrementContentsVersion();
 
     // Set the trajectory file position in the restart file
     dissolve.processingModuleData().realise<std::streampos>(streamPosName, uniqueName(), GenericItem::InRestartFileFlag) =

--- a/src/modules/neutronsq/gui/modulewidget_funcs.cpp
+++ b/src/modules/neutronsq/gui/modulewidget_funcs.cpp
@@ -95,7 +95,7 @@ void NeutronSQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
                                                        "Calculated", "Calculated");
 
             // Add on reference F(Q) data if present
-            if (referenceFileAndFormat.hasValidFileAndFormat())
+            if (referenceFileAndFormat.hasFilename())
                 graph_
                     ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", module_->uniqueName()),
                                                          "Reference F(Q)", "Reference")
@@ -116,7 +116,7 @@ void NeutronSQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
             repGR->setColour(StockColours::GreenStockColour);
 
             // Add on reference G(r) (from FT of F(Q)) if present
-            if (referenceFileAndFormat.hasValidFileAndFormat())
+            if (referenceFileAndFormat.hasFilename())
                 graph_
                     ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", module_->uniqueName()),
                                                          "Reference G(r) (via FT)", "Reference")

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -18,7 +18,7 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
     /*
      * Load and set up reference data (if a file/format was given)
      */
-    if (referenceFQ_.hasValidFileAndFormat())
+    if (referenceFQ_.hasFilename())
     {
         // Load the data
         Data1D referenceData;

--- a/src/modules/xraysq/gui/modulewidget_funcs.cpp
+++ b/src/modules/xraysq/gui/modulewidget_funcs.cpp
@@ -93,7 +93,7 @@ void XRaySQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
                                                        "Calculated", "Calculated");
 
             // Add on reference F(Q) data if present
-            if (referenceFileAndFormat.hasValidFileAndFormat())
+            if (referenceFileAndFormat.hasFilename())
                 graph_
                     ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", module_->uniqueName()),
                                                          "Reference F(Q)", "Reference")
@@ -114,7 +114,7 @@ void XRaySQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
             repGR->setColour(StockColours::GreenStockColour);
 
             // Add on reference G(r) (from FT of F(Q)) if present
-            if (referenceFileAndFormat.hasValidFileAndFormat())
+            if (referenceFileAndFormat.hasFilename())
                 graph_
                     ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", module_->uniqueName()),
                                                          "Reference G(r) (via FT)", "Reference")

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -19,7 +19,7 @@ bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
     /*
      * Load and set up reference data (if a file/format was given)
      */
-    if (referenceFQ_.hasValidFileAndFormat())
+    if (referenceFQ_.hasFilename())
     {
         // Load the data
         Data1D referenceData;

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -138,7 +138,7 @@ bool Process1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg,
     }
 
     // Save data?
-    if (exportFileAndFormat_.hasValidFileAndFormat())
+    if (exportFileAndFormat_.hasFilename())
     {
         if (procPool.isMaster())
         {

--- a/src/procedure/nodes/process2d.cpp
+++ b/src/procedure/nodes/process2d.cpp
@@ -138,7 +138,7 @@ bool Process2DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg,
     }
 
     // Save data?
-    if (exportFileAndFormat_.hasValidFileAndFormat())
+    if (exportFileAndFormat_.hasFilename())
     {
         if (procPool.isMaster())
         {

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -140,7 +140,7 @@ bool Process3DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg,
     }
 
     // Save data?
-    if (exportFileAndFormat_.hasValidFileAndFormat())
+    if (exportFileAndFormat_.hasFilename())
     {
         if (procPool.isMaster())
         {


### PR DESCRIPTION
This PR performs some simplification and modernisation of `FileAndFormat` class. In particular it leverages functionality in the underlying `EnumOptions` containing the available import/export formats in order to save code.

Other notable changes:
- The `FileAndFormat` class from which all import/export classes are derived now takes a reference to the parent `EnumOptionsBase` object on construction, tightening the relationship between the objects and allowing many virtual overloads to be removed.
- Overloaded functions specifically for direct import of coordinates into configurations have been added to relevant import classes.
- A GUI model for `EnumOptionsBase` has been added to reduce the need for the custom `ComboBoxPopulator` class.
