### PR TITLE
Bugfix 04/06/21 Various

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,9 @@ stamp-h1
 *.hh
 ui_*
 moc_*
-src/dissolve-mpi
-src/dissolve-gui
-src/dissolve
 *.kdev4
 build/
-cmake-build-*/
+build-*/
 *.exe
 
 # Miscellaneous

--- a/src/io/import/data1d.cpp
+++ b/src/io/import/data1d.cpp
@@ -30,8 +30,8 @@ void Data1DImportFileFormat::setUpKeywords()
     keywords_.add("Columns", new IntegerKeyword(0, 0), "Error", "Column index to use for error values");
     keywords_.add("Manipulations", new DoubleKeyword(-1.0, -1.0), "RemoveAverage",
                   "X axis value from which to form average value to subtract from data (-1 for no subtraction)");
-    keywords_.add("Manipulations", new RangeKeyword(Range(0.0, 0.0), Vec3Labels::MinMaxDeltaLabels), "Trim",
-                  "Trim the range of the loaded data to be within the specified boundaries");
+    keywords_.add("Manipulations", new DoubleKeyword(0.0), "XMin", "Set the minimum X value to allow when reading in the data");
+    keywords_.add("Manipulations", new DoubleKeyword(0.0), "XMax", "Set the maximum X value to allow when reading in the data");
     keywords_.add("Manipulations", new IntegerKeyword(0, 0), "RemovePoints",
                   "Remove a number of points from the start of the data");
 }
@@ -85,10 +85,11 @@ bool Data1DImportFileFormat::importData(LineParser &parser, Data1D &data)
     for (auto n = 0; n < keywords_.asInt("RemovePoints"); ++n)
         data.removeFirstPoint();
     // -- Trim range?
-    if (keywords_.hasBeenSet("Trim"))
+    if (keywords_.hasBeenSet("XMin") || keywords_.hasBeenSet("XMax"))
     {
-        const auto range = keywords_.retrieve<Range>("Trim");
-        Filters::trim(data, range.minimum(), range.maximum());
+        auto xMin = keywords_.hasBeenSet("XMin") ? keywords_.asDouble("XMin") : data.xAxis().front() - 1.0;
+        auto xMax = keywords_.hasBeenSet("XMax") ? keywords_.asDouble("XMax") : data.xAxis().back() + 1.0;
+        Filters::trim(data, xMin, xMax);
     }
     // -- Subtract average level from data?
     const auto removeAverage = keywords_.asDouble("RemoveAverage");

--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -196,21 +196,19 @@ void normalisedMovingAverage(Data1D &data, int avgSize)
 double subtractAverage(Data1D &data, double xStart)
 {
     // Grab x and y arrays
-    const auto &x = data.xAxis();
-    auto &y = data.values();
+    const auto &xAxis = data.xAxis();
+    auto &values = data.values();
 
     auto sum = 0.0;
     auto nPoints = 0;
-    for (auto n = 0; n < x.size(); ++n)
-    {
-        if (x[n] >= xStart)
+    for (auto &&[x, y] : zip(xAxis, values))
+        if (x >= xStart)
         {
-            sum += y[n];
+            sum += y;
             ++nPoints;
         }
-    }
 
-    std::transform(y.begin(), y.end(), y.begin(), [sum, nPoints](auto value) { return value - sum / nPoints; });
+    std::transform(values.begin(), values.end(), values.begin(), [sum, nPoints](auto value) { return value - sum / nPoints; });
 
     return sum / nPoints;
 }
