### PR TITLE
Tab Management

### DIFF
--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -96,9 +96,6 @@ int main(int args, char **argv)
 
     auto result = app.exec();
 
-    // Clear all data
-    dissolve.clear();
-
     // End parallel communication
     ProcessPool::finalise();
 

--- a/src/gui/gettabnamedialog.h
+++ b/src/gui/gettabnamedialog.h
@@ -17,14 +17,14 @@ class GetTabNameDialog : public QDialog
     Q_OBJECT
 
     public:
-    GetTabNameDialog(QWidget *parent, const std::vector<std::shared_ptr<MainTab>> &currentTabs);
+    GetTabNameDialog(QWidget *parent, const std::vector<MainTab *> &currentTabs);
     ~GetTabNameDialog();
 
     private:
     // Main form declaration
     Ui::GetTabNameDialog ui_;
-    // RefList of current tabs
-    const std::vector<std::shared_ptr<MainTab>> &currentTabs_;
+    // List of all current tabs
+    const std::vector<MainTab *> &currentTabs_;
     // Current tab that we are renaming
     const MainTab *currentTab_;
 

--- a/src/gui/gettabnamedialog_funcs.cpp
+++ b/src/gui/gettabnamedialog_funcs.cpp
@@ -4,9 +4,9 @@
 #include "base/sysfunc.h"
 #include "gui/gettabnamedialog.h"
 #include "gui/maintab.h"
+#include <QPointer>
 
-GetTabNameDialog::GetTabNameDialog(QWidget *parent, const std::vector<std::shared_ptr<MainTab>> &currentTabs)
-    : currentTabs_(currentTabs)
+GetTabNameDialog::GetTabNameDialog(QWidget *parent, const std::vector<MainTab *> &currentTabs) : currentTabs_(currentTabs)
 {
     ui_.setupUi(this);
 }
