### PR TITLE
Bugfix 04/08/21 GUI Input File Loading

### DIFF
--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -163,13 +163,10 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
         }
 
         if (!loadResult)
-        {
             QMessageBox::warning(this, "Input file contained errors.",
                                  "The input file failed to load correctly.\nCheck the simulation carefully, and "
                                  "see the messages for more details.",
                                  QMessageBox::Ok, QMessageBox::Ok);
-            return false;
-        }
     }
     else
         return Messenger::error("Input file does not exist.\n");


### PR DESCRIPTION
Trivial PR to better handle "bad" input files loaded in to the GUI - previously, a message box was displayed but no other content was visible. Now, the GUI is updated with the partially-loaded content, and allows any error messages to be viewed.