@@ -229,8 +227,7 @@ void trim(Data1D &data, double xMin, double xMax, bool interpolateEnds, double i
             // X axis value now exceeds the xMax - interpolate the end?
             if (interpolateEnds)
             {
-                // Is there a usable data point with lower x than the present one that we can use for our
-                // interpolation?
+                // Is there a usable data point with lower x than the present one that we can use for our interpolation?
                 if (n > 0)
                 {
                     double intervalFraction = (xMax - x[n - 1]) / (x[n] - x[n - 1]);

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -340,8 +340,8 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                              "intramolecular).\n",
                              interEnergy + intraEnergy, interEnergy, intraEnergy);
             Messenger::print("Intramolecular contributions are - bonds = {:15.9e} kJ/mol, angles = {:15.9e} kJ/mol, "
-                             "torsions = {:15.9e} kJ/mol.\n",
-                             bondEnergy, angleEnergy, torsionEnergy);
+                             "torsions = {:15.9e} kJ/mol, impropers = {:15.9e} kJ/mol.\n",
+                             bondEnergy, angleEnergy, torsionEnergy, improperEnergy);
 
             // Store current energies in the Configuration in case somebody else needs them
             auto &interData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Inter", cfg->niceName()),
@@ -359,6 +359,9 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
             auto &torsionData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Torsions", cfg->niceName()),
                                                                                 uniqueName(), GenericItem::InRestartFileFlag);
             torsionData.addPoint(dissolve.iteration(), torsionEnergy);
+            auto &improperData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Impropers", cfg->niceName()),
+                                                                                 uniqueName(), GenericItem::InRestartFileFlag);
+            torsionData.addPoint(dissolve.iteration(), improperEnergy);
 
             // Append to arrays of total energies
             auto &totalEnergyArray = dissolve.processingModuleData().realise<Data1D>(
@@ -401,13 +404,13 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
                     parser.writeLineF("# Energies for Configuration '{}'.\n", cfg->name());
                     parser.writeLine("# All values in kJ/mol.\n");
                     parser.writeLine("# Iteration   Total         Inter         Bond          Angle        "
-                                     " Torsion       Gradient      S?\n");
+                                     " Torsion      Improper    Gradient      S?\n");
                 }
                 else
                     parser.appendOutput(filename);
-                parser.writeLineF("  {:10d}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {}\n",
+                parser.writeLineF("  {:10d}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {}\n",
                                   dissolve.iteration(), interEnergy + intraEnergy, interEnergy, bondEnergy, angleEnergy,
-                                  torsionEnergy, grad, stable);
+                                  torsionEnergy, improperEnergy, grad, stable);
                 parser.closeFiles();
             }
         }

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -262,8 +262,10 @@ bool EPSRModule::process(Dissolve &dissolve, ProcessPool &procPool)
         differenceData = originalReferenceData;
         Interpolator::addInterpolated(differenceData, weightedSQ.total(), -1.0);
 
-        // Calculate and store r-factor
-        auto rFactor = Error::rFactor(originalReferenceData, weightedSQ.total(), true);
+        // Calculate r-factor over fit range and store
+        auto tempRefData = originalReferenceData;
+        Filters::trim(tempRefData, qMin, qMax);
+        auto rFactor = Error::rFactor(tempRefData, weightedSQ.total(), true);
         rFacTot += rFactor;
         errors.addPoint(dissolve.iteration(), rFactor);
         Messenger::print("Current R-Factor for reference data '{}' is {:.5f}.\n", module->uniqueName(), rFactor);

--- a/src/modules/neutronsq/init.cpp
+++ b/src/modules/neutronsq/init.cpp
@@ -29,6 +29,12 @@ void NeutronSQModule::initialise()
                                                                                   StructureFactors::NoNormalisation),
                   "ReferenceNormalisation", "Normalisation to remove from reference data before use",
                   KeywordBase::ModificationRequiresSetUpOption);
+    keywords_.add("Reference Data", new DoubleKeyword(0.0), "ReferenceFTQMin",
+                  "Set the minimum Q value to use when Fourier-transforming the data");
+    keywords_.add("Reference Data", new DoubleKeyword(0.0), "ReferenceFTQMax",
+                  "Set the maximum Q value to use when Fourier-transforming the data");
+    keywords_.add("Reference Data", new DoubleKeyword(0.05), "ReferenceFTDeltaR",
+                  "Set the spacing in r to use when generating the Fourier-transformed data");
     keywords_.add("Reference Data",
                   new EnumOptionsKeyword<WindowFunction::Form>(WindowFunction::forms() = WindowFunction::Form::Lorch0),
                   "ReferenceWindowFunction", "Window function to apply when Fourier-transforming reference S(Q) to g(r)",

--- a/src/modules/neutronsq/init.cpp
+++ b/src/modules/neutronsq/init.cpp
@@ -44,6 +44,8 @@ void NeutronSQModule::initialise()
     keywords_.add("Export", new BoolKeyword(false), "SaveGR", "Save weighted g(r) and G(r)", "<True|False>");
     keywords_.add("Export", new BoolKeyword(false), "SaveReference", "Save the reference data and its Fourier transform",
                   "<True|False>");
+    keywords_.add("Export", new BoolKeyword(false), "SaveRepresentativeGR",
+                  "Save representative G(r), obtained from Fourier transform of the calculated F(Q)");
     keywords_.add("Export", new BoolKeyword(false), "SaveSQ", "Save weighted partial and total structure factors",
                   "<True|False>");
 }

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -7,6 +7,7 @@
 #include "classes/species.h"
 #include "io/export/data1d.h"
 #include "main/dissolve.h"
