### PR TITLE
Box updates 2

### DIFF
--- a/benchmark/box/box_benchmark.cpp
+++ b/benchmark/box/box_benchmark.cpp
@@ -19,10 +19,10 @@ template <typename BoxType> BoxType createTestBox()
         OrthorhombicBox box(lengths);
         return box;
     }
-    else if constexpr (std::is_same_v<BoxType, MonoclinicBox>)
+    else if constexpr (std::is_same_v<BoxType, MonoclinicAlphaBox>)
     {
         Vec3<double> lengths(1.00, 1.00, 1.00);
-        MonoclinicBox box(lengths, 45);
+        MonoclinicAlphaBox box(lengths, 45);
         return box;
     }
     else if constexpr (std::is_same_v<BoxType, TriclinicBox>)
@@ -130,14 +130,14 @@ BENCHMARK_TEMPLATE(BM_Box_MinimumVector, OrthorhombicBox);
 BENCHMARK_TEMPLATE(BM_Box_RandomCoordinate, OrthorhombicBox);
 BENCHMARK_TEMPLATE(BM_Box_Fold, OrthorhombicBox);
 BENCHMARK_TEMPLATE(BM_Box_FoldFrac, OrthorhombicBox);
-BENCHMARK_TEMPLATE(BM_Box_MinimumDistance, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_MinimumDistanceSquared, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_MinimumImage, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_MinimumVector, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_MinimumImage, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_RandomCoordinate, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_Fold, MonoclinicBox);
-BENCHMARK_TEMPLATE(BM_Box_FoldFrac, MonoclinicBox);
+BENCHMARK_TEMPLATE(BM_Box_MinimumDistance, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_MinimumDistanceSquared, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_MinimumImage, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_MinimumVector, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_MinimumImage, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_RandomCoordinate, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_Fold, MonoclinicAlphaBox);
+BENCHMARK_TEMPLATE(BM_Box_FoldFrac, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_MinimumDistance, TriclinicBox);
 BENCHMARK_TEMPLATE(BM_Box_MinimumDistanceSquared, TriclinicBox);
 BENCHMARK_TEMPLATE(BM_Box_MinimumImage, TriclinicBox);

