### PR TITLE
Remove ListItem dependency from Isotopologues and IsotopeData

### DIFF
--- a/src/classes/isotopedata.h
+++ b/src/classes/isotopedata.h
@@ -4,10 +4,9 @@
 #pragma once
 
 #include "data/isotopes.h"
-#include "templates/listitem.h"
 
 // sotopeData Definition
-class IsotopeData : public ListItem<IsotopeData>
+class IsotopeData
 {
     public:
     IsotopeData(Sears91::Isotope isotope = Sears91::Isotope::Unknown, double population = 0.0, double fraction = 0.0);

--- a/src/classes/isotopologue.cpp
+++ b/src/classes/isotopologue.cpp
@@ -6,7 +6,7 @@
 #include "classes/species.h"
 #include "data/isotopes.h"
 
-Isotopologue::Isotopologue() : ListItem<Isotopologue>() {}
+Isotopologue::Isotopologue() {}
 
 /*
  * Basic Information

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -6,8 +6,6 @@
 #include "data/elements.h"
 #include "data/isotopes.h"
 #include "templates/list.h"
-#include "templates/listitem.h"
-#include "templates/refdatalist.h"
 #include <memory>
 #include <tuple>
 #include <vector>
@@ -19,7 +17,7 @@ class Species;
 /*
  * Isotopologue Definition
  */
-class Isotopologue : public ListItem<Isotopologue>
+class Isotopologue
 {
     public:
     Isotopologue();

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -60,18 +60,16 @@ bool Isotopologues::addNext()
     }
 
     // Find unique (unused) Isotopologue
-    Isotopologue *iso;
-    for (iso = species_->isotopologues().first(); iso != nullptr; iso = iso->next())
-        if (!contains(iso))
-            break;
+    auto it = std::find_if(species_->isotopologues().begin(), species_->isotopologues().end(),
+                           [this](auto &i) { return contains(i.get()); });
 
-    if (iso == nullptr)
+    if (it == species_->isotopologues().end())
     {
         Messenger::error("Couldn't find an unused Isotopologue in Species '{}'.\n", species_->name());
         return false;
     }
 
-    mix_.emplace_back(iso, 1.0);
+    mix_.emplace_back(it->get(), 1.0);
 
     return true;
 }

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -114,7 +114,7 @@ bool Species::checkSetUp() const
     /*
      * Check Isotopologues
      */
