### PR TITLE
Box Scaling

### DIFF
--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -141,22 +141,30 @@ Vec3<double> Box::reciprocalAxisLengths() const
 // Return reciprocal axes matrix
 const Matrix3 &Box::reciprocalAxes() const { return reciprocalAxes_; }
 
-// Scale Box by specified factor
-void Box::scale(double factor)
+// Scale Box lengths by specified factors
+void Box::scale(Vec3<double> scaleFactors)
 {
+    // Make a check here for cubic boxes, in which case all elements in scaleFactors must be equal
+    if (type_ == BoxType::Cubic)
+    {
+        auto abSame = (fabs(scaleFactors.x - scaleFactors.y) < 1.0e-5);
+        auto acSame = (fabs(scaleFactors.x - scaleFactors.z) < 1.0e-5);
+        if (!abSame || !acSame)
+            throw(std::runtime_error(fmt::format("Irregular scaling of cubic box requested (scale factors = {}, {}, {}\n",
+                                                 scaleFactors.x, scaleFactors.y, scaleFactors.z)));
+    }
+
     // Scale lengths
-    a_ *= factor;
-    b_ *= factor;
-    c_ *= factor;
+    a_ *= scaleFactors.x;
+    b_ *= scaleFactors.y;
+    c_ *= scaleFactors.z;
     ra_ = 1.0 / a_;
     rb_ = 1.0 / b_;
     rc_ = 1.0 / c_;
 
     // Scale axes
-    axes_.columnMultiply(0, factor);
-    axes_.columnMultiply(1, factor);
-    axes_.columnMultiply(2, factor);
-
+    axes_.columnMultiply(scaleFactors);
+    axes_.print();
     // Calculate box volume
     volume_ = axes_.determinant();
 

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -361,3 +361,18 @@ Vec3<double> Box::foldFrac(const Vec3<double> &r) const
 
     return frac;
 }
+
+// Determine axis scale factors to give requested volume, with scaling ratios provided
+Vec3<double> Box::scaleFactors(double requestedVolume, Vec3<bool> scalableAxes) const
+{
+    // Sanity check
+    if (!scalableAxes.x && !scalableAxes.y && !scalableAxes.z)
+        throw(std::runtime_error("No axes specified as scalable, so no scaling factor can be calculated.\n"));
+
+    // Determine root power
+    auto rootPower = 1.0 / (scalableAxes.x + scalableAxes.y + scalableAxes.z);
+
+    auto ratio = pow(requestedVolume, rootPower) / pow(volume_, rootPower);
+
+    return {scalableAxes.x ? ratio : 1.0, scalableAxes.y ? ratio : 1.0, scalableAxes.z ? ratio : 1.0};
+}

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -87,8 +87,8 @@ class Box
     Vec3<double> reciprocalAxisLengths() const;
     // Return reciprocal axes matrix
     const Matrix3 &reciprocalAxes() const;
-    // Scale Box by specified factor
-    void scale(double factor);
+    // Scale Box lengths by specified factors
+    void scale(Vec3<double> scaleFactors);
 
     /*
      * Coordinate Conversion

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -172,6 +172,8 @@ class Box
     Vec3<double> fold(const Vec3<double> &r) const;
     // Return folded fractional coordinate (i.e. inside current Box)
     Vec3<double> foldFrac(const Vec3<double> &r) const;
+    // Determine axis scale factors to give requested volume, with scaling ratios provided
+    Vec3<double> scaleFactors(double requestedVolume, Vec3<bool> scalableAxes = {true, true, true}) const;
 };
 
 // Non-Periodic Box Definition

--- a/src/classes/cellarray.cpp
+++ b/src/classes/cellarray.cpp
@@ -494,9 +494,9 @@ void CellArray::clear() { cells_.clear(); }
  * Operations
  */
 
