### PR TITLE
Species Term Assignment

### DIFF
--- a/src/classes/empiricalformula.cpp
+++ b/src/classes/empiricalformula.cpp
@@ -43,7 +43,7 @@ std::string EmpiricalFormula::formula(const Species *species, bool richText)
 }
 
 // Return empirical formula for supplied SpeciesAtom vector
-std::string EmpiricalFormula::formula(const std::vector<const SpeciesAtom *> &atoms, bool richText)
+std::string EmpiricalFormula::formula(const std::vector<SpeciesAtom *> &atoms, bool richText)
 {
     std::vector<int> elCounts(Elements::nElements, 0);
 

--- a/src/classes/empiricalformula.h
+++ b/src/classes/empiricalformula.h
@@ -21,5 +21,5 @@ class EmpiricalFormula
     // Return empirical formula for supplied Species
     static std::string formula(const Species *species, bool richText = false);
     // Return empirical formula for supplied SpeciesAtom vector
-    static std::string formula(const std::vector<const SpeciesAtom *> &atoms, bool richText = false);
+    static std::string formula(const std::vector<SpeciesAtom *> &atoms, bool richText = false);
 };

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -60,7 +60,7 @@ class Species
     // List of atoms in the Species
     std::list<SpeciesAtom> atoms_;
     // Vector of selected atoms
-    std::vector<const SpeciesAtom *> selectedAtoms_;
+    std::vector<SpeciesAtom *> selectedAtoms_;
     // Version of the atom selection
     VersionCounter atomSelectionVersion_;
     // AtomType mixture present in the Species
@@ -100,7 +100,7 @@ class Species
     // Select atoms along any path from the specified one, ignoring the bond(s) provided
     void selectFromAtom(SpeciesAtom *i, SpeciesBond &exclude, OptionalReferenceWrapper<SpeciesBond> excludeToo = std::nullopt);
     // Return current atom selection
-    const std::vector<const SpeciesAtom *> &selectedAtoms() const;
+    const std::vector<SpeciesAtom *> &selectedAtoms() const;
     // Return number of selected atoms
     int nSelectedAtoms() const;
     // Return whether the current selection comprises atoms of a single element

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -188,7 +188,7 @@ void Species::selectFromAtom(SpeciesAtom *i, SpeciesBond &exclude, OptionalRefer
 }
 
 // Return current atom selection
-const std::vector<const SpeciesAtom *> &Species::selectedAtoms() const { return selectedAtoms_; }
+const std::vector<SpeciesAtom *> &Species::selectedAtoms() const { return selectedAtoms_; }
 
 // Return number of selected Atoms
 int Species::nSelectedAtoms() const { return selectedAtoms_.size(); }

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -85,6 +85,9 @@ SpeciesAtom *SpeciesAngle::j() const { return j_; }
 // Return third SpeciesAtom
 SpeciesAtom *SpeciesAngle::k() const { return k_; }
 
