### PR TITLE
Transmute Species

### DIFF
--- a/src/gui/helpers/comboboxcontroller.h
+++ b/src/gui/helpers/comboboxcontroller.h
@@ -81,3 +81,19 @@ Iter combo_box_updater(QComboBox *comboBox, Iter begin, Iter end, Lam getItemTex
     else
         return currentItem;
 }
+
+template <class Data> int combo_box_set_current(QComboBox *comboBox, Data item)
+{
+    for (auto index = 0; index < comboBox->count(); ++index)
+    {
+        // If the data pointer matches, update the text and break. Otherwise, delete the item
+        auto itemData = comboBox->itemData(index, Qt::UserRole).value<Data>();
+        if (itemData == item)
+        {
+            comboBox->setCurrentIndex(index);
+            return index;
+        }
+    }
+
+    throw(std::runtime_error("Tried to set a ComboBox to an item that it doesn't contain.\n"));
+}

--- a/src/gui/keywordwidgets/node_funcs.cpp
+++ b/src/gui/keywordwidgets/node_funcs.cpp
@@ -59,7 +59,8 @@ void NodeKeywordWidget::updateValue()
     auto availableNodes = keyword_->onlyInScope()
                               ? keyword_->parentNode()->nodesInScope(keyword_->nodeType(), keyword_->nodeClass())
                               : keyword_->parentNode()->nodes(keyword_->nodeType(), keyword_->nodeClass());
-    combo_box_updater(ui_.NodeCombo, availableNodes.begin(), availableNodes.end(), [](auto *item) { return item->name(); });
+    combo_box_updater(ui_.NodeCombo, availableNodes.begin(), availableNodes.end(), [](auto *item) { return item->name(); },
+                      true);
 
     refreshing_ = false;
 }

--- a/src/gui/keywordwidgets/node_funcs.cpp
+++ b/src/gui/keywordwidgets/node_funcs.cpp
@@ -62,5 +62,8 @@ void NodeKeywordWidget::updateValue()
     combo_box_updater(ui_.NodeCombo, availableNodes.begin(), availableNodes.end(), [](auto *item) { return item->name(); },
                       true);
 
+    // Set the current item
+    combo_box_set_current(ui_.NodeCombo, keyword_->data());
+
     refreshing_ = false;
 }

--- a/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
+++ b/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
@@ -63,5 +63,8 @@ void NodeAndIntegerKeywordWidget::updateValue()
     combo_box_updater(ui_.NodeCombo, availableNodes.begin(), availableNodes.end(), [](auto item) { return item->name(); },
                       true);
 
+    // Set the current item
+    combo_box_set_current(ui_.NodeCombo, keyword_->data().first);
+
     refreshing_ = false;
 }

--- a/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
+++ b/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
@@ -60,7 +60,8 @@ void NodeAndIntegerKeywordWidget::updateValue()
     // Get the list of available nodes of the specified type
     auto availableNodes = keyword_->onlyInScope() ? keyword_->parentNode()->nodesInScope(keyword_->nodeType())
                                                   : keyword_->parentNode()->nodes(keyword_->nodeType());
-    combo_box_updater(ui_.NodeCombo, availableNodes.begin(), availableNodes.end(), [](auto item) { return item->name(); });
+    combo_box_updater(ui_.NodeCombo, availableNodes.begin(), availableNodes.end(), [](auto item) { return item->name(); },
+                      true);
 
     refreshing_ = false;
 }

