### PR TITLE
Remove ListItem dependency from SiteStack

### DIFF
--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -198,7 +198,7 @@ class Configuration : public ListItem<Configuration>
      */
     private:
     // List of current SiteStacks
-    List<SiteStack> siteStacks_;
+    std::vector<std::unique_ptr<SiteStack>> siteStacks_;
 
     public:
     // Calculate / retrieve stack of sites for specified SpeciesSite

--- a/src/classes/configuration_sites.cpp
+++ b/src/classes/configuration_sites.cpp
@@ -13,7 +13,7 @@ const SiteStack *Configuration::siteStack(SpeciesSite *site)
                            [site](const auto &stack) { return stack->speciesSite() == site; });
     if (it == siteStacks_.end())
     {
-        siteStacks_.emplace_back();
+        siteStacks_.emplace_back(std::make_unique<SiteStack>());
         it = siteStacks_.end() - 1;
     }
 

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -9,7 +9,7 @@
 #include "data/atomicmasses.h"
 #include <numeric>
 
-SiteStack::SiteStack() : ListItem<SiteStack>()
+SiteStack::SiteStack()
 {
     configuration_ = nullptr;
     configurationIndex_ = -1;

--- a/src/classes/sitestack.h
+++ b/src/classes/sitestack.h
@@ -14,7 +14,7 @@ class SpeciesSite;
 class Molecule;
 
 // Site Stack Definition
-class SiteStack : public ListItem<SiteStack>
+class SiteStack
 {
     public:
     SiteStack();

--- a/src/classes/sitestack.h
+++ b/src/classes/sitestack.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include "classes/site.h"
-#include "templates/array.h"
-#include "templates/listitem.h"
 
 // Forward Declarations
 class Box;

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -218,7 +218,7 @@ bool SelectProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std
     double r;
     for (SpeciesSite *site : speciesSites_)
     {
-        const SiteStack *siteStack = cfg->siteStack(site);
+        const auto *siteStack = cfg->siteStack(site);
         if (siteStack == nullptr)
             return false;
 


### PR DESCRIPTION
Just a small PR to put SiteStacks in a proper vector.  I went with `unique_ptr` against because I had some issues with references getting invalidated on my first attempt.  This is another part of #257.