--- a/benchmark/box/box_benchmark.cpp
+++ b/benchmark/box/box_benchmark.cpp
@@ -134,7 +134,6 @@ BENCHMARK_TEMPLATE(BM_Box_MinimumDistance, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_MinimumDistanceSquared, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_MinimumImage, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_MinimumVector, MonoclinicAlphaBox);
-BENCHMARK_TEMPLATE(BM_Box_MinimumImage, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_RandomCoordinate, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_Fold, MonoclinicAlphaBox);
 BENCHMARK_TEMPLATE(BM_Box_FoldFrac, MonoclinicAlphaBox);

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -6,7 +6,9 @@ add_library(
   atomtypelist.cpp
   box.cpp
   box_cubic.cpp
-  box_monoclinic.cpp
+  box_monoclinicalpha.cpp
+  box_monoclinicbeta.cpp
+  box_monoclinicgamma.cpp
   box_nonperiodic.cpp
   box_orthorhombic.cpp
   box_triclinic.cpp

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -15,7 +15,20 @@ class ProcessPool;
 class Box
 {
     public:
-    Box();
+    // Box Type Enum
+    enum class BoxType
+    {
+        NonPeriodic,     /* Non-periodic system - cubic box, but no minimum image calculation */
+        Cubic,           /* Cubic box with A == B == C, alphe == beta == gamma == 90 */
+        Orthorhombic,    /* Orthorhombic box with A != B != C, alphe == beta == gamma = 90 */
+        MonoclinicAlpha, /* Monoclinic box with A != B != C, alpha != 90, and beta == gamma == 90 */
+        MonoclinicBeta,  /* Monoclinic box with A != B != C, beta != 90, and alpha == gamma == 90 */
+        MonoclinicGamma, /* Monoclinic box with A != B != C, gamma != 90, and alpha == beta == 90 */
+        Triclinic        /* Triclinic box with A != B != C, alpha != beta != gamma != 90 */
+    };
+    // Return enum options for BoxType
+    static EnumOptions<BoxType> boxTypes();
+    Box(Box::BoxType boxType, const Vec3<double> lengths, const Vec3<double> angles);
     virtual ~Box() = default;
     Box &operator=(const Box &source) = default;
 
@@ -23,18 +36,6 @@ class Box
      * Basic Definition
      */
     public:
-    // Box Type Enum
-    enum class BoxType
-    {
-        NonPeriodic,  /* Non-periodic system - cubic box, but no minimum image calculation */
-        Cubic,        /* Cubic box with A == B == C, alphe == beta == gamma == 90 */
-        Orthorhombic, /* Orthorhombic box with A != B != C, alphe == beta == gamma = 90 */
-        Monoclinic,   /* Monoclinic box with A != B != C, alpha != 90, and beta == gamma == 90 */
-        Triclinic     /* Triclinic box with A != B != C, alpha != beta != gamma != 90 */
-    };
-    // Return enum options for BoxType
-    static EnumOptions<BoxType> boxTypes();
-
     protected:
     // Box type
     BoxType type_;
@@ -270,12 +271,72 @@ class OrthorhombicBox : public Box
     double minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const override;
 };
 
-// Monoclinic Box Definition
-class MonoclinicBox : public Box
+// MonoclinicAlpha Box Definition
+class MonoclinicAlphaBox : public Box
 {
     public:
-    MonoclinicBox(const Vec3<double> lengths, double beta);
-    ~MonoclinicBox() override = default;
+    MonoclinicAlphaBox(const Vec3<double> lengths, double alpha);
+    ~MonoclinicAlphaBox() override = default;
+
+    /*
+     * Coordinate Conversion
+     */
+    public:
+    // Convert specified fractional coordinates to real-space coordinates
+    void toReal(Vec3<double> &r) const override;
+    // Convert specified real-space coordinates to fractional coordinates
+    void toFractional(Vec3<double> &r) const override;
+
+    /*
+     * Minimum Image Calculations
+     */
+    public:
+    // Return minimum image coordinates of r1 with respect to r2
+    Vec3<double> minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+    // Return minimum image vector from r1 to r2
+    Vec3<double> minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+    // Return minimum image distance from r1 to r2
+    double minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+    // Return minimum image squared distance from r1 to r2
+    double minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+};
+
+// MonoclinicBeta Box Definition
+class MonoclinicBetaBox : public Box
+{
+    public:
+    MonoclinicBetaBox(const Vec3<double> lengths, double beta);
+    ~MonoclinicBetaBox() override = default;
+
+    /*
+     * Coordinate Conversion
+     */
+    public:
+    // Convert specified fractional coordinates to real-space coordinates
+    void toReal(Vec3<double> &r) const override;
+    // Convert specified real-space coordinates to fractional coordinates
+    void toFractional(Vec3<double> &r) const override;
+
+    /*
+     * Minimum Image Calculations
+     */
+    public:
+    // Return minimum image coordinates of r1 with respect to r2
+    Vec3<double> minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+    // Return minimum image vector from r1 to r2
+    Vec3<double> minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+    // Return minimum image distance from r1 to r2
+    double minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+    // Return minimum image squared distance from r1 to r2
+    double minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const override;
+};
+
+// MonoclinicGamma Box Definition
+class MonoclinicGammaBox : public Box
+{
+    public:
+    MonoclinicGammaBox(const Vec3<double> lengths, double gamma);
+    ~MonoclinicGammaBox() override = default;
 
     /*
      * Coordinate Conversion

--- a/src/classes/box_cubic.cpp
+++ b/src/classes/box_cubic.cpp
@@ -4,22 +4,7 @@
 #include "classes/atom.h"
 #include "classes/box.h"
 
-CubicBox::CubicBox(double length) : Box()
-{
-    type_ = Box::BoxType::Cubic;
-
-    // Construct axes_
-    axes_.setColumn(0, length, 0.0, 0.0);
-    axes_.setColumn(1, 0.0, length, 0.0);
-    axes_.setColumn(2, 0.0, 0.0, length);
-
-    // Store box length and reciprocal
-    a_ = length;
-    ra_ = 1.0 / a_;
-
-    // Finalise associated data
-    finalise();
-}
+CubicBox::CubicBox(double length) : Box(Box::BoxType::Cubic, {length, length, length}, {90.0, 90.0, 90.0}) {}
 
 /*
  * Coordinate Conversion

--- a/src/classes/box_cubic.cpp
+++ b/src/classes/box_cubic.cpp
@@ -22,104 +22,66 @@ CubicBox::CubicBox(double length) : Box()
 }
 
 /*
- * Minimum Image Routines (virtual implementations)
+ * Coordinate Conversion
+ */
+
+// Convert specified fractional coordinates to real-space coordinates
+void CubicBox::toReal(Vec3<double> &r) const
+{
+    r.x *= a_;
+    r.y *= a_;
+    r.z *= a_;
+}
+
+// Convert specified real-space coordinates to fractional coordinates
+void CubicBox::toFractional(Vec3<double> &r) const
+{
+    r.x *= ra_;
+    r.y *= ra_;
+    r.z *= ra_;
+}
+
+/*
+ * Minimum Image Calculation
  */
 
 // Return minimum image coordinates of r1 with respect to r2
 Vec3<double> CubicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mimVec = r1;
-    mimVec -= r2;
-
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * ra_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.z -= int(mimVec.z * ra_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * a_;
-
-    mimVec += r2;
-    return mimVec;
+    Vec3<double> v21 = r1 - r2;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
+    return v21;
 }
 
 // Return minimum image vector from r1 to r2
 Vec3<double> CubicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mimVec = r2;
-    mimVec -= r1;
-
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * ra_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.z -= int(mimVec.z * ra_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * a_;
-
-    return mimVec;
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12;
 }
 
 // Return minimum image distance from r1 to r2
 double CubicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mimVec = r2;
-    mimVec -= r1;
-
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * ra_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.z -= int(mimVec.z * ra_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * a_;
-
-    return mimVec.magnitude();
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12.magnitude();
 }
 
-// Return minimum image distance from r1 to r2
+// Return minimum image squared distance from r1 to r2
 double CubicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    double x = r2.x - r1.x, y = r2.y - r1.y, z = r2.z - r1.z;
-
-    x -= int(x * ra_ + (x < 0.0 ? -0.5 : 0.5)) * a_;
-    y -= int(y * ra_ + (y < 0.0 ? -0.5 : 0.5)) * a_;
-    z -= int(z * ra_ + (z < 0.0 ? -0.5 : 0.5)) * a_;
-
-    return (x * x + y * y + z * z);
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12.magnitudeSq();
 }
-
-/*
- * Utility Routines (Virtual Implementations)
- */
-
-// Return random coordinate inside Box
-Vec3<double> CubicBox::randomCoordinate() const
-{
-    Vec3<double> pos;
-    pos.x = a_ * DissolveMath::random();
-    pos.y = a_ * DissolveMath::random();
-    pos.z = a_ * DissolveMath::random();
-    return pos;
-}
-
-// Return folded coordinate (i.e. inside current Box)
-Vec3<double> CubicBox::fold(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    static Vec3<double> frac;
-    frac.set(r.x * ra_, r.y * ra_, r.z * ra_);
-
-    // Fold into Box
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-
-    return frac * a_;
-}
-
-// Return folded fractional coordinate (i.e. inside current Box)
-Vec3<double> CubicBox::foldFrac(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    static Vec3<double> frac;
-    frac.set(r.x * ra_, r.y * ra_, r.z * ra_);
-
-    // Fold into Box
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-
-    return frac;
-}
-
-// Convert supplied fractional coordinates to real space
-Vec3<double> CubicBox::fracToReal(const Vec3<double> &r) const { return r * a_; }

--- a/src/classes/box_monoclinicalpha.cpp
+++ b/src/classes/box_monoclinicalpha.cpp
@@ -16,23 +16,19 @@ MonoclinicAlphaBox::MonoclinicAlphaBox(const Vec3<double> lengths, double alpha)
 // Convert specified fractional coordinates to real-space coordinates
 void MonoclinicAlphaBox::toReal(Vec3<double> &r) const
 {
-    auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
-    auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
-    auto z = r.x * axesArray_[2] + r.y * axesArray_[5] + r.z * axesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= axesArray_[0];
+    r.y *= axesArray_[4];
+    r.y += r.z * axesArray_[7];
+    r.z *= axesArray_[8];
 }
 
 // Convert specified real-space coordinates to fractional coordinates
 void MonoclinicAlphaBox::toFractional(Vec3<double> &r) const
 {
-    auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
-    auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
-    auto z = r.x * inverseAxesArray_[2] + r.y * inverseAxesArray_[5] + r.z * inverseAxesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= inverseAxesArray_[0];
+    r.y *= inverseAxesArray_[4];
+    r.y += r.z * inverseAxesArray_[7];
+    r.z *= inverseAxesArray_[8];
 }
 
 /*
@@ -43,15 +39,11 @@ void MonoclinicAlphaBox::toFractional(Vec3<double> &r) const
 Vec3<double> MonoclinicAlphaBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
-    Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
-                       v21.x * inverseAxesArray_[1] + v21.y * inverseAxesArray_[4] + v21.z * inverseAxesArray_[7],
-                       v21.x * inverseAxesArray_[2] + v21.y * inverseAxesArray_[5] + v21.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v21.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6] + r2.x;
-    v21.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7] + r2.y;
-    v21.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8] + r2.z;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
 
     return v21;
 }
@@ -60,15 +52,10 @@ Vec3<double> MonoclinicAlphaBox::minimumImage(const Vec3<double> &r1, const Vec3
 double MonoclinicAlphaBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitude();
 }
@@ -77,15 +64,10 @@ double MonoclinicAlphaBox::minimumDistance(const Vec3<double> &r1, const Vec3<do
 Vec3<double> MonoclinicAlphaBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12;
 }
@@ -94,15 +76,10 @@ Vec3<double> MonoclinicAlphaBox::minimumVector(const Vec3<double> &r1, const Vec
 double MonoclinicAlphaBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitudeSq();
 }

--- a/src/classes/box_monoclinicalpha.cpp
+++ b/src/classes/box_monoclinicalpha.cpp
@@ -4,8 +4,8 @@
 #include "classes/atom.h"
 #include "classes/box.h"
 
-TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles)
-    : Box(Box::BoxType::Triclinic, lengths, angles)
+MonoclinicAlphaBox::MonoclinicAlphaBox(const Vec3<double> lengths, double alpha)
+    : Box(Box::BoxType::MonoclinicAlpha, lengths, {alpha, 90.0, 90.0})
 {
 }
 
@@ -14,7 +14,7 @@ TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles
  */
 
 // Convert specified fractional coordinates to real-space coordinates
-void TriclinicBox::toReal(Vec3<double> &r) const
+void MonoclinicAlphaBox::toReal(Vec3<double> &r) const
 {
     auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
     auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
@@ -25,7 +25,7 @@ void TriclinicBox::toReal(Vec3<double> &r) const
 }
 
 // Convert specified real-space coordinates to fractional coordinates
-void TriclinicBox::toFractional(Vec3<double> &r) const
+void MonoclinicAlphaBox::toFractional(Vec3<double> &r) const
 {
     auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
     auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
@@ -40,7 +40,7 @@ void TriclinicBox::toFractional(Vec3<double> &r) const
  */
 
 // Return minimum image coordinates of r1 with respect to r2
-Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
+Vec3<double> MonoclinicAlphaBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
     Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
@@ -57,7 +57,7 @@ Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<doubl
 }
 
 // Return minimum image distance from r1 to r2
-double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
+double MonoclinicAlphaBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
@@ -74,7 +74,7 @@ double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> 
 }
 
 // Return minimum image vector from r1 to r2
-Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
+Vec3<double> MonoclinicAlphaBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
@@ -91,7 +91,7 @@ Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<doub
 }
 
 // Return minimum image squared distance from r1 to r2
-double TriclinicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
+double MonoclinicAlphaBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],

--- a/src/classes/box_monoclinicbeta.cpp
+++ b/src/classes/box_monoclinicbeta.cpp
@@ -4,8 +4,8 @@
 #include "classes/atom.h"
 #include "classes/box.h"
 
-TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles)
-    : Box(Box::BoxType::Triclinic, lengths, angles)
+MonoclinicBetaBox::MonoclinicBetaBox(const Vec3<double> lengths, double beta)
+    : Box(Box::BoxType::MonoclinicBeta, lengths, {90.0, beta, 90.0})
 {
 }
 
@@ -14,7 +14,7 @@ TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles
  */
 
 // Convert specified fractional coordinates to real-space coordinates
-void TriclinicBox::toReal(Vec3<double> &r) const
+void MonoclinicBetaBox::toReal(Vec3<double> &r) const
 {
     auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
     auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
@@ -25,7 +25,7 @@ void TriclinicBox::toReal(Vec3<double> &r) const
 }
 
 // Convert specified real-space coordinates to fractional coordinates
-void TriclinicBox::toFractional(Vec3<double> &r) const
+void MonoclinicBetaBox::toFractional(Vec3<double> &r) const
 {
     auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
     auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
@@ -40,7 +40,7 @@ void TriclinicBox::toFractional(Vec3<double> &r) const
  */
 
 // Return minimum image coordinates of r1 with respect to r2
-Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
+Vec3<double> MonoclinicBetaBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
     Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
@@ -57,7 +57,7 @@ Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<doubl
 }
 
 // Return minimum image distance from r1 to r2
-double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
+double MonoclinicBetaBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
@@ -74,7 +74,7 @@ double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> 
 }
 
 // Return minimum image vector from r1 to r2
-Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
+Vec3<double> MonoclinicBetaBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
@@ -91,7 +91,7 @@ Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<doub
 }
 
 // Return minimum image squared distance from r1 to r2
-double TriclinicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
+double MonoclinicBetaBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],