-    for (auto *iso = isotopologues_.first(); iso != nullptr; iso = iso->next())
+    for (auto &iso : isotopologues_)
     {
         for (auto [atomType, isotope] : iso->isotopes())
         {

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -256,7 +256,7 @@ class Species
     // Natural Isotopologue
     Isotopologue naturalIsotopologue_;
     // List of isotopic variants defined for this species
-    List<Isotopologue> isotopologues_;
+    std::vector<std::unique_ptr<Isotopologue>> isotopologues_;
 
     public:
     // Update current Isotopologues
@@ -272,7 +272,7 @@ class Species
     // Return nth Isotopologue in the list
     Isotopologue *isotopologue(int n);
     // Return Isotopologue List
-    const List<Isotopologue> &isotopologues() const;
+    const std::vector<std::unique_ptr<Isotopologue>> &isotopologues() const;
     // Return whether the specified Isotopologue exists
     bool hasIsotopologue(const Isotopologue *iso) const;
     // Generate unique Isotopologue name with base name provided

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -772,7 +772,7 @@ bool Species::write(LineParser &parser, std::string_view prefix)
         if (!parser.writeLineF("\n{}# Isotopologues\n", newPrefix))
             return false;
 
-        for (auto *iso = isotopologues_.first(); iso != nullptr; iso = iso->next())
+        for (auto &iso : isotopologues_)
         {
             if (!parser.writeLineF("{}{}  '{}'", newPrefix, keywords().keyword(Species::SpeciesKeyword::Isotopologue),
                                    iso->name()))

--- a/src/classes/species_isotopologues.cpp
+++ b/src/classes/species_isotopologues.cpp
@@ -80,11 +80,11 @@ const Isotopologue *Species::findIsotopologue(std::string_view name, const Isoto
     if (DissolveSys::sameString("Natural", name))
         return naturalIsotopologue();
 
-    for (auto &iso : isotopologues_)
-        if (iso.get() == exclude)
-            continue;
-        else if (DissolveSys::sameString(name, iso->name()))
-            return iso.get();
+    auto it = std::find_if(isotopologues_.begin(), isotopologues_.end(), [exclude, name](auto &iso) {
+        return iso.get() != exclude && DissolveSys::sameString(name, iso->name());
+    });
+    if (it != isotopologues_.end())
+        return it->get();
 
     return nullptr;
 }

--- a/src/classes/species_isotopologues.cpp
+++ b/src/classes/species_isotopologues.cpp
@@ -8,7 +8,7 @@
 // Update current Isotopologues
 void Species::updateIsotopologues(OptionalReferenceWrapper<const std::vector<std::shared_ptr<AtomType>>> atomTypes)
 {
-    for (Isotopologue *iso = isotopologues_.first(); iso != nullptr; iso = iso->next())
+    for (auto &iso : isotopologues_)
     {
         if (atomTypes)
             iso->checkAtomTypes(*atomTypes);
@@ -23,12 +23,12 @@ const Isotopologue *Species::naturalIsotopologue() const { return &naturalIsotop
 // Add a new Isotopologue to this species
 Isotopologue *Species::addIsotopologue(std::string_view baseName)
 {
-    Isotopologue *iso = isotopologues_.add();
+    auto &iso = isotopologues_.emplace_back(std::make_unique<Isotopologue>());
     iso->setParent(this);
     iso->setName(uniqueIsotopologueName(baseName));
     iso->update();
 
-    return iso;
+    return iso.get();
 }
 
 // Remove specified Isotopologue from this Species
@@ -36,24 +36,29 @@ void Species::removeIsotopologue(Isotopologue *iso)
 {
     if (iso == nullptr)
         Messenger::error("NULL_POINTER - NULL Isotopologue passed to Species::removeIsotopologue().\n");
-    else if (isotopologues_.contains(iso))
+    else if (std::any_of(isotopologues_.begin(), isotopologues_.end(), [iso](auto &i) { return i.get() == iso; }))
     {
         Messenger::print("Removing Isotopologue '{}' from Species '{}'.\n", iso->name(), name_);
-        isotopologues_.remove(iso);
+        isotopologues_.erase(
+            std::remove_if(isotopologues_.begin(), isotopologues_.end(), [iso](auto &i) { return i.get() == iso; }),
+            isotopologues_.end());
     }
 }
 
 // Return number of defined Isotopologues
-int Species::nIsotopologues() const { return isotopologues_.nItems(); }
+int Species::nIsotopologues() const { return isotopologues_.size(); }
 
 // Return nth Isotopologue in the list
-Isotopologue *Species::isotopologue(int n) { return isotopologues_[n]; }
+Isotopologue *Species::isotopologue(int n) { return isotopologues_[n].get(); }
 
 // Return Isotopologue List
-const List<Isotopologue> &Species::isotopologues() const { return isotopologues_; }
+const std::vector<std::unique_ptr<Isotopologue>> &Species::isotopologues() const { return isotopologues_; }
 
 // Return whether the specified Isotopologue exists
-bool Species::hasIsotopologue(const Isotopologue *iso) const { return isotopologues_.contains(iso); }
+bool Species::hasIsotopologue(const Isotopologue *iso) const
+{
+    return std::any_of(isotopologues_.begin(), isotopologues_.end(), [iso](auto &i) { return i.get() == iso; });
+}
 
 // Generate unique Isotopologue name with base name provided
 std::string Species::uniqueIsotopologueName(std::string_view base, const Isotopologue *exclude)
@@ -75,14 +80,18 @@ const Isotopologue *Species::findIsotopologue(std::string_view name, const Isoto
     if (DissolveSys::sameString("Natural", name))
         return naturalIsotopologue();
 
-    for (auto *iso = isotopologues_.first(); iso != nullptr; iso = iso->next())
-        if (iso == exclude)
+    for (auto &iso : isotopologues_)
+        if (iso.get() == exclude)
             continue;
         else if (DissolveSys::sameString(name, iso->name()))
-            return iso;
+            return iso.get();
 
     return nullptr;
 }
 
 // Return index of specified Isotopologue
-int Species::indexOfIsotopologue(const Isotopologue *iso) const { return isotopologues_.indexOf(iso); }
+int Species::indexOfIsotopologue(const Isotopologue *iso) const
+{
+    auto i = std::find_if(isotopologues_.begin(), isotopologues_.end(), [iso](auto &i) { return i.get() == iso; });
+    return i - isotopologues_.begin();
+}

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -74,8 +74,7 @@ std::vector<std::string> IsotopologueSetKeywordWidget::availableIsotopologueName
 
     // Construct valid names list
     std::vector<std::string> validNames = {"Natural"};
-    ListIterator<Isotopologue> topeIterator(isotopologues.species()->isotopologues());
-    while (Isotopologue *tope = topeIterator.iterate())
+    for (auto &tope : isotopologues.species()->isotopologues())
         validNames.push_back(std::string(tope->name()));
 
     return validNames;
@@ -119,12 +118,11 @@ void IsotopologueSetKeywordWidget::addButton_clicked(bool checked)
             set.add(sp->naturalIsotopologue(), 1.0);
         else
         {
-            ListIterator<Isotopologue> topeIterator(sp->isotopologues());
-            while (auto *tope = topeIterator.iterate())
+            for (auto &tope : sp->isotopologues())
             {
-                if (!topes.contains(tope))
+                if (!topes.contains(tope.get()))
                 {
-                    set.add(tope, 1.0);
+                    set.add(tope.get(), 1.0);
                     break;
                 }
             }
@@ -161,12 +159,11 @@ void IsotopologueSetKeywordWidget::addButton_clicked(bool checked)
             set.add(sp->naturalIsotopologue(), 1.0);
         else
         {
-            ListIterator<Isotopologue> topeIterator(sp->isotopologues());
-            while (Isotopologue *tope = topeIterator.iterate())
+            for (auto &tope : sp->isotopologues())
             {
-                if (!topes.contains(tope))
+                if (!topes.contains(tope.get()))
                 {
-                    set.add(tope, 1.0);
+                    set.add(tope.get(), 1.0);
                     break;
                 }
             }

--- a/src/gui/models/speciesIsoModel.cpp
+++ b/src/gui/models/speciesIsoModel.cpp
@@ -11,7 +11,7 @@ SpeciesIsoModel::SpeciesIsoModel(Species &species) : species_(species) {}
 int SpeciesIsoModel::rowCount(const QModelIndex &parent) const
 {
     if (!parent.isValid())
-        return species_.isotopologues().nItems();
+        return species_.isotopologues().size();
     return species_.isotopologue(parent.row())->isotopes().size();
 }
 
@@ -34,7 +34,7 @@ QVariant SpeciesIsoModel::data(const QModelIndex &index, int role) const
 
     if (!index.parent().isValid())
     {
-        if (index.row() > species_.isotopologues().nItems())
+        if (index.row() > species_.isotopologues().size())
             return QVariant();
         if (index.column() > 0)
             return QVariant();
@@ -132,7 +132,7 @@ bool SpeciesIsoModel::setData(const QModelIndex &index, const QVariant &value, i
     {
         if (index.row() != 0)
             return false;
-        if (index.row() > species_.isotopologues().nItems())
+        if (index.row() > species_.isotopologues().size())
             return false;
         auto iso = species_.isotopologue(index.row());
         iso->setName(value.toString().toStdString());


### PR DESCRIPTION
This is part of #257.  IsotopeData just needed to have ListItem removed as a parent class, but there were some remaining List stragglers for Isotopologues.