@@ -42,9 +42,9 @@ void GetTabNameDialog::on_NameEdit_textChanged(const QString text)
         nameValid = false;
     else
     {
-        for (const auto tab : currentTabs_)
+        for (const auto &tab : currentTabs_)
         {
-            if (currentTab_ == tab.get())
+            if (currentTab_ == tab)
                 continue;
 
             if (tab->title() == text)

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -230,7 +230,7 @@ class DissolveWindow : public QMainWindow
 
     public:
     // Return list of all current tabs
-    const std::vector<std::shared_ptr<MainTab>> allTabs() const;
+    const std::vector<MainTab *> allTabs() const;
 
     public slots:
     // Disable sensitive controls

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -77,9 +77,6 @@ DissolveWindow::DissolveWindow(Dissolve &dissolve)
 // Catch window close event
 void DissolveWindow::closeEvent(QCloseEvent *event)
 {
-    // Mark the window as refreshing, so we don't try to update any more widgets
-    refreshing_ = true;
-
     if (!checkSaveCurrentInput())
     {
         event->ignore();
@@ -101,7 +98,9 @@ void DissolveWindow::closeEvent(QCloseEvent *event)
     }
 
     // Clear tabs before we try to close down the application, otherwise we'll get in to trouble with object deletion
+    refreshing_ = true;
     ui_.MainTabs->clearTabs();
+    ui_.MainTabs->clear();
 
     event->accept();
 }

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -209,6 +209,7 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
         loadState();
 
     localSimulation_ = true;
+    modified_ = false;
 
     // Check the beat file
     QString beatFile = QStringLiteral("%1.beat").arg(QString::fromStdString(std::string(dissolve_.inputFilename())));
@@ -219,6 +220,7 @@ bool DissolveWindow::openLocalFile(std::string_view inputFile, std::string_view 
     }
 
     dissolveState_ = EditingState;
+
     // Fully update GUI
     fullUpdate();
 

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -82,4 +82,4 @@ void DissolveWindow::on_MainTabs_currentChanged(int index)
 }
 
 // Return list of all current tabs
-const std::vector<std::shared_ptr<MainTab>> DissolveWindow::allTabs() const { return ui_.MainTabs->allTabs(); }
+const std::vector<MainTab *> DissolveWindow::allTabs() const { return ui_.MainTabs->allTabs(); }

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -9,6 +9,7 @@
 #include "gui/messagestab.h"
 #include "gui/speciestab.h"
 #include "gui/workspacetab.h"
+#include <QPointer>
 #include <QTabWidget>
 #include <memory>
 #include <vector>
@@ -42,24 +43,24 @@ class MainTabsWidget : public QTabWidget
      * Tab Data
      */
     private:
-    // Reference vector of all available tabs
-    std::vector<std::shared_ptr<MainTab>> allTabs_;
+    // Reference list of all available tabs
+    std::vector<MainTab *> allTabs_;
     // Messages tab
-    std::shared_ptr<MessagesTab> messagesTab_;
-    // Forcefield tab
-    std::shared_ptr<ForcefieldTab> forcefieldTab_;
+    QPointer<MessagesTab> messagesTab_;
+    // Pointer to Forcefield tab
+    QPointer<ForcefieldTab> forcefieldTab_;
     // List of Species tabs
-    std::vector<std::shared_ptr<SpeciesTab>> speciesTabs_;
+    std::vector<QPointer<SpeciesTab>> speciesTabs_;
     // List of Configuration tabs
-    std::vector<std::shared_ptr<ConfigurationTab>> configurationTabs_;
+    std::vector<QPointer<ConfigurationTab>> configurationTabs_;
     // List of processing layer tabs
-    std::vector<std::shared_ptr<LayerTab>> processingLayerTabs_;
+    std::vector<QPointer<LayerTab>> processingLayerTabs_;
     // List of Workspace tabs
-    std::vector<std::shared_ptr<WorkspaceTab>> workspaceTabs_;
+    std::vector<QPointer<WorkspaceTab>> workspaceTabs_;
 
     public:
     // Return reference list of all current tabs
-    const std::vector<std::shared_ptr<MainTab>> &allTabs() const;
+    const std::vector<MainTab *> &allTabs() const;
     // Return currently-selected Species (if a SpeciesTab is the current one)
     Species *currentSpecies() const;
     // Return currently-selected Configuration (if a ConfigurationTab is the current one)
@@ -67,19 +68,17 @@ class MainTabsWidget : public QTabWidget
     // Return currently-selected ModuleLayer (if a LayerTab is the current one)
     ModuleLayer *currentLayer() const;
     // Return MessagesTab
-    std::shared_ptr<MessagesTab> messagesTab();
+    MessagesTab *messagesTab();
     // Find SpeciesTab containing specified page widget
-    std::shared_ptr<SpeciesTab> speciesTab(QWidget *page);
+    QPointer<SpeciesTab> speciesTab(QWidget *page);
     // Find ConfigurationTab containing specified page widget
-    std::shared_ptr<ConfigurationTab> configurationTab(QWidget *page);
+    QPointer<ConfigurationTab> configurationTab(QWidget *page);
     // Find LayerTab containing specified page widget
-    std::shared_ptr<LayerTab> processingLayerTab(QWidget *page);
+    QPointer<LayerTab> processingLayerTab(QWidget *page);
     // Find WorkspaceTab containing specified page widget
-    std::shared_ptr<WorkspaceTab> workspaceTab(QWidget *page);
+    QPointer<WorkspaceTab> workspaceTab(QWidget *page);
     // Find tab with title specified
-    std::shared_ptr<MainTab> findTab(const QString title);
-    // Find tab with specified page widget
-    std::shared_ptr<MainTab> findTab(QWidget *page);
+    MainTab *findTab(const QString title);
     // Generate unique tab name with base name provided
     const QString uniqueTabName(const QString base);
 
@@ -94,18 +93,16 @@ class MainTabsWidget : public QTabWidget
     // Remove tab containing the specified page widget
     void removeByPage(QWidget *page);
     // Add on a new workspace tab
-    std::shared_ptr<MainTab> addWorkspaceTab(DissolveWindow *dissolveWindow, const QString title);
+    MainTab *addWorkspaceTab(DissolveWindow *dissolveWindow, const QString title);
 
     /*
      * Display
      */
     public:
     // Return current tab
-    std::shared_ptr<MainTab> currentTab() const;
+    MainTab *currentTab() const;
     // Make specified tab the current one
-    void setCurrentTab(std::shared_ptr<MainTab> tab);
-    // Make specified tab the current one (by index)
-    void setCurrentTab(int tabIndex);
+    void setCurrentTab(const MainTab *tab);
     // Make specified Species tab the current one
     void setCurrentTab(Species *species);
     // Make specified Configuration tab the current one
@@ -143,8 +140,6 @@ class MainTabsWidget : public QTabWidget
     private:
     // List of close buttons and their associated pageWidgets
     std::vector<std::tuple<QToolButton *, QWidget *>> closeButtons_;
-    // Overload insertTab for shared_ptr
-    int insertTab(int index, std::shared_ptr<QWidget> widget, const QString &title);
 
     private slots:
     // Tab close button clicked

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -193,7 +193,7 @@ void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
         return;
 
     // Cast up the tab to a ConfigurationTab so we can get the ModuleLayer pointer
-    auto cfgTab = std::dynamic_pointer_cast<ConfigurationTab>(tab);
+    auto cfgTab = dynamic_cast<ConfigurationTab *>(tab);
     if (!cfgTab)
         return;
 

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -303,11 +303,11 @@ void DissolveWindow::on_LayerDeleteAction_triggered(bool checked)
 {
     // Get the current tab - make sure it is a ConfigurationTab
     auto tab = ui_.MainTabs->currentTab();
-    if ((!tab) || (tab->type() != MainTab::TabType::Configuration))
+    if ((!tab) || (tab->type() != MainTab::TabType::Layer))
         return;
 
-    // Cast up the tab to a ConfigurationTab so we can get the ModuleLayer pointer
-    auto layerTab = std::dynamic_pointer_cast<LayerTab>(tab);
+    // Cast up the tab to a LayerTab
+    auto layerTab = dynamic_cast<LayerTab *>(tab);
     if (!layerTab)
         return;
 

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -197,7 +197,7 @@ void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
         return;
 
     // Cast up the tab to a SpeciesTab
-    auto spTab = std::dynamic_pointer_cast<SpeciesTab>(tab);
+    auto spTab = dynamic_cast<SpeciesTab *>(tab);
     if (!spTab)
         return;
 

--- a/src/gui/modulelisteditor_funcs.cpp
+++ b/src/gui/modulelisteditor_funcs.cpp
@@ -91,7 +91,8 @@ bool ModuleListEditor::setUp(DissolveWindow *dissolveWindow, ModuleLayer *module
     ui_.ModulePaletteGroup->setVisible(false);
 
     // Set the currently selected module to the first one in the list
-    chartWidget_->setCurrentModule(moduleLayer_->modules().front().get());
+    if (!moduleLayer_->modules().empty())
+        chartWidget_->setCurrentModule(moduleLayer_->modules().front().get());
 
     updateControls();
 

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -13,8 +13,6 @@ ModuleLayer::ModuleLayer() : ModuleList()
     name_ = "Untitled Layer";
 }
 
-ModuleLayer::~ModuleLayer() = default;
-
 /*
  * Layer Definition
  */

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -14,7 +14,7 @@ class ModuleLayer : public ModuleList
 {
     public:
     ModuleLayer();
-    ~ModuleLayer();
+    ~ModuleLayer() override = default;
 
     /*
      * Layer Definition

--- a/src/module/list.h
+++ b/src/module/list.h
@@ -19,7 +19,7 @@ class ModuleList
 {
     public:
     ModuleList();
-    ~ModuleList();
+    virtual ~ModuleList();
     operator std::vector<std::unique_ptr<Module>> &();
 
     /*


### PR DESCRIPTION
This PR moves storage of the various tabs from `std::vector<std::shared_ptr>` to `std::vector<QPointer>`, since the former imposed additional memory management _on top of_ that already present in Qt (via `QObject`). This caused odd behaviour and repeatable crashes in places. Some other small issues discovered while performing this work are also fixed.

Moving to `QPointer`and the crash fixes will be incorporated into v0.8.3.