--- a/src/classes/box_monoclinicbeta.cpp
+++ b/src/classes/box_monoclinicbeta.cpp
@@ -16,23 +16,19 @@ MonoclinicBetaBox::MonoclinicBetaBox(const Vec3<double> lengths, double beta)
 // Convert specified fractional coordinates to real-space coordinates
 void MonoclinicBetaBox::toReal(Vec3<double> &r) const
 {
-    auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
-    auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
-    auto z = r.x * axesArray_[2] + r.y * axesArray_[5] + r.z * axesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= axesArray_[0];
+    r.x += r.z * axesArray_[6];
+    r.y *= axesArray_[4];
+    r.z *= axesArray_[8];
 }
 
 // Convert specified real-space coordinates to fractional coordinates
 void MonoclinicBetaBox::toFractional(Vec3<double> &r) const
 {
-    auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
-    auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
-    auto z = r.x * inverseAxesArray_[2] + r.y * inverseAxesArray_[5] + r.z * inverseAxesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= inverseAxesArray_[0];
+    r.x += r.z * inverseAxesArray_[6];
+    r.y *= inverseAxesArray_[4];
+    r.z *= inverseAxesArray_[8];
 }
 
 /*
@@ -43,15 +39,11 @@ void MonoclinicBetaBox::toFractional(Vec3<double> &r) const
 Vec3<double> MonoclinicBetaBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
-    Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
-                       v21.x * inverseAxesArray_[1] + v21.y * inverseAxesArray_[4] + v21.z * inverseAxesArray_[7],
-                       v21.x * inverseAxesArray_[2] + v21.y * inverseAxesArray_[5] + v21.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v21.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6] + r2.x;
-    v21.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7] + r2.y;
-    v21.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8] + r2.z;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
 
     return v21;
 }
@@ -60,15 +52,10 @@ Vec3<double> MonoclinicBetaBox::minimumImage(const Vec3<double> &r1, const Vec3<
 double MonoclinicBetaBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitude();
 }
@@ -77,15 +64,10 @@ double MonoclinicBetaBox::minimumDistance(const Vec3<double> &r1, const Vec3<dou
 Vec3<double> MonoclinicBetaBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12;
 }
@@ -94,15 +76,10 @@ Vec3<double> MonoclinicBetaBox::minimumVector(const Vec3<double> &r1, const Vec3
 double MonoclinicBetaBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitudeSq();
 }

--- a/src/classes/box_monoclinicgamma.cpp
+++ b/src/classes/box_monoclinicgamma.cpp
@@ -16,23 +16,19 @@ MonoclinicGammaBox::MonoclinicGammaBox(const Vec3<double> lengths, double gamma)
 // Convert specified fractional coordinates to real-space coordinates
 void MonoclinicGammaBox::toReal(Vec3<double> &r) const
 {
-    auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
-    auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
-    auto z = r.x * axesArray_[2] + r.y * axesArray_[5] + r.z * axesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= axesArray_[0];
+    r.x += r.y * axesArray_[3];
+    r.y *= axesArray_[4];
+    r.z *= axesArray_[8];
 }
 
 // Convert specified real-space coordinates to fractional coordinates
 void MonoclinicGammaBox::toFractional(Vec3<double> &r) const
 {
-    auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
-    auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
-    auto z = r.x * inverseAxesArray_[2] + r.y * inverseAxesArray_[5] + r.z * inverseAxesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= inverseAxesArray_[0];
+    r.x += r.y * inverseAxesArray_[3];
+    r.y *= inverseAxesArray_[4];
+    r.z *= inverseAxesArray_[8];
 }
 
 /*
@@ -43,15 +39,11 @@ void MonoclinicGammaBox::toFractional(Vec3<double> &r) const
 Vec3<double> MonoclinicGammaBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
-    Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
-                       v21.x * inverseAxesArray_[1] + v21.y * inverseAxesArray_[4] + v21.z * inverseAxesArray_[7],
-                       v21.x * inverseAxesArray_[2] + v21.y * inverseAxesArray_[5] + v21.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v21.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6] + r2.x;
-    v21.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7] + r2.y;
-    v21.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8] + r2.z;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
 
     return v21;
 }
@@ -60,15 +52,10 @@ Vec3<double> MonoclinicGammaBox::minimumImage(const Vec3<double> &r1, const Vec3
 double MonoclinicGammaBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitude();
 }
@@ -77,15 +64,10 @@ double MonoclinicGammaBox::minimumDistance(const Vec3<double> &r1, const Vec3<do
 Vec3<double> MonoclinicGammaBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12;
 }
@@ -94,15 +76,10 @@ Vec3<double> MonoclinicGammaBox::minimumVector(const Vec3<double> &r1, const Vec
 double MonoclinicGammaBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitudeSq();
 }

--- a/src/classes/box_monoclinicgamma.cpp
+++ b/src/classes/box_monoclinicgamma.cpp
@@ -4,33 +4,9 @@
 #include "classes/atom.h"
 #include "classes/box.h"
 
-MonoclinicBox::MonoclinicBox(const Vec3<double> lengths, double beta) : Box()
+MonoclinicGammaBox::MonoclinicGammaBox(const Vec3<double> lengths, double gamma)
+    : Box(Box::BoxType::MonoclinicGamma, lengths, {90.0, 90.0, gamma})
 {
-    type_ = Box::BoxType::Monoclinic;
-
-    // Construct axes
-    alpha_ = 90.0;
-    beta_ = beta;
-    gamma_ = 90.0;
-    // Assume that A lays along x-axis and C lays along the z-axis (since gamma = 90)
-    axes_.setColumn(0, 1.0, 0.0, 0.0);
-    axes_.setColumn(1, 0.0, 1.0, 0.0);
-    // The C vector will only have components in x and z
-    double cosBeta = cos(beta_ / DEGRAD);
-    axes_.setColumn(2, cosBeta, 0.0, sqrt(1.0 - cosBeta * cosBeta));
-
-    // Multiply the unit vectors to have the correct lengths
-    axes_.columnMultiply(0, lengths.x);
-    axes_.columnMultiply(1, lengths.y);
-    axes_.columnMultiply(2, lengths.z);
-
-    // Store Box lengths
-    a_ = lengths.x;
-    b_ = lengths.y;
-    c_ = lengths.z;
-
-    // Finalise associated data
-    finalise();
 }
 
 /*
@@ -38,7 +14,7 @@ MonoclinicBox::MonoclinicBox(const Vec3<double> lengths, double beta) : Box()
  */
 
 // Convert specified fractional coordinates to real-space coordinates
-void MonoclinicBox::toReal(Vec3<double> &r) const
+void MonoclinicGammaBox::toReal(Vec3<double> &r) const
 {
     auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
     auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
@@ -49,7 +25,7 @@ void MonoclinicBox::toReal(Vec3<double> &r) const
 }
 
 // Convert specified real-space coordinates to fractional coordinates
-void MonoclinicBox::toFractional(Vec3<double> &r) const
+void MonoclinicGammaBox::toFractional(Vec3<double> &r) const
 {
     auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
     auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
@@ -64,7 +40,7 @@ void MonoclinicBox::toFractional(Vec3<double> &r) const
  */
 
 // Return minimum image coordinates of r1 with respect to r2
-Vec3<double> MonoclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
+Vec3<double> MonoclinicGammaBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
     Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
@@ -81,7 +57,7 @@ Vec3<double> MonoclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<doub
 }
 
 // Return minimum image distance from r1 to r2
-double MonoclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
+double MonoclinicGammaBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
@@ -98,7 +74,7 @@ double MonoclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double>
 }
 
 // Return minimum image vector from r1 to r2
-Vec3<double> MonoclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
+Vec3<double> MonoclinicGammaBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
@@ -115,7 +91,7 @@ Vec3<double> MonoclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<dou
 }
 
 // Return minimum image squared distance from r1 to r2
-double MonoclinicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
+double MonoclinicGammaBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
     Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],

--- a/src/classes/box_nonperiodic.cpp
+++ b/src/classes/box_nonperiodic.cpp
@@ -4,23 +4,7 @@
 #include "classes/atom.h"
 #include "classes/box.h"
 
-NonPeriodicBox::NonPeriodicBox(double length) : Box()
-{
-    type_ = Box::BoxType::NonPeriodic;
-    periodic_.set(false, false, false);
-
-    // Construct axes_
-    axes_.setColumn(0, length, 0.0, 0.0);
-    axes_.setColumn(1, 0.0, length, 0.0);
-    axes_.setColumn(2, 0.0, 0.0, length);
-
-    // Store Box length
-    a_ = length;
-    ra_ = 1.0 / a_;
-
-    // Finalise associated data
-    finalise();
-}
+NonPeriodicBox::NonPeriodicBox(double length) : Box(Box::BoxType::NonPeriodic, {length, length, length}, {90.0, 90.0, 90.0}) {}
 
 /*
  * Coordinate Conversion

--- a/src/classes/box_nonperiodic.cpp
+++ b/src/classes/box_nonperiodic.cpp
@@ -23,65 +23,66 @@ NonPeriodicBox::NonPeriodicBox(double length) : Box()
 }
 
 /*
- * Minimum Image Routines (virtual implementations)
+ * Coordinate Conversion
+ */
+
+// Convert specified fractional coordinates to real-space coordinates
+void NonPeriodicBox::toReal(Vec3<double> &r) const
+{
+    r.x *= a_;
+    r.y *= a_;
+    r.z *= a_;
+}
+
+// Convert specified real-space coordinates to fractional coordinates
+void NonPeriodicBox::toFractional(Vec3<double> &r) const
+{
+    r.x *= ra_;
+    r.y *= ra_;
+    r.z *= ra_;
+}
+
+/*
+ * Minimum Image Calculation
  */
 
 // Return minimum image coordinates of r1 with respect to r2
