### PR TITLE
Remove ListItem base from Configuration

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -10,7 +10,7 @@
 #include "classes/species.h"
 #include "modules/energy/energy.h"
 
-Configuration::Configuration() : ListItem<Configuration>(), generator_(ProcedureNode::GenerationContext, "EndGenerator")
+Configuration::Configuration() : generator_(ProcedureNode::GenerationContext, "EndGenerator")
 {
     box_ = nullptr;
 

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -29,7 +29,7 @@ class ProcessPool;
 class Species;
 
 // Configuration
-class Configuration : public ListItem<Configuration>
+class Configuration
 {
     public:
     Configuration();

--- a/src/classes/coredata.cpp
+++ b/src/classes/coredata.cpp
@@ -399,9 +399,9 @@ Configuration *CoreData::addConfiguration()
 // Remove specified Configuration
 void CoreData::removeConfiguration(Configuration *cfg)
 {
-    auto it = std::find_if(configurations_.begin(), configurations_.end(), [cfg](const auto &c) { return cfg == c.get(); });
-    if (it != configurations_.end())
-        configurations_.erase(it);
+    configurations_.erase(
+        std::remove_if(configurations_.begin(), configurations_.end(), [cfg](const auto &c) { return cfg == c.get(); }),
+        configurations_.end());
 }
 
 // Return number of Configurations in list

--- a/src/classes/coredata.cpp
+++ b/src/classes/coredata.cpp
@@ -388,27 +388,32 @@ Species *CoreData::findSpecies(std::string_view name) const
 // Add new Configuration
 Configuration *CoreData::addConfiguration()
 {
-    Configuration *newConfiguration = configurations_.add();
+    auto &newConfiguration = configurations_.emplace_back(std::make_unique<Configuration>());
 
     // Create a suitable unique name
     newConfiguration->setName(uniqueConfigurationName("NewConfiguration"));
 
-    return newConfiguration;
+    return newConfiguration.get();
 }
 
 // Remove specified Configuration
-void CoreData::removeConfiguration(Configuration *cfg) { configurations_.remove(cfg); }
+void CoreData::removeConfiguration(Configuration *cfg)
+{
+    auto it = std::find_if(configurations_.begin(), configurations_.end(), [cfg](const auto &c) { return cfg == c.get(); });
+    if (it != configurations_.end())
+        configurations_.erase(it);
+}
 
 // Return number of Configurations in list
-int CoreData::nConfigurations() const { return configurations_.nItems(); }
+int CoreData::nConfigurations() const { return configurations_.size(); }
 
 // Return core Configurations list
-List<Configuration> &CoreData::configurations() { return configurations_; }
+std::vector<std::unique_ptr<Configuration>> &CoreData::configurations() { return configurations_; }
 
-const List<Configuration> &CoreData::configurations() const { return configurations_; }
+const std::vector<std::unique_ptr<Configuration>> &CoreData::configurations() const { return configurations_; }
 
 // Return nth Configuration in list
-Configuration *CoreData::configuration(int n) { return configurations_[n]; }
+Configuration *CoreData::configuration(int n) { return configurations_[n].get(); }
 
 // Generate unique Configuration name with base name provided
 std::string CoreData::uniqueConfigurationName(std::string_view base) const
@@ -431,11 +436,11 @@ std::string CoreData::uniqueConfigurationName(std::string_view base) const
 // Search for Configuration by name
 Configuration *CoreData::findConfiguration(std::string_view name) const
 {
-    for (auto *cfg = configurations_.first(); cfg != nullptr; cfg = cfg->next())
-        if (DissolveSys::sameString(cfg->name(), name))
-            return cfg;
-
-    return nullptr;
+    auto it = std::find_if(configurations_.begin(), configurations_.end(),
+                           [&name](const auto &cfg) { return DissolveSys::sameString(cfg->name(), name); });
+    if (it == configurations_.end())
+        return nullptr;
+    return it->get();
 }
 
 /*

--- a/src/classes/coredata.h
+++ b/src/classes/coredata.h
@@ -149,7 +149,7 @@ class CoreData
      */
     private:
     // Core Configurations list
-    List<Configuration> configurations_;
+    std::vector<std::unique_ptr<Configuration>> configurations_;
 
     public:
     // Add new Configuration
@@ -159,8 +159,8 @@ class CoreData
     // Return number of Configuration in list
     int nConfigurations() const;
     // Return core Configuration list
-    List<Configuration> &configurations();
-    const List<Configuration> &configurations() const;
+    std::vector<std::unique_ptr<Configuration>> &configurations();
+    const std::vector<std::unique_ptr<Configuration>> &configurations() const;
     // Return nth Configuration in list
     Configuration *configuration(int n);
     // Generate unique Configuration name with base name provided

--- a/src/gui/getconfigurationnamedialog_funcs.cpp
+++ b/src/gui/getconfigurationnamedialog_funcs.cpp
@@ -42,10 +42,9 @@ void GetConfigurationNameDialog::on_NameEdit_textChanged(const QString text)
         nameValid = false;
     else
     {
-        ListIterator<Configuration> configIterator(coreData_.configurations());
-        while (Configuration *cfg = configIterator.iterate())
+        for (auto &cfg : coreData_.configurations())
         {
-            if (configuration_ == cfg)
+            if (configuration_ == cfg.get())
                 continue;
 
             if (DissolveSys::sameString(cfg->name(), qPrintable(text)))

--- a/src/gui/keywordwidgets/configurationreflist_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationreflist_funcs.cpp
@@ -39,7 +39,7 @@ ConfigurationRefListKeywordWidget::ConfigurationRefListKeywordWidget(QWidget *pa
 void ConfigurationRefListKeywordWidget::updateSelectionRow(int row, Configuration *cfg, bool createItem)
 {
     // Grab the target reference list
-    RefList<Configuration> &selection = keyword_->data();
+    auto &selection = keyword_->data();
 
     QListWidgetItem *item;
     if (createItem)
@@ -51,7 +51,8 @@ void ConfigurationRefListKeywordWidget::updateSelectionRow(int row, Configuratio
     }
     else
         item = ui_.SelectionList->item(row);
-    item->setCheckState(selection.contains(cfg) ? Qt::Checked : Qt::Unchecked);
+    bool contains = std::find(selection.begin(), selection.end(), cfg) != selection.end();
+    item->setCheckState(contains ? Qt::Checked : Qt::Unchecked);
 }
 
 // List item changed
@@ -136,12 +137,12 @@ void ConfigurationRefListKeywordWidget::updateWidgetValues(const CoreData &coreD
 void ConfigurationRefListKeywordWidget::updateKeywordData()
 {
     // Loop over items in the QListWidget, adding the associated Configurations for any that are checked
-    RefList<Configuration> newSelection;
+    std::vector<Configuration *> newSelection;
     for (auto n = 0; n < ui_.SelectionList->count(); ++n)
     {
         QListWidgetItem *item = ui_.SelectionList->item(n);
         if (item->checkState() == Qt::Checked)
-            newSelection.append(VariantPointer<Configuration>(item->data(Qt::UserRole)));
+            newSelection.push_back(VariantPointer<Configuration>(item->data(Qt::UserRole)));
     }
     keyword_->setData(newSelection);
 }
@@ -150,13 +151,13 @@ void ConfigurationRefListKeywordWidget::updateKeywordData()
 void ConfigurationRefListKeywordWidget::updateSummaryText()
 {
     // Create summary text for the KeywordDropDown button
-    RefList<Configuration> &selection = keyword_->data();
-    if (selection.nItems() == 0)
+    auto &selection = keyword_->data();
+    if (selection.size() == 0)
         setSummaryText("<None>");
     else
     {
         QString summaryText;
-        for (Configuration *cfg : selection)
+        for (auto *cfg : selection)
             summaryText +=
                 QString("%1%2").arg(summaryText.isEmpty() ? "" : ", ").arg(QString::fromStdString(std::string(cfg->name())));
 

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -224,16 +224,15 @@ void MainTabsWidget::reconcileTabs(DissolveWindow *dissolveWindow)
     baseIndex += dissolve.nSpecies();
 
     // Configurations - Global tab indices run from 1+nSpecies (first tab after last Species) to 1+nSpecies+nConfigurations
-    ListIterator<Configuration> configurationIterator(dissolve.configurations());
     currentTabIndex = 0;
-    while (Configuration *cfg = configurationIterator.iterate())
+    for (auto &cfg : dissolve.configurations())
     {
         // Loop over existing tabs
         while (currentTabIndex < configurationTabs_.size())
         {
             // If the existing tab is displaying the current Configuration already, then we can move on. Otherwise,
             // delete it
-            if (configurationTabs_[currentTabIndex]->configuration() == cfg)
+            if (configurationTabs_[currentTabIndex]->configuration() == cfg.get())
                 break;
             else
             {
@@ -246,7 +245,7 @@ void MainTabsWidget::reconcileTabs(DissolveWindow *dissolveWindow)
         if (currentTabIndex == configurationTabs_.size())
         {
             QString tabTitle = QString::fromStdString(std::string(cfg->name()));
-            auto newTab = std::make_shared<ConfigurationTab>(dissolveWindow, dissolve, this, tabTitle, cfg);
+            auto newTab = std::make_shared<ConfigurationTab>(dissolveWindow, dissolve, this, tabTitle, cfg.get());
             configurationTabs_.push_back(newTab);
             allTabs_.push_back(newTab);
             insertTab(baseIndex + currentTabIndex, newTab, tabTitle);

--- a/src/gui/modulelisteditor_funcs.cpp
+++ b/src/gui/modulelisteditor_funcs.cpp
@@ -251,10 +251,9 @@ void ModuleListEditor::on_AvailableModulesTree_itemDoubleClicked(QTreeWidgetItem
             newInstance->addTargetConfiguration(localConfiguration_);
         else
         {
-            ListIterator<Configuration> configIterator(dissolveWindow_->dissolve().configurations());
-            while (Configuration *cfg = configIterator.iterate())
+            for (auto &cfg : dissolveWindow_->dissolve().configurations())
             {
-                newInstance->addTargetConfiguration(cfg);
+                newInstance->addTargetConfiguration(cfg.get());
                 if ((newInstance->nRequiredTargets() != Module::OneOrMoreTargets) &&
                     (newInstance->nRequiredTargets() == newInstance->nTargetConfigurations()))
                     break;

--- a/src/gui/selectconfigurationdialog.h
+++ b/src/gui/selectconfigurationdialog.h
@@ -35,5 +35,5 @@ class SelectConfigurationDialog : public QDialog
     // Run the dialog, returning a single selected Configuration
     Configuration *selectConfiguration();
     // Run the dialog, returning a list of selected Configuration
-    RefList<Configuration> selectConfiguration(int minConfiguration, int maxConfiguration);
+    std::vector<Configuration *> selectConfiguration(int minConfiguration, int maxConfiguration);
 };

--- a/src/gui/selectconfigurationdialog_funcs.cpp
+++ b/src/gui/selectconfigurationdialog_funcs.cpp
@@ -26,7 +26,7 @@ void SelectConfigurationDialog::on_ConfigurationWidget_speciesSelectionChanged(b
 void SelectConfigurationDialog::on_ConfigurationWidget_speciesDoubleClicked()
 {
     // Check current selection size for validity
-    if (ui_.ConfigurationWidget->currentConfiguration().nItems() != 1)
+    if (ui_.ConfigurationWidget->currentConfiguration().size() != 1)
         return;
 
     accept();
@@ -44,13 +44,13 @@ Configuration *SelectConfigurationDialog::selectConfiguration()
     show();
 
     if (exec() == QDialog::Accepted)
-        return ui_.ConfigurationWidget->currentConfiguration().firstItem();
+        return ui_.ConfigurationWidget->currentConfiguration().front();
     else
         return nullptr;
 }
 
 // Run the dialog, returning a list of selected Configuration
-RefList<Configuration> SelectConfigurationDialog::selectConfiguration(int minConfiguration, int maxConfiguration)
+std::vector<Configuration *> SelectConfigurationDialog::selectConfiguration(int minConfiguration, int maxConfiguration)
 {
     ui_.ConfigurationWidget->reset(minConfiguration, maxConfiguration);
 
@@ -59,5 +59,5 @@ RefList<Configuration> SelectConfigurationDialog::selectConfiguration(int minCon
     if (exec() == QDialog::Accepted)
         return ui_.ConfigurationWidget->currentConfiguration();
     else
-        return RefList<Configuration>();
+        return {};
 }

--- a/src/gui/selectconfigurationwidget.h
+++ b/src/gui/selectconfigurationwidget.h
@@ -75,5 +75,5 @@ class SelectConfigurationWidget : public QWidget
     // Return number of species currently selected
     int nSelected() const;
     // Return the currently-selected Configuration
-    RefList<Configuration> currentConfiguration() const;
+    std::vector<Configuration *> currentConfiguration() const;
 };

--- a/src/gui/selectconfigurationwidget_funcs.cpp
+++ b/src/gui/selectconfigurationwidget_funcs.cpp
@@ -111,9 +111,9 @@ int SelectConfigurationWidget::nSelected() const
 }
 
 // Return the currently-selected Configuration
-RefList<Configuration> SelectConfigurationWidget::currentConfiguration() const
+std::vector<Configuration *> SelectConfigurationWidget::currentConfiguration() const
 {
-    RefList<Configuration> selection;
+    std::vector<Configuration *> selection;
 
     // Loop over items in the list and construct the selection RefList
     for (auto n = 0; n < ui_.ConfigurationList->count(); ++n)
@@ -121,7 +121,7 @@ RefList<Configuration> SelectConfigurationWidget::currentConfiguration() const
         QListWidgetItem *item = ui_.ConfigurationList->item(n);
 
         if (item->isSelected())
-            selection.append(VariantPointer<Configuration>(item->data(Qt::UserRole)));
+            selection.push_back(VariantPointer<Configuration>(item->data(Qt::UserRole)));
     }
 
     return selection;

--- a/src/keywords/atomtypeselection.cpp
+++ b/src/keywords/atomtypeselection.cpp
@@ -8,7 +8,8 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 
-AtomTypeSelectionKeyword::AtomTypeSelectionKeyword(AtomTypeList &selection, const std::vector<Configuration *> &sourceConfigurations)
+AtomTypeSelectionKeyword::AtomTypeSelectionKeyword(AtomTypeList &selection,
+                                                   const std::vector<Configuration *> &sourceConfigurations)
     : KeywordData<AtomTypeList &>(KeywordBase::AtomTypeSelectionData, selection), sourceConfigurations_(sourceConfigurations)
 {
 }

--- a/src/keywords/atomtypeselection.cpp
+++ b/src/keywords/atomtypeselection.cpp
@@ -8,7 +8,7 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 
-AtomTypeSelectionKeyword::AtomTypeSelectionKeyword(AtomTypeList &selection, const RefList<Configuration> &sourceConfigurations)
+AtomTypeSelectionKeyword::AtomTypeSelectionKeyword(AtomTypeList &selection, const std::vector<Configuration *> &sourceConfigurations)
     : KeywordData<AtomTypeList &>(KeywordBase::AtomTypeSelectionData, selection), sourceConfigurations_(sourceConfigurations)
 {
 }

--- a/src/keywords/atomtypeselection.h
+++ b/src/keywords/atomtypeselection.h
@@ -14,7 +14,7 @@ class Configuration;
 class AtomTypeSelectionKeyword : public KeywordData<AtomTypeList &>
 {
     public:
-    AtomTypeSelectionKeyword(AtomTypeList &selection_, const RefList<Configuration> &sourceConfigurations);
+    AtomTypeSelectionKeyword(AtomTypeList &selection_, const std::vector<Configuration *> &sourceConfigurations);
     ~AtomTypeSelectionKeyword() override;
 
     /*
@@ -22,7 +22,7 @@ class AtomTypeSelectionKeyword : public KeywordData<AtomTypeList &>
      */
     private:
     // Source Configurations from which we take our valid AtomTypes
-    const RefList<Configuration> &sourceConfigurations_;
+    const std::vector<Configuration *> &sourceConfigurations_;
 
     public:
     // Determine whether current data is 'empty', and should be considered as 'not set'

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -19,7 +19,7 @@ ConfigurationRefListKeyword::~ConfigurationRefListKeyword() = default;
  */
 
 // Determine whether current data is 'empty', and should be considered as 'not set'
-bool ConfigurationRefListKeyword::isDataEmpty() const { return data_.size() == 0; }
+bool ConfigurationRefListKeyword::isDataEmpty() const { return data_.empty(); }
 
 // Return maximum number of Configurations to allow in the list
 int ConfigurationRefListKeyword::maxListSize() const { return maxListSize_; }

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -6,8 +6,8 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 
-ConfigurationRefListKeyword::ConfigurationRefListKeyword(RefList<Configuration> &references, int maxListSize)
-    : KeywordData<RefList<Configuration> &>(KeywordBase::ConfigurationRefListData, references)
+ConfigurationRefListKeyword::ConfigurationRefListKeyword(std::vector<Configuration *> &references, int maxListSize)
+    : KeywordData<std::vector<Configuration *> &>(KeywordBase::ConfigurationRefListData, references)
 {
     maxListSize_ = maxListSize;
 }
@@ -19,7 +19,7 @@ ConfigurationRefListKeyword::~ConfigurationRefListKeyword() = default;
  */
 
 // Determine whether current data is 'empty', and should be considered as 'not set'
-bool ConfigurationRefListKeyword::isDataEmpty() const { return data_.nItems() == 0; }
+bool ConfigurationRefListKeyword::isDataEmpty() const { return data_.size() == 0; }
 
 // Return maximum number of Configurations to allow in the list
 int ConfigurationRefListKeyword::maxListSize() const { return maxListSize_; }
@@ -46,14 +46,14 @@ bool ConfigurationRefListKeyword::read(LineParser &parser, int startArg, const C
                                     parser.argsv(n));
 
         // Check maximum size of list
-        if ((maxListSize_ != -1) && (data_.nItems() >= maxListSize_))
+        if ((maxListSize_ != -1) && (data_.size() >= maxListSize_))
             return Messenger::error("Too many configurations given to keyword. Maximum allowed is {}.\n", maxListSize_);
 
         // Check that the configuration isn't already in the list
-        if (data_.contains(cfg))
+        if (std::find(data_.begin(), data_.end(), cfg) != data_.end())
             return Messenger::error("Configuration '{}' is already present in the list.\n", cfg->name());
 
-        data_.append(cfg);
+        data_.push_back(cfg);
     }
 
     set_ = true;
@@ -80,4 +80,8 @@ bool ConfigurationRefListKeyword::write(LineParser &parser, std::string_view key
  */
 
 // Prune any references to the supplied Configuration in the contained data
-void ConfigurationRefListKeyword::removeReferencesTo(Configuration *cfg) { data_.remove(cfg); }
+void ConfigurationRefListKeyword::removeReferencesTo(Configuration *cfg)
+{
+    auto it = std::find(data_.begin(), data_.end(), cfg);
+    data_.erase(it);
+}

--- a/src/keywords/configurationreflist.cpp
+++ b/src/keywords/configurationreflist.cpp
@@ -82,6 +82,5 @@ bool ConfigurationRefListKeyword::write(LineParser &parser, std::string_view key
 // Prune any references to the supplied Configuration in the contained data
 void ConfigurationRefListKeyword::removeReferencesTo(Configuration *cfg)
 {
-    auto it = std::find(data_.begin(), data_.end(), cfg);
-    data_.erase(it);
+    data_.erase(std::remove(data_.begin(), data_.end(), cfg), data_.end());
 }

--- a/src/keywords/configurationreflist.h
+++ b/src/keywords/configurationreflist.h
@@ -11,10 +11,10 @@
 class Configuration;
 
 // Keyword with Configuration RefList Data
-class ConfigurationRefListKeyword : public KeywordData<RefList<Configuration> &>
+class ConfigurationRefListKeyword : public KeywordData<std::vector<Configuration *> &>
 {
     public:
-    ConfigurationRefListKeyword(RefList<Configuration> &references, int maxListSize);
+    ConfigurationRefListKeyword(std::vector<Configuration *> &references, int maxListSize);
     ~ConfigurationRefListKeyword() override;
 
     /*

--- a/src/main/comms.cpp
+++ b/src/main/comms.cpp
@@ -35,7 +35,7 @@ bool Dissolve::setUpMPIPools()
 
     // Set up pool based on selected strategy
     auto cfgIndex = 0;
-    for (auto *cfg = coreData_.configurations().first(); cfg != nullptr; cfg = cfg->next())
+    for (auto &cfg : coreData_.configurations())
     {
         Messenger::print("Configuration '{}':\n", cfg->name());
 

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -162,8 +162,8 @@ class Dissolve
     // Return number of defined Configurations
     int nConfigurations() const;
     // Return Configuration list
-    List<Configuration> &configurations();
-    const List<Configuration> &configurations() const;
+    std::vector<std::unique_ptr<Configuration>> &configurations();
+    const std::vector<std::unique_ptr<Configuration>> &configurations() const;
     // Find configuration by name
     Configuration *findConfiguration(std::string_view name) const;
     // Find configuration by 'nice' name

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -282,7 +282,7 @@ bool Dissolve::saveInput(std::string_view filename)
     // Write Configurations
     if (!parser.writeBannerComment("Configurations"))
         return false;
-    for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
+    for (auto &cfg : configurations())
     {
         if (!parser.writeLineF("\n{}  '{}'\n", BlockKeywords::keywords().keyword(BlockKeywords::ConfigurationBlockKeyword),
                                cfg->name()))
@@ -622,7 +622,7 @@ bool Dissolve::saveRestart(std::string_view filename)
         return false;
 
     // Configurations
-    for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
+    for (const auto &cfg : configurations())
     {
         if (!parser.writeLineF("Configuration  '{}'\n", cfg->name()))
             return false;

--- a/src/main/objects.cpp
+++ b/src/main/objects.cpp
@@ -29,8 +29,7 @@ void Dissolve::removeReferencesTo(Species *sp)
     KeywordBase::objectNoLongerValid<Species>(sp);
 
     // Check Configurations - if the Species was used, we must clear the configuration contents
-    ListIterator<Configuration> configIterator(configurations());
-    while (Configuration *cfg = configIterator.iterate())
+    for (auto &cfg : configurations())
         if (cfg->containsSpecies(sp))
             cfg->empty();
 }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -44,7 +44,7 @@ bool Dissolve::prepare()
         at->setIndex(count++);
 
     // Check Configurations
-    for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
+    for (auto &cfg : configurations())
     {
         // Check Box extent against pair potential range
         auto maxPPRange = cfg->box()->inscribedSphereRadius();
@@ -175,7 +175,7 @@ bool Dissolve::iterate(int nIterations)
          */
         Messenger::banner("Configuration Upkeep");
 
-        for (auto *cfg = configurations().first(); cfg != nullptr; cfg = cfg->next())
+        for (auto &cfg : configurations())
         {
             Messenger::heading("'{}'", cfg->name());
 

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -139,9 +139,9 @@ bool Module::isDisabled() const { return !enabled_; }
 bool Module::addTargetConfiguration(Configuration *cfg)
 {
     // Check how many Configurations we accept before we do anything else
-    if ((nRequiredTargets() == Module::OneOrMoreTargets) || (targetConfigurations_.nItems() < nRequiredTargets()))
+    if ((nRequiredTargets() == Module::OneOrMoreTargets) || (targetConfigurations_.size() < nRequiredTargets()))
     {
-        targetConfigurations_.append(cfg);
+        targetConfigurations_.push_back(cfg);
         keywords_.setAsModified("Configuration");
         return true;
     }
@@ -195,17 +195,18 @@ bool Module::addTargetConfigurations(const std::vector<std::unique_ptr<Configura
 // Remove Configuration target
 bool Module::removeTargetConfiguration(Configuration *cfg)
 {
-    if (!targetConfigurations_.contains(cfg))
+    auto it = std::find(targetConfigurations_.begin(), targetConfigurations_.end(), cfg);
+    if (it == targetConfigurations_.end())
         return Messenger::error("Can't remove Configuration '{}' from Module '{}' as it isn't currently a target.\n",
                                 cfg->name(), uniqueName());
 
-    targetConfigurations_.remove(cfg);
+    targetConfigurations_.erase(it);
 
     return true;
 }
 
 // Return number of targeted Configurations
-int Module::nTargetConfigurations() const { return targetConfigurations_.nItems(); }
+int Module::nTargetConfigurations() const { return targetConfigurations_.size(); }
 
 // Return whether the number of targeted Configurations is valid
 bool Module::hasValidNTargetConfigurations(bool reportError) const
@@ -238,10 +239,13 @@ bool Module::hasValidNTargetConfigurations(bool reportError) const
 }
 
 // Return first targeted Configuration
-const RefList<Configuration> &Module::targetConfigurations() const { return targetConfigurations_; }
+const std::vector<Configuration *> &Module::targetConfigurations() const { return targetConfigurations_; }
 
 // Return if the specified Configuration is in the targets list
-bool Module::isTargetConfiguration(Configuration *cfg) const { return targetConfigurations_.contains(cfg); }
+bool Module::isTargetConfiguration(Configuration *cfg) const
+{
+    return std::find(targetConfigurations_.begin(), targetConfigurations_.end(), cfg) != targetConfigurations_.end();
+}
 
 // Copy Configuration targets from specified Module
 void Module::copyTargetConfigurations(Module *sourceModule)

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -161,33 +161,31 @@ bool Module::addTargetConfiguration(Configuration *cfg)
 }
 
 // Add Configuration targets
-bool Module::addTargetConfigurations(const List<Configuration> &configs)
+bool Module::addTargetConfigurations(const std::vector<std::unique_ptr<Configuration>> &configs)
 {
     if (nRequiredTargets() == Module::ZeroTargets)
         return Messenger::error("Module targets no configurations, so none will be set from the {} provided.\n",
-                                configs.nItems());
+                                configs.size());
     else if (nRequiredTargets() == Module::OneOrMoreTargets)
     {
-        Messenger::print("Adding {} configurations as targets for module '{}'...\n", configs.nItems(), uniqueName());
+        Messenger::print("Adding {} configurations as targets for module '{}'...\n", configs.size(), uniqueName());
 
-        ListIterator<Configuration> configIterator(configs);
-        while (Configuration *cfg = configIterator.iterate())
-            if (!addTargetConfiguration(cfg))
+        for (auto &cfg : configs)
+            if (!addTargetConfiguration(cfg.get()))
                 return Messenger::error("Failed to add configuration '{}' to module '{}'.\n", cfg->name(), uniqueName());
     }
     else if (nTargetConfigurations() == nRequiredTargets())
         return Messenger::error("Refusing to add any of the {} provided configurations as targets for the module '{}' "
                                 "as it already has it's specified number ({}).\n",
-                                configs.nItems(), uniqueName(), nRequiredTargets());
+                                configs.size(), uniqueName(), nRequiredTargets());
     else
     {
         auto spaces = nRequiredTargets() - nTargetConfigurations();
         Messenger::print("Adding up to {} configurations from the {} provided as targets for module '{}'...\n", spaces,
-                         configs.nItems(), uniqueName());
+                         configs.size(), uniqueName());
 
-        ListIterator<Configuration> configIterator(configs);
-        while (Configuration *cfg = configIterator.iterate())
-            if (!addTargetConfiguration(cfg))
+        for (auto &cfg : configs)
+            if (!addTargetConfiguration(cfg.get()))
                 return Messenger::error("Failed to add configuration '{}' to module '{}'.\n", cfg->name(), uniqueName());
     }
 

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -116,7 +116,7 @@ class Module : public ListItem<Module>
      */
     protected:
     // Configurations that are targeted by this Module
-    RefList<Configuration> targetConfigurations_;
+    std::vector<Configuration *> targetConfigurations_;
     // Whether this module is a local Module in a Configuration
     bool configurationLocal_;
 
@@ -132,7 +132,7 @@ class Module : public ListItem<Module>
     // Return whether the number of targeted Configurations is valid
     bool hasValidNTargetConfigurations(bool reportError = false) const;
     // Return targeted Configurations
-    const RefList<Configuration> &targetConfigurations() const;
+    const std::vector<Configuration *> &targetConfigurations() const;
     // Return if the specified Configuration is in the targets list
     bool isTargetConfiguration(Configuration *cfg) const;
     // Copy Configuration targets from specified Module

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -124,7 +124,7 @@ class Module : public ListItem<Module>
     // Add Configuration target
     bool addTargetConfiguration(Configuration *cfg);
     // Add Configuration targets
-    bool addTargetConfigurations(const List<Configuration> &configs);
+    bool addTargetConfigurations(const std::vector<std::unique_ptr<Configuration>> &configs);
     // Remove Configuration target
     bool removeTargetConfiguration(Configuration *cfg);
     // Return number of targeted Configurations

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -9,15 +9,12 @@
 bool AnalyseModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.size() == 0)
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -9,7 +9,7 @@
 bool AnalyseModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.size() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations

--- a/src/modules/atomshake/process.cpp
+++ b/src/modules/atomshake/process.cpp
@@ -21,7 +21,7 @@ bool AtomShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -15,7 +15,7 @@
 bool BenchmarkModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Get options

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -21,7 +21,7 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-  if (targetConfigurations_.empty())
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
     auto *cfg = targetConfigurations_.front();
 

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -21,9 +21,9 @@ bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+  if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     const auto averaging = keywords_.asInt("Averaging");
     auto averagingScheme = Averaging::averagingSchemes().enumeration(keywords_.asString("AveragingScheme"));

--- a/src/modules/calculate_angle/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_angle/gui/modulewidget_funcs.cpp
@@ -117,7 +117,7 @@ void CalculateAngleModuleWidget::setGraphDataTargets(CalculateAngleModule *modul
     dAngleBCGraph_->clearRenderables();
 
     // Get Configuration target
-    Configuration *cfg = module_->targetConfigurations().firstItem();
+    Configuration *cfg = module_->targetConfigurations().front();
     if (!cfg)
         return;
 

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { re
 bool CalculateAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
@@ -44,7 +44,7 @@ bool CalculateAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
         selectC_->setKeyword<std::vector<const ProcedureNode *>>("ExcludeSameSite", {selectA_});
 
     // Grab Configuration pointer
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -58,11 +58,11 @@ bool CalculateAvgMolModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
 bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Grab Configuration and Box pointers
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
     const auto *box = cfg->box();
 
     // Set up process pool - must do this to ensure we are using all available processes

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateAxisAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) 
 bool CalculateAxisAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.size() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateAxisAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) 
 bool CalculateAxisAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.size() == 0)
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
@@ -30,7 +30,7 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, ProcessPool &procPool
         selectB_->setKeyword<std::vector<const ProcedureNode *>>("ExcludeSameMolecule", {selectA_});
 
     // Grab Configuration pointer
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateDAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { r
 bool CalculateDAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.size() == 0)
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
@@ -30,7 +30,7 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
         selectC_->setKeyword<std::vector<const ProcedureNode *>>("ExcludeSameMolecule", {selectA_});
 
     // Grab Configuration pointer
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateDAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { r
 bool CalculateDAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.size() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly

--- a/src/modules/calculate_rdf/process.cpp
+++ b/src/modules/calculate_rdf/process.cpp
@@ -15,7 +15,7 @@ bool CalculateRDFModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { retu
 bool CalculateRDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
@@ -26,7 +26,7 @@ bool CalculateRDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         selectB_->setKeyword<std::vector<const ProcedureNode *>>("ExcludeSameMolecule", {selectA_});
 
     // Grab Configuration pointer
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
@@ -82,7 +82,7 @@ void CalculateSDFModuleWidget::updateControls(ModuleWidget::UpdateType updateTyp
         sdfRenderable_ = sdfGraph_->createRenderable<RenderableData3D>(fmt::format("{}//Process3D//SDF", module_->uniqueName()),
                                                                        fmt::format("SDF"));
         sdfRenderable_->setColour(StockColours::BlueStockColour);
-        auto *cfg = module_->targetConfigurations().firstItem();
+        auto *cfg = module_->targetConfigurations().front();
         if (cfg)
         {
             auto lowerCutoff = (cfg->nMolecules() / cfg->box()->volume()) * 3.0;

--- a/src/modules/calculate_sdf/process.cpp
+++ b/src/modules/calculate_sdf/process.cpp
@@ -13,7 +13,7 @@
 bool CalculateSDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
@@ -28,7 +28,7 @@ bool CalculateSDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
         selectB_->setKeyword<std::vector<const ProcedureNode *>>("ExcludeSameMolecule", {selectA_});
 
     // Grab Configuration pointer
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -16,15 +16,12 @@ bool ChecksModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -92,7 +92,7 @@ class EnergyModule : public Module
     // Check energy stability of specified Configuration
     static EnergyStability checkStability(GenericList &processingData, const Configuration *cfg);
     // Check energy stability of specified Configurations, returning the number that are unstable
-    static int nUnstable(GenericList &processingData, const RefList<Configuration> &configurations);
+    static int nUnstable(GenericList &processingData, const std::vector<Configuration *> &configurations);
 
     /*
      * GUI Widget

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -313,7 +313,7 @@ EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processi
 }
 
 // Check energy stability of specified Configurations, returning the number that failed
-int EnergyModule::nUnstable(GenericList &processingData, const RefList<Configuration> &configurations)
+int EnergyModule::nUnstable(GenericList &processingData, const std::vector<Configuration *> &configurations)
 {
     auto nFailed = 0;
 

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -32,15 +32,12 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        auto *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
         auto strategy = procPool.bestStrategy();

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -53,12 +53,12 @@ bool EPSRModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
                                     "it's data in the EPSR module.",
                                     rdfModule->uniqueName());
 
-        if ((targetConfiguration_ != nullptr) && (targetConfiguration_ != rdfModule->targetConfigurations().firstItem()))
+        if ((targetConfiguration_ != nullptr) && (targetConfiguration_ != rdfModule->targetConfigurations().front()))
             return Messenger::error("RDF module '{}' targets a configuration which is different from another target "
                                     "module, and which is not permitted when using it's data in the EPSR module.",
                                     rdfModule->uniqueName());
         else
-            targetConfiguration_ = rdfModule->targetConfigurations().firstItem();
+            targetConfiguration_ = rdfModule->targetConfigurations().front();
 
         rho = targetConfiguration_->atomicDensity();
     }

--- a/src/modules/export_coordinates/process.cpp
+++ b/src/modules/export_coordinates/process.cpp
@@ -20,10 +20,10 @@ bool ExportCoordinatesModule::process(Dissolve &dissolve, ProcessPool &procPool)
         coordinatesFormat_.setFilename(fmt::format("{}.{}", coordinatesFormat_.filename(), dissolve.iteration()));
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/export_trajectory/process.cpp
+++ b/src/modules/export_trajectory/process.cpp
@@ -16,11 +16,11 @@ bool ExportTrajectoryModule::process(Dissolve &dissolve, ProcessPool &procPool)
         Messenger::error("No valid file/format set for trajectory export.\n");
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -38,15 +38,12 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 

--- a/src/modules/geomopt/process.cpp
+++ b/src/modules/geomopt/process.cpp
@@ -22,15 +22,12 @@ bool GeometryOptimisationModule::process(Dissolve &dissolve, ProcessPool &procPo
     Messenger::print("\n");
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 

--- a/src/modules/import_trajectory/process.cpp
+++ b/src/modules/import_trajectory/process.cpp
@@ -11,10 +11,10 @@
 bool ImportTrajectoryModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
-    auto *cfg = targetConfigurations_.firstItem();
+    auto *cfg = targetConfigurations_.front();
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(cfg->processPool());

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -23,15 +23,12 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -24,7 +24,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Get control parameters

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -23,15 +23,12 @@ bool MolShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto *cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 

--- a/src/modules/rdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/rdf/gui/modulewidget_funcs.cpp
@@ -101,7 +101,7 @@ void RDFModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
         }
         else if (ui_.ConfigurationPartialsButton->isChecked())
         {
-            auto targetPrefix = fmt::format("{}//UnweightedGR", optConfig.item()->niceName());
+            auto targetPrefix = fmt::format("{}//UnweightedGR", (*optConfig)->niceName());
             targetPartials_ = processingData_.valueIf<PartialSet>(targetPrefix, module_->uniqueName());
             createPartialSetRenderables(targetPrefix);
         }

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -20,7 +20,7 @@ bool RDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     const auto averaging = keywords_.asInt("Averaging");

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -14,7 +14,7 @@ bool SkeletonModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -14,15 +14,12 @@ bool TestModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.nItems() == 0)
+    if (targetConfigurations_.empty())
         return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
 
     // Loop over target Configurations
-    for (RefListItem<Configuration> *ri = targetConfigurations_.first(); ri != nullptr; ri = ri->next())
+    for (auto cfg : targetConfigurations_)
     {
-        // Grab Configuration pointer
-        Configuration *cfg = ri->item();
-
         // Set up process pool - must do this to ensure we are using all available processes
         procPool.assignProcessesToGroups(cfg->processPool());
 


### PR DESCRIPTION
The main `List<Configuration>` was replaced with a `std::vector<std::unique_ptr<Configuration>>` while all of the `RefList<Configuration>` could then be converted to `std:vector<Configuration*>`.  This is another part of #257.