+#include "math/filters.h"
 #include "math/ft.h"
 #include "modules/neutronsq/neutronsq.h"
 #include "modules/rdf/rdf.h"
@@ -59,7 +60,10 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
             }
         }
 
-        // Get window function to use for transformation of S(Q) to g(r)
+        // Get Q-range and window function to use for transformation of F(Q) to G(r)
+        auto ftQMin = keywords_.hasBeenSet("ReferenceFTQMin") ? keywords_.asDouble("ReferenceFTQMin") : 0.0;
+        auto ftQMax = keywords_.hasBeenSet("ReferenceFTQMax") ? keywords_.asDouble("ReferenceFTQMax")
+                                                              : referenceData.xAxis().back() + 1.0;
         const auto wf = keywords_.enumeration<WindowFunction::Form>("ReferenceWindowFunction");
         if (wf == WindowFunction::Form::None)
             Messenger::print("No window function will be applied in Fourier transform of reference data to g(r).");
@@ -78,9 +82,11 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
         auto &storedDataFT =
             dissolve.processingModuleData().realise<Data1D>("ReferenceDataFT", uniqueName(), GenericItem::ProtectedFlag);
         storedDataFT = referenceData;
+        Filters::trim(storedDataFT, ftQMin, ftQMax);
+        auto deltaR = keywords_.asDouble("ReferenceFTDeltaR");
         auto rho = rdfModule->effectiveDensity();
         Messenger::print("Effective atomic density used in Fourier transform of reference data is {} atoms/Angstrom3.\n", rho);
-        Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), 0.0, 0.05, 30.0, WindowFunction(wf));
+        Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), deltaR, deltaR, 30.0, WindowFunction(wf));
 
         // Save data?
         if (keywords_.asBool("SaveReference"))

--- a/src/modules/xraysq/init.cpp
+++ b/src/modules/xraysq/init.cpp
@@ -27,6 +27,12 @@ void XRaySQModule::initialise()
                   new EnumOptionsKeyword<StructureFactors::NormalisationType>(StructureFactors::normalisationTypes() =
                                                                                   StructureFactors::NoNormalisation),
                   "ReferenceNormalisation", "Normalisation to remove from reference data");
+    keywords_.add("Reference Data", new DoubleKeyword(0.0), "ReferenceFTQMin",
+                  "Set the minimum Q value to use when Fourier-transforming the data");
+    keywords_.add("Reference Data", new DoubleKeyword(0.0), "ReferenceFTQMax",
+                  "Set the maximum Q value to use when Fourier-transforming the data");
+    keywords_.add("Reference Data", new DoubleKeyword(0.05), "ReferenceFTDeltaR",
+                  "Set the spacing in r to use when generating the Fourier-transformed data");
     keywords_.add("Reference Data",
                   new EnumOptionsKeyword<WindowFunction::Form>(WindowFunction::forms() = WindowFunction::Form::Lorch0),
                   "ReferenceWindowFunction", "Window function to apply when Fourier-transforming reference S(Q) to g(r)",

--- a/src/modules/xraysq/init.cpp
+++ b/src/modules/xraysq/init.cpp
@@ -41,10 +41,12 @@ void XRaySQModule::initialise()
     // Export
     keywords_.add("Export", new BoolKeyword(false), "SaveFormFactors",
                   "Whether to save combined form factor weightings for atomtype pairs", "<True|False>");
-    keywords_.add("Export", new BoolKeyword(false), "SaveReference",
-                  "Whether to save the reference data and its Fourier transform", "<True|False>");
     keywords_.add("Export", new BoolKeyword(false), "SaveGR",
                   "Whether to save weighted g(r) and G(r) to disk after calculation", "<True|False>");
+    keywords_.add("Export", new BoolKeyword(false), "SaveReference",
+                  "Whether to save the reference data and its Fourier transform", "<True|False>");
+    keywords_.add("Export", new BoolKeyword(false), "SaveRepresentativeGR",
+                  "Save representative G(r), obtained from Fourier transform of the calculated F(Q)");
     keywords_.add("Export", new BoolKeyword(false), "SaveSQ",
                   "Whether to save weighted S(Q) and F(Q) to disk after calculation", "<True|False>");
 }

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -7,6 +7,7 @@
 #include "classes/xrayweights.h"
 #include "io/export/data1d.h"
 #include "main/dissolve.h"