-Vec3<double> NonPeriodicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const { return r1; }
+Vec3<double> NonPeriodicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
+{
+    Vec3<double> v21 = r1 - r2;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
+    return v21;
+}
 
 // Return minimum image vector from r1 to r2
-Vec3<double> NonPeriodicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const { return r2 - r1; }
+Vec3<double> NonPeriodicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
+{
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12;
+}
 
 // Return minimum image distance from r1 to r2
-double NonPeriodicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const { return (r2 - r1).magnitude(); }
+double NonPeriodicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
+{
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12.magnitude();
+}
 
 // Return minimum image squared distance from r1 to r2
 double NonPeriodicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    return (r2 - r1).magnitudeSq();
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12.magnitudeSq();
 }
-
-/*
- * Utility Routines (Virtual Implementations)
- */
-
-// Return random coordinate inside Box
-Vec3<double> NonPeriodicBox::randomCoordinate() const
-{
-    static Vec3<double> pos;
-    pos.x = a_ * DissolveMath::random();
-    pos.y = a_ * DissolveMath::random();
-    pos.z = a_ * DissolveMath::random();
-    return pos;
-}
-
-// Return folded coordinate (i.e. inside current Box)
-Vec3<double> NonPeriodicBox::fold(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    static Vec3<double> frac;
-    frac.set(r.x * ra_, r.y * ra_, r.z * ra_);
-
-    // Fold into Box and divide by integer Cell sizes
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-    return frac * a_;
-}
-
-// Return folded coordinate (i.e. inside current Box)
-Vec3<double> NonPeriodicBox::foldFrac(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    static Vec3<double> frac;
-    frac.set(r.x * ra_, r.y * ra_, r.z * ra_);
-
-    // Fold into Box and divide by integer Cell sizes
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-    return frac;
-}
-
-// Convert supplied fractional coordinates to real space
-Vec3<double> NonPeriodicBox::fracToReal(const Vec3<double> &r) const { return r * a_; }

--- a/src/classes/box_orthorhombic.cpp
+++ b/src/classes/box_orthorhombic.cpp
@@ -26,106 +26,66 @@ OrthorhombicBox::OrthorhombicBox(const Vec3<double> lengths) : Box()
 }
 
 /*
- * Minimum Image Routines (virtual implementations)
+ * Coordinate Conversion
+ */
+
+// Convert specified fractional coordinates to real-space coordinates
+void OrthorhombicBox::toReal(Vec3<double> &r) const
+{
+    r.x *= a_;
+    r.y *= b_;
+    r.z *= c_;
+}
+
+// Convert specified real-space coordinates to fractional coordinates
+void OrthorhombicBox::toFractional(Vec3<double> &r) const
+{
+    r.x *= ra_;
+    r.y *= rb_;
+    r.z *= rc_;
+}
+
+/*
+ * Minimum Image Calculation
  */
 
 // Return minimum image coordinates of r1 with respect to r2
 Vec3<double> OrthorhombicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mimVec = r1;
-    mimVec -= r2;
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * rb_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * b_;
-    mimVec.z -= int(mimVec.z * rc_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * c_;
-
-    return mimVec + r2;
-}
-
-// Return minimum image vector from r1 to r2
-Vec3<double> OrthorhombicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
-{
-    auto mimVec = r2;
-    mimVec -= r1;
-
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * rb_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * b_;
-    mimVec.z -= int(mimVec.z * rc_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * c_;
-
-    return mimVec;
+    Vec3<double> v21 = r1 - r2;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
+    return v21;
 }
 
 // Return minimum image distance from r1 to r2
 double OrthorhombicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mimVec = r2;
-    mimVec -= r1;
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12.magnitude();
+}
 
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * rb_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * b_;
-    mimVec.z -= int(mimVec.z * rc_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * c_;
-
-    return mimVec.magnitude();
+// Return minimum image vector from r1 to r2
+Vec3<double> OrthorhombicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
+{
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12;
 }
 
 // Return minimum image squared distance from r1 to r2
 double OrthorhombicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mimVec = r2;
-    mimVec -= r1;
-
-    mimVec.x -= int(mimVec.x * ra_ + (mimVec.x < 0.0 ? -0.5 : 0.5)) * a_;
-    mimVec.y -= int(mimVec.y * rb_ + (mimVec.y < 0.0 ? -0.5 : 0.5)) * b_;
-    mimVec.z -= int(mimVec.z * rc_ + (mimVec.z < 0.0 ? -0.5 : 0.5)) * c_;
-
-    return mimVec.magnitudeSq();
-}
-
-/*
- * Utility Routines (Virtual Implementations)
- */
-
-// Return random coordinate inside Box
-Vec3<double> OrthorhombicBox::randomCoordinate() const
-{
-    Vec3<double> pos;
-    pos.x = a_ * DissolveMath::random();
-    pos.y = b_ * DissolveMath::random();
-    pos.z = c_ * DissolveMath::random();
-    return pos;
-}
-
-// Return folded coordinate (i.e. inside current Box)
-Vec3<double> OrthorhombicBox::fold(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    Vec3<double> frac(r.x * ra_, r.y * rb_, r.z * rc_);
-
-    // Fold into Box and divide by integer Cell sizes
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-    frac.x *= a_;
-    frac.y *= b_;
-    frac.z *= c_;
-    return frac;
-}
-
-// Return folded fractional coordinate (i.e. inside current Box)
-Vec3<double> OrthorhombicBox::foldFrac(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    Vec3<double> frac(r.x * ra_, r.y * rb_, r.z * rc_);
-
-    // Fold into Box and divide by integer Cell sizes
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-    return frac;
-}
-
-// Convert supplied fractional coordinates to real space
-Vec3<double> OrthorhombicBox::fracToReal(const Vec3<double> &r) const
-{
-    // Multiply by box lengths
-    return Vec3<double>(r.x * a_, r.y * b_, r.z * c_);
+    Vec3<double> v12 = r2 - r1;
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
+    return v12.magnitudeSq();
 }

--- a/src/classes/box_orthorhombic.cpp
+++ b/src/classes/box_orthorhombic.cpp
@@ -4,26 +4,7 @@
 #include "classes/atom.h"
 #include "classes/box.h"
 
