### PR TITLE
Bugfix 16/06/21 Various

### DIFF
--- a/src/classes/braggreflection.cpp
+++ b/src/classes/braggreflection.cpp
@@ -104,6 +104,7 @@ bool BraggReflection::deserialise(LineParser &parser)
     index_ = parser.argi(0);
     q_ = parser.argd(1);
     nKVectors_ = parser.argi(2);
+    hkl_ = parser.arg3i(3);
 
     // Read intensities array
     if (!GenericItemDeserialiser::deserialise<Array2D<double>>(intensities_, parser))
@@ -116,7 +117,7 @@ bool BraggReflection::deserialise(LineParser &parser)
 bool BraggReflection::serialise(LineParser &parser) const
 {
     // Write index, Q centre, and number of contributing K-vectors
-    if (!parser.writeLineF("{}  {}  {}\n", index_, q_, nKVectors_))
+    if (!parser.writeLineF("{} {} {} {} {} {}\n", index_, q_, nKVectors_, hkl_.x, hkl_.y, hkl_.z))
         return false;
 
     // Write intensities array

--- a/src/classes/energykernel.cpp
+++ b/src/classes/energykernel.cpp
@@ -272,9 +272,6 @@ double EnergyKernel::correct(const Atom &i)
 double EnergyKernel::energy(const CellArray &cellArray, bool interMolecular, ProcessPool::DivisionStrategy strategy,
                             bool performSum)
 {
-    // Get sub-strategy to use
-    ProcessPool::DivisionStrategy subStrategy = ProcessPool::subDivisionStrategy(strategy);
-
     // List of cell neighbour pairs
     auto &cellNeighbourPairs = cellArray.getCellNeighbourPairs();
 

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -531,8 +531,14 @@ bool PartialSet::deserialise(LineParser &parser, const CoreData &coreData)
                 return false;
             auto nPoints = parser.argi(0);
             auto partError = parser.argb(1);
+            if (partError)
+                part.addErrors();
             auto boundError = parser.argb(2);
+            if (boundError)
+                bound.addErrors();
             auto unboundError = parser.argb(3);
+            if (unboundError)
+                unbound.addErrors();
 
             part.xAxis().reserve(nPoints);
             part.values().reserve(nPoints);
@@ -585,9 +591,6 @@ std::string writeDataPoint(int i, Data1D data)
 // Write data through specified LineParser
 bool PartialSet::serialise(LineParser &parser) const
 {
-    // TODO To reduce filesize we could write abscissa first, and then each Y datset afterwards since they all share a
-    // common scale
-
     if (!parser.writeLineF("{}\n", fingerprint_))
         return false;
 
@@ -614,8 +617,7 @@ bool PartialSet::serialise(LineParser &parser) const
         {
             if (!parser.writeLineF("{} {} {} {}\n", part.xAxis(i), writeDataPoint(i, part), writeDataPoint(i, bound),
                                    writeDataPoint(i, unbound)))
-                ;
-            return false;
+                return false;
         }
 
         return EarlyReturn<bool>::Continue;

--- a/src/gui/models/masterTermModel.cpp
+++ b/src/gui/models/masterTermModel.cpp
@@ -118,7 +118,7 @@ bool MasterTermBondModel::setData(const QModelIndex &index, const QVariant &valu
                 SpeciesBond::BondFunction bf = SpeciesBond::bondFunctions().enumeration(value.toString().toStdString());
                 masterIntra->setForm(bf);
             }
-            catch (std::runtime_error e)
+            catch (std::runtime_error &e)
             {
                 return false;
             }
@@ -181,7 +181,7 @@ bool MasterTermAngleModel::setData(const QModelIndex &index, const QVariant &val
                 auto bf = SpeciesAngle::angleFunctions().enumeration(value.toString().toStdString());
                 masterIntra->setForm(bf);
             }
-            catch (std::runtime_error e)
+            catch (std::runtime_error &e)
             {
                 return false;
             }
@@ -244,7 +244,7 @@ bool MasterTermTorsionModel::setData(const QModelIndex &index, const QVariant &v
                 auto bf = SpeciesTorsion::torsionFunctions().enumeration(value.toString().toStdString());
                 masterIntra->setForm(bf);
             }
-            catch (std::runtime_error e)
+            catch (std::runtime_error &e)
             {
                 return false;
             }

--- a/src/modules/calculate_avgmol/functions.cpp
+++ b/src/modules/calculate_avgmol/functions.cpp
@@ -43,7 +43,7 @@ void CalculateAvgMolModule::updateArrays(Dissolve &dissolve)
 void CalculateAvgMolModule::updateSpecies(const SampledVector &x, const SampledVector &y, const SampledVector &z)
 {
     for (auto &&[i, rx, ry, rz] : zip(averageSpecies_.atoms(), x.values(), y.values(), z.values()))
-        averageSpecies_.setAtomCoordinates(&i, Vec3<double>(rx, ry, rz));
+        averageSpecies_.setAtomCoordinates(&i, {rx, ry, rz});
 }
 
 /*

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -358,7 +358,7 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
             torsionData.addPoint(dissolve.iteration(), torsionEnergy);
             auto &improperData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Impropers", cfg->niceName()),
                                                                                  uniqueName(), GenericItem::InRestartFileFlag);
-            torsionData.addPoint(dissolve.iteration(), improperEnergy);
+            improperData.addPoint(dissolve.iteration(), improperEnergy);
 
             // Append to arrays of total energies
             auto &totalEnergyArray = dissolve.processingModuleData().realise<Data1D>(

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -120,7 +120,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
         // Read in or assign random velocities
         // Realise the velocity array from the moduleData
         auto [velocities, status] = dissolve.processingModuleData().realiseIf<std::vector<Vec3<double>>>(
-            fmt::format("{}//Velocities", cfg->niceName()), uniqueName(), GenericItem::NoFlags);
+            fmt::format("{}//Velocities", cfg->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
         if (status == GenericItem::ItemStatus::Created)
         {
             randomVelocities = true;
@@ -130,6 +130,7 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
             Messenger::print("Random initial velocities will be assigned.\n");
         else
             Messenger::print("Existing velocities will be used.\n");
+        Messenger::print("\n");
 
         // Initialise the random number buffer for all processes
         procPool.initialiseRandomBuffer(ProcessPool::PoolProcessesCommunicator);


### PR DESCRIPTION
Bugfix PR to address some small bugs:

- Fix storage of improper energy - this was mistakenly added to the torsion vector.
- Store MD velocities in restart file - should fix jumping intramolecular energy after restart, observed by CG.
- Store HKL in restart file - restarting a simulation with a Bragg calculation would lose HKL information on the intensities.
- Revert to brace-initialisation - following some back-and-forth with `Vec3<T>` ctors.
- Remove unused var.
- Fix PartialSet (de)serialisation - serialising always failed because of a mis-placed `;`, and deserialising ignored error flags.
- Catch refs of error objects.
