### PR TITLE
NETA Strings

### DIFF
--- a/src/neta/neta.h
+++ b/src/neta/neta.h
@@ -15,7 +15,8 @@ class SpeciesAtom;
 class NETADefinition
 {
     public:
-    NETADefinition(std::string_view definition = "");
+    explicit NETADefinition(std::string_view definition = "");
+    NETADefinition(const SpeciesAtom *i, int maxDepth = 1);
     ~NETADefinition() = default;
 
     /*
@@ -36,6 +37,8 @@ class NETADefinition
     bool create(const Forcefield *associatedFF = nullptr);
     // Set definition string and create definition
     bool create(std::string_view definition, const Forcefield *associatedFF = nullptr);
+    // Create from specified atom and its connectivity
+    bool create(const SpeciesAtom *i, int maxDepth = 1);
     // Set generating string
     void setDefinitionString(std::string_view definition);
     // Return original generating string

--- a/unit/classes/neta.cpp
+++ b/unit/classes/neta.cpp
@@ -211,6 +211,28 @@ TEST_F(NETATest, Matching)
     testNETA("Hydrogen atoms present in CH3 group", rings_, neta, {13, 14, 15});
 }
 
+TEST_F(NETATest, Creation)
+{
+    // Carbon atom - full description
+    NETADefinition neta(&methane_.atom(0));
+    EXPECT_EQ(neta.definitionString(), "nbonds=4,nh=4");
+    testNETA("Carbon atom in methane", methane_, neta, {0});
+
+    // Methane hydrogen atom
+    // -- Basic connectivity
+    neta.create(&methane_.atom(1), 0);
+    EXPECT_EQ(neta.definitionString(), "nbonds=1,-C");
+    testNETA("Hydrogen atom in methane", methane_, neta, {1, 2, 3, 4});
+    // -- Primary neighbour connectivity
+    neta.create(&methane_.atom(1), 1);
+    EXPECT_EQ(neta.definitionString(), "nbonds=1,-C(nbonds=4,nh=4)");
+    testNETA("Hydrogen atom in methane", methane_, neta, {1, 2, 3, 4});
+    // -- Secondary neighbour connectivity (equivalent to primary)
+    neta.create(&methane_.atom(1), 2);
+    EXPECT_EQ(neta.definitionString(), "nbonds=1,-C(nbonds=4,nh=4)");
+    testNETA("Hydrogen atom in methane", methane_, neta, {1, 2, 3, 4});
+}
+
 TEST_F(NETATest, Forcefield)
 {
     class Forcefield_TEST : public Forcefield


### PR DESCRIPTION
This PR adds basic creation of NETA strings from a specified `SpeciesAtom` - this allows connectivity descriptions to be generated automatically and used for similarity matching, forcefield creation etc.

Currently, only basic connectivity is considered - including ring information is left for a future commit when such functionality is required.