### PR TITLE
Input File Writing

### DIFF
--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -656,9 +656,8 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        std::vector<std::string_view> jkl = {std::string(improper.j()->atomType()->name()),
-                                             std::string(improper.k()->atomType()->name()),
-                                             std::string(improper.l()->atomType()->name())};
+        std::vector<std::string_view> jkl = {improper.j()->atomType()->name(), improper.k()->atomType()->name(),
+                                             improper.l()->atomType()->name()};
         std::sort(jkl.begin(), jkl.end());
         generateMasterTerm(improper, fmt::format("{}-{}", improper.i()->atomType()->name(), joinStrings(jkl, "-")),
                            [&coreData](std::string_view name) { return coreData.getMasterImproper(name); },

--- a/src/classes/speciessite.cpp
+++ b/src/classes/speciessite.cpp
@@ -384,7 +384,7 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
     if (!originAtoms_.empty())
     {
         if (!parser.writeLineF("{}  {}  {}\n", prefix, keywords().keyword(OriginKeyword),
-                               joinStrings(originAtomIndices(), "  ")))
+                               joinStrings(originAtomIndices(), "  ", [](const auto i) { return i + 1; })))
             return false;
     }
 
@@ -395,14 +395,16 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
     // X-Axis atom indices
     if (!xAxisAtoms_.empty())
     {
-        if (!parser.writeLineF("{}  {}{}\n", prefix, keywords().keyword(XAxisKeyword), joinStrings(xAxisAtomIndices(), "  ")))
+        if (!parser.writeLineF("{}  {}  {}\n", prefix, keywords().keyword(XAxisKeyword),
+                               joinStrings(xAxisAtomIndices(), "  ", [](const auto i) { return i + 1; })))
             return false;
     }
 
     // Y-Axis atom indices
     if (!yAxisAtoms_.empty())
     {
-        if (!parser.writeLineF("{}  {}{}\n", prefix, keywords().keyword(YAxisKeyword), joinStrings(yAxisAtomIndices(), "  ")))
+        if (!parser.writeLineF("{}  {}  {}\n", prefix, keywords().keyword(YAxisKeyword),
+                               joinStrings(yAxisAtomIndices(), "  ", [](const auto i) { return i + 1; })))
             return false;
     }
 

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -225,7 +225,7 @@ void for_each(ParallelPolicy, Iter begin, Iter end, UnaryOp unaryOp)
 }
 } // namespace dissolve
 
-// Join the parameters into a comma separated string
+// Join elements into a delimited string
 template <typename Iterator> std::string joinStrings(Iterator begin, Iterator end, std::string delim = ", ")
 {
     if (begin == end)
@@ -235,11 +235,23 @@ template <typename Iterator> std::string joinStrings(Iterator begin, Iterator en
     std::for_each(std::next(begin), end, [&stream, &delim](const auto value) { stream << delim << fmt::format("{}", value); });
     return stream.str();
 }
-
-// Join the parameters into a comma separated string
+template <typename Iterator, class Lam> std::string joinStrings(Iterator begin, Iterator end, std::string delim, Lam lambda)
+{
+    if (begin == end)
+        return std::string();
+    std::stringstream stream;
+    stream << fmt::format("{}", lambda(*begin));
+    std::for_each(std::next(begin), end,
+                  [&stream, &lambda, &delim](const auto value) { stream << delim << fmt::format("{}", lambda(value)); });
+    return stream.str();
+}
 template <class Class> std::string joinStrings(Class range, std::string delim = ", ")
 {
     return joinStrings(range.begin(), range.end(), delim);
+}
+template <class Class, class Lam> std::string joinStrings(Class range, std::string delim = ", ", Lam lambda = nullptr)
+{
+    return joinStrings(range.begin(), range.end(), delim, lambda);
 }
 
 // Split a string over a delimiter and store the results in an iterator.  Returns the number of elements split, or -1 if the


### PR DESCRIPTION
This PR addresses a few issues related to writing of terms to the input file.

- A new lambda-enabled overload of the `joinStrings` algorithm has been added to increase flexibility and address writing of incorrect site origin/axis atom indices.
- Improper master term names were generated from a `std::vector` of `std::string_view` constructed from in-place initialised `std::string`s, which presumably causes #743.

Closes #743.
