### PR TITLE
Singularity Container

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -29,10 +29,10 @@ stages:
           - checkout: self
             fetchDepth: 1
           - template: templates/set-short-hash.yml
-          - template: templates/build-linux.yml
-            parameters:
-              extraflags: "-DBUILD_SYSTEM_TESTS:bool=true -DBUILD_UNIT_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug"
-          - template: templates/package-linux.yml
+            #- template: templates/build-linux.yml
+            #parameters:
+            #  extraflags: "-DBUILD_SYSTEM_TESTS:bool=true -DBUILD_UNIT_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug"
+            #- template: templates/package-linux.yml
           - template: templates/package-singularity.yml
           - task: PublishBuildArtifacts@1
             inputs:

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -45,6 +45,7 @@ stages:
             displayName: 'Publish Linux Artifacts'
       - job: "linux_serial"
         displayName: "Ubuntu, Serial, CLI"
+        condition: eq(1,0)
         pool:
           vmImage: "ubuntu-latest"
         steps:
@@ -63,6 +64,7 @@ stages:
             displayName: "Publish Serial Test Artifacts"
       - job: "linux_mpi"
         displayName: "Ubuntu, MPI, CLI"
+        condition: eq(1,0)
         pool:
           vmImage: "ubuntu-latest"
         steps:
@@ -79,6 +81,7 @@ stages:
             displayName: "Publish MPI Test Artifacts"
       - job: "osx"
         displayName: "OSX, Threads, CLI/GUI"
+        condition: eq(1,0)
         timeoutInMinutes: 120
         pool:
           vmImage: "macos-latest"
@@ -95,6 +98,7 @@ stages:
             displayName: "Publish OSX Artifacts"
       - job: "windows"
         displayName: "Windows, Threads, CLI/GUI"
+        condition: eq(1,0)
         timeoutInMinutes: 120
         pool:
           vmImage: "windows-latest"
@@ -110,8 +114,3 @@ stages:
               ArtifactName: "windows-artifacts"
             displayName: "Publish Windows Artifacts"
 
-  # Run Tests
-  - stage: "tests"
-    displayName: "Testing"
-    jobs:
-      - template: templates/tests.yml

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -33,6 +33,7 @@ stages:
             parameters:
               extraflags: "-DBUILD_SYSTEM_TESTS:bool=true -DBUILD_UNIT_TESTS:bool=true -DCMAKE_BUILD_TYPE=Debug"
           - template: templates/package-linux.yml
+          - template: templates/package-singularity.yml
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "build/"

--- a/.azure-pipelines/templates/package-linux.yml
+++ b/.azure-pipelines/templates/package-linux.yml
@@ -35,6 +35,6 @@ steps:
     displayName: 'Create AppImages'
   - bash: |
       set -ex
-      mkdir packages
+      if [ ! -e packages/ ]; then mkdir packages; fi
       mv Dissolve-*-x86_64.AppImage packages
     displayName: 'Move Artifacts'

--- a/.azure-pipelines/templates/package-singularity.yml
+++ b/.azure-pipelines/templates/package-singularity.yml
@@ -1,0 +1,28 @@
+parameters:
+  - name: qtver
+    default: 6.1.1
+
+steps:
+  - bash: |
+      set -ex
+      sudo apt-get update
+      sudo apt-get install -y build-essential libssl-dev uuid-dev libgpgme11-dev squashfs-tools
+    displayName: 'Install Prerequisites'
+  - bash: |
+      export GOPATH=$(Agent.HomeDirectory)/go
+      go get -d github.com/sylabs/singularity
+      set -ex
+      cd ${GOPATH}/src/github.com/sylabs/singularity && git fetch
+      ./mconfig && make -C ./builddir && sudo make -C ./builddir install
+    displayName: 'Compile Singularity'
+  - bash: |
+      set -ex
+      # Extract the version from the source
+      export VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
+      sudo singularity build Dissolve-${VERSION}.sif ci/singularity/leap15.2.def
+    displayName: 'Build Container'
+  - bash: |
+      set -ex
+      if [ ! -e packages/ ]; then mkdir packages; fi
+      mv Dissolve-*.sif packages
+    displayName: 'Move Artifacts'

