### PR TITLE
Remove list dependency from ChartBlock and ChartHotSpot

### DIFF
--- a/src/gui/charts/chart.hui
+++ b/src/gui/charts/chart.hui
@@ -92,7 +92,7 @@ class ChartBase : public QWidget
     // Selected ChartBlock
     ChartBlock *selectedBlock_;
     // Drop hotspots available on the chart
-    List<ChartHotSpot> hotSpots_;
+    std::vector<ChartHotSpot> hotSpots_;
     // Current hotspot the dragged object is over (if any)
     ChartHotSpot *currentHotSpot_;
 

--- a/src/gui/charts/chart_funcs.cpp
+++ b/src/gui/charts/chart_funcs.cpp
@@ -258,7 +258,7 @@ MimeStrings ChartBase::mimeInfo(ChartBlock *block) { return MimeStrings(); }
 // Return hotspot, if any, under specified point
 ChartHotSpot *ChartBase::hotSpotAt(QPoint point)
 {
-    auto it = std::find_if(hotSpots_.begin(), hotSpots_.end(), [&point](auto &hotSpot){return hotSpot.contains(point);});
+    auto it = std::find_if(hotSpots_.begin(), hotSpots_.end(), [&point](auto &hotSpot) { return hotSpot.contains(point); });
 
     return it == hotSpots_.end() ? nullptr : &*it;
 }

--- a/src/gui/charts/chart_funcs.cpp
+++ b/src/gui/charts/chart_funcs.cpp
@@ -258,11 +258,9 @@ MimeStrings ChartBase::mimeInfo(ChartBlock *block) { return MimeStrings(); }
 // Return hotspot, if any, under specified point
 ChartHotSpot *ChartBase::hotSpotAt(QPoint point)
 {
-    for (auto *hotSpot = hotSpots_.first(); hotSpot != nullptr; hotSpot = hotSpot->next())
-        if (hotSpot->contains(point))
-            return hotSpot;
+    auto it = std::find_if(hotSpots_.begin(), hotSpots_.end(), [&point](auto &hotSpot){return hotSpot.contains(point);});
 
-    return nullptr;
+    return it == hotSpots_.end() ? nullptr : &*it;
 }
 
 // Reset after drop

--- a/src/gui/charts/chartblock.cpp
+++ b/src/gui/charts/chartblock.cpp
@@ -5,7 +5,7 @@
 #include <QPropertyAnimation>
 #include <QWidget>
 
-ChartBlock::ChartBlock() : ListItem<ChartBlock>() {}
+ChartBlock::ChartBlock() {}
 
 ChartBlock::~ChartBlock() {}
 

--- a/src/gui/charts/chartblock.h
+++ b/src/gui/charts/chartblock.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "templates/listitem.h"
 #include <QPoint>
 #include <QRect>
 
@@ -11,7 +10,7 @@
 class QWidget;
 
 // Chart Block - Base class for any widget displayed in a chart