-OrthorhombicBox::OrthorhombicBox(const Vec3<double> lengths) : Box()
-{
-    type_ = Box::BoxType::Orthorhombic;
-
-    // Construct axes_
-    axes_.setColumn(0, lengths.x, 0.0, 0.0);
-    axes_.setColumn(1, 0.0, lengths.y, 0.0);
-    axes_.setColumn(2, 0.0, 0.0, lengths.z);
-
-    // Store Box lengths
-    a_ = lengths.x;
-    b_ = lengths.y;
-    c_ = lengths.z;
-    ra_ = 1.0 / a_;
-    rb_ = 1.0 / b_;
-    rc_ = 1.0 / c_;
-
-    // Finalise associated data
-    finalise();
-}
+OrthorhombicBox::OrthorhombicBox(const Vec3<double> lengths) : Box(Box::BoxType::Orthorhombic, lengths, {90.0, 90.0, 90.0}) {}
 
 /*
  * Coordinate Conversion

--- a/src/classes/box_triclinic.cpp
+++ b/src/classes/box_triclinic.cpp
@@ -40,102 +40,99 @@ TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles
 }
 
 /*
- * Minimum Image Routines (virtual implementations)
+ * Coordinate Conversion
+ */
+
+// Convert specified fractional coordinates to real-space coordinates
+void TriclinicBox::toReal(Vec3<double> &r) const
+{
+    auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
+    auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
+    auto z = r.x * axesArray_[2] + r.y * axesArray_[5] + r.z * axesArray_[8];
+    r.x = x;
+    r.y = y;
+    r.z = z;
+}
+
+// Convert specified real-space coordinates to fractional coordinates
+void TriclinicBox::toFractional(Vec3<double> &r) const
+{
+    auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
+    auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
+    auto z = r.x * inverseAxesArray_[2] + r.y * inverseAxesArray_[5] + r.z * inverseAxesArray_[8];
+    r.x = x;
+    r.y = y;
+    r.z = z;
+}
+
+/*
+ * Minimum Image Calculation
  */
 
 // Return minimum image coordinates of r1 with respect to r2
 Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    auto mim = inverseAxes_ * (r2 - r1);
-    if (mim.x < -0.5)
-        mim.x += 1.0;
-    else if (mim.x > 0.5)
-        mim.x -= 1.0;
-    if (mim.y < -0.5)
-        mim.y += 1.0;
-    else if (mim.y > 0.5)
-        mim.y -= 1.0;
-    if (mim.z < -0.5)
-        mim.z += 1.0;
-    else if (mim.z > 0.5)
-        mim.z -= 1.0;
-    return axes_ * mim + r2;
-}
+    Vec3<double> v21 = r1 - r2;
+    Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
+                       v21.x * inverseAxesArray_[1] + v21.y * inverseAxesArray_[4] + v21.z * inverseAxesArray_[7],
+                       v21.x * inverseAxesArray_[2] + v21.y * inverseAxesArray_[5] + v21.z * inverseAxesArray_[8]);
 
-// Return minimum image vector from r1 to r2
-Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
-{
-    auto mim = inverseAxes_ * (r2 - r1);
-    if (mim.x < -0.5)
-        mim.x += 1.0;
-    else if (mim.x > 0.5)
-        mim.x -= 1.0;
-    if (mim.y < -0.5)
-        mim.y += 1.0;
-    else if (mim.y > 0.5)
-        mim.y -= 1.0;
-    if (mim.z < -0.5)
-        mim.z += 1.0;
-    else if (mim.z > 0.5)
-        mim.z -= 1.0;
-    return axes_ * mim;
+    wrap(rFrac);
+
+    v21.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6] + r2.x;
+    v21.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7] + r2.y;
+    v21.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8] + r2.z;
+
+    return v21;
 }
 
 // Return minimum image distance from r1 to r2
 double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    return minimumVector(r1, r2).magnitude();
+    Vec3<double> v12 = r2 - r1;
+    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
+                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
+                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
+
+    wrap(rFrac);
+
+    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
+    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
+    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+
+    return v12.magnitude();
+}
+
+// Return minimum image vector from r1 to r2
+Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
+{
+    Vec3<double> v12 = r2 - r1;
+    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
+                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
+                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
+
+    wrap(rFrac);
+
+    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
+    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
+    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+
+    return v12;
 }
 
 // Return minimum image squared distance from r1 to r2
 double TriclinicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
-    return minimumVector(r1, r2).magnitudeSq();
-}
+    Vec3<double> v12 = r2 - r1;
+    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
+                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
+                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-/*
- * Utility Routines (Virtual Implementations)
- */
+    wrap(rFrac);
 
-// Return random coordinate inside Box
-Vec3<double> TriclinicBox::randomCoordinate() const
-{
-    Vec3<double> pos(DissolveMath::random(), DissolveMath::random(), DissolveMath::random());
-    return axes_ * pos;
-}
+    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
+    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
+    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
 
-// Return folded coordinate (i.e. inside current Box)
-Vec3<double> TriclinicBox::fold(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    auto frac = inverseAxes_ * r;
-
-    // Fold into Box and remultiply by inverse matrix
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-
-    return axes_ * frac;
-}
-
-// Return folded fractional coordinate (i.e. inside current Box)
-Vec3<double> TriclinicBox::foldFrac(const Vec3<double> &r) const
-{
-    // Convert coordinate to fractional coords
-    auto frac = inverseAxes_ * r;
-
-    // Fold into Box
-    frac.x -= floor(frac.x);
-    frac.y -= floor(frac.y);
-    frac.z -= floor(frac.z);
-
-    return frac;
-}
-
-// Convert supplied fractional coordinates to real space
-Vec3<double> TriclinicBox::fracToReal(const Vec3<double> &r) const
-{
-    // Multiply by axes matrix
-    // TODO Can speedup this part since we know which matrix elements are zero
-    return axes_ * r;
+    return v12.magnitudeSq();
 }

