### PR TITLE
openRecent CLI Fixes

### DIFF
--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -50,6 +50,9 @@ int main(int args, char **argv)
     DissolveWindow dissolveWindow(dissolve);
     dissolveWindow.show();
 
+    // Create recent files menu
+    dissolveWindow.createRecentMenu();
+
     // Print GPL license information
     Messenger::print("Dissolve-GUI {} version {}, Copyright (C) 2021 Team Dissolve and contributors.\n", Version::appType(),
                      Version::info());
@@ -87,8 +90,7 @@ int main(int args, char **argv)
             }
         }
     }
-    // Create recent files menu
-    dissolveWindow.createRecentMenu();
+
     // Update the main window and exec the app
     dissolveWindow.fullUpdate();
 

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -289,7 +289,7 @@ void DissolveWindow::updateRecentActionList()
             fileInfo = QFileInfo(recentFilePaths.at(i));
             strippedName = fileInfo.fileName();
             filePath = fileInfo.absoluteDir().absolutePath();
-            recentFileActionList_.at(i)->setText(strippedName + "    (" +filePath+")");
+            recentFileActionList_.at(i)->setText(strippedName + "    (" + filePath + ")");
             recentFileActionList_.at(i)->setData(recentFilePaths.at(i));
             recentFileActionList_.at(i)->setVisible(true);
         }

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -148,6 +148,10 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
     auto loadResult = false;
     if (inputFileInfo.exists())
     {
+        // Add file to recent menu
+        QString filePath = inputFileInfo.absoluteDir().absolutePath();
+        std::string fileName = dissolve_.inputFilename().data();
+        addRecentFile(filePath + QString::fromStdString("/" + fileName));
         QDir::setCurrent(inputFileInfo.absoluteDir().absolutePath());
         try
         {
@@ -216,10 +220,6 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
     }
 
     dissolveState_ = EditingState;
-    // Add file to recent menu
-    QString filePath = inputFileInfo.absoluteDir().absolutePath();
-    std::string fileName = dissolve_.inputFilename().data();
-    addRecentFile(filePath + QString::fromStdString("/" + fileName));
     // Fully update GUI
     fullUpdate();
 

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -219,7 +219,7 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
     // Add file to recent menu
     QString filePath = inputFileInfo.absoluteDir().absolutePath();
     std::string fileName = dissolve_.inputFilename().data();
-    addRecentFile(filePath + QString::fromStdString("/"+fileName));
+    addRecentFile(filePath + QString::fromStdString("/" + fileName));
     // Fully update GUI
     fullUpdate();
 
@@ -286,7 +286,7 @@ void DissolveWindow::updateRecentActionList()
         if (i < recentFilePaths.size())
         {
             QString strippedName = QFileInfo(recentFilePaths.at(i)).fileName();
-            recentFileActionList_.at(i)->setText(strippedName+"    "+recentFilePaths.at(i));
+            recentFileActionList_.at(i)->setText(strippedName + "    " + recentFilePaths.at(i));
             recentFileActionList_.at(i)->setData(recentFilePaths.at(i));
             recentFileActionList_.at(i)->setVisible(true);
         }

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -20,6 +20,7 @@
 #include <QMdiSubWindow>
 #include <QMessageBox>
 #include <QSettings>
+#include <iostream>
 
 DissolveWindow::DissolveWindow(Dissolve &dissolve)
     : QMainWindow(nullptr), dissolve_(dissolve), recentFileNo_(10), threadController_(this, dissolve)
@@ -283,8 +284,10 @@ void DissolveWindow::updateRecentActionList()
     {
         if (i < recentFilePaths.size())
         {
-            QString strippedName = QFileInfo(recentFilePaths.at(i)).fileName();
-            recentFileActionList_.at(i)->setText(strippedName + "    " + recentFilePaths.at(i));
+            QFileInfo fileInfo = QFileInfo(recentFilePaths.at(i));
+            QString strippedName = fileInfo.fileName();
+            QString filePath = fileInfo.absoluteDir().absolutePath();
+            recentFileActionList_.at(i)->setText(strippedName + "    (" +filePath+")");
             recentFileActionList_.at(i)->setData(recentFilePaths.at(i));
             recentFileActionList_.at(i)->setVisible(true);
         }

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -282,11 +282,13 @@ void DissolveWindow::updateRecentActionList()
     // Fill recent menu
     for (auto i = 0u; i < recentFileNo_; ++i)
     {
+        QFileInfo fileInfo;
+        QString strippedName, filePath;
         if (i < recentFilePaths.size())
         {
-            QFileInfo fileInfo = QFileInfo(recentFilePaths.at(i));
-            QString strippedName = fileInfo.fileName();
-            QString filePath = fileInfo.absoluteDir().absolutePath();
+            fileInfo = QFileInfo(recentFilePaths.at(i));
+            strippedName = fileInfo.fileName();
+            filePath = fileInfo.absoluteDir().absolutePath();
             recentFileActionList_.at(i)->setText(strippedName + "    (" +filePath+")");
             recentFileActionList_.at(i)->setData(recentFilePaths.at(i));
             recentFileActionList_.at(i)->setVisible(true);

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -22,7 +22,7 @@
 #include <QSettings>
 
 DissolveWindow::DissolveWindow(Dissolve &dissolve)
-    : QMainWindow(nullptr), dissolve_(dissolve), threadController_(this, dissolve), recentFileNo_(10)
+    : QMainWindow(nullptr), dissolve_(dissolve), recentFileNo_(10), threadController_(this, dissolve)
 {
     // Initialise resources
     Q_INIT_RESOURCE(main);
@@ -149,9 +149,7 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
     if (inputFileInfo.exists())
     {
         // Add file to recent menu
-        QString filePath = inputFileInfo.absoluteDir().absolutePath();
-        std::string fileName = dissolve_.inputFilename().data();
-        addRecentFile(filePath + QString::fromStdString("/" + fileName));
+        addRecentFile(inputFileInfo.absoluteFilePath());
         QDir::setCurrent(inputFileInfo.absoluteDir().absolutePath());
         try
         {

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -217,7 +217,9 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
 
     dissolveState_ = EditingState;
     // Add file to recent menu
-    addRecentFile(QString::fromStdString(std::string(inputFile)));
+    QString filePath = inputFileInfo.absoluteDir().absolutePath();
+    std::string fileName = dissolve_.inputFilename().data();
+    addRecentFile(filePath + QString::fromStdString("/"+fileName));
     // Fully update GUI
     fullUpdate();
 
@@ -284,7 +286,7 @@ void DissolveWindow::updateRecentActionList()
         if (i < recentFilePaths.size())
         {
             QString strippedName = QFileInfo(recentFilePaths.at(i)).fileName();
-            recentFileActionList_.at(i)->setText(strippedName);
+            recentFileActionList_.at(i)->setText(strippedName+"    "+recentFilePaths.at(i));
             recentFileActionList_.at(i)->setData(recentFilePaths.at(i));
             recentFileActionList_.at(i)->setVisible(true);
         }


### PR DESCRIPTION
Moved function call order to prevent usage of menu before creation.
Found and fixed other CLI related bugs and issues
closes #785 