--- a/ci/singularity/leap15.2.def
+++ b/ci/singularity/leap15.2.def
@@ -1,0 +1,84 @@
+BootStrap: zypper
+OSVersion: 15.2
+MirrorURL: http://download.opensuse.org/distribution/leap/15.2/repo/oss/
+UpdateURL: http://download.opensuse.org/update/leap/15.2/oss
+Include: rpm zypper
+
+Stage: build
+
+%setup
+    mkdir ${SINGULARITY_ROOTFS}/opt/dissolve-src
+    mkdir ${SINGULARITY_ROOTFS}/opt/dissolve-build
+
+%files
+    # Copy source dir in from build CI
+    /home/vsts/work/1/s/* opt/dissolve-src
+    
+%post
+    # Add KDE repo for Qt6
+    zypper addrepo --no-gpgcheck https://download.opensuse.org/repositories/KDE:/Qt6/openSUSE_Leap_15.2/ KDE-Qt6
+    zypper refresh
+
+    # Install build pre-requisites
+    zypper install -y ninja gcc9 gcc9-c++ python3-pip antlr4-tool antlr4-java libantlr4-runtime4_7_2 libantlr4-runtime-devel qt6-base-common-devel qt6-core-devel qt6-gui-devel qt6-widgets-devel qt6-opengl-devel qt6-openglwidgets-devel ftgl-devel
+    pip install conan
+
+    # Set up build
+    cd /opt/dissolve-build
+    conan install /opt/dissolve-src -s compiler.version=9
+    cmake /opt/dissolve-src -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=true -DCMAKE_CXX_COMPILER:string="g++-9" -DCMAKE_C_COMPILER:string="gcc-9"
+    ninja
+
+BootStrap: zypper
+OSVersion: 15.2
+MirrorURL: http://download.opensuse.org/distribution/leap/15.2/repo/oss/
+UpdateURL: http://download.opensuse.org/update/leap/15.2/oss
+Include: rpm zypper
+
+Stage: final
+
+%help
+
+    A singularity container for Dissolve, including command-line and GUI multithreaded versions.
+
+%files from build
+    
+    # Binaries
+    /opt/dissolve-build/bin/dissolve opt/dissolve/
+    /opt/dissolve-build/bin/dissolve-gui opt/dissolve/
+
+    # Extra Data
+    /opt/dissolve-src/examples opt/dissolve/examples
+
+    # Libraries
+    /usr/lib64/libQt6OpenGLWidgets.so* usr/lib64
+    /usr/lib64/libQt6Widgets.so* usr/lib64
+    /usr/lib64/libQt6OpenGL.so* usr/lib64
+    /usr/lib64/libQt6Gui.so* usr/lib64
+    /usr/lib64/libQt6XcbQpa.so* usr/lib64
+    /usr/lib64/libQt6Core.so* usr/lib64
+    /usr/lib64/libQt6DBus.so* usr/lib64
+    /usr/lib64/qt6 usr/lib64
+
+%post
+
+    # Install packages required at runtime
+    zypper install -y libantlr4-runtime4_7_2 libftgl2 fontconfig libxkbcommon0 libharfbuzz0 libicu-suse65_1 libdouble-conversion3 libb2-1 libpcre2-16-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xkb1 libX11-xcb1 libxcb-xinput0 libxkbcommon-x11-0 libXcursor1 libxcb-glx0 dejavu-fonts
+
+%runscript
+
+    # If the container is executed, this line will be run and all arguments will be passed to it
+    exec /opt/dissolve/dissolve-gui "$@"
+
+%apphelp dissolve
+    Dissolve command-line multithreaded version.
+
+%apprun dissolve
+    exec /opt/dissolve/dissolve "$@"
+
+%apphelp dissolve-gui
+    Dissolve GUI multithreaded version.
+
+%apprun dissolve-gui
+    exec /opt/dissolve/dissolve-gui "$@"
+

--- a/ci/singularity/ubuntu20.04.def
+++ b/ci/singularity/ubuntu20.04.def
@@ -1,0 +1,69 @@
+Bootstrap: library
+From: ubuntu:20.04
+
+Stage: init
+
+%post
+    # Install Qt via aqtinstall as a precursor to the main stage in order to avoid bringing in unnecessary dependencies.
+    # The necessary libs will be copied over in the next stage.
+    apt-get update
+    apt-get install -y software-properties-common
+    apt-add-repository universe
+    apt-get install -y --no-install-recommends python3 python3-pip
+    pip install wheel aqtinstall
+    aqt install --outputdir /opt/qt 6.1.1 linux desktop -m qtcore qtgui qtwidgets qtopengl qtopenglwidgets
+
+Bootstrap: library
+From: ubuntu:20.04
+
+Stage: final
+
+%help
+
+    A singularity container for Dissolve, including command-line and GUI multithreaded versions.
+
+%setup
+
+    mkdir ${SINGULARITY_ROOTFS}/opt/dissolve
+    mkdir ${SINGULARITY_ROOTFS}/opt/dissolve/examples
+
+%files from init
+    
+    /opt/qt/6.1.1/gcc_64/lib/libQt6OpenGLWidgets.so.* usr/lib
+    /opt/qt/6.1.1/gcc_64/lib/libQt6Widgets.so.* usr/lib
+    /opt/qt/6.1.1/gcc_64/lib/libQt6OpenGL.so.* usr/lib
+    /opt/qt/6.1.1/gcc_64/lib/libQt6Gui.so.* usr/lib
+    /opt/qt/6.1.1/gcc_64/lib/libQt6Core.so.* usr/lib
+    /opt/qt/6.1.1/gcc_64/lib/libQt6DBus.so.* usr/lib
+
+%files
+
+    ./build/bin/dissolve opt/dissolve/
+    ./build/bin/dissolve-gui opt/dissolve/
+    ./examples/* opt/dissolve/examples
+
+%post
+
+    # Install packages required at runtime
+    apt-get update
+    apt-get install -y software-properties-common
+    apt-add-repository universe
+    apt-get install -y libfreetype6 libftgl2 libopengl0 libegl1 libxkbcommon-x11-0 libxcb-render0 libxcb-render-util0 libxcb-shape0 libxcb-randr0 libxcb-xfixes0 libxcb-xkb1 libxcb-sync1 libxcb-shm0 libxcb-icccm4 libxcb-keysyms1 libxcb-image0 libxcb-util1 libfontconfig
+
+%runscript
+
+    # If the container is executed, this line will be run and all arguments will be passed to it
+    exec /opt/dissolve/dissolve-gui "$@"
+
+%apphelp dissolve
+    Dissolve command-line multithreaded version.
+
+%apprun dissolve
+    exec /opt/dissolve/dissolve "$@"
+
+%apphelp dissolve-gui
+    Dissolve GUI multithreaded version.
+
+%apprun dissolve-gui
+    exec /opt/dissolve/dissolve-gui "$@"
+


### PR DESCRIPTION
This PR introduces building of Singularity containers for Dissolve. The containers contain both the command-line and GUI versions, with the latter being the default run target, and the former accessed by passing `--app dissolve`.

Two flavours of container are defined in `ci/singularity/`, each with a specific issue for discussion:

### Ubuntu 20.04

This simply brings in the binary artifacts from the build stage of the CI, but which has a missing runtime dependency in the form of `libicui18n.so.56` which doesn't appear to be in any accessible Ubuntu repo. I assume that this dependency comes from the Qt6 packages brought in by `aqtinstall`, and which presumably breaks the AppImages as well.

### OpenSuSE Leap 15.2

This builds Dissolve from scratch (again) but all required libraries are native since they are all in official OpenSuSE repositories. The GUI opens without error, but as soon as a `QOpenGLWidget` is constructed by loading / starting a new simulation we get lots a GLX error:
```
Falling back to using screens root_visual.
qt.glx: qglx_findConfig: Failed to finding matching FBConfig for QSurfaceFormat(version 2.0, options QFlags<QSurfaceFormat::FormatOption>(), depthBufferSize -1, redBufferSize 1, greenBufferSize 1, blueBufferSize 1, alphaBufferSize -1, stencilBufferSize -1, samples -1, swapBehavior QSurfaceFormat::SingleBuffer, swapInterval 1, colorSpace QColorSpace(), profile  QSurfaceFormat::NoProfile)
Could not initialize GLX
```