--- a/src/keywords/speciesvector.cpp
+++ b/src/keywords/speciesvector.cpp
@@ -51,6 +51,9 @@ bool SpeciesVectorKeyword::read(LineParser &parser, int startArg, const CoreData
 // Write keyword data to specified LineParser
 bool SpeciesVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
+    if (isDataEmpty())
+        return true;
+
     // Loop over list of Species
     std::string speciesString;
     for (const auto *sp : data_)

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   select.cpp
   sequence.cpp
   sum1d.cpp
+  transmute.cpp
   add.h
   box.h
   calculateangle.h
@@ -74,6 +75,7 @@ add_library(
   process3d.h
   regionbase.h
   remove.h
+  transmute.h
   select.h
   sequence.h
   sum1d.h

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   pick.cpp
   pickbase.cpp
   pickcylinder.cpp
+  pickproximity.cpp
   process1d.cpp
   process2d.cpp
   process3d.cpp
@@ -67,6 +68,7 @@ add_library(
   pick.h
   pickbase.h
   pickcylinder.h
+  pickproximity.h
   process1d.h
   process2d.h
   process3d.h

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -54,7 +54,8 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Remove, "Remove"},
                      {ProcedureNode::NodeType::Select, "Select"},
                      {ProcedureNode::NodeType::Sequence, "Sequence"},
-                     {ProcedureNode::NodeType::Sum1D, "Sum1D"}});
+                     {ProcedureNode::NodeType::Sum1D, "Sum1D"},
+                     {ProcedureNode::NodeType::Transmute, "Transmute"}});
 }
 
 // Return enum option info for NodeContext

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -47,6 +47,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Parameters, "Parameters"},
                      {ProcedureNode::NodeType::Pick, "Pick"},
                      {ProcedureNode::NodeType::PickCylinder, "PickCylinder"},
+                     {ProcedureNode::NodeType::PickProximity, "PickProximity"},
                      {ProcedureNode::NodeType::Process1D, "Process1D"},
                      {ProcedureNode::NodeType::Process2D, "Process2D"},
                      {ProcedureNode::NodeType::Process3D, "Process3D"},

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -138,13 +138,14 @@ ProcedureNode::NodeContext ProcedureNode::scopeContext() const
 }
 
 // Return named node if it is currently in scope (and matches the type / class given)