-// Scale Cells by supplied factor
-void CellArray::scale(double factor)
+// Scale Cells by supplied factors along each axis
+void CellArray::scale(Vec3<double> scaleFactors)
 {
-    realCellSize_ *= factor;
-    axes_ *= factor;
+    realCellSize_.multiply(scaleFactors);
+    axes_.columnMultiply(scaleFactors);
 }

--- a/src/classes/cellarray.h
+++ b/src/classes/cellarray.h
@@ -91,6 +91,6 @@ class CellArray
      * Operations
      */
     public:
-    // Scale Cells sizes by supplied factor
-    void scale(double factor);
+    // Scale Cells by supplied factors along each axis
+    void scale(Vec3<double> scaleFactors);
 };

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -142,8 +142,8 @@ class Configuration
     const std::vector<std::shared_ptr<Atom>> &atoms() const;
     // Return nth Atom
     std::shared_ptr<Atom> atom(int n);
-    // Scale contents of the box by the specified factor
-    void scaleContents(double factor);
+    // Scale contents of the box by the specified factors along each axis
+    void scaleContents(Vec3<double> scaleFactors);
 
     /*
      * Periodic Box and Cells
@@ -167,8 +167,8 @@ class Configuration
     void createBox(const Matrix3 axes);
     // Return Box
     const Box *box() const;
-    // Scale Box (and associated Cells) by specified factor
-    void scaleBox(double factor);
+    // Scale Box lengths (and associated Cells) by specified factors
+    void scaleBox(Vec3<double> scaleFactors);
     // Set requested size factor for Box
     void setRequestedSizeFactor(double factor);
     // Return requested size factor for Box

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -36,14 +36,11 @@ void Configuration::createBox(const Matrix3 axes)
 // Return Box
 const Box *Configuration::box() const { return box_.get(); }
 
-// Scale Box lengths (and associated Cells) by specified factor
-void Configuration::scaleBox(double factor)
+// Scale Box lengths (and associated Cells) by specified factors
+void Configuration::scaleBox(Vec3<double> scaleFactors)
 {
-    // Scale Box
-    box_->scale(factor);
-
-    // Apply factor to Cells
-    cells_.scale(factor);
+    box_->scale(scaleFactors);
+    cells_.scale(scaleFactors);
 }
 
 // Set requested size factor for Box
@@ -85,10 +82,10 @@ void Configuration::applySizeFactor(const PotentialMap &potentialMap)
                              requestedSizeFactor_, appliedSizeFactor_);
 
             // Scale molecule centres of geometry
-            scaleContents(sizeFactorRatio);
+            scaleContents({sizeFactorRatio, sizeFactorRatio, sizeFactorRatio});
 
             // Now scale the Box and its Cells
-            scaleBox(sizeFactorRatio);
+            scaleBox({sizeFactorRatio, sizeFactorRatio, sizeFactorRatio});
 
             // Re-assign all Atoms to Cells
             updateCellContents();

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -201,29 +201,38 @@ std::shared_ptr<Atom> Configuration::atom(int n)
     return atoms_[n];
 }
 
-// Scale contents of the box by the specified factor
-void Configuration::scaleContents(double factor)
+// Scale contents of the box by the specified factors along each axis
+void Configuration::scaleContents(Vec3<double> scaleFactors)
 {
-    Vec3<double> oldCog, newCog, newPos;
+    Vec3<double> r, cog;
     for (auto &mol : molecules_)
     {
         // If the related species has a periodic box, scale atom positions rather than COG position
         if (mol->species()->box()->type() != Box::BoxType::NonPeriodic)
         {
             for (auto &i : mol->atoms())
-                i->setCoordinates(i->r() * factor);
+            {
+                r = i->r();
+                box()->toFractional(r);
+                r.multiply(scaleFactors);
+                box()->toReal(r);
+                i->setCoordinates(r);
+            }
         }
         else
         {
             // First, work out the centre of geometry of the Molecule, and fold it into the Box
-            oldCog = box()->fold(mol->centreOfGeometry(box()));
+            cog = box()->fold(mol->centreOfGeometry(box()));
 
-            // Scale centre of geometry by supplied factor
-            newCog = oldCog * factor;
+            // Scale centre of geometry along axes by supplied factors
+            r = cog;
+            box()->toFractional(r);
+            r.multiply(scaleFactors);
+            box()->toReal(r);
 
             // Loop over Atoms in Molecule, setting new coordinates as we go
             for (auto &i : mol->atoms())
-                i->setCoordinates(newCog + box()->minimumVector(i->r(), oldCog));
+                i->setCoordinates(r + box()->minimumVector(i->r(), cog));
         }
     }
 }

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -143,7 +143,7 @@ bool Configuration::read(LineParser &parser, const std::vector<std::unique_ptr<S
     cells_.generate(box_.get(), requestedCellDivisionLength_, pairPotentialRange);
 
     // Scale box and cells according to the applied size factor
-    scaleBox(appliedSizeFactor_);
+    scaleBox({appliedSizeFactor_, appliedSizeFactor_, appliedSizeFactor_});
 
     // Update Cell locations for Atoms
     updateCellContents();

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -275,12 +275,19 @@ template <class T> class Vec3
             return 1;
         return 2;
     }
-    // Multiply elements of this vector with those of supplied vector
+    // Multiply elements of this vector with factors supplied
     void multiply(double facx, double facy, double facz)
     {
         x *= facx;
         y *= facy;
         z *= facz;
+    }
+    // Multiply elements of this vector by those of supplied vector
+    void multiply(Vec3<double> v)
+    {
+        x *= v.x;
+        y *= v.y;
+        z *= v.z;
     }
     // Normalise the vector to unity
     void normalise()

--- a/web/content/docs/procedures/nodes/addnode.md
+++ b/web/content/docs/procedures/nodes/addnode.md
@@ -27,6 +27,8 @@ When adding molecules of the target species to the current configuration, there 
 3. The box volume is scaled to give the supplied density ([`BoxAction`]({{< ref "boxactionstyle" >}}) = `ScaleVolume`) - The box volume is scaled to give the requested density, taking into account the existing box contents and the new population of molecules requested. Existing molecules within the box have their centres of geometry scaled as well.
 4. The box is set ([`BoxAction`]({{< ref "boxactionstyle" >}}) = `Set`) from a definition on the species itself (if it is periodic). This is typically used when the species is a framework-type model (e.g. a metal organic framework) and it is to be used as the main basis for a configuration.
 
+When resizing the box, the default is to scale equally in all directions A, B, and C. The scaling can be restricted to two or even one principal axis by setting `ScaleA`, `ScaleB`, and/or `ScaleC` to `false`. At least one axis must remain scalable, for obvious reasons!
+
 ## Configuration
 
 ### Control Keywords
@@ -39,4 +41,7 @@ When adding molecules of the target species to the current configuration, there 
 |`Positioning`|[`PositioningType`]({{< ref "positioningtype" >}})|`Random`|Positioning type for individual molecules.|
 |`Region`|`name`|--|Region node controlling the location of inserted species into the configuration.|
 |`Rotate`|`true|false`|`true`|Whether to randomly rotate molecules on insertion.|
+|`ScaleA`|`true|false`|`true`|Whether to scale the A cell axis when changing the cell volume.|
+|`ScaleB`|`true|false`|`true`|Whether to scale the B cell axis when changing the cell volume.|
+|`ScaleC`|`true|false`|`true`|Whether to scale the C cell axis when changing the cell volume.|
 |`Species`|`name`|--|{{< required-label >}} Target species to add.|


### PR DESCRIPTION
This PR adds the ability to restrict scaling of box axes to as few as one when changing box volume in the `AddSpecies` node.

The specific requirement of this is to allow a monoclinic cell with enforced *A* and *B* axis lengths to be kept fixed, while the *C* axis is freely scaled to accommodate the necessary volume changes.

Closes #737. 