+#include "math/filters.h"
 #include "math/ft.h"
 #include "modules/rdf/rdf.h"
 #include "modules/sq/sq.h"
@@ -61,7 +62,10 @@ bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
             }
         }
 
-        // Get window function to use for transformation of reference S(Q) to g(r)
+        // Get Q-range and window function to use for transformation of F(Q) to G(r)
+        auto ftQMin = keywords_.hasBeenSet("ReferenceFTQMin") ? keywords_.asDouble("ReferenceFTQMin") : 0.0;
+        auto ftQMax = keywords_.hasBeenSet("ReferenceFTQMax") ? keywords_.asDouble("ReferenceFTQMax")
+                                                              : referenceData.xAxis().back() + 1.0;
         const auto wf = keywords_.enumeration<WindowFunction::Form>("ReferenceWindowFunction");
         if (wf == WindowFunction::Form::None)
             Messenger::print("No window function will be applied in Fourier transform of reference data to g(r).");
@@ -80,9 +84,11 @@ bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
         auto &storedDataFT =
             dissolve.processingModuleData().realise<Data1D>("ReferenceDataFT", uniqueName(), GenericItem::ProtectedFlag);
         storedDataFT = referenceData;
+        Filters::trim(storedDataFT, ftQMin, ftQMax);
+        auto deltaR = keywords_.asDouble("ReferenceFTDeltaR");
         auto rho = rdfModule->effectiveDensity();
         Messenger::print("Effective atomic density used in Fourier transform of reference data is {} atoms/Angstrom3.\n", rho);
-        Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), 0.0, 0.05, 30.0, WindowFunction(wf));
+        Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), deltaR, deltaR, 30.0, WindowFunction(wf));
 
         // Save data?
         if (keywords_.asBool("SaveReference"))

--- a/tests/epsr/water-neutron-xray.txt
+++ b/tests/epsr/water-neutron-xray.txt
@@ -188,7 +188,8 @@ Layer  'RDF / Neutron / XRay'
     Isotopologue  'Water'  'Natural'  1.000000
     Reference  mint  '../_data/epsr25/water1000-neutron-xray/H2O.mint01'
     EndReference
-    #SaveSQ  On
+    ReferenceFTQMin  0.5
+    ReferenceFTQMax  30.0
   EndModule
   
   # Test total neutron-weighted F(Q)
@@ -205,7 +206,8 @@ Layer  'RDF / Neutron / XRay'
     Isotopologue  'Water'  'Deuterated'  1.000000
     Reference  mint  '../_data/epsr25/water1000-neutron-xray/D2O.mint01'
     EndReference
-    #SaveSQ  On
+    ReferenceFTQMin  0.5
+    ReferenceFTQMax  30.0
   EndModule
 
   Module  DataTest  'F(Q) D2O'
@@ -223,7 +225,8 @@ Layer  'RDF / Neutron / XRay'
     Isotopologue  'Water'  'Deuterated'  1.000000
     Reference  mint  '../_data/epsr25/water1000-neutron-xray/HDO.mint01'
     EndReference
-    #SaveSQ  On
+    ReferenceFTQMin  0.5
+    ReferenceFTQMax  30.0
   EndModule
 
   Module  DataTest  'F(Q) HDO'