+// Return vector of involved atoms
+std::vector<const SpeciesAtom *> SpeciesAngle::atoms() const { return {i_, j_, k_}; }
+
 // Return index (in parent Species) of first SpeciesAtom
 int SpeciesAngle::indexI() const
 {

--- a/src/classes/speciesangle.h
+++ b/src/classes/speciesangle.h
@@ -45,6 +45,8 @@ class SpeciesAngle : public SpeciesIntra
     SpeciesAtom *j() const;
     // Return third SpeciesAtom
     SpeciesAtom *k() const;
+    // Return vector of involved atoms
+    std::vector<const SpeciesAtom *> atoms() const override;
     // Return index (in parent Species) of first SpeciesAtom
     int indexI() const;
     // Return index (in parent Species) of second (central) SpeciesAtom

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -85,6 +85,9 @@ SpeciesAtom *SpeciesBond::i() const { return i_; }
 // Return second SpeciesAtom involved in SpeciesBond
 SpeciesAtom *SpeciesBond::j() const { return j_; }
 
+// Return vector of involved atoms
+std::vector<const SpeciesAtom *> SpeciesBond::atoms() const { return {i_, j_}; }
+
 // Return the 'other' SpeciesAtom in the SpeciesBond
 SpeciesAtom *SpeciesBond::partner(const SpeciesAtom *i) const { return (i == i_ ? j_ : i_); }
 

--- a/src/classes/speciesbond.h
+++ b/src/classes/speciesbond.h
@@ -39,6 +39,8 @@ class SpeciesBond : public SpeciesIntra
     SpeciesAtom *i() const;
     // Return second SpeciesAtom
     SpeciesAtom *j() const;
+    // Return vector of involved atoms
+    std::vector<const SpeciesAtom *> atoms() const override;
     // Return the 'other' SpeciesAtom
     SpeciesAtom *partner(const SpeciesAtom *i) const;
     // Return index (in parent Species) of first SpeciesAtom

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -106,6 +106,9 @@ SpeciesAtom *SpeciesImproper::k() const { return k_; }
 // Return fourth SpeciesAtom
 SpeciesAtom *SpeciesImproper::l() const { return l_; }
 
+// Return vector of involved atoms
+std::vector<const SpeciesAtom *> SpeciesImproper::atoms() const { return {i_, j_, k_, l_}; }
+
 // Return whether the improper uses the specified SpeciesAtom
 bool SpeciesImproper::uses(SpeciesAtom *spAtom) const
 {

--- a/src/classes/speciesimproper.h
+++ b/src/classes/speciesimproper.h
@@ -50,6 +50,8 @@ class SpeciesImproper : public SpeciesIntra
     SpeciesAtom *k() const;
     // Return fourth SpeciesAtom
     SpeciesAtom *l() const;
+    // Return vector of involved atoms
+    std::vector<const SpeciesAtom *> atoms() const override;
     // Return whether the improper uses the specified SpeciesAtom
     bool uses(SpeciesAtom *spAtom) const;
     // Return index (in parent Species) of first SpeciesAtom

--- a/src/classes/speciesintra.cpp
+++ b/src/classes/speciesintra.cpp
@@ -43,7 +43,7 @@ std::vector<const SpeciesAtom *> SpeciesIntra::atoms() const { return {}; }
  */
 
 // Set linked master from which parameters should be taken
-void SpeciesIntra::setMasterParameters(MasterIntra *master) { masterParameters_ = master; }
+void SpeciesIntra::setMasterParameters(const MasterIntra *master) { masterParameters_ = master; }
 
 // Return linked master from which parameters should be taken
 const MasterIntra *SpeciesIntra::masterParameters() const { return masterParameters_; }

--- a/src/classes/speciesintra.cpp
+++ b/src/classes/speciesintra.cpp
@@ -32,6 +32,13 @@ SpeciesIntra &SpeciesIntra::operator=(const SpeciesIntra &source)
 }
 
 /*
+ * SpeciesAtom Information
+ */
+
+// Return vector of involved atoms
+std::vector<const SpeciesAtom *> SpeciesIntra::atoms() const { return {}; }
+
+/*
  * Interaction Parameters
  */
 

--- a/src/classes/speciesintra.cpp
+++ b/src/classes/speciesintra.cpp
@@ -137,7 +137,7 @@ const std::vector<double> &SpeciesIntra::parameters() const
  */
 
 // Set attached SpeciesAtoms for the terminus specified
-void SpeciesIntra::setAttachedAtoms(int terminus, const std::vector<const SpeciesAtom *> &atoms)
+void SpeciesIntra::setAttachedAtoms(int terminus, const std::vector<SpeciesAtom *> &atoms)
 {
     attached_[terminus].clear();
 

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -23,6 +23,13 @@ class SpeciesIntra
     SpeciesIntra &operator=(SpeciesIntra &&source) = delete;
 
     /*
+     * SpeciesAtom Information
+     * */
+    public:
+    // Return vector of involved atoms
+    virtual std::vector<const SpeciesAtom *> atoms() const;
+
+    /*
      * Interaction Parameters
      */
     public:

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -44,7 +44,7 @@ class SpeciesIntra
 
     protected:
     // Linked master from which parameters should be taken (if relevant)
-    MasterIntra *masterParameters_;
+    const MasterIntra *masterParameters_;
     // Index of functional form of interaction
     int form_;
     // Parameters for interaction
@@ -52,7 +52,7 @@ class SpeciesIntra
 
     public:
     // Set linked master from which parameters should be taken
-    void setMasterParameters(MasterIntra *master);
+    void setMasterParameters(const MasterIntra *master);
     // Return linked master from which parameters should be taken
     const MasterIntra *masterParameters() const;
     // Detach from MasterIntra, if we are currently referencing one

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -86,7 +86,7 @@ class SpeciesIntra
 
     public:
     // Set attached SpeciesAtoms for terminus specified
-    void setAttachedAtoms(int terminus, const std::vector<const SpeciesAtom *> &atoms);
+    void setAttachedAtoms(int terminus, const std::vector<SpeciesAtom *> &atoms);
     // Set attached SpeciesAtoms for terminus specified (single SpeciesAtom)
     void setAttachedAtoms(int terminus, SpeciesAtom *atom);
     // Return vector of attached indices for terminus specified

--- a/src/classes/speciessite.cpp
+++ b/src/classes/speciessite.cpp
@@ -55,7 +55,7 @@ bool SpeciesSite::addOriginAtom(int atomIndex)
 }
 
 // Set origin atoms
-bool SpeciesSite::setOriginAtoms(const std::vector<const SpeciesAtom *> &atoms)
+bool SpeciesSite::setOriginAtoms(const std::vector<SpeciesAtom *> &atoms)
 {
     originAtoms_.clear();
 
@@ -115,7 +115,7 @@ bool SpeciesSite::addXAxisAtom(int atomIndex)
 }
 
 // Set x-axis atoms
-bool SpeciesSite::setXAxisAtoms(const std::vector<const SpeciesAtom *> &atoms)
+bool SpeciesSite::setXAxisAtoms(const std::vector<SpeciesAtom *> &atoms)
 {
     xAxisAtoms_.clear();
 
@@ -163,7 +163,7 @@ bool SpeciesSite::addYAxisAtom(int atomIndex)
 }
 
 // Set y-axis atoms
-bool SpeciesSite::setYAxisAtoms(const std::vector<const SpeciesAtom *> &atoms)
+bool SpeciesSite::setYAxisAtoms(const std::vector<SpeciesAtom *> &atoms)
 {
     yAxisAtoms_.clear();
 

--- a/src/classes/speciessite.h
+++ b/src/classes/speciessite.h
@@ -62,7 +62,7 @@ class SpeciesSite
     // Add origin atom from index
     bool addOriginAtom(int atomIndex);
     // Set origin atoms
-    bool setOriginAtoms(const std::vector<const SpeciesAtom *> &atoms);
+    bool setOriginAtoms(const std::vector<SpeciesAtom *> &atoms);
     // Return integer array of indices from which the origin should be formed
     std::vector<int> originAtomIndices() const;
     // Set whether the origin should be calculated with mass-weighted positions
@@ -74,7 +74,7 @@ class SpeciesSite
     // Add x-axis atom from index
     bool addXAxisAtom(int atomIndex);
     // Set x-axis atoms
-    bool setXAxisAtoms(const std::vector<const SpeciesAtom *> &atoms);
+    bool setXAxisAtoms(const std::vector<SpeciesAtom *> &atoms);
     // Return integer array of indices from which x-axis should be formed
     std::vector<int> xAxisAtomIndices() const;
     // Add y-axis atom
@@ -82,7 +82,7 @@ class SpeciesSite
     // Add y-axis atom from index
     bool addYAxisAtom(int atomIndex);
     // Set y-axis atoms
-    bool setYAxisAtoms(const std::vector<const SpeciesAtom *> &atoms);
+    bool setYAxisAtoms(const std::vector<SpeciesAtom *> &atoms);
     // Return integer array of indices from which y-axis should be formed
     std::vector<int> yAxisAtomIndices() const;
     // Return whether the site has defined axes sites

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -105,6 +105,9 @@ SpeciesAtom *SpeciesTorsion::k() const { return k_; }
 // Return fourth SpeciesAtom
 SpeciesAtom *SpeciesTorsion::l() const { return l_; }
 
+// Return vector of involved atoms
+std::vector<const SpeciesAtom *> SpeciesTorsion::atoms() const { return {i_, j_, k_, l_}; }
+
 // Return index (in parent Species) of first SpeciesAtom
 int SpeciesTorsion::indexI() const
 {

--- a/src/classes/speciestorsion.h
+++ b/src/classes/speciestorsion.h
@@ -50,6 +50,8 @@ class SpeciesTorsion : public SpeciesIntra
     SpeciesAtom *k() const;
     // Return fourth SpeciesAtom
     SpeciesAtom *l() const;
+    // Return vector of involved atoms
+    std::vector<const SpeciesAtom *> atoms() const override;
     // Return index (in parent Species) of first SpeciesAtom
     int indexI() const;
     // Return index (in parent Species) of second SpeciesAtom

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -29,6 +29,7 @@ set(components_MOC_HDRS
     wizard.hui
     # Dialogs
     addforcefieldtermsdialog.h
+    copyspeciestermsdialog.h
     datamanagerdialog.h
     editspeciesdialog.h
     getconfigurationnamedialog.h
@@ -68,6 +69,7 @@ set(components_UIS
     wizardheader.ui
     # Dialogs
     addforcefieldtermsdialog.ui
+    copyspeciestermsdialog.ui
     datamanagerdialog.ui
     editspeciesdialog.ui
     getconfigurationnamedialog.ui
@@ -133,6 +135,7 @@ set(components_SRCS
     wizard_funcs.cpp
     # Dialogs
     addforcefieldtermsdialog_funcs.cpp
+    copyspeciestermsdialog_funcs.cpp
     datamanagerdialog_funcs.cpp
     editspeciesdialog_funcs.cpp
     getconfigurationnamedialog_funcs.cpp

--- a/src/gui/copyspeciestermsdialog.h
+++ b/src/gui/copyspeciestermsdialog.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "gui/ui_copyspeciestermsdialog.h"
+#include "gui/wizard.hui"
+#include "main/dissolve.h"
+
+// Copy Species Terms Dialog
+class CopySpeciesTermsDialog : public WizardDialog
+{
+    Q_OBJECT
+
+    public:
+    CopySpeciesTermsDialog(QWidget *parent, Dissolve &dissolve, Species *sp);
+    ~CopySpeciesTermsDialog() = default;
+
+    private:
+    // Main form declaration
+    Ui::CopySpeciesTermsDialog ui_;
+
+    /*
+     * Data
+     */
+    private:
+    // Main instance of Dissolve that we're using as a reference
+    Dissolve &dissolve_;
+    // Temporary core data for applying Species terms
+    CoreData temporaryCoreData_;
+    // Temporary Dissolve reference for creating / importing layers
+    Dissolve temporaryDissolve_;
+    // Target Species that we are acquiring forcefield terms for
+    Species *targetSpecies_;
+    // Species pointer with newly-applied Species terms
+    Species *modifiedSpecies_;
+
+    /*
+     * Wizard
+     */
+    private:
+    // Pages Enum
+    enum WizardPage
+    {
+        SelectSpeciesPage, /* Select Species from which to copy terms */
+        IntramolecularPage /* Select intramolecular terms to copy */
+    };
+
+    protected:
+    // Return whether progression to the next page from the current page is allowed
+    bool progressionAllowed(int index) const override;
+    // Perform any necessary actions before moving to the next page
+    bool prepareForNextPage(int currentIndex) override;
+    // Determine next page for the current page, based on current data
+    std::optional<int> determineNextPage(int currentIndex) override;
+    // Perform any necessary actions before moving to the previous page
+    bool prepareForPreviousPage(int currentIndex) override;
+    // Perform any final actions before the wizard is closed
+    void finalise() override;
+
+    /*
+     * Select Species Page
+     */
+    private slots:
+    void on_SpeciesWidget_speciesSelectionChanged(bool isValid);
+    void on_SpeciesWidget_speciesDoubleClicked();
+
+    /*
+     * Intramolecular Page
+     */
+    private:
+    // Terms to copy
+    std::vector<std::pair<SpeciesBond *, const SpeciesBond *>> bondTerms_;
+    std::vector<std::pair<SpeciesAngle *, const SpeciesAngle *>> angleTerms_;
+    std::vector<std::pair<SpeciesTorsion *, const SpeciesTorsion *>> torsionTerms_;
+    std::vector<std::pair<SpeciesImproper *, const SpeciesImproper *>> improperTerms_;
+
+    private:
+    // Find terms of the specified type that can be copied
+    template <class I>
+    void findTermsToCopy(std::vector<std::pair<I *, const I *>> &termVector, const std::vector<I> &sourceTerms,
+                         std::vector<I> &targetTerms);
+    // Copy terms between pairs
+    template <class I> void copyTerms(const std::vector<std::pair<I *, const I *>> &termVector);
+    // Prepare for copy of terms
+    void prepareCopy();
+};

--- a/src/gui/copyspeciestermsdialog.ui
+++ b/src/gui/copyspeciestermsdialog.ui
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CopySpeciesTermsDialog</class>
+ <widget class="QDialog" name="CopySpeciesTermsDialog">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>553</width>
+    <height>414</height>
+   </rect>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>10</pointsize>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Add Forcefield Terms</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QWidget" name="WizardHeaderWidget" native="true"/>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="MainStack">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="SelectSpeciesPage">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="SelectSpeciesWidget" name="SpeciesWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="IntramolecularTermsPage">
+      <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0">
+       <property name="spacing">
+        <number>4</number>
+       </property>
+       <property name="leftMargin">
+        <number>4</number>
+       </property>
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>4</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="SelectTermsGroup">
+         <property name="title">
+          <string>What intramolecular terms should be borrowed?</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>4</number>
+          </property>
+          <property name="topMargin">
+           <number>4</number>
+          </property>
+          <property name="rightMargin">
+           <number>4</number>
+          </property>
+          <property name="bottomMargin">
+           <number>4</number>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer_8">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>76</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_14">
+            <property name="spacing">
+             <number>4</number>
+            </property>
+            <item>
+             <widget class="QRadioButton" name="CopyAllRadio">
+              <property name="text">
+               <string>Apply intramolecular terms to the whole species</string>
+              </property>
+              <property name="icon">
+               <iconset resource="main.qrc">
+                <normaloff>:/wizard/icons/wizard_allatoms.svg</normaloff>:/wizard/icons/wizard_allatoms.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>40</width>
+                <height>40</height>
+               </size>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="CopySelectionRadio">
+              <property name="text">
+               <string>Apply intramolecular terms between selected atoms</string>
+              </property>
+              <property name="icon">
+               <iconset resource="main.qrc">
+                <normaloff>:/wizard/icons/wizard_selectedatoms.svg</normaloff>:/wizard/icons/wizard_selectedatoms.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>40</width>
+                <height>40</height>
+               </size>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="IntramolecularOptionsGroup">
+              <property name="title">
+               <string>Options</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QCheckBox" name="CopyNoOverwriteCheck">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>If enabled, any existing valid intramolecular terms will be preserved</string>
+                 </property>
+                 <property name="text">
+                  <string>Don't overwrite existing terms</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="CopyBondsCheck">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>If selected, suitable bond terms from the target species will be copied</string>
+                 </property>
+                 <property name="text">
+                  <string>Copy bond terms</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="CopyAnglesCheck">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>If selected, suitable angle terms from the target species will be copied</string>
+                 </property>
+                 <property name="text">
+                  <string>Copy angle terms</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="CopyTorsionsCheck">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>If selected, suitable torsion terms from the target species will be copied</string>
+                 </property>
+                 <property name="text">
+                  <string>Copy torsion terms</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="CopyImpropersCheck">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string>If selected, suitable improper terms from the target species will be copied</string>
+                 </property>
+                 <property name="text">
+                  <string>Copy improper terms (not yet available)</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_9">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>76</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="WizardFooterWidget" native="true"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SelectSpeciesWidget</class>
+   <extends>QWidget</extends>
+   <header>gui/selectspecieswidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="main.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/gui/copyspeciestermsdialog_funcs.cpp
+++ b/src/gui/copyspeciestermsdialog_funcs.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "classes/atomtype.h"
+#include "classes/species.h"
+#include "gui/copyspeciestermsdialog.h"
+
+CopySpeciesTermsDialog::CopySpeciesTermsDialog(QWidget *parent, Dissolve &dissolve, Species *sp)
+    : WizardDialog(parent), dissolve_(dissolve), temporaryDissolve_(temporaryCoreData_), targetSpecies_(sp)
+{
+    ui_.setupUi(this);
+
+    modifiedSpecies_ = nullptr;
+
+    // Set initial state of controls
+    ui_.CopySelectionRadio->setChecked(targetSpecies_->nSelectedAtoms() > 0);
+    ui_.SpeciesWidget->setSpecies(dissolve.coreData().species());
+
+    // Register pages with the wizard
+    registerPage(CopySpeciesTermsDialog::SelectSpeciesPage, "Select Species", CopySpeciesTermsDialog::IntramolecularPage);
+    registerPage(CopySpeciesTermsDialog::IntramolecularPage, "Copy Intramolecular Terms");
+
+    initialise(this, ui_.MainStack, CopySpeciesTermsDialog::SelectSpeciesPage);
+}
+
+/*
+ * Controls
+ */
+
+// Return whether progression to the next page from the current page is allowed
+bool CopySpeciesTermsDialog::progressionAllowed(int index) const
+{
+    if (index == CopySpeciesTermsDialog::SelectSpeciesPage)
+        return !ui_.SpeciesWidget->currentSpecies().empty();
+
+    return true;
+}
+
+// Perform any necessary actions before moving to the next page
+bool CopySpeciesTermsDialog::prepareForNextPage(int currentIndex)
+{
+    if (currentIndex == CopySpeciesTermsDialog::IntramolecularPage)
+        prepareCopy();
+
+    return true;
+}
+
+// Determine next page for the current page, based on current data
+std::optional<int> CopySpeciesTermsDialog::determineNextPage(int currentIndex) { return std::nullopt; }
+
+// Perform any necessary actions before moving to the previous page
+bool CopySpeciesTermsDialog::prepareForPreviousPage(int currentIndex) { return true; }
+
+// Find terms of the specified type that can be copied
+template <class I>
+void CopySpeciesTermsDialog::findTermsToCopy(std::vector<std::pair<I *, const I *>> &termVector,
+                                             const std::vector<I> &sourceTerms, std::vector<I> &targetTerms)
+{
+    auto onlySelected = ui_.CopySelectionRadio->isChecked();
+    auto onlyUnassigned = ui_.CopyNoOverwriteCheck->isChecked();
+    termVector.clear();
+    for (auto &targetTerm : targetTerms)
+    {
+        // Only selected and/or unasssigned terms?
+        if (onlySelected && !targetTerm.isSelected())
+            continue;
+        if (onlyUnassigned && targetTerm.form() != 0)
+            continue;
+
+        // Check for a suitable term in the target species
+        auto js = targetTerm.atoms();
+        auto it = std::find_if(sourceTerms.begin(), sourceTerms.end(), [js](const auto &sourceTerm) {
+            // Assess atom types between the two terms, from both vector directions
+            auto n = 0;
+            auto sameForwards = true, sameBackwards = true;
+            for (const auto *i : sourceTerm.atoms())
+            {
+                if (sameForwards && i->atomType() != js[n]->atomType())
+                    sameForwards = false;
+                if (sameBackwards && i->atomType() != js[js.size() - n - 1]->atomType())
+                    sameBackwards = false;
+                ++n;
+            }
+            return sameForwards || sameBackwards;
+        });
+        if (it != sourceTerms.end())
+            termVector.emplace_back(&targetTerm, &(*it));
+    }
+}
+
+// Copy terms between pairs
+template <class I> void CopySpeciesTermsDialog::copyTerms(const std::vector<std::pair<I *, const I *>> &termVector)
+{
+    for (auto [target, source] : termVector)
+    {
+        if (source->masterParameters())
+            target->setMasterParameters(source->masterParameters());
+        else
+        {
+            target->detachFromMasterIntra();
+            target->setFormAndParameters(source->form(), source->parameters());
+        }
+    }
+}
+
+// Prepare term assignment maps
+void CopySpeciesTermsDialog::prepareCopy()
+{
+    bondTerms_.clear();
+    angleTerms_.clear();
+    torsionTerms_.clear();
+
+    if (ui_.SpeciesWidget->currentSpecies().empty())
+        return;
+    auto *sp = ui_.SpeciesWidget->currentSpecies().front();
+
+    // Assemble list of bonds terms to copy
+    if (ui_.CopyBondsCheck->isChecked())
+        findTermsToCopy(bondTerms_, sp->bonds(), targetSpecies_->bonds());
+    if (ui_.CopyAnglesCheck->isChecked())
+        findTermsToCopy(angleTerms_, sp->angles(), targetSpecies_->angles());
+    if (ui_.CopyTorsionsCheck->isChecked())
+        findTermsToCopy(torsionTerms_, sp->torsions(), targetSpecies_->torsions());
+}
+
+// Perform any final actions before the wizard is closed
+void CopySpeciesTermsDialog::finalise()
+{
+    prepareCopy();
+
+    // Act on the prepared term lists
+    copyTerms(bondTerms_);
+    copyTerms(angleTerms_);
+    copyTerms(torsionTerms_);
+}
+
+/*
+ * Select Species Page
+ */
+
+void CopySpeciesTermsDialog::on_SpeciesWidget_speciesSelectionChanged(bool isValid) { updateProgressionControls(); }
+
+void CopySpeciesTermsDialog::on_SpeciesWidget_speciesDoubleClicked() { goToPage(CopySpeciesTermsDialog::IntramolecularPage); }
+
+/*
+ * Intramolecular Page
+ */

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -170,6 +170,7 @@ class DissolveWindow : public QMainWindow
     void on_SpeciesAddForcefieldTermsAction_triggered(bool checked);
     void on_SpeciesSimplifyAtomTypesAction_triggered(bool checked);
     void on_SpeciesReduceToMasterTermsAction_triggered(bool checked);
+    void on_SpeciesCopyTermsAction_triggered(bool checked);
     void on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked);
     void on_SpeciesSetAtomTypesInSelectionAction_triggered(bool checked);
     // Configuration

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -166,11 +166,12 @@ class DissolveWindow : public QMainWindow
     void on_SpeciesImportFromXYZAction_triggered(bool checked);
     void on_SpeciesImportLigParGenAction_triggered(bool checked);
     void on_SpeciesRenameAction_triggered(bool checked);
+    void on_SpeciesDeleteAction_triggered(bool checked);
     void on_SpeciesAddForcefieldTermsAction_triggered(bool checked);
-    void on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked);
     void on_SpeciesSimplifyAtomTypesAction_triggered(bool checked);
     void on_SpeciesReduceToMasterTermsAction_triggered(bool checked);
-    void on_SpeciesDeleteAction_triggered(bool checked);
+    void on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked);
+    void on_SpeciesSetAtomTypesInSelectionAction_triggered(bool checked);
     // Configuration
     void on_ConfigurationCreateEmptyAction_triggered(bool checked);
     void on_ConfigurationCreateSimpleRandomMixAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -102,7 +102,7 @@
     </property>
     <widget class="QMenu" name="FileOpenRecentMenu">
      <property name="title">
-      <string>Open R&amp;ecent...</string>
+      <string>Open R&amp;ecent</string>
      </property>
     </widget>
     <addaction name="FileNewAction"/>
@@ -180,7 +180,7 @@
       </font>
      </property>
      <property name="title">
-      <string>&amp;Create...</string>
+      <string>&amp;Create</string>
      </property>
      <property name="icon">
       <iconset>
@@ -196,7 +196,7 @@
       </font>
      </property>
      <property name="title">
-      <string>&amp;Import...</string>
+      <string>&amp;Import</string>
      </property>
      <addaction name="SpeciesImportFromDissolveAction"/>
      <addaction name="SpeciesImportFromXYZAction"/>
@@ -209,7 +209,7 @@
       </font>
      </property>
      <property name="title">
-      <string>Red&amp;uce Forcefield Terms...</string>
+      <string>Red&amp;uce Forcefield Terms</string>
      </property>
      <addaction name="SpeciesSimplifyAtomTypesAction"/>
      <addaction name="SpeciesReduceToMasterTermsAction"/>
@@ -221,6 +221,8 @@
     <addaction name="separator"/>
     <addaction name="SpeciesAddForcefieldTermsAction"/>
     <addaction name="SpeciesReduceForcefieldTermsMenu"/>
+    <addaction name="separator"/>
+    <addaction name="SpeciesSetAtomTypesInSelectionAction"/>
     <addaction name="separator"/>
     <addaction name="SpeciesRegenerateIntraFromConnectivityAction"/>
    </widget>
@@ -238,7 +240,7 @@
       <rect>
        <x>990</x>
        <y>290</y>
-       <width>223</width>
+       <width>211</width>
        <height>172</height>
       </rect>
      </property>
@@ -248,7 +250,7 @@
       </font>
      </property>
      <property name="title">
-      <string>&amp;Create...</string>
+      <string>&amp;Create</string>
      </property>
      <property name="icon">
       <iconset>
@@ -269,7 +271,7 @@
       </font>
      </property>
      <property name="title">
-      <string>&amp;Export to...</string>
+      <string>&amp;Export to</string>
      </property>
      <addaction name="ConfigurationExportToXYZAction"/>
     </widget>
@@ -295,7 +297,7 @@
       </font>
      </property>
      <property name="title">
-      <string>&amp;Create...</string>
+      <string>&amp;Create</string>
      </property>
      <property name="icon">
       <iconset>
@@ -558,7 +560,7 @@
   </action>
   <action name="SimulationSetRandomSeedAction">
    <property name="text">
-    <string>Set &amp;Random Seed</string>
+    <string>Set &amp;Random Seed...</string>
    </property>
   </action>
   <action name="LayerAddAction">
@@ -826,6 +828,11 @@
   <action name="SpeciesReduceToMasterTermsAction">
    <property name="text">
     <string>To Master Terms</string>
+   </property>
+  </action>
+  <action name="SpeciesSetAtomTypesInSelectionAction">
+   <property name="text">
+    <string>Set Atom &amp;Types in Selection...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -221,6 +221,7 @@
     <addaction name="separator"/>
     <addaction name="SpeciesAddForcefieldTermsAction"/>
     <addaction name="SpeciesReduceForcefieldTermsMenu"/>
+    <addaction name="SpeciesCopyTermsAction"/>
     <addaction name="separator"/>
     <addaction name="SpeciesSetAtomTypesInSelectionAction"/>
     <addaction name="separator"/>
@@ -833,6 +834,11 @@
   <action name="SpeciesSetAtomTypesInSelectionAction">
    <property name="text">
     <string>Set Atom &amp;Types in Selection...</string>
+   </property>
+  </action>
+  <action name="SpeciesCopyTermsAction">
+   <property name="text">
+    <string>C&amp;opy Terms From Species...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -367,6 +367,7 @@ void DissolveWindow::updateMenus()
     ui_.SpeciesDeleteAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesAddForcefieldTermsAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesReduceForcefieldTermsMenu->setEnabled(activeTab->type() == MainTab::TabType::Species);
+    ui_.SpeciesCopyTermsAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesRegenerateIntraFromConnectivityAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesSetAtomTypesInSelectionAction->setEnabled(activeTab->type() == MainTab::TabType::Species &&
                                                          ui_.MainTabs->currentSpecies()->isSelectionSingleElement());

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -368,6 +368,8 @@ void DissolveWindow::updateMenus()
     ui_.SpeciesAddForcefieldTermsAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesReduceForcefieldTermsMenu->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesRegenerateIntraFromConnectivityAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
+    ui_.SpeciesSetAtomTypesInSelectionAction->setEnabled(activeTab->type() == MainTab::TabType::Species &&
+                                                         ui_.MainTabs->currentSpecies()->isSelectionSingleElement());
 
     // Configuration Menu
     ui_.ConfigurationRenameAction->setEnabled(activeTab->type() == MainTab::TabType::Configuration);

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -3,6 +3,7 @@
 
 #include "classes/species.h"
 #include "gui/addforcefieldtermsdialog.h"
+#include "gui/copyspeciestermsdialog.h"
 #include "gui/editspeciesdialog.h"
 #include "gui/gui.h"
 #include "gui/importligpargendialog.h"
@@ -148,6 +149,23 @@ void DissolveWindow::on_SpeciesAddForcefieldTermsAction_triggered(bool checked)
     AddForcefieldTermsDialog addForcefieldTermsDialog(this, dissolve_, species);
 
     if (addForcefieldTermsDialog.exec() == QDialog::Accepted)
+    {
+        // Fully update GUI
+        setModified();
+        fullUpdate();
+    }
+}
+
+void DissolveWindow::on_SpeciesCopyTermsAction_triggered(bool checked)
+{
+    // Get the current Species (if a SpeciesTab is selected)
+    auto species = ui_.MainTabs->currentSpecies();
+    if (!species)
+        return;
+
+    CopySpeciesTermsDialog copySpeciesTermsDialog(this, dissolve_, species);
+
+    if (copySpeciesTermsDialog.exec() == QDialog::Accepted)
     {
         // Fully update GUI
         setModified();

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -7,6 +7,7 @@
 #include "gui/gui.h"
 #include "gui/importligpargendialog.h"
 #include "gui/importspeciesdialog.h"
+#include "gui/selectatomtypedialog.h"
 #include "gui/selectelementdialog.h"
 #include "gui/speciestab.h"
 #include <QFileDialog>
@@ -115,6 +116,28 @@ void DissolveWindow::on_SpeciesRenameAction_triggered(bool checked)
     tab->rename();
 }
 
+void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
+{
+    // Get the current tab - make sure it is a SpeciesTab
+    auto tab = ui_.MainTabs->currentTab();
+    if ((!tab) || (tab->type() != MainTab::TabType::Species))
+        return;
+
+    // Cast up the tab to a SpeciesTab
+    auto spTab = dynamic_cast<SpeciesTab *>(tab);
+    if (!spTab)
+        return;
+
+    // Check that we really want to delete the Species
+    if (!spTab->close())
+        return;
+
+    // Update the GUI
+    ui_.MainTabs->removeByPage(spTab->page());
+    setModified();
+    fullUpdate();
+}
+
 void DissolveWindow::on_SpeciesAddForcefieldTermsAction_triggered(bool checked)
 {
     // Get the current Species (if a SpeciesTab is selected)
@@ -130,32 +153,6 @@ void DissolveWindow::on_SpeciesAddForcefieldTermsAction_triggered(bool checked)
         setModified();
         fullUpdate();
     }
-}
-
-void DissolveWindow::on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked)
-{
-    // Get the current Species (if a SpeciesTab is selected)
-    auto species = ui_.MainTabs->currentSpecies();
-    if (!species)
-        return;
-
-    // Confirm with the user
-    QMessageBox queryBox;
-    queryBox.setText(
-        "This will delete and regenerate all angle and torsion terms, and any defined improper terms.\nThis cannot be undone!");
-    queryBox.setInformativeText("Proceed?");
-    queryBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    queryBox.setDefaultButton(QMessageBox::No);
-    auto ret = queryBox.exec();
-
-    if (ret != QMessageBox::Yes)
-        return;
-
-    species->updateIntramolecularTerms();
-
-    setModified();
-    updateWindowTitle();
-    ui_.MainTabs->currentTab()->updateControls();
 }
 
 void DissolveWindow::on_SpeciesSimplifyAtomTypesAction_triggered(bool checked)
@@ -189,24 +186,53 @@ void DissolveWindow::on_SpeciesReduceToMasterTermsAction_triggered(bool checked)
     fullUpdate();
 }
 