-const ProcedureNode *ProcedureNode::nodeInScope(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType,
+const ProcedureNode *ProcedureNode::nodeInScope(std::string_view name, const ProcedureNode *excludeNode,
+                                                std::optional<ProcedureNode::NodeType> optNodeType,
                                                 std::optional<ProcedureNode::NodeClass> optNodeClass) const
 {
     if (!scope_)
         return nullptr;
 
-    return scope_->nodeInScope(this, name, optNodeType, optNodeClass);
+    return scope_->nodeInScope(this, name, excludeNode, optNodeType, optNodeClass);
 }
 
 // Return list of nodes in this node's scope (and matches the type / class given)

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -150,7 +150,8 @@ class ProcedureNode : public ListItem<ProcedureNode>
     // Return context of scope in which this node exists
     ProcedureNode::NodeContext scopeContext() const;
     // Return named node if it is currently in scope (and matches the type / class given)
-    const ProcedureNode *nodeInScope(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
+    const ProcedureNode *nodeInScope(std::string_view name, const ProcedureNode *excludeNode = nullptr,
+                                     std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
                                      std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;
     // Return list of nodes in this node's scope (and matches the type / class given)
     std::vector<const ProcedureNode *> nodesInScope(std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -62,6 +62,7 @@ class ProcedureNode : public ListItem<ProcedureNode>
         Parameters,
         Pick,
         PickCylinder,
+        PickProximity,
         Process1D,
         Process2D,
         Process3D,

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -69,7 +69,8 @@ class ProcedureNode : public ListItem<ProcedureNode>
         Remove,
         Select,
         Sequence,
-        Sum1D
+        Sum1D,
+        Transmute
     };
     // Return enum option info for NodeType
     static EnumOptions<NodeType> nodeTypes();

--- a/src/procedure/nodes/nodes.h
+++ b/src/procedure/nodes/nodes.h
@@ -30,6 +30,7 @@
 #include "procedure/nodes/parameters.h"
 #include "procedure/nodes/pick.h"
 #include "procedure/nodes/pickcylinder.h"
+#include "procedure/nodes/pickproximity.h"
 #include "procedure/nodes/process1d.h"
 #include "procedure/nodes/process2d.h"
 #include "procedure/nodes/process3d.h"

--- a/src/procedure/nodes/nodes.h
+++ b/src/procedure/nodes/nodes.h
@@ -38,3 +38,4 @@
 #include "procedure/nodes/select.h"
 #include "procedure/nodes/sequence.h"
 #include "procedure/nodes/sum1d.h"
+#include "procedure/nodes/transmute.h"

--- a/src/procedure/nodes/pick.cpp
+++ b/src/procedure/nodes/pick.cpp
@@ -34,6 +34,8 @@ bool PickProcedureNode::prepare(Configuration *cfg, std::string_view prefix, Gen
 // Execute node, targetting the supplied Configuration
 bool PickProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
 {
+    Messenger::print("[Pick] Molecules will be selected from {}.\n", moleculePoolName());
+
     // Create our molecules vector
     pickedMolecules_.clear();
 

--- a/src/procedure/nodes/pick.cpp
+++ b/src/procedure/nodes/pick.cpp
@@ -50,7 +50,7 @@ bool PickProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::
         pickedMolecules_.push_back(mol);
     }
 
-    Messenger::print("[Pick] Total molecules selected = {}.\n", pickedMolecules_.size());
+    Messenger::print("[Pick] Total molecules picked = {}.\n", pickedMolecules_.size());
 
     return true;
 }

--- a/src/procedure/nodes/pickbase.cpp
+++ b/src/procedure/nodes/pickbase.cpp
@@ -40,6 +40,20 @@ const std::vector<std::shared_ptr<Molecule>> &PickProcedureNodeBase::moleculePoo
     return cfg->molecules();
 }
 
+// Return source molecule pool name
+std::string PickProcedureNodeBase::moleculePoolName() const
+{
+    auto *node = keywords_.retrieve<const ProcedureNode *>("Source");
+    if (node)
+    {
+        auto *pickNode = dynamic_cast<const PickProcedureNodeBase *>(node);
+        assert(pickNode);
+        return fmt::format("picked selection '{}'", pickNode->name());
+    }
+
+    return "configuration";
+}
+
 // Return vector of picked Molecules
 std::vector<std::shared_ptr<Molecule>> &PickProcedureNodeBase::pickedMolecules() { return pickedMolecules_; }
 const std::vector<std::shared_ptr<Molecule>> &PickProcedureNodeBase::pickedMolecules() const { return pickedMolecules_; }

--- a/src/procedure/nodes/pickbase.cpp
+++ b/src/procedure/nodes/pickbase.cpp
@@ -8,7 +8,7 @@
 PickProcedureNodeBase::PickProcedureNodeBase(ProcedureNode::NodeType nodeType)
     : ProcedureNode(nodeType, ProcedureNode::NodeClass::Pick)
 {
-    keywords_.add("Control", new NodeKeyword(this, ProcedureNode::NodeClass::Pick, true), "Source",
+    keywords_.add("Control", new NodeKeyword(this, ProcedureNode::NodeClass::Pick, true), "From",
                   "Previous selection of molecules from which to pick");
 }
 
@@ -29,7 +29,7 @@ bool PickProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext context
 // Return source molecule pool
 const std::vector<std::shared_ptr<Molecule>> &PickProcedureNodeBase::moleculePool(const Configuration *cfg) const
 {
-    auto *node = keywords_.retrieve<const ProcedureNode *>("Source");
+    auto *node = keywords_.retrieve<const ProcedureNode *>("From");
     if (node)
     {
         auto *pickNode = dynamic_cast<const PickProcedureNodeBase *>(node);
@@ -43,7 +43,7 @@ const std::vector<std::shared_ptr<Molecule>> &PickProcedureNodeBase::moleculePoo
 // Return source molecule pool name
 std::string PickProcedureNodeBase::moleculePoolName() const
 {
-    auto *node = keywords_.retrieve<const ProcedureNode *>("Source");
+    auto *node = keywords_.retrieve<const ProcedureNode *>("From");
     if (node)
     {
         auto *pickNode = dynamic_cast<const PickProcedureNodeBase *>(node);

--- a/src/procedure/nodes/pickbase.h
+++ b/src/procedure/nodes/pickbase.h
@@ -34,6 +34,8 @@ class PickProcedureNodeBase : public ProcedureNode
     protected:
     // Return source molecule pool
     const std::vector<std::shared_ptr<Molecule>> &moleculePool(const Configuration *cfg) const;
+    // Return source molecule pool name
+    std::string moleculePoolName() const;
 
     public:
     // Return vector of picked Molecules

--- a/src/procedure/nodes/pickcylinder.cpp
+++ b/src/procedure/nodes/pickcylinder.cpp
@@ -25,6 +25,8 @@ PickCylinderProcedureNode::PickCylinderProcedureNode(Vec3<double> originFrac, Ve
 bool PickCylinderProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
                                         GenericList &targetList)
 {
+    Messenger::print("[PickCylinder] Molecules will be selected from {}.\n", moleculePoolName());
+
     // Create our molecules vector
     pickedMolecules_.clear();
 
@@ -48,7 +50,7 @@ bool PickCylinderProcedureNode::execute(ProcessPool &procPool, Configuration *cf
             pickedMolecules_.push_back(mol);
     }
 
-    Messenger::print("[Pick] Total molecules selected = {}.\n", pickedMolecules_.size());
+    Messenger::print("[PickCylinder] Total molecules selected = {}.\n", pickedMolecules_.size());
 
     return true;
 }

--- a/src/procedure/nodes/pickcylinder.cpp
+++ b/src/procedure/nodes/pickcylinder.cpp
@@ -50,7 +50,7 @@ bool PickCylinderProcedureNode::execute(ProcessPool &procPool, Configuration *cf
             pickedMolecules_.push_back(mol);
     }
 
-    Messenger::print("[PickCylinder] Total molecules selected = {}.\n", pickedMolecules_.size());
+    Messenger::print("[PickCylinder] Total molecules picked = {}.\n", pickedMolecules_.size());
 
     return true;
 }

--- a/src/procedure/nodes/pickproximity.cpp
+++ b/src/procedure/nodes/pickproximity.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "procedure/nodes/pickproximity.h"
+#include "base/lineparser.h"
+#include "classes/configuration.h"
+#include "classes/species.h"
+#include "keywords/types.h"
+#include "templates/algorithms.h"
+
+PickProximityProcedureNode::PickProximityProcedureNode() : PickProcedureNodeBase(ProcedureNode::NodeType::PickProximity)
+{
+    keywords_.add("Control", new SpeciesVectorKeyword, "Species", "Species to count");
+    keywords_.add("Control", new IntegerKeyword(0), "MinCount", "Minimum number");
+    keywords_.add("Control", new IntegerKeyword(0), "MaxCount", "Maximum number");
+    keywords_.add("Control", new DoubleKeyword(0.0, 0.0), "MinDistance", "Minimum distance");
+    keywords_.add("Control", new DoubleKeyword(0.0, 0.0), "MaxDistance", "Maximum distance");
+}
+
+/*
+ * Execute
+ */
+
+// Execute node, targetting the supplied Configuration
+bool PickProximityProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
+                                         GenericList &targetList)
+{
+    Messenger::print("[PickProximity] Molecules will be selected from {}.\n", moleculePoolName());
+
+    // Clear our molecules vector
+    pickedMolecules_.clear();
+
+    // Retrieve control values
+    auto rMin = keywords_.hasBeenSet("MinDistance") ? keywords_.asDouble("MinDistance") : 0.0;
+    std::optional<double> rMax;
+    if (keywords_.hasBeenSet("MaxDistance"))
+        rMax = keywords_.asDouble("MaxDistance");
+    auto nMin = keywords_.hasBeenSet("MinCount") ? keywords_.asInt("MinCount") : 0;
+    std::optional<int> nMax;
+    if (keywords_.hasBeenSet("MaxCount"))
+        nMax = keywords_.asInt("MaxCount");
+    auto &species = keywords_.retrieve<std::vector<const Species *>>("Species");
+
+    // Print info
+    if (!species.empty())
+        Messenger::print("[PickProximity] Proximal species are: {}.\n",
+                         joinStrings(species, " ", [](const auto &sp) { return sp->name(); }));
+    if (rMax.has_value())
+        Messenger::print("[PickProximity] Allowed distance range is {} <= r <= {} Angstroms.\n", rMin, rMax.value());
+    else
+        Messenger::print("[PickProximity] Allowed distance range is r >= {} Angstroms.\n", rMin);
+
+    if (nMax.has_value())
+        Messenger::print("[PickProximity] Allowed coordination count is {} <= N <= {}.\n", nMin, nMax.value());
+    else
+        Messenger::print("[PickProximity] Allowed coordination count is N >= {}.\n", nMin);
+
+    const auto *box = cfg->box();
+
+    // Loop over all target molecules
+    for (const auto &molI : moleculePool(cfg))
+    {
+        auto count = 0;
+
+        // Get centre of geometry of molecule
+        auto iCog = molI->centreOfGeometry(box);
+
+        // Loop over all molecules
+        for (const auto &molJ : cfg->molecules())
+        {
+            // Count surrounding species (if defined)
+            if (std::find(species.begin(), species.end(), molJ->species()) != species.end())
+            {
+                // Get centre of geometry of species
+                auto jCog = molJ->centreOfGeometry(box);
+
+                // Calculate i-j minimum distance
+                auto r = box->minimumDistance(iCog, jCog);
+
+                // Check distance criteria
+                if (r >= rMin && (!rMax.has_value() || r <= rMax.value()))
+                    ++count;
+            }
+        }
+
+        // Check total count against criteria
+        if (count >= nMin && (!nMax.has_value() || count <= nMax.value()))
+            pickedMolecules_.push_back(molI);
+    }
+
+    Messenger::print("[PickProximity] Total molecules picked = {}.\n", pickedMolecules_.size());
+
+    return true;
+}

--- a/src/procedure/nodes/pickproximity.h
+++ b/src/procedure/nodes/pickproximity.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/node.h"
+#include "procedure/nodes/pickbase.h"
+#include <memory>
+
+// Forward Declarations
+class Molecule;
+
+// Pick by Proximity Node
+class PickProximityProcedureNode : public PickProcedureNodeBase
+{
+    public:
+    explicit PickProximityProcedureNode();
+    ~PickProximityProcedureNode() override = default;
+
+    /*
+     * Execute
+     */
+    public:
+    // Execute node, targetting the supplied Configuration
+    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+};

--- a/src/procedure/nodes/remove.cpp
+++ b/src/procedure/nodes/remove.cpp
@@ -50,7 +50,7 @@ bool RemoveProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std
         for (auto *sp : species)
             cfg->removeMolecules(sp);
 
-    // Remove molecules bu selection
+    // Remove molecules by selection
     if (node)
     {
         auto *pickNode = dynamic_cast<const PickProcedureNodeBase *>(node);

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -469,6 +469,9 @@ bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &core
             case (ProcedureNode::NodeType::PickCylinder):
                 newNode = new PickCylinderProcedureNode();
                 break;
+            case (ProcedureNode::NodeType::PickProximity):
+                newNode = new PickProximityProcedureNode();
+                break;
             case (ProcedureNode::NodeType::Process1D):
                 newNode = new Process1DProcedureNode();
                 break;

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -185,27 +185,33 @@ std::vector<const ProcedureNode *> SequenceProcedureNode::nodes(std::optional<Pr
 
 // Return named node if it is currently in scope (and matches the type / class given)
 const ProcedureNode *SequenceProcedureNode::nodeInScope(const ProcedureNode *queryingNode, std::string_view name,
+                                                        const ProcedureNode *excludeNode,
                                                         std::optional<ProcedureNode::NodeType> optNodeType,
                                                         std::optional<ProcedureNode::NodeClass> optNodeClass) const
 {
+    // If one was give, start from the querying node and work backwards...
     if (queryingNode)
+    {
         assert(sequence_.contains(queryingNode));
 
-    // Start from the target node and work backwards...
-    for (auto *node = queryingNode; node != nullptr; node = node->prev())
-    {
-        if (DissolveSys::sameString(node->name(), name))
+        for (auto *node = queryingNode; node != nullptr; node = node->prev())
         {
-            // Check type / class
-            if ((!optNodeType && !optNodeClass) || (optNodeType && optNodeType.value() == node->type()) ||
-                (optNodeClass && optNodeClass.value() == node->nodeClass()))
-                return node;
+            if (node == excludeNode)
+                continue;
+
+            if (DissolveSys::sameString(node->name(), name))
+            {
+                // Check type / class
+                if ((!optNodeType && !optNodeClass) || (optNodeType && optNodeType.value() == node->type()) ||
+                    (optNodeClass && optNodeClass.value() == node->nodeClass()))
+                    return node;
+            }
         }
     }
 
     // Not in our list. Recursively check our parent(s)
     if (parentNode_)
-        return parentNode_->nodeInScope(name, optNodeType, optNodeClass);
+        return parentNode_->nodeInScope(name, excludeNode, optNodeType, optNodeClass);
 
     // Not found
     return nullptr;
@@ -216,18 +222,20 @@ std::vector<const ProcedureNode *>
 SequenceProcedureNode::nodesInScope(const ProcedureNode *queryingNode, std::optional<ProcedureNode::NodeType> optNodeType,
                                     std::optional<ProcedureNode::NodeClass> optNodeClass) const
 {
-    if (queryingNode)
-        assert(sequence_.contains(queryingNode));
-
     std::vector<const ProcedureNode *> matches;
 
-    // Start from the target node and work backwards...
-    for (auto *node = queryingNode; node != nullptr; node = node->prev())
+    // If one was give, start from the querying node and work backwards...
+    if (queryingNode)
     {
-        // Check type / class
-        if ((!optNodeType && !optNodeClass) || (optNodeType && optNodeType.value() == node->type()) ||
-            (optNodeClass && optNodeClass.value() == node->nodeClass()))
-            matches.push_back(node);
+        assert(sequence_.contains(queryingNode));
+
+        for (auto *node = queryingNode->prev(); node != nullptr; node = node->prev())
+        {
+            // Check type / class
+            if ((!optNodeType && !optNodeClass) || (optNodeType && optNodeType.value() == node->type()) ||
+                (optNodeClass && optNodeClass.value() == node->nodeClass()))
+                matches.push_back(node);
+        }
     }
 
     // Not in our list. Recursively check our parent(s)

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -499,6 +499,9 @@ bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &core
                 /* This should never be called */
                 newNode = new SequenceProcedureNode(ProcedureNode::NoContext, procedure(), this);
                 break;
+            case (ProcedureNode::NodeType::Transmute):
+                newNode = new TransmuteProcedureNode();
+                break;
             default:
                 throw(std::runtime_error(
                     fmt::format("Epic Developer Fail - Don't know how to create a node of type '{}'.\n", parser.argsv(0))));

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -87,6 +87,7 @@ class SequenceProcedureNode : public ProcedureNode
                                              std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;
     // Return named node if it is currently in scope (and matches the type / class given)
     const ProcedureNode *nodeInScope(const ProcedureNode *queryingNode, std::string_view name,
+                                     const ProcedureNode *excludeNode = nullptr,
                                      std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
                                      std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;
     // Return list of nodes in scope (and matching the type / class given)

--- a/src/procedure/nodes/transmute.cpp
+++ b/src/procedure/nodes/transmute.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "procedure/nodes/transmute.h"
+#include "base/lineparser.h"
+#include "base/sysfunc.h"
+#include "classes/box.h"
+#include "classes/configuration.h"
+#include "classes/coredata.h"
+#include "classes/species.h"
+#include "keywords/types.h"
+#include "procedure/nodes/pick.h"
+
+TransmuteProcedureNode::TransmuteProcedureNode() : ProcedureNode(ProcedureNode::NodeType::Transmute)
+{
+    // Set up keywords
+    keywords_.add("Control", new SpeciesKeyword(), "Target", "Target species to transmute selected molecules in to");
+    keywords_.add("Control", new SpeciesVectorKeyword(), "Species", "Species to transmute targets in to");
+    keywords_.add("Control", new NodeKeyword(this, ProcedureNode::NodeClass::Pick, true), "Selection",
+                  "Picked selection of molecules to transmute");
+}
+
+/*
+ * Identity
+ */
+
+// Return whether specified context is relevant for this node type
+bool TransmuteProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
+{
+    return (context == ProcedureNode::GenerationContext);
+}
+
+// Return whether a name for the node must be provided
+bool TransmuteProcedureNode::mustBeNamed() const { return false; }
+
+/*
+ * Execute
+ */
+
+// Execute node, targetting the supplied Configuration
+bool TransmuteProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
+                                     GenericList &targetList)
+{
+    auto *sp = keywords_.retrieve<const Species *>("Target");
+    auto &species = keywords_.retrieve<std::vector<const Species *>>("Species");
+    auto *node = keywords_.retrieve<const ProcedureNode *>("Selection");
+
+    // Check target species
+    if (!sp)
+        return Messenger::error("Species to transmute into must be provided.\n");
+
+    // Assemble a vector of molecules to transmute
+    std::vector<std::shared_ptr<Molecule>> targets;
+
+    // Transmute molecules by Species type
+    if (!species.empty())
+        for (const auto &mol : cfg->molecules())
+            if (std::find(species.begin(), species.end(), mol->species()) != species.end())
+                targets.push_back(mol);
+
+    // Transmute molecules by selection
+    if (node)
+    {
+        auto *pickNode = dynamic_cast<const PickProcedureNodeBase *>(node);
+        assert(pickNode);
+        std::copy(pickNode->pickedMolecules().begin(), pickNode->pickedMolecules().end(), std::back_inserter(targets));
+    }
+
+    // Perform the magic
+    const auto *box = cfg->box();
+    for (const auto &mol : targets)
+    {
+        auto newMol = cfg->addMolecule(sp);
+        newMol->setCentreOfGeometry(box, mol->centreOfGeometry(box));
+    }
+
+    // Remove the old molecules
+    cfg->removeMolecules(targets);
+
+    Messenger::print("[Transmute] Transmuted {} molecules into '{}'.\n", targets.size(), sp->name());
+
+    return true;
+}

--- a/src/procedure/nodes/transmute.h
+++ b/src/procedure/nodes/transmute.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/units.h"
+#include "procedure/nodes/node.h"
+#include "procedure/nodevalue.h"
+
+// Forward Declarations
+class Species;
+
+// Transmute Node
+class TransmuteProcedureNode : public ProcedureNode
+{
+    public:
+    TransmuteProcedureNode();
+    ~TransmuteProcedureNode() override = default;
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether specified context is relevant for this node type
+    bool isContextRelevant(ProcedureNode::NodeContext context) override;
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Execute
+     */
+    public:
+    // Execute node, targetting the supplied Configuration
+    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+};


### PR DESCRIPTION
This PR adds in two further `ProcedureNode`s - `PickProximity` to select molecules based on their proximity to other molecules (i.e. by coordination number) and a basic `Transmute` which converts a target picked selection of molecules (of any type) into new molecules of a target species.

The `Transmute` node will be extended in future PRs to introduce randomisation / rotation / orientation of the new molecules, but this is left until other related aspects of the code are implemented, in particular a forthcoming PR updating the `Box` classes and node in order to permit the necessary groundwork before transmutation.
