### PR TITLE
AtomType Model Upgrade

### DIFF
--- a/src/classes/atomtypemix.cpp
+++ b/src/classes/atomtypemix.cpp
@@ -90,7 +90,7 @@ void AtomTypeMix::finalise()
 }
 
 // Finalise list, calculating fractional populations etc., and accounting for exchangeable sites in boundCoherent values
-void AtomTypeMix::finalise(const std::vector<const AtomType *> &exchangeableTypes)
+void AtomTypeMix::finalise(const std::vector<std::shared_ptr<AtomType>> &exchangeableTypes)
 {
     // Perform basic tasks
     finalise();
@@ -100,7 +100,7 @@ void AtomTypeMix::finalise(const std::vector<const AtomType *> &exchangeableType
     for (auto &atd : types_)
     {
         // If this type is not exchangeable, move on
-        if (std::find(exchangeableTypes.begin(), exchangeableTypes.end(), atd.atomType().get()) == exchangeableTypes.end())
+        if (std::find(exchangeableTypes.begin(), exchangeableTypes.end(), atd.atomType()) == exchangeableTypes.end())
             continue;
 
         // Sum total atomic fraction and weighted bound coherent scattering length
@@ -113,7 +113,7 @@ void AtomTypeMix::finalise(const std::vector<const AtomType *> &exchangeableType
     for (auto &atd : types_)
     {
         // If this type is not exchangaeble, move on
-        if (std::find(exchangeableTypes.begin(), exchangeableTypes.end(), atd.atomType().get()) == exchangeableTypes.end())
+        if (std::find(exchangeableTypes.begin(), exchangeableTypes.end(), atd.atomType()) == exchangeableTypes.end())
             continue;
 
         // Set the bound coherent scattering length of this component to the average of all exchangable components

--- a/src/classes/atomtypemix.h
+++ b/src/classes/atomtypemix.h
@@ -46,7 +46,7 @@ class AtomTypeMix
     // Finalise, calculating fractional populations etc.
     void finalise();
     // Finalise, calculating fractional populations etc., and accounting for exchangeable sites in boundCoherent values
-    void finalise(const std::vector<const AtomType *> &exchangeableTypes);
+    void finalise(const std::vector<std::shared_ptr<AtomType>> &exchangeableTypes);
     // Make all AtomTypeData reference only their natural isotope
     void naturalise();
     // Check for presence of AtomType

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -240,7 +240,7 @@ void NeutronWeights::calculateWeightingMatrices()
 }
 
 // Create AtomType list and matrices based on stored Isotopologues information
-void NeutronWeights::createFromIsotopologues(const std::vector<const AtomType *> &exchangeableTypes)
+void NeutronWeights::createFromIsotopologues(const std::vector<std::shared_ptr<AtomType>> &exchangeableTypes)
 {
     // Loop over Isotopologues entries and ensure relative populations of Isotopologues sum to 1.0
     for (auto &topes : isotopologueMixtures_)

--- a/src/classes/neutronweights.h
+++ b/src/classes/neutronweights.h
@@ -62,7 +62,7 @@ class NeutronWeights
 
     public:
     // Create AtomType list and matrices based on stored Isotopologues information
-    void createFromIsotopologues(const std::vector<const AtomType *> &exchangeableTypes);
+    void createFromIsotopologues(const std::vector<std::shared_ptr<AtomType>> &exchangeableTypes);
     // Reduce data to be naturally-weighted
     void naturalise();
     // Return AtomTypeMix

--- a/src/gui/importspeciesdialog_funcs.cpp
+++ b/src/gui/importspeciesdialog_funcs.cpp
@@ -28,7 +28,7 @@ ImportSpeciesDialog::ImportSpeciesDialog(QWidget *parent, Dissolve &dissolve)
             SLOT(speciesSelectionChanged(const QItemSelection &, const QItemSelection &)));
 
     // Set model, signals, and lambdas for atom types list
-    atomTypesModel_.setIconFunction([&](const auto *atomType) {
+    atomTypesModel_.setIconFunction([&](const std::shared_ptr<AtomType> &atomType) {
         return QIcon(dissolve_.findAtomType(atomType->name()) ? ":/general/icons/general_warn.svg"
                                                               : ":/general/icons/general_true.svg");
     });

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -80,5 +80,6 @@ void AtomTypeVectorKeywordWidget::updateSummaryText()
     if (keyword_->data().empty())
         setSummaryText("<None>");
     else
-        setSummaryText(QString::fromStdString(joinStrings(keyword_->data(), ", ", [](const auto *at) { return at->name(); })));
+        setSummaryText(
+            QString::fromStdString(joinStrings(keyword_->data(), ", ", [](const auto &at) { return at.get()->name(); })));
 }

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -32,6 +32,7 @@ set(models_MOC_HDRS
 qt6_wrap_cpp(models_MOC_SRCS ${models_MOC_HDRS})
 
 set(models_SRCS
+    atomTypeFilterProxy.cpp
     atomTypeModel.cpp
     braggReflectionFilterProxy.cpp
     braggReflectionModel.cpp
@@ -65,6 +66,7 @@ set(models_SRCS
 
 qt_wrap_cpp(
   models_SRCS
+  atomTypeFilterProxy.h
   atomTypeModel.h
   braggReflectionModel.h
   dataManagerReferencePointModel.h

--- a/src/gui/models/atomTypeFilterProxy.cpp
+++ b/src/gui/models/atomTypeFilterProxy.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/models/atomTypeFilterProxy.h"
+#include "classes/atomtype.h"
+#include "data/elements.h"
+
+// Set filter element
+void AtomTypeFilterProxy::setFilterElement(Elements::Element Z)
+{
+    filterElement_ = Z;
+    invalidateFilter();
+}
+
+// Clear filter element
+void AtomTypeFilterProxy::clearFilterElement()
+{
+    filterElement_ = std::nullopt;
+    invalidateFilter();
+}
+
+/*
+ * QSortFilterProxyModel overrides
+ */
+
+bool AtomTypeFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent) const
+{
+    if (!filterElement_)
+        return true;
+
+    const auto at = sourceModel()->data(sourceModel()->index(row, 0, parent), Qt::UserRole).value<std::shared_ptr<AtomType>>();
+    return at->Z() == filterElement_.value();
+}

--- a/src/gui/models/atomTypeFilterProxy.h
+++ b/src/gui/models/atomTypeFilterProxy.h
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "data/elements.h"
+#include <QSortFilterProxyModel>
+
+// Forward Declarations
+class QModelIndex;
+
+class AtomTypeFilterProxy : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+    public:
+    AtomTypeFilterProxy() = default;
+
+    private:
+    // Filter element
+    std::optional<Elements::Element> filterElement_;
+
+    public:
+    // Set filter element
+    void setFilterElement(Elements::Element Z);
+    // Clear filter element
+    void clearFilterElement();
+
+    /*
+     * QSortFilterProxyModel overrides
+     */
+    private:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const;
+};

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -17,20 +17,24 @@ void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &specie
 }
 
 // Set function to return QIcon for item
-void AtomTypeModel::setIconFunction(std::function<QIcon(const AtomType *atomType)> func) { iconFunction_ = func; }
+void AtomTypeModel::setIconFunction(std::function<QIcon(const std::shared_ptr<AtomType> &atomType)> func)
+{
+    iconFunction_ = func;
+}
 
 // Set vector containing checked items
-void AtomTypeModel::setCheckStateData(std::vector<const AtomType *> &checkedItemsVector)
+void AtomTypeModel::setCheckStateData(std::vector<std::shared_ptr<AtomType>> &checkedItemsVector)
 {
     beginResetModel();
     checkedItems_ = checkedItemsVector;
     endResetModel();
 }
 
-AtomType *AtomTypeModel::rawData(const QModelIndex &index) const
+// Return object represented by specified model index
+const std::shared_ptr<AtomType> &AtomTypeModel::rawData(const QModelIndex &index) const
 {
     assert(atomTypes_);
-    return atomTypes_->get()[index.row()].get();
+    return atomTypes_->get()[index.row()];
 }
 
 /*
@@ -107,7 +111,7 @@ bool AtomTypeModel::setData(const QModelIndex &index, const QVariant &value, int
     }
     else if (role == Qt::EditRole)
     {
-        auto *atomType = rawData(index);
+        auto &atomType = rawData(index);
         std::vector<double> values;
 
         switch (index.column())

--- a/src/gui/models/atomTypeModel.h
+++ b/src/gui/models/atomTypeModel.h
@@ -19,21 +19,19 @@ class AtomTypeModel : public QAbstractListModel
     // Source AtomType data
     OptionalReferenceWrapper<const std::vector<std::shared_ptr<AtomType>>> atomTypes_;
     // Vector containing checked items (if relevant)
-    OptionalReferenceWrapper<std::vector<const AtomType *>> checkedItems_;
+    OptionalReferenceWrapper<std::vector<std::shared_ptr<AtomType>>> checkedItems_;
     // Icon return function
-    std::function<QIcon(const AtomType *atomType)> iconFunction_;
-
-    private:
-    // Return object represented by specified model index
-    AtomType *rawData(const QModelIndex &index) const;
+    std::function<QIcon(const std::shared_ptr<AtomType> &atomType)> iconFunction_;
 
     public:
     // Set source AtomType data
     void setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes);
     // Set function to return QIcon for item
-    void setIconFunction(std::function<QIcon(const AtomType *atomType)> func);
+    void setIconFunction(std::function<QIcon(const std::shared_ptr<AtomType> &atomType)> func);
     // Set vector containing checked items
-    void setCheckStateData(std::vector<const AtomType *> &checkedItemsVector);
+    void setCheckStateData(std::vector<std::shared_ptr<AtomType>> &checkedItemsVector);
+    // Return object represented by specified model index
+    const std::shared_ptr<AtomType> &rawData(const QModelIndex &index) const;
 
     /*
      * QAbstractItemModel overrides

--- a/src/keywords/atomtypevector.cpp
+++ b/src/keywords/atomtypevector.cpp
@@ -6,7 +6,8 @@
 #include "classes/atomtype.h"
 #include "classes/coredata.h"
 
-AtomTypeVectorKeyword::AtomTypeVectorKeyword() : KeywordData<std::vector<const AtomType *>>(KeywordBase::AtomTypeVectorData, {})
+AtomTypeVectorKeyword::AtomTypeVectorKeyword()
+    : KeywordData<std::vector<std::shared_ptr<AtomType>>>(KeywordBase::AtomTypeVectorData, {})
 {
 }
 
@@ -42,11 +43,11 @@ bool AtomTypeVectorKeyword::read(LineParser &parser, int startArg, const CoreDat
         auto atomType = *it;
 
         // If the AtomType is in the list already, complain
-        if (std::find(data_.begin(), data_.end(), atomType.get()) != data_.end())
+        if (std::find(data_.begin(), data_.end(), atomType) != data_.end())
             return Messenger::error("AtomType '{}' specified in selection list twice.\n", parser.argsv(n));
 
         // All OK - add it to our selection list
-        data_.push_back(atomType.get());
+        data_.push_back(atomType);
     }
 
     set_ = true;
@@ -75,7 +76,7 @@ bool AtomTypeVectorKeyword::write(LineParser &parser, std::string_view keywordNa
 // Prune any references to the supplied AtomType in the contained data
 void AtomTypeVectorKeyword::removeReferencesTo(std::shared_ptr<AtomType> at)
 {
-    auto it = std::find(data_.begin(), data_.end(), at.get());
+    auto it = std::find(data_.begin(), data_.end(), at);
     if (it != data_.end())
         data_.erase(it);
 }

--- a/src/keywords/atomtypevector.h
+++ b/src/keywords/atomtypevector.h
@@ -11,7 +11,7 @@
 class Configuration;
 
 // Keyword with vector of AtomType pointers
-class AtomTypeVectorKeyword : public KeywordData<std::vector<const AtomType *>>
+class AtomTypeVectorKeyword : public KeywordData<std::vector<std::shared_ptr<AtomType>>>
 {
     public:
     AtomTypeVectorKeyword();

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -168,7 +168,7 @@ bool NeutronSQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
     // Create, print, and store weights
     Messenger::print("Isotopologue and isotope composition:\n\n");
-    weights.createFromIsotopologues(keywords_.retrieve<std::vector<const AtomType *>>("Exchangeable"));
+    weights.createFromIsotopologues(keywords_.retrieve<std::vector<std::shared_ptr<AtomType>>>("Exchangeable"));
     weights.print();
 
     // Does a PartialSet for the weighted S(Q) already exist for this Configuration?

--- a/src/procedure/nodes/dynamicsite.cpp
+++ b/src/procedure/nodes/dynamicsite.cpp
@@ -45,7 +45,7 @@ bool DynamicSiteProcedureNode::mustBeNamed() const { return false; }
 
 // Generate sites from the specified Molecule
 void DynamicSiteProcedureNode::generateSites(const std::shared_ptr<const Molecule> &molecule,
-                                             const std::vector<const AtomType *> &atomTypes)
+                                             const std::vector<std::shared_ptr<AtomType>> &atomTypes)
 {
     // Loop over Atoms in the Molecule
     for (auto &i : molecule->atoms())
@@ -58,7 +58,7 @@ void DynamicSiteProcedureNode::generateSites(const std::shared_ptr<const Molecul
         }
 
         // If the Atom's AtomType is listed in our target AtomType list, add this atom as a site
-        if (std::find(atomTypes.begin(), atomTypes.end(), i->speciesAtom()->atomType().get()) != atomTypes.end())
+        if (std::find(atomTypes.begin(), atomTypes.end(), i->speciesAtom()->atomType()) != atomTypes.end())
         {
             generatedSites_.emplace_back(Site(molecule, i->r()));
             continue;
@@ -82,7 +82,7 @@ bool DynamicSiteProcedureNode::execute(ProcessPool &procPool, Configuration *cfg
 
     // Grab exclusion lists, the atom types vector, and any specific Molecule parent
     const auto &excludedMolecules = parent_->excludedMolecules();
-    const auto atomTypes = keywords_.retrieve<std::vector<const AtomType *>>("AtomType");
+    const auto atomTypes = keywords_.retrieve<std::vector<std::shared_ptr<AtomType>>>("AtomType");
     std::shared_ptr<const Molecule> moleculeParent = parent_->sameMoleculeMolecule();
 
     /*

--- a/src/procedure/nodes/dynamicsite.h
+++ b/src/procedure/nodes/dynamicsite.h
@@ -55,7 +55,8 @@ class DynamicSiteProcedureNode : public ProcedureNode
 
     private:
     // Generate dynamic sites from the specified Molecule
-    void generateSites(const std::shared_ptr<const Molecule> &molecule, const std::vector<const AtomType *> &atomTypes);
+    void generateSites(const std::shared_ptr<const Molecule> &molecule,
+                       const std::vector<std::shared_ptr<AtomType>> &atomTypes);
 
     public:
     // Return Array of generated sites

--- a/unit/classes/neutronweights.cpp
+++ b/unit/classes/neutronweights.cpp
@@ -117,7 +117,7 @@ TEST_F(NeutronWeightsTest, NullWater)
     EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(atH2_)->get().fraction(), 1.0e-6);
     EXPECT_NEAR(pow(Sears91::boundCoherent(Sears91::O_Natural) / 3.0, 2) / 100.0, nwts.boundCoherentSquareOfAverage(), 1.0e-6);
     // Making the H atomtype exchangeable should make no difference
-    nwts.createFromIsotopologues({atH2_.get()});
+    nwts.createFromIsotopologues({atH2_});
     EXPECT_NEAR(pow(Sears91::boundCoherent(Sears91::O_Natural) / 3.0, 2) / 100.0, nwts.boundCoherentSquareOfAverage(), 1.0e-6);
 }
 


### PR DESCRIPTION
Small PR to change the pointer return types in certain `AtomType`-related vectors into `std::shared_ptr` from raw pointers to aid compatibility with other functions throughout the code where the `std::shared_ptr` is required, and updates the associated model to add a proxy filtering by element.

This work allows the integration of a suitable `AtomType` selector dialog in a PR to follow.