-void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
+void DissolveWindow::on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked)
 {
-    // Get the current tab - make sure it is a SpeciesTab
-    auto tab = ui_.MainTabs->currentTab();
-    if ((!tab) || (tab->type() != MainTab::TabType::Species))
+    // Get the current Species (if a SpeciesTab is selected)
+    auto species = ui_.MainTabs->currentSpecies();
+    if (!species)
         return;
 
-    // Cast up the tab to a SpeciesTab
-    auto spTab = dynamic_cast<SpeciesTab *>(tab);
-    if (!spTab)
+    // Confirm with the user
+    QMessageBox queryBox;
+    queryBox.setText(
+        "This will delete and regenerate all angle and torsion terms, and any defined improper terms.\nThis cannot be undone!");
+    queryBox.setInformativeText("Proceed?");
+    queryBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    queryBox.setDefaultButton(QMessageBox::No);
+    auto ret = queryBox.exec();
+
+    if (ret != QMessageBox::Yes)
         return;
 
-    // Check that we really want to delete the Species
-    if (!spTab->close())
-        return;
+    species->updateIntramolecularTerms();
 
-    // Update the GUI
-    ui_.MainTabs->removeByPage(spTab->page());
     setModified();
+    updateWindowTitle();
+    ui_.MainTabs->currentTab()->updateControls();
+}
+
+void DissolveWindow::on_SpeciesSetAtomTypesInSelectionAction_triggered(bool checked)
+{
+    // Get the current Species (if a SpeciesTab is selected)
+    auto species = ui_.MainTabs->currentSpecies();
+    if (!species)
+        return;
+
+    // Check current selection
+    if (species->nSelectedAtoms() == 0 || !species->isSelectionSingleElement())
+        return;
+
+    SelectAtomTypeDialog atomTypeDialog(this, dissolve_.coreData(), "Select Atom Type");
+    auto at = atomTypeDialog.selectAtomType(species->selectedAtoms().front()->Z());
+    if (!at)
+        return;
+
+    for (auto *i : species->selectedAtoms())
+        i->setAtomType(at);
+    species->updateAtomTypes();
+
+    setModified();
+
     fullUpdate();
 }

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -47,25 +47,28 @@ QVariant SpeciesAtomModel::data(const QModelIndex &index, int role) const
 
 QVariant SpeciesAtomModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
