### PR TITLE
Move away from deprecated CLI dependency

### DIFF
--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -32,6 +32,7 @@ steps:
       export LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
       mkdir build
       cd build
+      conan search cli
       conan install .. -s compiler.libcxx=libstdc++11 --build missing
       cmake -G "Ninja" -DMULTI_THREADING:bool=${{ parameters.threading }} -DGUI:bool=${{ parameters.gui }} -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
       ninja

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -32,7 +32,6 @@ steps:
       export LD_LIBRARY_PATH=$QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH
       mkdir build
       cd build
-      conan search cli
       conan install .. -s compiler.libcxx=libstdc++11 --build missing
       cmake -G "Ninja" -DMULTI_THREADING:bool=${{ parameters.threading }} -DGUI:bool=${{ parameters.gui }} -DBUILD_ANTLR_RUNTIME:bool=true ${{ parameters.extraflags }} ../
       ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ target_link_libraries(
          ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
   PRIVATE # External libs
           antlr4-runtime ${EXTRA_LINK_LIBS} ${THREADING_LINK_LIBS}
-  INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11
+  INTERFACE CONAN_PKG::fmt CONAN_PKG::cli11
 )
 
 # Build GUI target executables
@@ -347,6 +347,6 @@ if(GUI)
             ${FREETYPE_LIBRARIES}
             ${EXTRA_LINK_LIBS}
             ${THREADING_LINK_LIBS}
-    INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11 CONAN_PKG::pugixml
+    INTERFACE CONAN_PKG::fmt CONAN_PKG::cli11 CONAN_PKG::pugixml
   )
 endif(GUI)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-CLI11/1.9.1@cliutils/stable
+cli11/1.9.1
 fmt/7.0.3
 gtest/1.10.0
 pugixml/1.11

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -28,4 +28,4 @@ add_library(
 )
 
 include_directories(main PRIVATE ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries(main PRIVATE CONAN_PKG::fmt CONAN_PKG::CLI11)
+target_link_libraries(main PRIVATE CONAN_PKG::fmt CONAN_PKG::cli11)

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -23,7 +23,7 @@ function(dissolve_unit_test src_file)
     ${TEST_NAME}
     PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS} ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
     PRIVATE antlr4-runtime ${EXTRA_LINK_LIBS} GTest::gtest_main
-    INTERFACE CONAN_PKG::fmt CONAN_PKG::CLI11
+    INTERFACE CONAN_PKG::fmt CONAN_PKG::cli11
   )
 
   if(GUI)


### PR DESCRIPTION
The CLI11 dependency has been deprecated, so I've updated it.