--- a/src/classes/box_triclinic.cpp
+++ b/src/classes/box_triclinic.cpp
@@ -16,23 +16,21 @@ TriclinicBox::TriclinicBox(const Vec3<double> lengths, const Vec3<double> angles
 // Convert specified fractional coordinates to real-space coordinates
 void TriclinicBox::toReal(Vec3<double> &r) const
 {
-    auto x = r.x * axesArray_[0] + r.y * axesArray_[3] + r.z * axesArray_[6];
-    auto y = r.x * axesArray_[1] + r.y * axesArray_[4] + r.z * axesArray_[7];
-    auto z = r.x * axesArray_[2] + r.y * axesArray_[5] + r.z * axesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= axesArray_[0];
+    r.x += r.y * axesArray_[3] + r.z * axesArray_[6];
+    r.y *= axesArray_[4];
+    r.y += r.z * axesArray_[7];
+    r.z *= axesArray_[8];
 }
 
 // Convert specified real-space coordinates to fractional coordinates
 void TriclinicBox::toFractional(Vec3<double> &r) const
 {
-    auto x = r.x * inverseAxesArray_[0] + r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
-    auto y = r.x * inverseAxesArray_[1] + r.y * inverseAxesArray_[4] + r.z * inverseAxesArray_[7];
-    auto z = r.x * inverseAxesArray_[2] + r.y * inverseAxesArray_[5] + r.z * inverseAxesArray_[8];
-    r.x = x;
-    r.y = y;
-    r.z = z;
+    r.x *= inverseAxesArray_[0];
+    r.x += r.y * inverseAxesArray_[3] + r.z * inverseAxesArray_[6];
+    r.y *= inverseAxesArray_[4];
+    r.y += r.z * inverseAxesArray_[7];
+    r.z *= inverseAxesArray_[8];
 }
 
 /*
@@ -43,15 +41,11 @@ void TriclinicBox::toFractional(Vec3<double> &r) const
 Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v21 = r1 - r2;
-    Vec3<double> rFrac(v21.x * inverseAxesArray_[0] + v21.y * inverseAxesArray_[3] + v21.z * inverseAxesArray_[6],
-                       v21.x * inverseAxesArray_[1] + v21.y * inverseAxesArray_[4] + v21.z * inverseAxesArray_[7],
-                       v21.x * inverseAxesArray_[2] + v21.y * inverseAxesArray_[5] + v21.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v21.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6] + r2.x;
-    v21.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7] + r2.y;
-    v21.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8] + r2.z;
+    toFractional(v21);
+    wrap(v21);
+    toReal(v21);
+    v21 += r2;
 
     return v21;
 }
@@ -60,15 +54,10 @@ Vec3<double> TriclinicBox::minimumImage(const Vec3<double> &r1, const Vec3<doubl
 double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitude();
 }
@@ -77,15 +66,10 @@ double TriclinicBox::minimumDistance(const Vec3<double> &r1, const Vec3<double> 
 Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12;
 }
@@ -94,15 +78,10 @@ Vec3<double> TriclinicBox::minimumVector(const Vec3<double> &r1, const Vec3<doub
 double TriclinicBox::minimumDistanceSquared(const Vec3<double> &r1, const Vec3<double> &r2) const
 {
     Vec3<double> v12 = r2 - r1;
-    Vec3<double> rFrac(v12.x * inverseAxesArray_[0] + v12.y * inverseAxesArray_[3] + v12.z * inverseAxesArray_[6],
-                       v12.x * inverseAxesArray_[1] + v12.y * inverseAxesArray_[4] + v12.z * inverseAxesArray_[7],
-                       v12.x * inverseAxesArray_[2] + v12.y * inverseAxesArray_[5] + v12.z * inverseAxesArray_[8]);
 
-    wrap(rFrac);
-
-    v12.x = rFrac.x * axesArray_[0] + rFrac.y * axesArray_[3] + rFrac.z * axesArray_[6];
-    v12.y = rFrac.x * axesArray_[1] + rFrac.y * axesArray_[4] + rFrac.z * axesArray_[7];
-    v12.z = rFrac.x * axesArray_[2] + rFrac.y * axesArray_[5] + rFrac.z * axesArray_[8];
+    toFractional(v12);
+    wrap(v12);
+    toReal(v12);
 
     return v12.magnitudeSq();
 }

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -340,7 +340,7 @@ bool CellArray::generate(const Box *box, double cellSize, double pairPotentialRa
             fracCentre.z = fractionalCellSize_.z * 0.5;
             for (auto z = 0; z < divisions_.z; ++z)
             {
-                cells_[count] = Cell(count, Vec3<int>(x, y, z), box_->fracToReal(fracCentre));
+                cells_[count] = Cell(count, Vec3<int>(x, y, z), box_->getReal(fracCentre));
                 fracCentre.z += fractionalCellSize_.z;
                 ++count;
             }

--- a/src/gui/render/renderableconfiguration.cpp
+++ b/src/gui/render/renderableconfiguration.cpp
@@ -60,7 +60,7 @@ void RenderableConfiguration::transformValues()
     limitsMin_.zero();
 
     // Transform extreme upper right corner from unit to real space to get maxima
-    limitsMax_ = source_->box()->fracToReal(Vec3<double>(1.0, 1.0, 1.0));
+    limitsMax_ = source_->box()->getReal(Vec3<double>(1.0, 1.0, 1.0));
 
     positiveLimitsMin_ = limitsMin_;
     positiveLimitsMax_ = limitsMax_;

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -93,12 +93,14 @@ Matrix3 &Matrix3::operator*=(const double a)
     return *this;
 }
 
-// Array access (operator [])
 double &Matrix3::operator[](int index) { return matrix_[index]; }
 
 /*
  * General Routines
  */
+
+// Return the current matrix array
+const std::array<double, 9> &Matrix3::matrix() const { return matrix_; }
 
 // Reset to the identity matrix
 void Matrix3::setIdentity() { matrix_ = {1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0}; }
@@ -591,12 +593,12 @@ Vec3<double> Matrix3::transform(double x, double y, double z) const
 }
 
 // Transform coordinates supplied and return as Vec3<double>
-Vec3<double> Matrix3::transform(Vec3<double> vec) const
+Vec3<double> Matrix3::transform(Vec3<double> r) const
 {
     Vec3<double> result;
-    result.x = vec.x * matrix_[0] + vec.y * matrix_[3] + vec.z * matrix_[6];
-    result.y = vec.x * matrix_[1] + vec.y * matrix_[4] + vec.z * matrix_[7];
-    result.z = vec.x * matrix_[2] + vec.y * matrix_[5] + vec.z * matrix_[8];
+    result.x = r.x * matrix_[0] + r.y * matrix_[3] + r.z * matrix_[6];
+    result.y = r.x * matrix_[1] + r.y * matrix_[4] + r.z * matrix_[7];
+    result.z = r.x * matrix_[2] + r.y * matrix_[5] + r.z * matrix_[8];
     return result;
 }
 

--- a/src/math/matrix3.h
+++ b/src/math/matrix3.h
@@ -33,6 +33,8 @@ class Matrix3
      * General Routines
      */
     public:
+    // Return the current matrix array
+    const std::array<double, 9> &matrix() const;
     // Reset the matrix to the identity
     void setIdentity();
     // Prints the matrix to stdout
@@ -122,7 +124,7 @@ class Matrix3
     // Transform coordinates supplied and return as Vec3<double>
     Vec3<double> transform(double x, double y, double z) const;
     // Transform coordinates supplied and return as Vec3<double>