-    if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+    if (role != Qt::DisplayRole)
         return {};
-    switch (section)
-    {
-        case 0:
-            return "E";
-        case 1:
-            return "AtomType";
-        case 2:
-            return "X";
-        case 3:
-            return "Y";
-        case 4:
-            return "Z";
-        case 5:
-            return "Charge";
-        default:
-            return {};
-    }
+    if (orientation == Qt::Horizontal)
+        switch (section)
+        {
+            case 0:
+                return "E";
+            case 1:
+                return "AtomType";
+            case 2:
+                return "X";
+            case 3:
+                return "Y";
+            case 4:
+                return "Z";
+            case 5:
+                return "Charge";
+            default:
+                return {};
+        }
+    else
+        return section + 1;
 }
 
 Qt::ItemFlags SpeciesAtomModel::flags(const QModelIndex &index) const

--- a/src/gui/selectspeciesdialog_funcs.cpp
+++ b/src/gui/selectspeciesdialog_funcs.cpp
@@ -39,7 +39,7 @@ const Species *SelectSpeciesDialog::selectSingleSpecies(int filterProxyFlags)
     show();
 
     if (exec() == QDialog::Accepted)
-        return ui_.SpeciesWidget->currentSpecies().front();
+        return ui_.SpeciesWidget->currentSpecies().empty() ? nullptr : ui_.SpeciesWidget->currentSpecies().front();
     else
         return nullptr;
 }

--- a/src/gui/speciesviewer.hui
+++ b/src/gui/speciesviewer.hui
@@ -38,6 +38,10 @@ class SpeciesViewer : public BaseViewer
     // Mouse moved
     void mouseMoved(int dx, int dy);
 
+    protected slots:
+    // Context menu requested
+    void contextMenuRequested(QPoint pos);
+
     /*
      * Interaction (BaseViewer virtuals)
      */


### PR DESCRIPTION
This PR adds several useful abilities from within the GUI:

- `SpeciesAtom`s can be selected in the viewer, and similar atoms selected by connectivity.
- `AtomType`s can be applied to a `SpeciesAtom` selection
- Forcefield terms can be copied over from a different (or the same) `Species`, giving more options for term assignment.