@@ -239,11 +242,27 @@ Layer  'RDF / Neutron / XRay'
     Normalisation  AverageOfSquares
     Reference  xy  '../_data/epsr25/water1000-neutron-xray/PCCPfofq.txt'
     EndReference
-    #SaveSQ  On
+    ReferenceFTQMin  0.5
   EndModule
 
   Module  DataTest  'F(Q) H2Ox'
     Data1D  'H2Ox//WeightedSQ//Total'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.u01'
+      Y  8
+    EndData1D
+  EndModule
+
+  Module DataTest  'ReferenceFT'
+    Threshold  5e-05
+    Data1D  'H2O//ReferenceDataFT'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.w01'
+      Y  4
+    EndData1D
+    Data1D  'D2O//ReferenceDataFT'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.w01'
+      Y  2
+    EndData1D
+    Data1D  'HDO//ReferenceDataFT'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.w01'
+      Y  6
+    EndData1D
+    Data1D  'H2Ox//ReferenceDataFT'  xy  '../_data/epsr25/water1000-neutron-xray/water.EPSR.w01'
       Y  8
     EndData1D
   EndModule

--- a/tests/epsr/water-neutron-xray.txt
+++ b/tests/epsr/water-neutron-xray.txt
@@ -190,6 +190,7 @@ Layer  'RDF / Neutron / XRay'
     EndReference
     ReferenceFTQMin  0.5
     ReferenceFTQMax  30.0
+    SaveRepresentativeGR  On
   EndModule
   
   # Test total neutron-weighted F(Q)
@@ -243,6 +244,7 @@ Layer  'RDF / Neutron / XRay'
     Reference  xy  '../_data/epsr25/water1000-neutron-xray/PCCPfofq.txt'
     EndReference
     ReferenceFTQMin  0.5
+    SaveRepresentativeGR  On
   EndModule
 
   Module  DataTest  'F(Q) H2Ox'

