### PR TITLE
Cause CI to fail when build fails

### DIFF
--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -31,6 +31,7 @@ steps:
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
+      nix build -L .#${{ parameters.package }}
       nix build -L .#${{ parameters.package }} | jq -r '.[].outputs | to_entries[].value' | cachix push dissolve-nix
     env:
       CACHIX_AUTH_TOKEN: $(CACHIX_AUTH_TOKEN)


### PR DESCRIPTION
Currently, the build on the CI has its output piped to a cache.  The problem is that the pipe then clobbers the exit code of the build, so the CI continues on even when the build fails.  The current hypothesis is to run the build twice.  The first run performs the actual build and unit tests and the CI will fail if this fails.  The second run is then piped out to the cache.  Since nix locally caches the builds, there's no extra time added to run the build twice.

This will close #844.