-    Vec3<double> transform(const Vec3<double> vec) const;
+    Vec3<double> transform(const Vec3<double> r) const;
 
     /*
      * Special Functions

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -241,15 +241,15 @@ bool AddProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::s
         {
             case (AddProcedureNode::PositioningType::Random):
                 fr.set(procPool.random(), procPool.random(), procPool.random());
-                newCentre = box->fracToReal(fr);
+                newCentre = box->getReal(fr);
                 mol->setCentreOfGeometry(box, newCentre);
                 break;
             case (AddProcedureNode::PositioningType::Region):
-                mol->setCentreOfGeometry(box, box->fracToReal(regionNode->randomFractionalCoordinate()));
+                mol->setCentreOfGeometry(box, box->getReal(regionNode->randomFractionalCoordinate()));
                 break;
             case (AddProcedureNode::PositioningType::Central):
                 fr.set(0.5, 0.5, 0.5);
-                newCentre = box->fracToReal(fr);
+                newCentre = box->getReal(fr);
                 mol->setCentreOfGeometry(box, newCentre);
                 break;
             case (AddProcedureNode::PositioningType::Current):

--- a/src/procedure/nodes/regionbase.cpp
+++ b/src/procedure/nodes/regionbase.cpp
@@ -70,8 +70,8 @@ bool RegionProcedureNodeBase::execute(ProcessPool &procPool, Configuration *cfg,
             for (auto z = 0; z < nVoxels_.z; ++z)
                 voxelMap_[{x, y, z}] = {
                     Vec3<int>(x, y, z),
-                    isVoxelValid(cfg, box_->fracToReal(Vec3<double>((x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
-                                                                    (z + 0.5) * voxelSizeFrac_.z)))};
+                    isVoxelValid(cfg, box_->getReal(Vec3<double>((x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
+                                                                 (z + 0.5) * voxelSizeFrac_.z)))};
 
     // Create linear array of all available voxels
     auto nFreeVoxels = std::count_if(voxelMap_.begin(), voxelMap_.end(), [](const auto &voxel) { return voxel.second; });

--- a/unit/test_box.cpp
+++ b/unit/test_box.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "classes/atomtype.h"
+#include "classes/energykernel.h"
+#include "classes/species.h"
+#include "main/dissolve.h"
+#include "templates/algorithms.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+
+Vec3<double> manualMim(const Box &box, const Vec3<double> r1, const Vec3<double> r2)
+{
+    auto mim = box.inverseAxes() * (r1 - r2);
+    if (mim.x < -0.5)
+        mim.x += 1.0;
+    else if (mim.x > 0.5)
+        mim.x -= 1.0;
+    if (mim.y < -0.5)
+        mim.y += 1.0;
+    else if (mim.y > 0.5)
+        mim.y -= 1.0;
+    if (mim.z < -0.5)
+        mim.z += 1.0;
+    else if (mim.z > 0.5)
+        mim.z -= 1.0;
+    return box.axes() * mim + r2;
+}
+
+void testBox(const Box &box)
+{
+    // Determine central coordinate from full axes matrix
+    auto centroid = box.axes() * Vec3<double>(0.5, 0.5, 0.5);
+
+    // For each corner, determine correct coordinates from full axes matrix, then test optimised imaging / vector functions
+    for (auto n = 0; n < 8; ++n)
+    {
+        auto corner = box.axes() * Vec3<double>((n & 1) ? 1.0 : 0.0, (n & 2) ? 1.0 : 0.0, (n & 4) ? 1.0 : 0.0);
+
+        // Calculate manual minimum image vector
+        auto mimCorner = manualMim(box, corner, centroid);
+
+        // Minimum distance
+        EXPECT_NEAR((mimCorner - centroid).magnitude(), box.minimumDistance(centroid, corner), 1.0e-8);
+
+        // Minimum distance squared
+        EXPECT_NEAR((mimCorner - centroid).magnitudeSq(), box.minimumDistanceSquared(centroid, corner), 1.0e-8);
+
+        // Minimum image vector
+        auto mim = box.minimumImage(corner, centroid);
+        EXPECT_NEAR(mimCorner.x, mim.x, 1.0e-8);
+        EXPECT_NEAR(mimCorner.y, mim.y, 1.0e-8);
+        EXPECT_NEAR(mimCorner.z, mim.z, 1.0e-8);
+
+        // Fold
+        auto scaledCorner = box.axes() * Vec3<double>((n & 1) ? -2.0 : 0.0, (n & 2) ? 5.0 : 0.0, (n & 4) ? -97.0 : 0.0);
+        scaledCorner += centroid;
+        auto p = box.fold(scaledCorner);
+        EXPECT_NEAR(p.x, centroid.x, 1.0e-8);
+        EXPECT_NEAR(p.y, centroid.y, 1.0e-8);
+        EXPECT_NEAR(p.z, centroid.z, 1.0e-8);
+        p = box.foldFrac(scaledCorner);
+        EXPECT_NEAR(p.x, 0.5, 1.0e-8);
+        EXPECT_NEAR(p.y, 0.5, 1.0e-8);
+        EXPECT_NEAR(p.z, 0.5, 1.0e-8);
+    }
+}
+
+TEST(BoxTest, Cubic) { testBox(CubicBox(10.0)); }
+
+TEST(BoxTest, Orthorhombic)
+{
+    testBox(OrthorhombicBox({10.0, 20.0, 30.0}));
+    testBox(OrthorhombicBox({15.0, 2.0, 88.0}));
+}
+
+TEST(BoxTest, Monoclinic)
+{
+    testBox(MonoclinicBox({30.0, 30.0, 30.0}, 66.0));
+    testBox(MonoclinicBox({10.0, 20.0, 30.0}, 66.0));
+}
+
+TEST(BoxTest, Triclinic)
+{
+    testBox(TriclinicBox({30.0, 30.0, 30.0}, {66.0, 33.0, 77.0}));
+    testBox(TriclinicBox({10.0, 20.0, 30.0}, {85.0, 80.0, 90.0}));
+    testBox(TriclinicBox({27.0, 25.5, 31.2311}, {89.0, 120.0, 70.0}));
+}
+
+} // namespace UnitTest

--- a/unit/test_box.cpp
+++ b/unit/test_box.cpp
@@ -78,8 +78,12 @@ TEST(BoxTest, Orthorhombic)
 
 TEST(BoxTest, Monoclinic)
 {
-    testBox(MonoclinicBox({30.0, 30.0, 30.0}, 66.0));
-    testBox(MonoclinicBox({10.0, 20.0, 30.0}, 66.0));
+    testBox(MonoclinicAlphaBox({30.0, 30.0, 30.0}, 66.0));
+    testBox(MonoclinicAlphaBox({10.0, 20.0, 30.0}, 120.0));
+    testBox(MonoclinicBetaBox({30.0, 30.0, 30.0}, 66.0));
+    testBox(MonoclinicBetaBox({10.0, 20.0, 30.0}, 120.0));
+    testBox(MonoclinicGammaBox({30.0, 30.0, 30.0}, 66.0));
+    testBox(MonoclinicGammaBox({10.0, 20.0, 30.0}, 120.0));
 }
 
 TEST(BoxTest, Triclinic)


### PR DESCRIPTION
This PR follows on from #750 and updates the set of `Box` classes, and covers two principal areas:

### Optimisation / Simplification

Initial attempts at simplification / optimisation reduced the number of required function reimplementations in each derived class to two - conversion of supplied `Vec3<double>` position to real or fractional coordinates. This allowed the `Box` base class to contain all of the necessary minimum image, fold etc. functions and simply call the overloaded `toFractional` or `toReal` functions as necessary. However, even with inlining / use of `constexpr` this turned out to be a significant performance hit.

Reverting to a point half-way between the old and trialled extremes seems to be a happy medium. A total of six reimplemented functions are required, covering the coordinate conversion and minimum image routines.  This gives the following rough results:

- Minimum image / vector / distance functions show speed increases of between 20 - 50% across the derived classes.
- Fold functions are roughly the same performance as before, but do not require reimplementation per-class
- Performance of random coordinate generation is slightly degraded by around 5 - 10%, but does not require reimplementation per-class.

### Monoclinic Boxes

Previously only a single `MonoclinicBox` class existed, and which assumed the non-right angle to be `beta`, however in practice the non-right angle may be any of the three available. As such, the original class is split into three separate classes, allowing optimisation of the matrix multiplications based on the known non-right angle.

### Related Issues
Closes #736.