--- a/web/content/docs/modules/correlation/neutronsq/_index.md
+++ b/web/content/docs/modules/correlation/neutronsq/_index.md
@@ -48,6 +48,9 @@ The application of instrumental broadening is the responsibility of the source [
 Keyword|Arguments|Default|Description|
 |:------|:-------:|:-----:|-----------|
 |`Reference`|[`Data1DFileAndFormat`]({{< ref "data1dformat" >}})|--|Format and filename of reference $F(Q)$ data, to be displayed in the GUI alongside calculated data, and made available for other modules to utilise (e.g. [`EPSR`]({{< ref "sq" >}})|
+|`ReferenceFTDeltaR`|`double`|0.05|Spacing in $r$ to use when generating the Fourier-transform of the $F(Q)$|
+|`ReferenceFTQMax`|`double`|--|Maximum Q value to use when Fourier-transforming the reference $F(Q)$ to its $G(r)$|
+|`ReferenceFTQMin`|`double`|--|Minimum Q value to use when Fourier-transforming the reference $F(Q)$ to its $G(r)$|
 |`ReferenceNormalisation`|[`NormalisationType`]({{< ref "normalisationtype" >}})|`None`|Assumed normalisation type to remove from the reference total structure factor data once loaded|
 |`ReferenceWindowFunction`|[`WindowFunction`]({{< ref "windowfunction" >}})|`Lorch0`|Window function to apply when Fourier-transforming reference $F(Q)$ to a reference $g(r)$|
 

--- a/web/content/docs/modules/correlation/neutronsq/_index.md
+++ b/web/content/docs/modules/correlation/neutronsq/_index.md
@@ -59,4 +59,5 @@ Keyword|Arguments|Default|Description|
 |:------|:-------:|:-----:|-----------|
 |`SaveGR`|`true|false`|`false`|Save weighted g(r) and G(r). Separate files are written for each partial between atom types $i$ and $j$, as well as the total.||
 |`SaveReference`|`true|false`|`false`|Save the reference data and its Fourier transform|
+|`SaveRepresentativeGR`|`true|false`|`false`|Save the representative $G(r)$ obtained from Fourier transform of the calculate $F(Q)$|
 |`SaveSQ`|`true|false`|`false`|Save weighted partial and total structure factors. Separate files are written for each partial between atom types $i$ and $j$, as well as the total.|

--- a/web/content/docs/modules/correlation/xraysq/_index.md
+++ b/web/content/docs/modules/correlation/xraysq/_index.md
@@ -53,4 +53,5 @@ Keyword|Arguments|Default|Description|
 |`SaveFormFactors`|`true|false`|`false`|Save Q-dependent form factors for each atom type pair|
 |`SaveGR`|`true|false`|`false`|Save weighted g(r) and G(r). Separate files are written for each partial between atom types $i$ and $j$, as well as the total.||
 |`SaveReference`|`true|false`|`false`|Save the reference data and its Fourier transform|
+|`SaveRepresentativeGR`|`true|false`|`false`|Save the representative $G(r)$ obtained from Fourier transform of the calculate $F(Q)$|
 |`SaveSQ`|`true|false`|`false`|Save weighted partial and total structure factors. Separate files are written for each partial between atom types $i$ and $j$, as well as the total.|

--- a/web/content/docs/modules/correlation/xraysq/_index.md
+++ b/web/content/docs/modules/correlation/xraysq/_index.md
@@ -41,6 +41,9 @@ The application of instrumental broadening is the responsibility of the source [
 Keyword|Arguments|Default|Description|
 |:------|:-------:|:-----:|-----------|
 |`Reference`|[`Data1DFileAndFormat`]({{< ref "data1dformat" >}})|--|Format and filename of reference $F(Q)$ data, to be displayed in the GUI alongside calculated data, and made available for other modules to utilise (e.g. [`EPSR`]({{< ref "epsr" >}})|
+|`ReferenceFTDeltaR`|`double`|0.05|Spacing in $r$ to use when generating the Fourier-transform of the $F(Q)$|
+|`ReferenceFTQMax`|`double`|--|Maximum Q value to use when Fourier-transforming the reference $F(Q)$ to its $G(r)$|
+|`ReferenceFTQMin`|`double`|--|Minimum Q value to use when Fourier-transforming the reference $F(Q)$ to its $G(r)$|
 |`ReferenceNormalisation`|[`NormalisationType`]({{< ref "normalisationtype" >}})|`None`|Assumed normalisation type to remove from the reference total structure factor data once loaded|
 |`ReferenceWindowFunction`|[`WindowFunction`]({{< ref "function1d" >}})|`Lorch0`|Window function to apply when Fourier-transforming reference $F(Q)$ to a reference $g(r)$|
 

--- a/web/content/docs/reference/fileandformat/data1dformat.md
+++ b/web/content/docs/reference/fileandformat/data1dformat.md
@@ -19,12 +19,13 @@ description: One-dimensional data import/export
 |:------|:--:|:-----:|-----------|
 |`Error`|`int`|--|Column index in the file from which to read error values|
 |`RemoveAverage`|`double`|--|Starting $x$ value from which to form an average $y$ value to subtract from the data|
-|`Trim`|`$x_{min}$`</br>`$x_{max}$`|--|Discard any data points outside of the range specified|
+|`XMin`|`$x_{min}$`|--|Discard any data points with $x$ values below the value specified|
+|`XMax`|`$x_{max}$`|--|Discard any data points with $x$ values above the value specified|
 |`X`|`int`|`1`|Column index in the file from which to read $x$ values|
 |`Y`|`int`|`2`|Column index in the file from which to read $y$ values|
 
 Note that if multiple keywords that modify the data are supplied, the order of operation is:
 
 1. Remove points from the beginning of the data (controlled by `RemovePoints`)
-2. Trim $x$ range of data (controlled by `Trim`)
+2. Trim $x$ range of data (controlled by `XMin` and `XMax`)
 3. Form and subtract average level (controlled by `RemoveAverage`)


### PR DESCRIPTION
This bugfix PR addresses a few issues discovered while using the code in production, and fixes one oustanding known issue.

Summary of issues addressed:
- Improper energy was not stored in the restart file alongside other quantities.
- Specifying a range when importing `Data1D` was completely broken.
- R-factors in the `EPSRModule` were calculated over the whole data range, as opposed to the fit range a la EPSR.
- There was no control over the range when Fourier transforming input experimental data - this is now allowed and tested.
- A specific option to save the representative G(r) from the `NeutronSQ` and `XRaySQ` modules has been added (closes #589).