-class ChartBlock : public ListItem<ChartBlock>
+class ChartBlock
 {
     public:
     ChartBlock();

--- a/src/gui/charts/charthotspot.cpp
+++ b/src/gui/charts/charthotspot.cpp
@@ -4,7 +4,7 @@
 #include "gui/charts/charthotspot.h"
 #include <stdio.h>
 
-ChartHotSpot::ChartHotSpot() : ListItem<ChartHotSpot>()
+ChartHotSpot::ChartHotSpot()
 {
     row_ = -1;
     column_ = -1;

--- a/src/gui/charts/charthotspot.h
+++ b/src/gui/charts/charthotspot.h
@@ -10,7 +10,7 @@
 class ChartBlock;
 
 // Chart HotSpot - Definition of an area onto which a dragged object can be dropped
-class ChartHotSpot : public ListItem<ChartHotSpot>
+class ChartHotSpot
 {
     public:
     ChartHotSpot();

--- a/src/gui/charts/modulelist.cpp
+++ b/src/gui/charts/modulelist.cpp
@@ -96,7 +96,7 @@ void ModuleListChart::paintEvent(QPaintEvent *event)
 
     // Highlight all hotspots
     if (false)
-        for(auto &hotSpot : hotSpots_)
+        for (auto &hotSpot : hotSpots_)
             painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 

--- a/src/gui/charts/modulelist.cpp
+++ b/src/gui/charts/modulelist.cpp
@@ -96,7 +96,7 @@ void ModuleListChart::paintEvent(QPaintEvent *event)
 
     // Highlight all hotspots
     if (false)
-	for(auto &hotSpot : hotSpots_)
+        for(auto &hotSpot : hotSpots_)
             painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 

--- a/src/gui/charts/modulelist.cpp
+++ b/src/gui/charts/modulelist.cpp
@@ -96,7 +96,7 @@ void ModuleListChart::paintEvent(QPaintEvent *event)
 
     // Highlight all hotspots
     if (false)
-        for(auto &hotSpot : hotSpots_)
+	for(auto &hotSpot : hotSpots_)
             painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 

--- a/src/gui/charts/modulelist.cpp
+++ b/src/gui/charts/modulelist.cpp
@@ -96,11 +96,8 @@ void ModuleListChart::paintEvent(QPaintEvent *event)
 
     // Highlight all hotspots
     if (false)
-    {
-        ListIterator<ChartHotSpot> hotSpotIterator(hotSpots_);
-        while (ChartHotSpot *hotSpot = hotSpotIterator.iterate())
-            painter.fillRect(hotSpot->geometry(), QBrush(QColor(200, 200, 0, 50)));
-    }
+        for(auto &hotSpot : hotSpots_)
+            painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 
 /*
@@ -160,10 +157,7 @@ void ModuleListChart::updateContentBlocks()
 
     // Set the correct number of hotspots (number of block widgets + 1)
     auto nHotSpots = moduleBlockWidgets_.nItems() + 1;
-    while (nHotSpots < hotSpots_.nItems())
-        hotSpots_.removeLast();
-    while (nHotSpots > hotSpots_.nItems())
-        hotSpots_.add();
+    hotSpots_.resize(nHotSpots);
 }
 
 // Set the currently-selected Module
@@ -430,7 +424,7 @@ QSize ModuleListChart::calculateNewWidgetGeometry(QSize currentSize)
     auto maxWidth = 0;
 
     // Get the first hot spot in the list (the list should have been made the correct size in updateContentBlocks()).
-    ChartHotSpot *hotSpot = hotSpots_.first();
+    auto hotSpot = hotSpots_.begin();
 
     // Loop over widgets
     ModuleBlock *lastVisibleBlock = nullptr;
@@ -450,7 +444,7 @@ QSize ModuleListChart::calculateNewWidgetGeometry(QSize currentSize)
         top += metrics.verticalModuleSpacing();
 
         // If our hotspot is the current one, increase the size.
-        if (hotSpot == currentHotSpot_)
+        if (&*hotSpot == currentHotSpot_)
             top += metrics.verticalInsertionSpacing();
 
         // Set top edge of this widget
@@ -480,7 +474,7 @@ QSize ModuleListChart::calculateNewWidgetGeometry(QSize currentSize)
         lastVisibleBlock = block;
 
         // Move to the next hotspot
-        hotSpot = hotSpot->next();
+        ++hotSpot;
     }
     // Handle final block
     top -= metrics.verticalModuleSpacing();
@@ -491,11 +485,11 @@ QSize ModuleListChart::calculateNewWidgetGeometry(QSize currentSize)
     // Set final hotspot geometry
     hotSpot->setGeometry(QRect(0, hotSpotTop, width(), height() - hotSpotTop));
     hotSpot->setSurroundingBlocks(lastVisibleBlock, nullptr);
-    hotSpot = hotSpot->next();
+    ++hotSpot;
 
     // Set the correct heights for all hotspots up to the current one - any after that are not required and will have zero
     // height
-    for (auto *spot = hotSpot; spot != nullptr; spot = spot->next())
+    for (auto spot = hotSpot; spot != hotSpots_.end(); ++spot)
         spot->setHeight(0);
 
     // If there is a current hotspot, set the insertion widget to be visible and set its geometry

--- a/src/gui/charts/procedure.cpp
+++ b/src/gui/charts/procedure.cpp
@@ -51,7 +51,7 @@ void ProcedureChart::paintEvent(QPaintEvent *event)
 
     // TEST - Highlight all hotspots
     if (false)
-        for(auto &hotSpot : hotSpots_)
+        for (auto &hotSpot : hotSpots_)
             painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 

--- a/src/gui/charts/procedure.cpp
+++ b/src/gui/charts/procedure.cpp
@@ -51,11 +51,8 @@ void ProcedureChart::paintEvent(QPaintEvent *event)
 
     // TEST - Highlight all hotspots
     if (false)
-    {
-        ListIterator<ChartHotSpot> hotSpotIterator(hotSpots_);
-        while (ChartHotSpot *hotSpot = hotSpotIterator.iterate())
-            painter.fillRect(hotSpot->geometry(), QBrush(QColor(200, 200, 0, 50)));
-    }
+        for(auto &hotSpot : hotSpots_)
+            painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 
 /*

--- a/src/gui/charts/procedure.cpp
+++ b/src/gui/charts/procedure.cpp
@@ -51,7 +51,7 @@ void ProcedureChart::paintEvent(QPaintEvent *event)
 
     // TEST - Highlight all hotspots
     if (false)
-	for(auto &hotSpot : hotSpots_)
+        for(auto &hotSpot : hotSpots_)
             painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 

--- a/src/gui/charts/procedure.cpp
+++ b/src/gui/charts/procedure.cpp
@@ -51,7 +51,7 @@ void ProcedureChart::paintEvent(QPaintEvent *event)
 
     // TEST - Highlight all hotspots
     if (false)
-        for(auto &hotSpot : hotSpots_)
+	for(auto &hotSpot : hotSpots_)
             painter.fillRect(hotSpot.geometry(), QBrush(QColor(200, 200, 0, 50)));
 }
 


### PR DESCRIPTION
This is a quickie to remove the `ListItem` dependency from `ChartBlock` and `ChartHotSpot`.  There's some other tidying that could be done, but I didn't want to get too deep into it, since we're planning to eventually remove all this code anyway.  This removes two more parts of #257.