### PR TITLE
Keywords 3 (Widget Producers)

### DIFF
--- a/src/gui/charts/moduleblock_funcs.cpp
+++ b/src/gui/charts/moduleblock_funcs.cpp
@@ -36,7 +36,8 @@ ModuleBlock::ModuleBlock(QWidget *parent, Module *module, Dissolve &dissolve)
     auto *optCfgKeyword = module_->keywords().find("Configuration");
     if (optCfgKeyword)
     {
-        auto *cfgWidget = new ConfigurationVectorKeywordWidget(nullptr, optCfgKeyword, dissolve.coreData());
+        auto *cfgWidget = new ConfigurationVectorKeywordWidget(
+            nullptr, dynamic_cast<ConfigurationVectorKeyword *>(optCfgKeyword), dissolve.coreData());
         connect(cfgWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(configurationKeywordEdited(int)));
         auto *layout = new QHBoxLayout;
         layout->addWidget(cfgWidget);

--- a/src/gui/keywordwidgets/CMakeLists.txt
+++ b/src/gui/keywordwidgets/CMakeLists.txt
@@ -86,6 +86,7 @@ set(keywordwidgets_SRCS
     nodevalue_funcs.cpp
     nodevalueenumoptions_funcs.cpp
     nodevector_funcs.cpp
+    producers.cpp
     range_funcs.cpp
     species_funcs.cpp
     speciessite_funcs.cpp
@@ -98,6 +99,7 @@ set(keywordwidgets_SRCS
     vec3labels.cpp
     vec3nodevalue_funcs.cpp
     base.h
+    producers.h
 )
 
 # Target 'keywordwidgets'

--- a/src/gui/keywordwidgets/atomtypevector.h
+++ b/src/gui/keywordwidgets/atomtypevector.h
@@ -21,7 +21,7 @@ class AtomTypeVectorKeywordWidget : public KeywordDropDown, public KeywordWidget
     Q_OBJECT
 
     public:
-    AtomTypeVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    AtomTypeVectorKeywordWidget(QWidget *parent, AtomTypeVectorKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -15,21 +15,18 @@
 Q_DECLARE_SMART_POINTER_METATYPE(std::shared_ptr)
 Q_DECLARE_METATYPE(std::shared_ptr<AtomType>)
 
-AtomTypeVectorKeywordWidget::AtomTypeVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+AtomTypeVectorKeywordWidget::AtomTypeVectorKeywordWidget(QWidget *parent, AtomTypeVectorKeyword *keyword,
+                                                         const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
     ui_.AtomTypeList->setModel(&atomTypeModel_);
+    atomTypeModel_.setCheckStateData(keyword_->data());
 
     // Connect signals / slots
     connect(&atomTypeModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<AtomTypeVectorKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into AtomTypeVectorKeyword.\n", keyword->name());
-    atomTypeModel_.setCheckStateData(keyword_->data());
 }
 
 /*

--- a/src/gui/keywordwidgets/bool.hui
+++ b/src/gui/keywordwidgets/bool.hui
@@ -13,7 +13,7 @@ class BoolKeywordWidget : public QCheckBox, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    BoolKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    BoolKeywordWidget(QWidget *parent, BoolKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/bool_funcs.cpp
+++ b/src/gui/keywordwidgets/bool_funcs.cpp
@@ -3,18 +3,11 @@
 
 #include "gui/keywordwidgets/bool.hui"
 
-BoolKeywordWidget::BoolKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QCheckBox(parent), KeywordWidgetBase(coreData)
+BoolKeywordWidget::BoolKeywordWidget(QWidget *parent, BoolKeyword *keyword, const CoreData &coreData)
+    : QCheckBox(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<BoolKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into BoolKeyword.\n", keyword->name());
-    else
-    {
-        // Set current value
-        setChecked(keyword_->data());
-    }
+    // Set current state
+    setChecked(keyword_->data());
 
     // Connect the
     connect(this, SIGNAL(clicked(bool)), this, SLOT(myClicked(bool)));

--- a/src/gui/keywordwidgets/configurationvector.h
+++ b/src/gui/keywordwidgets/configurationvector.h
@@ -18,7 +18,7 @@ class ConfigurationVectorKeywordWidget : public KeywordDropDown, public KeywordW
     Q_OBJECT
 
     public:
-    ConfigurationVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    ConfigurationVectorKeywordWidget(QWidget *parent, ConfigurationVectorKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/configurationvector_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationvector_funcs.cpp
@@ -11,9 +11,9 @@
 #include <QHBoxLayout>
 #include <QString>
 
-ConfigurationVectorKeywordWidget::ConfigurationVectorKeywordWidget(QWidget *parent, KeywordBase *keyword,
+ConfigurationVectorKeywordWidget::ConfigurationVectorKeywordWidget(QWidget *parent, ConfigurationVectorKeyword *keyword,
                                                                    const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
@@ -21,15 +21,8 @@ ConfigurationVectorKeywordWidget::ConfigurationVectorKeywordWidget(QWidget *pare
     // Connect signals / slots
     connect(ui_.SelectionList, SIGNAL(itemChanged(QListWidgetItem *)), this, SLOT(itemChanged(QListWidgetItem *)));
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<ConfigurationVectorKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '%s' into ConfigurationVectorKeyword.\n", keyword->name());
-    else
-    {
-        // Set current information
-        updateWidgetValues(coreData_);
-    }
+    // Set current information
+    updateWidgetValues(coreData_);
 }
 
 /*

--- a/src/gui/keywordwidgets/double.hui
+++ b/src/gui/keywordwidgets/double.hui
@@ -13,7 +13,7 @@ class DoubleKeywordWidget : public ExponentialSpin, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    DoubleKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    DoubleKeywordWidget(QWidget *parent, DoubleKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/double_funcs.cpp
+++ b/src/gui/keywordwidgets/double_funcs.cpp
@@ -4,24 +4,17 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/double.hui"
 
-DoubleKeywordWidget::DoubleKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : ExponentialSpin(parent), KeywordWidgetBase(coreData)
+DoubleKeywordWidget::DoubleKeywordWidget(QWidget *parent, DoubleKeyword *keyword, const CoreData &coreData)
+    : ExponentialSpin(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<DoubleKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into DoubleKeyword.\n", keyword->name());
-    else
-    {
-        // Set minimum and maximum values
-        if (keyword_->validationMin())
-            setMinimumLimit(keyword_->validationMin().value());
-        if (keyword_->validationMax())
-            setMaximumLimit(keyword_->validationMax().value());
+    // Set minimum and maximum values
+    if (keyword_->validationMin())
+        setMinimumLimit(keyword_->validationMin().value());
+    if (keyword_->validationMax())
+        setMaximumLimit(keyword_->validationMax().value());
 
-        // Set current value
-        setValue(keyword_->data());
-    }
+    // Set current value
+    setValue(keyword_->data());
 
     // Connect the valueChanged signal to our own slot
     connect(this, SIGNAL(valueChanged(double)), this, SLOT(myValueChanged(double)));

--- a/src/gui/keywordwidgets/enumoptions.hui
+++ b/src/gui/keywordwidgets/enumoptions.hui
@@ -13,7 +13,7 @@ class EnumOptionsKeywordWidget : public QComboBox, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    EnumOptionsKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    EnumOptionsKeywordWidget(QWidget *parent, EnumOptionsBaseKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/enumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/enumoptions_funcs.cpp
@@ -4,29 +4,22 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/enumoptions.hui"
 
-EnumOptionsKeywordWidget::EnumOptionsKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QComboBox(parent), KeywordWidgetBase(coreData)
+EnumOptionsKeywordWidget::EnumOptionsKeywordWidget(QWidget *parent, EnumOptionsBaseKeyword *keyword, const CoreData &coreData)
+    : QComboBox(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<EnumOptionsBaseKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into EnumOptionsBaseKeyword.\n", keyword->name());
-    else
+    // Get the underlying EnumOptionsBase
+    const EnumOptionsBase &options = keyword_->baseOptions();
+
+    // Populate the combo with the available keywords
+    for (int n = 0; n < options.nOptions(); ++n)
     {
-        // Get the underlying EnumOptionsBase
-        const EnumOptionsBase &options = keyword_->baseOptions();
-
-        // Populate the combo with the available keywords
-        for (int n = 0; n < options.nOptions(); ++n)
-        {
-            addItem(QString::fromStdString(std::string(options.keywordByIndex(n))));
-            if (options.index() == n)
-                setCurrentIndex(n);
-        }
-
-        // Turn off editability
-        setEditable(false);
+        addItem(QString::fromStdString(std::string(options.keywordByIndex(n))));
+        if (options.index() == n)
+            setCurrentIndex(n);
     }
+
+    // Turn off editability
+    setEditable(false);
 
     // Connect the currentTextChanged signal to our own slot
     connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(myCurrentIndexChanged(int)));

--- a/src/gui/keywordwidgets/expressionvariablevector.h
+++ b/src/gui/keywordwidgets/expressionvariablevector.h
@@ -19,7 +19,7 @@ class ExpressionVariableVectorKeywordWidget : public QWidget, public KeywordWidg
     Q_OBJECT
 
     public:
-    ExpressionVariableVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    ExpressionVariableVectorKeywordWidget(QWidget *parent, ExpressionVariableVectorKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -15,22 +15,16 @@
 Q_DECLARE_SMART_POINTER_METATYPE(std::shared_ptr)
 Q_DECLARE_METATYPE(std::shared_ptr<ExpressionVariable>)
 
-ExpressionVariableVectorKeywordWidget::ExpressionVariableVectorKeywordWidget(QWidget *parent, KeywordBase *keyword,
+ExpressionVariableVectorKeywordWidget::ExpressionVariableVectorKeywordWidget(QWidget *parent,
+                                                                             ExpressionVariableVectorKeyword *keyword,
                                                                              const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget
     ui_.setupUi(this);
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<ExpressionVariableVectorKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into ExpressionVariableVectorKeyword.\n", keyword->name());
-    else
-    {
-        // Set current information
-        updateValue();
-    }
+    // Set current information
+    updateValue();
 
     // Add suitable delegate to the table
     ui_.VariablesTable->setItemDelegateForColumn(2, new ExponentialSpinDelegate(this));

--- a/src/gui/keywordwidgets/fileandformat.h
+++ b/src/gui/keywordwidgets/fileandformat.h
@@ -15,7 +15,7 @@ class FileAndFormatKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    FileAndFormatKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    FileAndFormatKeywordWidget(QWidget *parent, FileAndFormatKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/fileandformat_funcs.cpp
+++ b/src/gui/keywordwidgets/fileandformat_funcs.cpp
@@ -10,15 +10,11 @@
 #include <QFileDialog>
 #include <QFileInfo>
 
-FileAndFormatKeywordWidget::FileAndFormatKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+FileAndFormatKeywordWidget::FileAndFormatKeywordWidget(QWidget *parent, FileAndFormatKeyword *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     ui_.setupUi(this);
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<FileAndFormatKeyword *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(fmt::format("Couldn't cast base keyword '{}' into FileAndFormatKeyword.\n", keyword->name())));
     enumOptionsModel_.setData(keyword_->data().formats());
 
     refreshing_ = true;

--- a/src/gui/keywordwidgets/function1d.h
+++ b/src/gui/keywordwidgets/function1d.h
@@ -15,7 +15,7 @@ class Function1DKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    Function1DKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    Function1DKeywordWidget(QWidget *parent, Function1DKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/function1d_funcs.cpp
+++ b/src/gui/keywordwidgets/function1d_funcs.cpp
@@ -10,8 +10,8 @@ Q_DECLARE_METATYPE(Functions::Function1D);
 
 #define MaxParams 6
 
-Function1DKeywordWidget::Function1DKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+Function1DKeywordWidget::Function1DKeywordWidget(QWidget *parent, Function1DKeyword *keyword, const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
@@ -32,11 +32,6 @@ Function1DKeywordWidget::Function1DKeywordWidget(QWidget *parent, KeywordBase *k
     connect(ui_.FunctionCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(functionCombo_currentIndexChanged(int)));
     for (auto *spin : spins_)
         connect(spin, SIGNAL(valueChanged(double)), this, SLOT(parameterSpin_valueChanged(double)));
-
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<Function1DKeyword *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(fmt::format("Couldn't cast base keyword '{}' into Function1DKeyword.\n", keyword->name())));
 
     // Get relevant function types to show in combo
     auto availableFunctions = Functions::matchingFunction1D(keyword_->functionProperties());

--- a/src/gui/keywordwidgets/integer.hui
+++ b/src/gui/keywordwidgets/integer.hui
@@ -13,7 +13,7 @@ class IntegerKeywordWidget : public QSpinBox, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    IntegerKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    IntegerKeywordWidget(QWidget *parent, IntegerKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/integer_funcs.cpp
+++ b/src/gui/keywordwidgets/integer_funcs.cpp
@@ -4,22 +4,15 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/integer.hui"
 
-IntegerKeywordWidget::IntegerKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QSpinBox(parent), KeywordWidgetBase(coreData)
+IntegerKeywordWidget::IntegerKeywordWidget(QWidget *parent, IntegerKeyword *keyword, const CoreData &coreData)
+    : QSpinBox(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<IntegerKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into IntegerKeyword.\n", keyword->name());
-    else
-    {
-        // Set minimum and maximum values
-        setRange(keyword_->validationMin() ? keyword_->validationMin().value() : -1e6,
-                 keyword_->validationMax() ? keyword_->validationMax().value() : 1e6);
+    // Set minimum and maximum values
+    setRange(keyword_->validationMin() ? keyword_->validationMin().value() : -1e6,
+             keyword_->validationMax() ? keyword_->validationMax().value() : 1e6);
 
-        // Set current value
-        setValue(keyword_->data());
-    }
+    // Set current value
+    setValue(keyword_->data());
 
     // Connect the
     connect(this, SIGNAL(valueChanged(int)), this, SLOT(myValueChanged(int)));

--- a/src/gui/keywordwidgets/isotopologueset.h
+++ b/src/gui/keywordwidgets/isotopologueset.h
@@ -19,7 +19,7 @@ class IsotopologueSetKeywordWidget : public KeywordDropDown, public KeywordWidge
     Q_OBJECT
 
     public:
-    IsotopologueSetKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    IsotopologueSetKeywordWidget(QWidget *parent, IsotopologueSetKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -11,8 +11,9 @@
 #include "module/module.h"
 #include "templates/algorithms.h"
 
-IsotopologueSetKeywordWidget::IsotopologueSetKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+IsotopologueSetKeywordWidget::IsotopologueSetKeywordWidget(QWidget *parent, IsotopologueSetKeyword *keyword,
+                                                           const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
@@ -22,6 +23,7 @@ IsotopologueSetKeywordWidget::IsotopologueSetKeywordWidget(QWidget *parent, Keyw
                                                           this, &IsotopologueSetKeywordWidget::availableIsotopologueNames));
     ui_.IsotopologueTree->setItemDelegateForColumn(2, new ExponentialSpinDelegate(this, 0.0));
     ui_.IsotopologueTree->setModel(&setModel_);
+    setModel_.setSourceData(keyword_->data());
 
     // Connect signals / slots
     connect(&setModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
@@ -33,13 +35,6 @@ IsotopologueSetKeywordWidget::IsotopologueSetKeywordWidget(QWidget *parent, Keyw
     connect(ui_.RemoveButton, SIGNAL(clicked(bool)), this, SLOT(removeButton_clicked(bool)));
     connect(ui_.IsotopologueTree->selectionModel(), SIGNAL(currentChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(currentItemChanged()));
-
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<IsotopologueSetKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into IsotopologueSetKeyword.\n", keyword->name());
-    else
-        setModel_.setSourceData(keyword_->data());
 
     updateSummaryText();
 }

--- a/src/gui/keywordwidgets/module.h
+++ b/src/gui/keywordwidgets/module.h
@@ -14,7 +14,7 @@ class ModuleKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    ModuleKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    ModuleKeywordWidget(QWidget *parent, ModuleKeywordBase *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/module_funcs.cpp
+++ b/src/gui/keywordwidgets/module_funcs.cpp
@@ -5,22 +5,15 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/module.h"
 
-ModuleKeywordWidget::ModuleKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+ModuleKeywordWidget::ModuleKeywordWidget(QWidget *parent, ModuleKeywordBase *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<ModuleKeywordBase *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into ModuleKeywordBase.\n", keyword->name());
-    else
-    {
-        updateValue();
-    }
+    updateValue();
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -18,7 +18,7 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
     Q_OBJECT
 
     public:
-    ModuleVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    ModuleVectorKeywordWidget(QWidget *parent, ModuleVectorKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -11,8 +11,8 @@
 #include <QHBoxLayout>
 #include <QString>
 
-ModuleVectorKeywordWidget::ModuleVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+ModuleVectorKeywordWidget::ModuleVectorKeywordWidget(QWidget *parent, ModuleVectorKeyword *keyword, const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
@@ -20,15 +20,8 @@ ModuleVectorKeywordWidget::ModuleVectorKeywordWidget(QWidget *parent, KeywordBas
     // Connect signals / slots
     connect(ui_.SelectionList, SIGNAL(itemChanged(QListWidgetItem *)), this, SLOT(itemChanged(QListWidgetItem *)));
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<ModuleVectorKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword into ModuleVectorKeyword.\n");
-    else
-    {
-        // Set current information
-        updateWidgetValues(coreData_);
-    }
+    // Set current information
+    updateWidgetValues(coreData_);
 }
 
 /*

--- a/src/gui/keywordwidgets/node.h
+++ b/src/gui/keywordwidgets/node.h
@@ -15,7 +15,7 @@ class NodeKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    NodeKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    NodeKeywordWidget(QWidget *parent, NodeKeywordBase *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/node_funcs.cpp
+++ b/src/gui/keywordwidgets/node_funcs.cpp
@@ -5,8 +5,8 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/node.h"
 
-NodeKeywordWidget::NodeKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+NodeKeywordWidget::NodeKeywordWidget(QWidget *parent, NodeKeywordBase *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
@@ -17,11 +17,6 @@ NodeKeywordWidget::NodeKeywordWidget(QWidget *parent, KeywordBase *keyword, cons
     // Connect signals / slots
     connect(&nodeModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<NodeKeywordBase *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(fmt::format("Couldn't cast base keyword '{}' into NodeKeywordBase.\n", keyword->name())));
 
     // Get allowed nodes, set model for combo box, and set current index
     allowedNodes_ = keyword_->allowedNodes();

--- a/src/gui/keywordwidgets/nodeandinteger.h
+++ b/src/gui/keywordwidgets/nodeandinteger.h
@@ -15,7 +15,7 @@ class NodeAndIntegerKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    NodeAndIntegerKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    NodeAndIntegerKeywordWidget(QWidget *parent, NodeAndIntegerKeywordBase *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
+++ b/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
@@ -7,8 +7,9 @@
 
 Q_DECLARE_METATYPE(const ProcedureNode *)
 
-NodeAndIntegerKeywordWidget::NodeAndIntegerKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+NodeAndIntegerKeywordWidget::NodeAndIntegerKeywordWidget(QWidget *parent, NodeAndIntegerKeywordBase *keyword,
+                                                         const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
@@ -19,12 +20,6 @@ NodeAndIntegerKeywordWidget::NodeAndIntegerKeywordWidget(QWidget *parent, Keywor
     // Connect signals / slots
     connect(&nodeModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<NodeAndIntegerKeywordBase *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(
-            fmt::format("Couldn't cast base keyword '{}' into NodeAndIntegerKeywordBase.\n", keyword->name())));
 
     // Get allowed nodes, set model for combo box, and set current index
     allowedNodes_ = keyword_->allowedNodes();

--- a/src/gui/keywordwidgets/nodevalue.h
+++ b/src/gui/keywordwidgets/nodevalue.h
@@ -14,7 +14,7 @@ class NodeValueKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    NodeValueKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    NodeValueKeywordWidget(QWidget *parent, NodeValueKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalue_funcs.cpp
@@ -3,24 +3,17 @@
 
 #include "gui/keywordwidgets/nodevalue.h"
 
-NodeValueKeywordWidget::NodeValueKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+NodeValueKeywordWidget::NodeValueKeywordWidget(QWidget *parent, NodeValueKeyword *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<NodeValueKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into NodeValueKeyword.\n", keyword->name());
-    else
-    {
-        // Set expression text
-        ui_.ValueEdit->setText(QString::fromStdString(keyword_->data().asString()));
-        checkValueValidity();
-    }
+    // Set expression text
+    ui_.ValueEdit->setText(QString::fromStdString(keyword_->data().asString()));
+    checkValueValidity();
 
     refreshing_ = false;
 }

--- a/src/gui/keywordwidgets/nodevalueenumoptions.h
+++ b/src/gui/keywordwidgets/nodevalueenumoptions.h
@@ -14,7 +14,7 @@ class NodeValueEnumOptionsKeywordWidget : public QWidget, public KeywordWidgetBa
     Q_OBJECT
 
     public:
-    NodeValueEnumOptionsKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    NodeValueEnumOptionsKeywordWidget(QWidget *parent, NodeValueEnumOptionsBaseKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
@@ -4,39 +4,32 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/nodevalueenumoptions.h"
 
-NodeValueEnumOptionsKeywordWidget::NodeValueEnumOptionsKeywordWidget(QWidget *parent, KeywordBase *keyword,
+NodeValueEnumOptionsKeywordWidget::NodeValueEnumOptionsKeywordWidget(QWidget *parent, NodeValueEnumOptionsBaseKeyword *keyword,
                                                                      const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<NodeValueEnumOptionsBaseKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into NodeValueEnumOptionsBaseKeyword.\n", keyword->name());
-    else
+    // Get the underlying EnumOptionsBase
+    const EnumOptionsBase &options = keyword_->baseOptions();
+
+    // Populate the combo with the available keywords
+    for (int n = 0; n < options.nOptions(); ++n)
     {
-        // Get the underlying EnumOptionsBase
-        const EnumOptionsBase &options = keyword_->baseOptions();
-
-        // Populate the combo with the available keywords
-        for (int n = 0; n < options.nOptions(); ++n)
-        {
-            ui_.OptionsCombo->addItem(QString::fromStdString(std::string(options.keywordByIndex(n))));
-            if (keyword_->enumerationIndex() == n)
-                ui_.OptionsCombo->setCurrentIndex(n);
-        }
-
-        // Set event filtering on the combo so that we do not blindly accept mouse wheel events (problematic since we
-        // will exist in a QScrollArea)
-        ui_.OptionsCombo->installEventFilter(new MouseWheelWidgetAdjustmentGuard(ui_.OptionsCombo));
-
-        // Update values
-        updateValue();
+        ui_.OptionsCombo->addItem(QString::fromStdString(std::string(options.keywordByIndex(n))));
+        if (keyword_->enumerationIndex() == n)
+            ui_.OptionsCombo->setCurrentIndex(n);
     }
+
+    // Set event filtering on the combo so that we do not blindly accept mouse wheel events (problematic since we
+    // will exist in a QScrollArea)
+    ui_.OptionsCombo->installEventFilter(new MouseWheelWidgetAdjustmentGuard(ui_.OptionsCombo));
+
+    // Update values
+    updateValue();
 
     refreshing_ = false;
 }

--- a/src/gui/keywordwidgets/nodevector.h
+++ b/src/gui/keywordwidgets/nodevector.h
@@ -16,7 +16,7 @@ class NodeVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    NodeVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    NodeVectorKeywordWidget(QWidget *parent, NodeVectorKeywordBase *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/nodevector_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevector_funcs.cpp
@@ -8,8 +8,8 @@
 #include "templates/algorithms.h"
 #include <QLabel>
 
-NodeVectorKeywordWidget::NodeVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+NodeVectorKeywordWidget::NodeVectorKeywordWidget(QWidget *parent, NodeVectorKeywordBase *keyword, const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
@@ -19,10 +19,6 @@ NodeVectorKeywordWidget::NodeVectorKeywordWidget(QWidget *parent, KeywordBase *k
     connect(&nodeModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<NodeVectorKeywordBase *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(fmt::format("Couldn't cast base keyword '{}' into NodeKeyword.\n", keyword->name())));
     allowedNodes_ = keyword_->allowedNodes();
     nodeModel_.setData(allowedNodes_);
     nodeModel_.setNodeSelectedFunction([&](const ProcedureNode *node) { return keyword_->addNode(node); });

--- a/src/gui/keywordwidgets/producers.cpp
+++ b/src/gui/keywordwidgets/producers.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/keywordwidgets/producers.h"
+#include "gui/keywordwidgets/widgets.h"
+#include "keywords/types.h"
+#include <ios>
+
+KeywordWidgetProducer::KeywordWidgetProducer()
+{
+    // Keywords with normal widgets
+    registerProducer<AtomTypeVectorKeyword, AtomTypeVectorKeywordWidget>();
+    registerProducer<BoolKeyword, BoolKeywordWidget>();
+    registerProducer<ConfigurationVectorKeyword, ConfigurationVectorKeywordWidget>();
+    registerProducer<DoubleKeyword, DoubleKeywordWidget>();
+    registerProducer<EnumOptionsBaseKeyword, EnumOptionsKeywordWidget>();
+    registerProducer<ExpressionVariableVectorKeyword, ExpressionVariableVectorKeywordWidget>();
+    registerProducer<FileAndFormatKeyword, FileAndFormatKeywordWidget>();
+    registerProducer<Function1DKeyword, Function1DKeywordWidget>();
+    registerProducer<IntegerKeyword, IntegerKeywordWidget>();
+    registerProducer<IsotopologueSetKeyword, IsotopologueSetKeywordWidget>();
+    registerProducer<ModuleKeywordBase, ModuleKeywordWidget>();
+    registerProducer<ModuleVectorKeyword, ModuleVectorKeywordWidget>();
+    registerProducer<NodeKeywordBase, NodeKeywordWidget>();
+    registerProducer<NodeValueEnumOptionsBaseKeyword, NodeValueEnumOptionsKeywordWidget>();
+    registerProducer<NodeValueKeyword, NodeValueKeywordWidget>();
+    registerProducer<RangeKeyword, RangeKeywordWidget>();
+    registerProducer<SpeciesKeyword, SpeciesKeywordWidget>();
+    registerProducer<SpeciesSiteKeyword, SpeciesSiteKeywordWidget>();
+    registerProducer<SpeciesSiteVectorKeyword, SpeciesSiteVectorKeywordWidget>();
+    registerProducer<SpeciesVectorKeyword, SpeciesVectorKeywordWidget>();
+    registerProducer<StringKeyword, StringKeywordWidget>();
+    registerProducer<Vec3DoubleKeyword, Vec3DoubleKeywordWidget>();
+    registerProducer<Vec3IntegerKeyword, Vec3IntegerKeywordWidget>();
+    registerProducer<Vec3NodeValueKeyword, Vec3NodeValueKeywordWidget>();
+
+    // Keywords with no widgets
+    registerNullProducer<Data1DStoreKeyword>();
+    registerNullProducer<Data2DStoreKeyword>();
+    registerNullProducer<Data3DStoreKeyword>();
+    registerNullProducer<DynamicSiteNodesKeyword>();
+    registerNullProducer<ElementVectorKeyword>();
+    registerNullProducer<ExpressionKeyword>();
+    registerNullProducer<GeometryListKeyword>();
+    registerNullProducer<IntegerDoubleVectorKeyword>();
+    registerNullProducer<IntegerStringVectorKeyword>();
+    registerNullProducer<NodeBranchKeyword>();
+    registerNullProducer<ProcedureKeyword>();
+    registerNullProducer<StringDoubleVectorKeyword>();
+    registerNullProducer<StringPairVectorKeyword>();
+    registerNullProducer<ValueStoreKeyword>();
+}
+
+/*
+ * Producers
+ */
+
+// Produce object of specified type
+std::pair<QWidget *, KeywordWidgetBase *> KeywordWidgetProducer::produce(KeywordBase *keyword, const CoreData &coreData) const
+{
+    auto it = producers_.find(keyword->typeIndex());
+    if (it == producers_.end())
+        throw(std::runtime_error(fmt::format(
+            "A producer has not been registered for type '{}', so a new widget for this keyword cannot be created.\n",
+            keyword->typeIndex().name())));
+
+    return (it->second)(keyword, coreData);
+}
+
+/*
+ * Instance
+ */
+
+// Return the producer instance
+const KeywordWidgetProducer &KeywordWidgetProducer::instance()
+{
+    static KeywordWidgetProducer instance;
+
+    return instance;
+}

--- a/src/gui/keywordwidgets/producers.h
+++ b/src/gui/keywordwidgets/producers.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "keywords/base.h"
+#include <any>
+#include <functional>
+#include <string>
+#include <typeindex>
+#include <unordered_map>
+
+// Forward Declarations
+class QWidget;
+
+// KeywordWidget Producer
+class KeywordWidgetProducer
+{
+    private:
+    KeywordWidgetProducer();
+
+    public:
+    KeywordWidgetProducer(const KeywordWidgetProducer &) = delete;
+    KeywordWidgetProducer(KeywordWidgetProducer &&) = delete;
+    KeywordWidgetProducer &operator=(const KeywordWidgetProducer &) = delete;
+    KeywordWidgetProducer &operator=(KeywordWidgetProducer &&) = delete;
+
+    /*
+     * Producers
+     */
+    private:
+    // Return type
+    using WidgetKeywordProduct = std::pair<QWidget *, KeywordWidgetBase *>;
+    // Producer function type
+    using ProducerFunction = std::function<WidgetKeywordProduct(KeywordBase *keyword, const CoreData &coreData)>;
+    // Producers for all data types
+    std::unordered_map<std::type_index, ProducerFunction> producers_;
+
+    private:
+    // Return widget pair from supplied widget derived class
+    template <class W> WidgetKeywordProduct formProduct(W *keywordWidget) { return {keywordWidget, keywordWidget}; }
+    // Register producer for specific class
+    template <class K> void registerProducer(ProducerFunction function) { producers_[typeid(K)] = std::move(function); }
+    template <class K, class W> void registerProducer()
+    {
+        producers_[typeid(K *)] = [&](KeywordBase *keyword, const CoreData &coreData) {
+            // Cast the base up to the full keyword
+            auto *k = dynamic_cast<K *>(keyword);
+            assert(k);
+            auto *w = new W(nullptr, keyword, coreData);
+            return WidgetKeywordProduct{w, w};
+        };
+    }
+    template <class K> void registerNullProducer()
+    {
+        producers_[typeid(K *)] = [&](KeywordBase *keyword, const CoreData &coreData) {
+            return WidgetKeywordProduct{nullptr, nullptr};
+        };
+    }
+    // Produce object of specified type
+    std::pair<QWidget *, KeywordWidgetBase *> produce(KeywordBase *keyword, const CoreData &coreData) const;
+
+    /*
+     * Instance
+     */
+    private:
+    // Return the producer instance
+    static const KeywordWidgetProducer &instance();
+
+    /*
+     * Static Functions
+     */
+    public:
+    // Create new item via template
+    static std::pair<QWidget *, KeywordWidgetBase *> create(KeywordBase *keyword, const CoreData &coreData)
+    {
+        return instance().produce(keyword, coreData);
+    }
+};

--- a/src/gui/keywordwidgets/producers.h
+++ b/src/gui/keywordwidgets/producers.h
@@ -47,7 +47,7 @@ class KeywordWidgetProducer
             // Cast the base up to the full keyword
             auto *k = dynamic_cast<K *>(keyword);
             assert(k);
-            auto *w = new W(nullptr, keyword, coreData);
+            auto *w = new W(nullptr, k, coreData);
             return WidgetKeywordProduct{w, w};
         };
     }

--- a/src/gui/keywordwidgets/range.h
+++ b/src/gui/keywordwidgets/range.h
@@ -14,7 +14,7 @@ class RangeKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    RangeKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    RangeKeywordWidget(QWidget *parent, RangeKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/range_funcs.cpp
+++ b/src/gui/keywordwidgets/range_funcs.cpp
@@ -5,24 +5,17 @@
 #include "gui/keywordwidgets/range.h"
 #include "vec3labels.h"
 
-RangeKeywordWidget::RangeKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+RangeKeywordWidget::RangeKeywordWidget(QWidget *parent, RangeKeyword *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<RangeKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into RangeKeyword.\n", keyword->name());
-    else
-    {
-        // Set current values
-        ui_.Spin1->setValue(keyword_->data().minimum());
-        ui_.Spin2->setValue(keyword_->data().maximum());
-    }
+    // Set current values
+    ui_.Spin1->setValue(keyword_->data().minimum());
+    ui_.Spin2->setValue(keyword_->data().maximum());
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)

--- a/src/gui/keywordwidgets/species.hui
+++ b/src/gui/keywordwidgets/species.hui
@@ -16,7 +16,7 @@ class SpeciesKeywordWidget : public QComboBox, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    SpeciesKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    SpeciesKeywordWidget(QWidget *parent, SpeciesKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/species_funcs.cpp
+++ b/src/gui/keywordwidgets/species_funcs.cpp
@@ -7,18 +7,11 @@
 #include "gui/helpers/mousewheeladjustmentguard.h"
 #include "gui/keywordwidgets/species.hui"
 
-SpeciesKeywordWidget::SpeciesKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QComboBox(parent), KeywordWidgetBase(coreData)
+SpeciesKeywordWidget::SpeciesKeywordWidget(QWidget *parent, SpeciesKeyword *keyword, const CoreData &coreData)
+    : QComboBox(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<SpeciesKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into SpeciesKeyword.\n", keyword->name());
-    else
-    {
-        // Set current information
-        updateValue();
-    }
+    // Set current information
+    updateValue();
 
     // Connect the
     connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(myIndexChanged(int)));

--- a/src/gui/keywordwidgets/speciessite.h
+++ b/src/gui/keywordwidgets/speciessite.h
@@ -18,7 +18,7 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
     Q_OBJECT
 
     public:
-    SpeciesSiteKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    SpeciesSiteKeywordWidget(QWidget *parent, SpeciesSiteKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -12,21 +12,14 @@
 #include <QRadioButton>
 #include <QSpacerItem>
 
-SpeciesSiteKeywordWidget::SpeciesSiteKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+SpeciesSiteKeywordWidget::SpeciesSiteKeywordWidget(QWidget *parent, SpeciesSiteKeyword *keyword, const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<SpeciesSiteKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into SpeciesSiteKeyword.\n", keyword->name());
-    else
-    {
-        // Set current information
-        updateWidgetValues(coreData_);
-    }
+    // Set current information
+    updateWidgetValues(coreData_);
 }
 
 /*

--- a/src/gui/keywordwidgets/speciessitevector.h
+++ b/src/gui/keywordwidgets/speciessitevector.h
@@ -20,7 +20,7 @@ class SpeciesSiteVectorKeywordWidget : public KeywordDropDown, public KeywordWid
     Q_OBJECT
 
     public:
-    SpeciesSiteVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    SpeciesSiteVectorKeywordWidget(QWidget *parent, SpeciesSiteVectorKeyword *keyword, const CoreData &coreData);
     ~SpeciesSiteVectorKeywordWidget() override = default;
 
     /*

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -7,17 +7,12 @@
 #include "gui/keywordwidgets/speciessitevector.h"
 #include "templates/algorithms.h"
 
-SpeciesSiteVectorKeywordWidget::SpeciesSiteVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+SpeciesSiteVectorKeywordWidget::SpeciesSiteVectorKeywordWidget(QWidget *parent, SpeciesSiteVectorKeyword *keyword,
+                                                               const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
-
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<SpeciesSiteVectorKeyword *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(
-            fmt::format("Couldn't cast base keyword '{}' into SpeciesSiteVectorKeyword.\n", keyword->name())));
 
     sitesFilterProxy_.setSourceModel(&sites_);
     ui_.SitesTree->setModel(&sitesFilterProxy_);

--- a/src/gui/keywordwidgets/speciesvector.h
+++ b/src/gui/keywordwidgets/speciesvector.h
@@ -19,7 +19,7 @@ class SpeciesVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetB
     Q_OBJECT
 
     public:
-    SpeciesVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    SpeciesVectorKeywordWidget(QWidget *parent, SpeciesVectorKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/speciesvector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesvector_funcs.cpp
@@ -10,22 +10,17 @@
 #include <QHBoxLayout>
 #include <QString>
 
-SpeciesVectorKeywordWidget::SpeciesVectorKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData)
+SpeciesVectorKeywordWidget::SpeciesVectorKeywordWidget(QWidget *parent, SpeciesVectorKeyword *keyword, const CoreData &coreData)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
     ui_.SpeciesList->setModel(&speciesModel_);
+    speciesModel_.setCheckStateData(keyword_->data());
 
     // Connect signals / slots
     connect(&speciesModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<SpeciesVectorKeyword *>(keyword);
-    if (!keyword_)
-        throw(std::runtime_error(fmt::format("Couldn't cast base keyword '{}' into SpeciesVectorKeyword.\n", keyword->name())));
-    speciesModel_.setCheckStateData(keyword_->data());
 }
 
 /*

--- a/src/gui/keywordwidgets/stdstring.hui
+++ b/src/gui/keywordwidgets/stdstring.hui
@@ -13,7 +13,7 @@ class StringKeywordWidget : public QLineEdit, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    StringKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    StringKeywordWidget(QWidget *parent, StringKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/stdstring_funcs.cpp
+++ b/src/gui/keywordwidgets/stdstring_funcs.cpp
@@ -3,15 +3,10 @@
 
 #include "gui/keywordwidgets/stdstring.hui"
 
-StringKeywordWidget::StringKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QLineEdit(parent), KeywordWidgetBase(coreData)
+StringKeywordWidget::StringKeywordWidget(QWidget *parent, StringKeyword *keyword, const CoreData &coreData)
+    : QLineEdit(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<StringKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into StringKeyword.\n", keyword->name());
-    else
-        setText(QString::fromStdString(keyword_->data()));
+    setText(QString::fromStdString(keyword_->data()));
 
     // Connect the currentTextChanged signal to our own slot
     connect(this, SIGNAL(textChanged(QString)), this, SLOT(myTextChanged(QString)));

--- a/src/gui/keywordwidgets/vec3double.h
+++ b/src/gui/keywordwidgets/vec3double.h
@@ -14,7 +14,7 @@ class Vec3DoubleKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    Vec3DoubleKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    Vec3DoubleKeywordWidget(QWidget *parent, Vec3DoubleKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/vec3double_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3double_funcs.cpp
@@ -5,39 +5,32 @@
 #include "gui/keywordwidgets/vec3double.h"
 #include "vec3labels.h"
 
-Vec3DoubleKeywordWidget::Vec3DoubleKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+Vec3DoubleKeywordWidget::Vec3DoubleKeywordWidget(QWidget *parent, Vec3DoubleKeyword *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<Vec3DoubleKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into Vec3DoubleKeyword.\n", keyword->name());
-    else
+    // Set minimum and maximum values for each component
+    if (keyword_->validationMin())
     {
-        // Set minimum and maximum values for each component
-        if (keyword_->validationMin())
-        {
-            ui_.Spin1->setMinimumLimit(keyword_->validationMin().value().x);
-            ui_.Spin2->setMinimumLimit(keyword_->validationMin().value().y);
-            ui_.Spin3->setMinimumLimit(keyword_->validationMin().value().z);
-        }
-        if (keyword_->validationMax())
-        {
-            ui_.Spin1->setMaximumLimit(keyword_->validationMax().value().x);
-            ui_.Spin2->setMaximumLimit(keyword_->validationMax().value().y);
-            ui_.Spin3->setMaximumLimit(keyword_->validationMax().value().z);
-        }
-
-        // Set current values
-        ui_.Spin1->setValue(keyword_->data().x);
-        ui_.Spin2->setValue(keyword_->data().y);
-        ui_.Spin3->setValue(keyword_->data().z);
+        ui_.Spin1->setMinimumLimit(keyword_->validationMin().value().x);
+        ui_.Spin2->setMinimumLimit(keyword_->validationMin().value().y);
+        ui_.Spin3->setMinimumLimit(keyword_->validationMin().value().z);
     }
+    if (keyword_->validationMax())
+    {
+        ui_.Spin1->setMaximumLimit(keyword_->validationMax().value().x);
+        ui_.Spin2->setMaximumLimit(keyword_->validationMax().value().y);
+        ui_.Spin3->setMaximumLimit(keyword_->validationMax().value().z);
+    }
+
+    // Set current values
+    ui_.Spin1->setValue(keyword_->data().x);
+    ui_.Spin2->setValue(keyword_->data().y);
+    ui_.Spin3->setValue(keyword_->data().z);
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)

--- a/src/gui/keywordwidgets/vec3integer.h
+++ b/src/gui/keywordwidgets/vec3integer.h
@@ -14,7 +14,7 @@ class Vec3IntegerKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    Vec3IntegerKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    Vec3IntegerKeywordWidget(QWidget *parent, Vec3IntegerKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/vec3integer_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3integer_funcs.cpp
@@ -5,33 +5,26 @@
 #include "gui/keywordwidgets/vec3integer.h"
 #include "gui/keywordwidgets/vec3labels.h"
 
-Vec3IntegerKeywordWidget::Vec3IntegerKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+Vec3IntegerKeywordWidget::Vec3IntegerKeywordWidget(QWidget *parent, Vec3IntegerKeyword *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<Vec3IntegerKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into Vec3IntegerKeyword.\n", keyword->name());
-    else
-    {
-        // Set minimum and maximum values for each component
-        ui_.Spin1->setRange(keyword_->validationMin() ? keyword_->validationMin().value().x : -1e6,
-                            keyword_->validationMax() ? keyword_->validationMax().value().x : 1e6);
-        ui_.Spin2->setRange(keyword_->validationMin() ? keyword_->validationMin().value().y : -1e6,
-                            keyword_->validationMax() ? keyword_->validationMax().value().y : 1e6);
-        ui_.Spin3->setRange(keyword_->validationMin() ? keyword_->validationMin().value().z : -1e6,
-                            keyword_->validationMax() ? keyword_->validationMax().value().z : 1e6);
+    // Set minimum and maximum values for each component
+    ui_.Spin1->setRange(keyword_->validationMin() ? keyword_->validationMin().value().x : -1e6,
+                        keyword_->validationMax() ? keyword_->validationMax().value().x : 1e6);
+    ui_.Spin2->setRange(keyword_->validationMin() ? keyword_->validationMin().value().y : -1e6,
+                        keyword_->validationMax() ? keyword_->validationMax().value().y : 1e6);
+    ui_.Spin3->setRange(keyword_->validationMin() ? keyword_->validationMin().value().z : -1e6,
+                        keyword_->validationMax() ? keyword_->validationMax().value().z : 1e6);
 
-        // Set current values
-        ui_.Spin1->setValue(keyword_->data().x);
-        ui_.Spin2->setValue(keyword_->data().y);
-        ui_.Spin3->setValue(keyword_->data().z);
-    }
+    // Set current values
+    ui_.Spin1->setValue(keyword_->data().x);
+    ui_.Spin2->setValue(keyword_->data().y);
+    ui_.Spin3->setValue(keyword_->data().z);
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)

--- a/src/gui/keywordwidgets/vec3nodevalue.h
+++ b/src/gui/keywordwidgets/vec3nodevalue.h
@@ -14,7 +14,7 @@ class Vec3NodeValueKeywordWidget : public QWidget, public KeywordWidgetBase
     Q_OBJECT
 
     public:
-    Vec3NodeValueKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData);
+    Vec3NodeValueKeywordWidget(QWidget *parent, Vec3NodeValueKeyword *keyword, const CoreData &coreData);
 
     /*
      * Keyword

--- a/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
@@ -4,20 +4,15 @@
 #include "gui/keywordwidgets/vec3labels.h"
 #include "gui/keywordwidgets/vec3nodevalue.h"
 
-Vec3NodeValueKeywordWidget::Vec3NodeValueKeywordWidget(QWidget *parent, KeywordBase *keyword, const CoreData &coreData)
-    : QWidget(parent), KeywordWidgetBase(coreData)
+Vec3NodeValueKeywordWidget::Vec3NodeValueKeywordWidget(QWidget *parent, Vec3NodeValueKeyword *keyword, const CoreData &coreData)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Setup our UI
     ui_.setupUi(this);
 
     refreshing_ = true;
 
-    // Cast the pointer up into the parent class type
-    keyword_ = dynamic_cast<Vec3NodeValueKeyword *>(keyword);
-    if (!keyword_)
-        Messenger::error("Couldn't cast base keyword '{}' into Vec3NodeValueKeyword.\n", keyword->name());
-    else
-        updateValue();
+    updateValue();
 
     // Set appropriate labels
     Vec3WidgetLabels::set(ui_.ValueALabel, keyword_->labelType(), 0);

--- a/src/gui/keywordwidgets/widget.hui
+++ b/src/gui/keywordwidgets/widget.hui
@@ -21,7 +21,7 @@ class KeywordsWidget : public QToolBox
 
     public:
     KeywordsWidget(QWidget *parent);
-    ~KeywordsWidget();
+    ~KeywordsWidget() = default;
 
     /*
      * Controls

--- a/src/gui/keywordwidgets/widget_funcs.cpp
+++ b/src/gui/keywordwidgets/widget_funcs.cpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2021 Team Dissolve and contributors
 
 #include "base/lineparser.h"
+#include "gui/keywordwidgets/producers.h"
 #include "gui/keywordwidgets/widget.hui"
-#include "gui/keywordwidgets/widgets.h"
 #include "main/dissolve.h"
 #include "module/module.h"
 #include <QFormLayout>
@@ -16,8 +16,6 @@ KeywordsWidget::KeywordsWidget(QWidget *parent) : QToolBox(parent)
     setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 }
 
-KeywordsWidget::~KeywordsWidget() {}
-
 /*
  * Controls
  */
@@ -26,209 +24,21 @@ KeywordsWidget::~KeywordsWidget() {}
 QWidget *KeywordsWidget::createKeywordWidget(RefList<KeywordWidgetBase> &keywordWidgets, KeywordBase *keyword,
                                              const CoreData &coreData)
 {
-    QWidget *widget = nullptr;
-    KeywordWidgetBase *base = nullptr;
-
-    // Ensure that we have the base keyword pointer, and its datatype
-    KeywordBase::KeywordDataType type = keyword->type();
-
     // Try to create a suitable widget
-    if (type == KeywordBase::AtomTypeVectorData)
-    {
-        auto *atomTypeVectorWidget = new AtomTypeVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(atomTypeVectorWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = atomTypeVectorWidget;
-        base = atomTypeVectorWidget;
-    }
-    else if (type == KeywordBase::BoolData)
-    {
-        BoolKeywordWidget *boolWidget = new BoolKeywordWidget(nullptr, keyword, coreData);
-        connect(boolWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = boolWidget;
-        base = boolWidget;
-    }
-    else if (type == KeywordBase::ConfigurationVectorData)
-    {
-        ConfigurationVectorKeywordWidget *configurationRefListWidget =
-            new ConfigurationVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(configurationRefListWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = configurationRefListWidget;
-        base = configurationRefListWidget;
-    }
-    else if (type == KeywordBase::DoubleData)
-    {
-        DoubleKeywordWidget *doubleWidget = new DoubleKeywordWidget(nullptr, keyword, coreData);
-        connect(doubleWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = doubleWidget;
-        base = doubleWidget;
-    }
-    else if (type == KeywordBase::EnumOptionsData)
-    {
-        EnumOptionsKeywordWidget *enumOptionsWidget = new EnumOptionsKeywordWidget(nullptr, keyword, coreData);
-        connect(enumOptionsWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = enumOptionsWidget;
-        base = enumOptionsWidget;
-    }
-    else if (type == KeywordBase::ExpressionVariableVectorData)
-    {
-        ExpressionVariableVectorKeywordWidget *expressionVariableVectorWidget =
-            new ExpressionVariableVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(expressionVariableVectorWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = expressionVariableVectorWidget;
-        base = expressionVariableVectorWidget;
-    }
-    else if (type == KeywordBase::FileAndFormatData)
-    {
-        FileAndFormatKeywordWidget *fileAndFormatWidget = new FileAndFormatKeywordWidget(nullptr, keyword, coreData);
-        connect(fileAndFormatWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = fileAndFormatWidget;
-        base = fileAndFormatWidget;
-    }
-    else if (type == KeywordBase::Function1DData)
-    {
-        Function1DKeywordWidget *function1DWidget = new Function1DKeywordWidget(nullptr, keyword, coreData);
-        connect(function1DWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = function1DWidget;
-        base = function1DWidget;
-    }
-    else if (type == KeywordBase::IntegerData)
-    {
-        IntegerKeywordWidget *intWidget = new IntegerKeywordWidget(nullptr, keyword, coreData);
-        connect(intWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = intWidget;
-        base = intWidget;
-    }
-    else if (type == KeywordBase::IsotopologueSetData)
-    {
-        IsotopologueSetKeywordWidget *isotopologueSetWidget = new IsotopologueSetKeywordWidget(nullptr, keyword, coreData);
-        connect(isotopologueSetWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = isotopologueSetWidget;
-        base = isotopologueSetWidget;
-    }
-    else if (type == KeywordBase::ModuleData)
-    {
-        ModuleKeywordWidget *moduleWidget = new ModuleKeywordWidget(nullptr, keyword, coreData);
-        connect(moduleWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = moduleWidget;
-        base = moduleWidget;
-    }
-    else if (type == KeywordBase::ModuleRefListData)
-    {
-        ModuleVectorKeywordWidget *ModuleVectorWidget = new ModuleVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(ModuleVectorWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = ModuleVectorWidget;
-        base = ModuleVectorWidget;
-    }
-    else if (type == KeywordBase::NodeData)
-    {
-        NodeKeywordWidget *nodeWidget = new NodeKeywordWidget(nullptr, keyword, coreData);
-        connect(nodeWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = nodeWidget;
-        base = nodeWidget;
-    }
-    else if (type == KeywordBase::NodeAndIntegerData)
-    {
-        NodeAndIntegerKeywordWidget *nodeAndIntegerWidget = new NodeAndIntegerKeywordWidget(nullptr, keyword, coreData);
-        connect(nodeAndIntegerWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = nodeAndIntegerWidget;
-        base = nodeAndIntegerWidget;
-    }
-    else if (type == KeywordBase::NodeValueData)
-    {
-        NodeValueKeywordWidget *nodeValueWidget = new NodeValueKeywordWidget(nullptr, keyword, coreData);
-        connect(nodeValueWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = nodeValueWidget;
-        base = nodeValueWidget;
-    }
-    else if (type == KeywordBase::NodeValueEnumOptionsData)
-    {
-        NodeValueEnumOptionsKeywordWidget *nodeValueEnumOptionsWidget =
-            new NodeValueEnumOptionsKeywordWidget(nullptr, keyword, coreData);
-        connect(nodeValueEnumOptionsWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = nodeValueEnumOptionsWidget;
-        base = nodeValueEnumOptionsWidget;
-    }
-    else if (type == KeywordBase::NodeVectorData)
-    {
-        NodeVectorKeywordWidget *nodeVectorWidget = new NodeVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(nodeVectorWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = nodeVectorWidget;
-        base = nodeVectorWidget;
-    }
-    else if (type == KeywordBase::RangeData)
-    {
-        RangeKeywordWidget *rangeWidget = new RangeKeywordWidget(nullptr, keyword, coreData);
-        connect(rangeWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = rangeWidget;
-        base = rangeWidget;
-    }
-    else if (type == KeywordBase::SpeciesData)
-    {
-        SpeciesKeywordWidget *speciesWidget = new SpeciesKeywordWidget(nullptr, keyword, coreData);
-        connect(speciesWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = speciesWidget;
-        base = speciesWidget;
-    }
-    else if (type == KeywordBase::SpeciesSiteData)
-    {
-        SpeciesSiteKeywordWidget *speciesSiteWidget = new SpeciesSiteKeywordWidget(nullptr, keyword, coreData);
-        connect(speciesSiteWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = speciesSiteWidget;
-        base = speciesSiteWidget;
-    }
-    else if (type == KeywordBase::SpeciesSiteVectorData)
-    {
-        SpeciesSiteVectorKeywordWidget *speciesSiteVectorWidget =
-            new SpeciesSiteVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(speciesSiteVectorWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = speciesSiteVectorWidget;
-        base = speciesSiteVectorWidget;
-    }
-    else if (type == KeywordBase::SpeciesVectorData)
-    {
-        SpeciesVectorKeywordWidget *speciesVectorWidget = new SpeciesVectorKeywordWidget(nullptr, keyword, coreData);
-        connect(speciesVectorWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = speciesVectorWidget;
-        base = speciesVectorWidget;
-    }
-    else if (type == KeywordBase::StringData)
-    {
-        StringKeywordWidget *charWidget = new StringKeywordWidget(nullptr, keyword, coreData);
-        connect(charWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = charWidget;
-        base = charWidget;
-    }
-    else if (type == KeywordBase::Vec3DoubleData)
-    {
-        Vec3DoubleKeywordWidget *vec3DoubleWidget = new Vec3DoubleKeywordWidget(nullptr, keyword, coreData);
-        connect(vec3DoubleWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = vec3DoubleWidget;
-        base = vec3DoubleWidget;
-    }
-    else if (type == KeywordBase::Vec3IntegerData)
-    {
-        Vec3IntegerKeywordWidget *vec3IntWidget = new Vec3IntegerKeywordWidget(nullptr, keyword, coreData);
-        connect(vec3IntWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = vec3IntWidget;
-        base = vec3IntWidget;
-    }
-    else if (type == KeywordBase::Vec3NodeValueData)
-    {
-        Vec3NodeValueKeywordWidget *vec3NodeValueWidget = new Vec3NodeValueKeywordWidget(nullptr, keyword, coreData);
-        connect(vec3NodeValueWidget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
-        widget = vec3NodeValueWidget;
-        base = vec3NodeValueWidget;
-    }
+    auto [w, base] = KeywordWidgetProducer::create(keyword, coreData);
+    if (!w || !base)
+        return nullptr;
 
-    // Set tooltip on widget (using the description from the keyword pointer passed, rather than its base) and add to the
-    // list of widgets
-    if (widget)
-    {
-        widget->setToolTip(QString::fromStdString(std::string(keyword->description())));
-        keywordWidgets.append(base);
-    }
+    // Connect signals
+    connect(w, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
 
-    return widget;
+    // Set tooltip on widget (using the description from the keyword pointer passed, rather than its base)
+    w->setToolTip(QString::fromStdString(std::string(keyword->description())));
+
+    // Add to the list of widgets
+    keywordWidgets.append(base);
+
+    return w;
 }
 
 // Set up keyword controls for specified keyword list
@@ -259,13 +69,7 @@ void KeywordsWidget::setUp(KeywordList &keywords, const CoreData &coreData)
 
             if (!widget)
             {
-                // WORKAROUND - Don't raise errors for datastore types (issue #36)
-                if ((keyword->type() == KeywordBase::Data1DStoreData) || (keyword->type() == KeywordBase::Data2DStoreData) ||
-                    (keyword->type() == KeywordBase::Data3DStoreData))
-                    continue;
-
-                Messenger::error("Can't create widget for keyword '{}' ({}).\n", keyword->name(),
-                                 KeywordBase::keywordDataType(keyword->type()));
+                Messenger::printVerbose("No widget created for keyword '{}'.\n", keyword->name());
                 continue;
             }
 

--- a/src/keywords/atomtypevector.cpp
+++ b/src/keywords/atomtypevector.cpp
@@ -7,7 +7,9 @@
 #include "classes/coredata.h"
 
 AtomTypeVectorKeyword::AtomTypeVectorKeyword(std::vector<std::shared_ptr<AtomType>> &data)
-    : KeywordBase(typeid(this)), data_(data) {}
+    : KeywordBase(typeid(this)), data_(data)
+{
+}
 
 /*
  * Data

--- a/src/keywords/atomtypevector.cpp
+++ b/src/keywords/atomtypevector.cpp
@@ -7,9 +7,7 @@
 #include "classes/coredata.h"
 
 AtomTypeVectorKeyword::AtomTypeVectorKeyword(std::vector<std::shared_ptr<AtomType>> &data)
-    : KeywordBase(typeid(this), KeywordBase::AtomTypeVectorData), data_(data)
-{
-}
+    : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/base.cpp
+++ b/src/keywords/base.cpp
@@ -7,8 +7,8 @@
 // Static Singletons
 RefList<KeywordBase> KeywordBase::allKeywords_;
 
-KeywordBase::KeywordBase(const std::type_index typeIndex, KeywordDataType type)
-    : type_(type), typeIndex_(typeIndex), set_(false)
+KeywordBase::KeywordBase(const std::type_index typeIndex)
+    : typeIndex_(typeIndex), set_(false)
 {
     // Add ourselves to the master reference list of keywords
     allKeywords_.append(this);
@@ -19,54 +19,6 @@ KeywordBase::~KeywordBase()
     // Remove ourselves from the master reference list of keywords
     allKeywords_.remove(this);
 }
-
-// Value Keyword Data Type Keywords
-std::string_view KeywordDataTypeKeywords[] = {"AtomTypeVector",
-                                              "Bool",
-                                              "ConfigurationRefList",
-                                              "Data1DStore",
-                                              "Data2DStore",
-                                              "Data3DStore",
-                                              "Double",
-                                              "DynamicSites",
-                                              "ElementVector",
-                                              "EnumOptions",
-                                              "Expression",
-                                              "ExpressionVariableList",
-                                              "FileAndFormat",
-                                              "Function1D",
-                                              "GeometryList",
-                                              "Integer",
-                                              "IsotopologueList",
-                                              "IsotopologueSet",
-                                              "LinkToKeyword",
-                                              "Module",
-                                              "ModuleGroups",
-                                              "ModuleRefList",
-                                              "Node",
-                                              "NodeAndInteger",
-                                              "NodeBranch",
-                                              "NodeValue",
-                                              "NodeValueEnumOptions",
-                                              "NodeVector",
-                                              "Procedure",
-                                              "Range",
-                                              "Species",
-                                              "SpeciesSite",
-                                              "SpeciesSiteVector",
-                                              "SpeciesVector",
-                                              "String",
-                                              "ValueStore",
-                                              "Vec3<Double>",
-                                              "Vec3<Integer>",
-                                              "Vec3<NodeValue>",
-                                              "Vector<Integer,Double>",
-                                              "Vector<Integer,String>",
-                                              "Vector<String,Double>",
-                                              "Vector<String,String>"};
-
-// Return ValueType name
-std::string_view KeywordBase::keywordDataType(KeywordDataType kdt) { return KeywordDataTypeKeywords[kdt]; }
 
 /*
  * Keyword Description
@@ -84,12 +36,6 @@ void KeywordBase::setOptionMask(int opttionMask) { optionMask_ = opttionMask; }
 
 // Flag that data has been set by some other means
 void KeywordBase::setAsModified() { set_ = true; }
-
-// Return data type stored by keyword
-KeywordBase::KeywordDataType KeywordBase::type() const { return type_; }
-
-// Return name of data type stored by keyword
-std::string_view KeywordBase::typeName() const { return KeywordDataTypeKeywords[type_]; }
 
 // Return keyword name
 std::string_view KeywordBase::name() const { return name_; }
@@ -118,12 +64,12 @@ bool KeywordBase::validNArgs(int nArgsProvided) const
 {
     if (nArgsProvided < minArguments())
     {
-        Messenger::error("Not enough arguments given to {} keyword '{}'.\n", typeName(), name());
+        Messenger::error("Not enough arguments given to keyword '{}'.\n", name());
         return false;
     }
     if ((maxArguments() >= 0) && (nArgsProvided > maxArguments()))
     {
-        Messenger::error("Too many arguments given to {} keyword '{}'.\n", typeName(), name());
+        Messenger::error("Too many arguments given to keyword '{}'.\n", name());
         return false;
     }
 

--- a/src/keywords/base.cpp
+++ b/src/keywords/base.cpp
@@ -7,8 +7,7 @@
 // Static Singletons
 RefList<KeywordBase> KeywordBase::allKeywords_;
 
-KeywordBase::KeywordBase(const std::type_index typeIndex)
-    : typeIndex_(typeIndex), set_(false)
+KeywordBase::KeywordBase(const std::type_index typeIndex) : typeIndex_(typeIndex), set_(false)
 {
     // Add ourselves to the master reference list of keywords
     allKeywords_.append(this);
@@ -31,8 +30,11 @@ void KeywordBase::setBaseInfo(std::string_view name, std::string_view descriptio
     description_ = description;
 }
 
+// Return typeindex for the keyword
+const std::type_index KeywordBase::typeIndex() const { return typeIndex_; }
+
 // Set option mask
-void KeywordBase::setOptionMask(int opttionMask) { optionMask_ = opttionMask; }
+void KeywordBase::setOptionMask(int optionMask) { optionMask_ = optionMask; }
 
 // Flag that data has been set by some other means
 void KeywordBase::setAsModified() { set_ = true; }

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -12,9 +12,11 @@ class AtomType;
 class Configuration;
 class CoreData;
 class Isotopologue;
+class KeywordWidgetBase;
 class LineParser;
 class Module;
 class ProcedureNode;
+class QWidget;
 class Species;
 class SpeciesSite;
 
@@ -55,6 +57,8 @@ class KeywordBase
     public:
     // Set base keyword information
     void setBaseInfo(std::string_view name, std::string_view description);
+    // Return typeindex for the keyword
+    const std::type_index typeIndex() const;
     // Set option mask
     void setOptionMask(int opttionMask);
     // Flag that data has been set by some other means

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -22,57 +22,8 @@ class SpeciesSite;
 class KeywordBase
 {
     public:
-    // Keyword Data Type
-    enum KeywordDataType
-    {
-        AtomTypeVectorData,
-        BoolData,
-        ConfigurationVectorData,
-        Data1DStoreData,
-        Data2DStoreData,
-        Data3DStoreData,
-        DoubleData,
-        DynamicSiteNodesData,
-        ElementVectorData,
-        EnumOptionsData,
-        ExpressionData,
-        ExpressionVariableVectorData,
-        FileAndFormatData,
-        Function1DData,
-        GeometryListData,
-        IntegerData,
-        IsotopologueListData,
-        IsotopologueSetData,
-        LinkToKeywordData,
-        ModuleData,
-        ModuleGroupsData,
-        ModuleRefListData,
-        NodeData,
-        NodeAndIntegerData,
-        NodeBranchData,
-        NodeValueData,
-        NodeValueEnumOptionsData,
-        NodeVectorData,
-        ProcedureData,
-        RangeData,
-        SpeciesData,
-        SpeciesSiteData,
-        SpeciesSiteVectorData,
-        SpeciesVectorData,
-        StringData,
-        ValueStoreData,
-        Vec3DoubleData,
-        Vec3IntegerData,
-        Vec3NodeValueData,
-        VectorIntegerDoubleData,
-        VectorIntegerStringData,
-        VectorDoublePairData,
-        VectorStringPairData
-    };
-    KeywordBase(const std::type_index typeIndex, KeywordDataType type);
+    KeywordBase(const std::type_index typeIndex);
     virtual ~KeywordBase();
-    // Return DataType name
-    static std::string_view keywordDataType(KeywordDataType kdt);
 
     /*
      * Keyword Description
@@ -88,8 +39,6 @@ class KeywordBase
     };
 
     private:
-    // Data type stored by keyword
-    KeywordDataType type_;
     // Type index of derived class
     const std::type_index typeIndex_;
     // Keyword name
@@ -110,10 +59,6 @@ class KeywordBase
     void setOptionMask(int opttionMask);
     // Flag that data has been set by some other means
     void setAsModified();
-    // Return data type stored by keyword
-    KeywordDataType type() const;
-    // Return name of data type stored by keyword
-    std::string_view typeName() const;
     // Return keyword name
     std::string_view name() const;
     // Return keyword description

--- a/src/keywords/bool.cpp
+++ b/src/keywords/bool.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-BoolKeyword::BoolKeyword(bool &data) : KeywordBase(typeid(this), KeywordBase::BoolData), data_(data) {}
+BoolKeyword::BoolKeyword(bool &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/configurationvector.cpp
+++ b/src/keywords/configurationvector.cpp
@@ -7,7 +7,7 @@
 #include "classes/coredata.h"
 
 ConfigurationVectorKeyword::ConfigurationVectorKeyword(std::vector<Configuration *> &data, int maxListSize)
-    : KeywordBase(typeid(this), KeywordBase::ConfigurationVectorData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
     maxListSize_ = maxListSize;
 }

--- a/src/keywords/data.h
+++ b/src/keywords/data.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "keywords/base.h"
+
+// Keyword Interface
+template <class T> class KeywordData : public KeywordBase
+{
+    public:
+    KeywordData(T data) : KeywordBase(), data_(data) {}
+
+    /*
+     * Data
+     */
+    protected:
+    // Data (POD or otherwise) that is to be set by reading from an input file
+    T data_;
+
+    protected:
+    // Determine whether current data is 'empty', and should be considered as 'not set'
+    bool isDataEmpty() const override
+    {
+        // Override this function to handle cases where, for instance, checks for empty lists need to be made.
+        return false;
+    }
+
+    public:
+    // Set data, validating as necessary
+    bool setData(T value)
+    {
+        if (isValid(value))
+        {
+            // Data is valid, so store it
+            data_ = value;
+
+            // Check here if the data is 'empty', in which case it is not strictly 'set'
+            set_ = isDataEmpty() ? false : true;
+
+            return true;
+        }
+
+        return false;
+    }
+    // Return data
+    T &data() { return data_; }
+    const T &data() const { return data_; }
+
+    /*
+     * Data Validation
+     */
+    public:
+    // Validate supplied value
+    virtual bool isValid(T value) { return true; }
+};

--- a/src/keywords/data1dstore.cpp
+++ b/src/keywords/data1dstore.cpp
@@ -6,9 +6,7 @@
 #include "classes/data1dstore.h"
 #include "io/import/data1d.h"
 
-Data1DStoreKeyword::Data1DStoreKeyword(Data1DStore &data) : KeywordBase(typeid(this), KeywordBase::Data1DStoreData), data_(data)
-{
-}
+Data1DStoreKeyword::Data1DStoreKeyword(Data1DStore &data) : KeywordBase(typeid(this)), data_(data) { }
 
 /*
  * Data

--- a/src/keywords/data1dstore.cpp
+++ b/src/keywords/data1dstore.cpp
@@ -6,7 +6,7 @@
 #include "classes/data1dstore.h"
 #include "io/import/data1d.h"
 
-Data1DStoreKeyword::Data1DStoreKeyword(Data1DStore &data) : KeywordBase(typeid(this)), data_(data) { }
+Data1DStoreKeyword::Data1DStoreKeyword(Data1DStore &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/data2dstore.cpp
+++ b/src/keywords/data2dstore.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 #include "classes/data2dstore.h"
 
-Data2DStoreKeyword::Data2DStoreKeyword(Data2DStore &data) : KeywordBase(typeid(this), KeywordBase::Data2DStoreData), data_(data)
+Data2DStoreKeyword::Data2DStoreKeyword(Data2DStore &data) : KeywordBase(typeid(this)), data_(data)
 {
 }
 

--- a/src/keywords/data2dstore.cpp
+++ b/src/keywords/data2dstore.cpp
@@ -5,9 +5,7 @@
 #include "base/lineparser.h"
 #include "classes/data2dstore.h"
 
-Data2DStoreKeyword::Data2DStoreKeyword(Data2DStore &data) : KeywordBase(typeid(this)), data_(data)
-{
-}
+Data2DStoreKeyword::Data2DStoreKeyword(Data2DStore &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/data3dstore.cpp
+++ b/src/keywords/data3dstore.cpp
@@ -5,9 +5,7 @@
 #include "base/lineparser.h"
 #include "classes/data3dstore.h"
 
-Data3DStoreKeyword::Data3DStoreKeyword(Data3DStore &data) : KeywordBase(typeid(this)), data_(data)
-{
-}
+Data3DStoreKeyword::Data3DStoreKeyword(Data3DStore &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/data3dstore.cpp
+++ b/src/keywords/data3dstore.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 #include "classes/data3dstore.h"
 
-Data3DStoreKeyword::Data3DStoreKeyword(Data3DStore &data) : KeywordBase(typeid(this), KeywordBase::Data3DStoreData), data_(data)
+Data3DStoreKeyword::Data3DStoreKeyword(Data3DStore &data) : KeywordBase(typeid(this)), data_(data)
 {
 }
 

--- a/src/keywords/double.cpp
+++ b/src/keywords/double.cpp
@@ -6,7 +6,7 @@
 #include "base/sysfunc.h"
 
 DoubleKeyword::DoubleKeyword(double &data, std::optional<double> minValue, std::optional<double> maxValue)
-    : KeywordBase(typeid(this), KeywordBase::DoubleData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
     minimumLimit_ = minValue;
     maximumLimit_ = maxValue;

--- a/src/keywords/dynamicsitenodes.cpp
+++ b/src/keywords/dynamicsitenodes.cpp
@@ -9,8 +9,7 @@
 
 DynamicSiteNodesKeyword::DynamicSiteNodesKeyword(std::vector<DynamicSiteProcedureNode *> &data, SelectProcedureNode *parentNode,
                                                  bool axesRequired)
-    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode),
-      axesRequired_(axesRequired)
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode), axesRequired_(axesRequired)
 {
 }
 

--- a/src/keywords/dynamicsitenodes.cpp
+++ b/src/keywords/dynamicsitenodes.cpp
@@ -9,7 +9,7 @@
 
 DynamicSiteNodesKeyword::DynamicSiteNodesKeyword(std::vector<DynamicSiteProcedureNode *> &data, SelectProcedureNode *parentNode,
                                                  bool axesRequired)
-    : KeywordBase(typeid(this), KeywordBase::DynamicSiteNodesData), data_(data), parentNode_(parentNode),
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode),
       axesRequired_(axesRequired)
 {
 }

--- a/src/keywords/elementvector.cpp
+++ b/src/keywords/elementvector.cpp
@@ -5,10 +5,7 @@
 #include "base/lineparser.h"
 #include "data/elements.h"
 
-ElementVectorKeyword::ElementVectorKeyword(std::vector<Elements::Element> &data)
-    : KeywordBase(typeid(this)), data_(data)
-{
-}
+ElementVectorKeyword::ElementVectorKeyword(std::vector<Elements::Element> &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/elementvector.cpp
+++ b/src/keywords/elementvector.cpp
@@ -6,7 +6,7 @@
 #include "data/elements.h"
 
 ElementVectorKeyword::ElementVectorKeyword(std::vector<Elements::Element> &data)
-    : KeywordBase(typeid(this), KeywordBase::ElementVectorData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
 }
 

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -11,10 +11,7 @@
 class EnumOptionsBaseKeyword : public KeywordBase
 {
     public:
-    explicit EnumOptionsBaseKeyword(EnumOptionsBase &baseOptions)
-        : KeywordBase(typeid(this)), baseOptions_(baseOptions)
-    {
-    }
+    explicit EnumOptionsBaseKeyword(EnumOptionsBase &baseOptions) : KeywordBase(typeid(this)), baseOptions_(baseOptions) {}
 
     /*
      * Source Options

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -11,8 +11,8 @@
 class EnumOptionsBaseKeyword : public KeywordBase
 {
     public:
-    EnumOptionsBaseKeyword(EnumOptionsBase &baseOptions)
-        : KeywordBase(typeid(this), KeywordBase::EnumOptionsData), baseOptions_(baseOptions)
+    explicit EnumOptionsBaseKeyword(EnumOptionsBase &baseOptions)
+        : KeywordBase(typeid(this)), baseOptions_(baseOptions)
     {
     }
 

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -6,7 +6,7 @@
 #include "expression/expression.h"
 
 ExpressionKeyword::ExpressionKeyword(Expression &data, const std::vector<std::shared_ptr<ExpressionVariable>> &variables)
-    : KeywordBase(typeid(this), KeywordBase::ExpressionData), data_(data), variables_(variables)
+    : KeywordBase(typeid(this)), data_(data), variables_(variables)
 {
 }
 

--- a/src/keywords/expressionvariablevector.cpp
+++ b/src/keywords/expressionvariablevector.cpp
@@ -10,7 +10,7 @@
 
 ExpressionVariableVectorKeyword::ExpressionVariableVectorKeyword(std::vector<std::shared_ptr<ExpressionVariable>> &data,
                                                                  ProcedureNode *parentNode)
-    : KeywordBase(typeid(this), KeywordBase::ExpressionVariableVectorData), data_(data), parentNode_(parentNode)
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode)
 {
 }
 

--- a/src/keywords/fileandformat.cpp
+++ b/src/keywords/fileandformat.cpp
@@ -6,7 +6,7 @@
 #include "io/fileandformat.h"
 
 FileAndFormatKeyword::FileAndFormatKeyword(FileAndFormat &data, std::string_view endKeyword)
-    : KeywordBase(typeid(this), KeywordBase::FileAndFormatData), data_(data), endKeyword_{endKeyword}
+    : KeywordBase(typeid(this)), data_(data), endKeyword_{endKeyword}
 {
 }
 

--- a/src/keywords/function1d.cpp
+++ b/src/keywords/function1d.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 
 Function1DKeyword::Function1DKeyword(Functions::Function1DWrapper &data, int functionProperties)
-    : KeywordBase(typeid(this), KeywordBase::Function1DData), data_(data), functionProperties_(functionProperties)
+    : KeywordBase(typeid(this)), data_(data), functionProperties_(functionProperties)
 {
 }
 

--- a/src/keywords/geometrylist.cpp
+++ b/src/keywords/geometrylist.cpp
@@ -6,7 +6,7 @@
 #include "classes/coredata.h"
 
 GeometryListKeyword::GeometryListKeyword::GeometryListKeyword(std::vector<Geometry> &data, Geometry::GeometryType geometryType)
-    : KeywordBase(typeid(this), KeywordBase::GeometryListData), data_(data), geometryType_(geometryType)
+    : KeywordBase(typeid(this)), data_(data), geometryType_(geometryType)
 {
 }
 

--- a/src/keywords/group.cpp
+++ b/src/keywords/group.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/group.h"
+#include "keywords/list.h"
+
+KeywordGroup::KeywordGroup(KeywordList &keywordList) : ListItem<KeywordGroup>(), keywordList_(keywordList) {}
+
+/*
+ * Identity
+ */
+
+// Set name of group
+void KeywordGroup::setName(std::string_view name) { name_ = name; }
+
+// Return name of group
+std::string_view KeywordGroup::name() const { return name_; }
+
+/*
+ * Keyword Group
+ */
+
+// Add specified keyword to the group
+void KeywordGroup::addKeywordToGroup(KeywordBase *object) { keywords_.append(object); }
+
+// Add keyword (pass-thru to KeywordList)
+bool KeywordGroup::add(KeywordBase *object, std::string_view keyword, std::string_view description, int optionMask)
+{
+    if (!keywordList_.add(object, keyword, description, optionMask))
+        return false;
+
+    addKeywordToGroup(object);
+
+    return false;
+}
+
+// Return first keyword in list
+RefList<KeywordBase> &KeywordGroup::keywords() { return keywords_; }

--- a/src/keywords/group.h
+++ b/src/keywords/group.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "keywords/base.h"
+#include "templates/listitem.h"
+#include "templates/reflist.h"
+
+// Forward Declarations
+class KeywordList;
+
+// Keyword Group
+class KeywordGroup : public ListItem<KeywordGroup>
+{
+    public:
+    KeywordGroup(KeywordList &keywordList);
+
+    /*
+     * Identity
+     */
+    private:
+    // Name of the group
+    std::string name_;
+
+    public:
+    // Set name of group
+    void setName(std::string_view name);
+    // Return name of group
+    std::string_view name() const;
+
+    /*
+     * Keyword Group
+     */
+    private:
+    // Associated KeywordList
+    KeywordList &keywordList_;
+    // List of keywords (in the referenced KeywordList) that are in this group
+    RefList<KeywordBase> keywords_;
+
+    private:
+    // Add specified keyword to the group
+    void addKeywordToGroup(KeywordBase *object);
+
+    public:
+    // Add keyword (pass-thru to KeywordList)
+    bool add(KeywordBase *object, std::string_view keyword, std::string_view description,
+             int optionMask = KeywordBase::NoOptions);
+    // Return reference list of keywords in group
+    RefList<KeywordBase> &keywords();
+};

--- a/src/keywords/integer.cpp
+++ b/src/keywords/integer.cpp
@@ -6,7 +6,7 @@
 #include "base/sysfunc.h"
 
 IntegerKeyword::IntegerKeyword(int &data, std::optional<int> minValue, std::optional<int> maxValue)
-    : KeywordBase(typeid(this), KeywordBase::IntegerData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
     minimumLimit_ = minValue;
     maximumLimit_ = maxValue;

--- a/src/keywords/isotopologueset.cpp
+++ b/src/keywords/isotopologueset.cpp
@@ -6,10 +6,7 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 
-IsotopologueSetKeyword::IsotopologueSetKeyword(IsotopologueSet &data)
-    : KeywordBase(typeid(this)), data_(data)
-{
-}
+IsotopologueSetKeyword::IsotopologueSetKeyword(IsotopologueSet &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/isotopologueset.cpp
+++ b/src/keywords/isotopologueset.cpp
@@ -7,7 +7,7 @@
 #include "classes/species.h"
 
 IsotopologueSetKeyword::IsotopologueSetKeyword(IsotopologueSet &data)
-    : KeywordBase(typeid(this), KeywordBase::IsotopologueSetData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
 }
 

--- a/src/keywords/linkto.cpp
+++ b/src/keywords/linkto.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/linkto.h"
+
+LinkToKeyword::LinkToKeyword(KeywordBase *keywordData) : KeywordData<KeywordBase *>(keywordData) {}
+
+LinkToKeyword::~LinkToKeyword() = default;
+
+/*
+ * Base Pointer Return (Overloading KeywordBase virtual)
+ */
+
+// Return base pointer for this (may be overloaded to provide access to other KeywordBase instance)
+KeywordBase *LinkToKeyword::base() { return data_; }
+
+/*
+ * Arguments
+ */
+
+// Return minimum number of arguments accepted
+int LinkToKeyword::minArguments() const
+{
+    Messenger::warn("Don't call LinkToKeyword::minArguments() - go through base().\n");
+    return data_->minArguments();
+}
+
+// Return maximum number of arguments accepted
+int LinkToKeyword::maxArguments() const
+{
+    Messenger::warn("Don't call LinkToKeyword::maxArguments() - go through base().\n");
+    return data_->maxArguments();
+}
+
+// Parse arguments from supplied LineParser, starting at given argument offset
+bool LinkToKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+{
+    Messenger::warn("Don't call LinkToKeyword::read() - go through base().\n");
+    return data_->read(parser, startArg, coreData);
+}
+
+// Write keyword data to specified LineParser
+bool LinkToKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
+{
+    Messenger::warn("Don't call LinkToKeyword::write() - go through base().\n");
+    return data_->write(parser, data_->name(), prefix);
+}

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -12,8 +12,7 @@
 class ModuleKeywordBase : public KeywordBase
 {
     public:
-    explicit ModuleKeywordBase(std::string_view moduleType)
-        : KeywordBase(typeid(this)), moduleType_(moduleType){};
+    explicit ModuleKeywordBase(std::string_view moduleType) : KeywordBase(typeid(this)), moduleType_(moduleType){};
     ~ModuleKeywordBase() override = default;
 
     /*

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -13,7 +13,7 @@ class ModuleKeywordBase : public KeywordBase
 {
     public:
     explicit ModuleKeywordBase(std::string_view moduleType)
-        : KeywordBase(typeid(this), KeywordBase::ModuleData), moduleType_(moduleType){};
+        : KeywordBase(typeid(this)), moduleType_(moduleType){};
     ~ModuleKeywordBase() override = default;
 
     /*

--- a/src/keywords/modulegroups.cpp
+++ b/src/keywords/modulegroups.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/modulegroups.h"
+#include "base/lineparser.h"
+#include "base/sysfunc.h"
+#include "classes/coredata.h"
+#include "module/group.h"
+#include "module/groups.h"
+#include "module/module.h"
+
+ModuleGroupsKeyword::ModuleGroupsKeyword(ModuleGroups &groups) : KeywordData<ModuleGroups &>(groups) {}
+
+/*
+ * Arguments
+ */
+
+// Return minimum number of arguments accepted
+int ModuleGroupsKeyword::minArguments() const { return 1; }
+
+// Return maximum number of arguments accepted
+int ModuleGroupsKeyword::maxArguments() const
+{
+    // Module name plus group name
+    return 2;
+}
+
+// Parse arguments from supplied LineParser, starting at given argument offset
+bool ModuleGroupsKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+{
+    // Find specified Module by its unique name
+    Module *module = coreData.findModule(parser.argsv(startArg));
+    if (!module)
+    {
+        Messenger::error("No Module named '{}' exists.\n", parser.argsv(startArg));
+        return false;
+    }
+
+    // Check the module's type
+    if (!data_.moduleTypeIsAllowed(module->type()))
+    {
+        std::string allowedTypes;
+        for (const auto &s : data_.allowedModuleTypes())
+            allowedTypes += allowedTypes.empty() ? s : ", " + s;
+        Messenger::error("Module '{}' is of type '{}', and is not permitted in these groups (allowed types = {}).\n",
+                         parser.argsv(startArg), module->type(), allowedTypes);
+        return false;
+    }
+
+    // If a second argument was given, this is the name of the group we should add the Module to. Otherwise, use the default
+    data_.addModule(module, parser.hasArg(startArg + 1) ? parser.argsv(startArg + 1) : "Default");
+
+    set_ = true;
+
+    return true;
+}
+
+// Write keyword data to specified LineParser
+bool ModuleGroupsKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
+{
+    // Loop over defined groups
+    for (auto &group : data_.groups())
+    {
+        // Loop over list of referenced Modules in this group
+        for (Module *module : group->modules())
+        {
+            if (!parser.writeLineF("{}{}  '{}'  '{}'\n", prefix, keywordName, module->uniqueName(), group->name()))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+/*
+ * Object Management
+ */
+
+// Prune any references to the supplied Module in the contained data
+void ModuleGroupsKeyword::removeReferencesTo(Module *module)
+{
+    // Loop over defined groups
+    for (auto &group : data_.groups())
+    {
+        if (group->contains(module))
+            group->remove(module);
+    }
+}

--- a/src/keywords/modulevector.cpp
+++ b/src/keywords/modulevector.cpp
@@ -10,13 +10,13 @@
 #include <utility>
 
 ModuleVectorKeyword::ModuleVectorKeyword(std::vector<Module *> &data, int maxModules)
-    : KeywordBase(typeid(this), KeywordBase::ModuleRefListData), data_(data), maxModules_(maxModules)
+    : KeywordBase(typeid(this)), data_(data), maxModules_(maxModules)
 {
 }
 
 ModuleVectorKeyword::ModuleVectorKeyword(std::vector<Module *> &data, std::vector<std::string> allowedModuleTypes,
                                          int maxModules)
-    : KeywordBase(typeid(this), KeywordBase::ModuleRefListData), data_(data), moduleTypes_(std::move(allowedModuleTypes)),
+    : KeywordBase(typeid(this)), data_(data), moduleTypes_(std::move(allowedModuleTypes)),
       maxModules_(maxModules)
 {
 }

--- a/src/keywords/modulevector.cpp
+++ b/src/keywords/modulevector.cpp
@@ -16,8 +16,7 @@ ModuleVectorKeyword::ModuleVectorKeyword(std::vector<Module *> &data, int maxMod
 
 ModuleVectorKeyword::ModuleVectorKeyword(std::vector<Module *> &data, std::vector<std::string> allowedModuleTypes,
                                          int maxModules)
-    : KeywordBase(typeid(this)), data_(data), moduleTypes_(std::move(allowedModuleTypes)),
-      maxModules_(maxModules)
+    : KeywordBase(typeid(this)), data_(data), moduleTypes_(std::move(allowedModuleTypes)), maxModules_(maxModules)
 {
 }
 

--- a/src/keywords/node.cpp
+++ b/src/keywords/node.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/node.h"
+#include "procedure/nodes/node.h"
+
+NodeKeyword::NodeKeyword(ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope,
+                         const ProcedureNode *node)
+    : NodeKeywordBase(parentNode, nodeType, onlyInScope), KeywordData<const ProcedureNode *>(node)
+{
+}
+
+NodeKeyword::NodeKeyword(ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope,
+                         const ProcedureNode *node)
+    : NodeKeywordBase(parentNode, nodeClass, onlyInScope), KeywordData<const ProcedureNode *>(node)
+{
+}
+
+/*
+ * Arguments
+ */
+
+// Return minimum number of arguments accepted
+int NodeKeyword::minArguments() const { return 1; }
+
+// Return maximum number of arguments accepted
+int NodeKeyword::maxArguments() const { return 1; }
+
+// Parse arguments from supplied LineParser, starting at given argument offset
+bool NodeKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+{
+    if (!parentNode())
+        return Messenger::error("Can't read keyword {} since the parent ProcedureNode has not been set.\n",
+                                KeywordBase::name());
+
+    // Locate the named node
+    auto *node =
+        onlyInScope() ? parentNode()->nodeInScope(parser.argsv(startArg)) : parentNode()->nodeExists(parser.argsv(startArg));
+    if (!node)
+        return Messenger::error("Node '{}' given to keyword {} doesn't exist.\n", parser.argsv(startArg), KeywordBase::name());
+
+    // Check the type
+    if (!validNode(node, nodeType_, nodeClass_, name()))
+        return false;
+
+    setData(node);
+
+    return true;
+}
+
+// Write keyword data to specified LineParser
+bool NodeKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
+{
+    // No need to write the keyword if the node pointer is null
+    if (data_ == nullptr)
+        return true;
+
+    if (!parser.writeLineF("{}{}  '{}'\n", prefix, KeywordBase::name(), data_->name()))
+        return false;
+
+    return true;
+}
+
+/*
+ * Object Management
+ */
+
+// Prune any references to the supplied ProcedureNode in the contained data
+void NodeKeyword::removeReferencesTo(ProcedureNode *node)
+{
+    if (data_ == node)
+        data_ = nullptr;
+}

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -13,11 +13,11 @@ class NodeKeywordBase : public NodeKeywordUnderlay, public KeywordBase
 {
     public:
     NodeKeywordBase(ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope)
-        : NodeKeywordUnderlay(parentNode, nodeType, onlyInScope), KeywordBase(typeid(this), KeywordBase::NodeData)
+        : NodeKeywordUnderlay(parentNode, nodeType, onlyInScope), KeywordBase(typeid(this))
     {
     }
     NodeKeywordBase(ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope)
-        : NodeKeywordUnderlay(parentNode, nodeClass, onlyInScope), KeywordBase(typeid(this), KeywordBase::NodeData)
+        : NodeKeywordUnderlay(parentNode, nodeClass, onlyInScope), KeywordBase(typeid(this))
     {
     }
     ~NodeKeywordBase() override = default;

--- a/src/keywords/nodeandinteger.cpp
+++ b/src/keywords/nodeandinteger.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/nodeandinteger.h"
+#include "procedure/nodes/node.h"
+
+NodeAndIntegerKeyword::NodeAndIntegerKeyword(ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope,
+                                             const ProcedureNode *node, int index)
+    : NodeKeywordBase(parentNode, nodeType, onlyInScope), KeywordData<std::pair<const ProcedureNode *, int>>({node, index})
+{
+}
+
+NodeAndIntegerKeyword::NodeAndIntegerKeyword(ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope,
+                                             const ProcedureNode *node, int index)
+    : NodeKeywordBase(parentNode, nodeClass, onlyInScope), KeywordData<std::pair<const ProcedureNode *, int>>({node, index})
+{
+}
+
+/*
+ * Arguments
+ */
+
+// Return minimum number of arguments accepted
+int NodeAndIntegerKeyword::minArguments() const { return 1; }
+
+// Return maximum number of arguments accepted
+int NodeAndIntegerKeyword::maxArguments() const { return 2; }
+
+// Parse arguments from supplied LineParser, starting at given argument offset
+bool NodeAndIntegerKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+{
+    if (!parentNode())
+        return Messenger::error("Can't read keyword {} since the parent ProcedureNode has not been set.\n",
+                                KeywordBase::name());
+
+    // Locate the named node in scope - don't prune by type yet (we'll check that in setNode())
+    auto *node =
+        onlyInScope() ? parentNode()->nodeInScope(parser.argsv(startArg)) : parentNode()->nodeExists(parser.argsv(startArg));
+    if (!node)
+        return Messenger::error("Node '{}' given to keyword {} doesn't exist.\n", parser.argsv(startArg), KeywordBase::name());
+
+    // Check the type
+    if (!validNode(node, nodeType_, nodeClass_, name()))
+        return false;
+
+    if (parser.hasArg(startArg + 1))
+        setData({node, parser.argi(startArg + 1)});
+    else
+        setData({node, 0});
+
+    return true;
+}
+
+// Write keyword data to specified LineParser
+bool NodeAndIntegerKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
+{
+    return parser.writeLineF("{}{}  '{}'  {}\n", prefix, KeywordBase::name(), data_.first ? data_.first->name() : "???",
+                             data_.second);
+}
+
+/*
+ * Object Management
+ */
+
+// Prune any references to the supplied ProcedureNode in the contained data
+void NodeAndIntegerKeyword::removeReferencesTo(ProcedureNode *node)
+{
+    if (data_.first == node)
+        data_.first = nullptr;
+}

--- a/src/keywords/nodeandinteger.h
+++ b/src/keywords/nodeandinteger.h
@@ -14,11 +14,11 @@ class NodeAndIntegerKeywordBase : public NodeKeywordUnderlay, public KeywordBase
 {
     public:
     NodeAndIntegerKeywordBase(ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope)
-        : NodeKeywordUnderlay(parentNode, nodeType, onlyInScope), KeywordBase(typeid(this), KeywordBase::NodeAndIntegerData)
+        : NodeKeywordUnderlay(parentNode, nodeType, onlyInScope), KeywordBase(typeid(this))
     {
     }
     NodeAndIntegerKeywordBase(ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope)
-        : NodeKeywordUnderlay(parentNode, nodeClass, onlyInScope), KeywordBase(typeid(this), KeywordBase::NodeAndIntegerData)
+        : NodeKeywordUnderlay(parentNode, nodeClass, onlyInScope), KeywordBase(typeid(this))
     {
     }
     ~NodeAndIntegerKeywordBase() override = default;

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -8,8 +8,7 @@
 
 NodeBranchKeyword::NodeBranchKeyword(SequenceProcedureNode *&data, ProcedureNode *parentNode,
                                      ProcedureNode::NodeContext branchContext)
-    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode),
-      branchContext_(branchContext)
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode), branchContext_(branchContext)
 {
 }
 

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -8,7 +8,7 @@
 
 NodeBranchKeyword::NodeBranchKeyword(SequenceProcedureNode *&data, ProcedureNode *parentNode,
                                      ProcedureNode::NodeContext branchContext)
-    : KeywordBase(typeid(this), KeywordBase::NodeBranchData), data_(data), parentNode_(parentNode),
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode),
       branchContext_(branchContext)
 {
 }

--- a/src/keywords/nodevalue.cpp
+++ b/src/keywords/nodevalue.cpp
@@ -6,7 +6,7 @@
 #include "procedure/nodes/node.h"
 
 NodeValueKeyword::NodeValueKeyword(NodeValue &data, ProcedureNode *parentNode)
-    : KeywordBase(typeid(this), KeywordBase::NodeValueData), data_(data), parentNode_(parentNode)
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode)
 {
 }
 

--- a/src/keywords/nodevalueenumoptions.h
+++ b/src/keywords/nodevalueenumoptions.h
@@ -17,7 +17,7 @@ class NodeValueEnumOptionsBaseKeyword : public KeywordBase
 {
     public:
     NodeValueEnumOptionsBaseKeyword(EnumOptionsBase &baseOptions)
-        : KeywordBase(typeid(this), KeywordBase::NodeValueEnumOptionsData), baseOptions_(baseOptions)
+        : KeywordBase(typeid(this)), baseOptions_(baseOptions)
     {
     }
 

--- a/src/keywords/nodevalueenumoptions.h
+++ b/src/keywords/nodevalueenumoptions.h
@@ -16,10 +16,7 @@ class ProcedureNode;
 class NodeValueEnumOptionsBaseKeyword : public KeywordBase
 {
     public:
-    NodeValueEnumOptionsBaseKeyword(EnumOptionsBase &baseOptions)
-        : KeywordBase(typeid(this)), baseOptions_(baseOptions)
-    {
-    }
+    NodeValueEnumOptionsBaseKeyword(EnumOptionsBase &baseOptions) : KeywordBase(typeid(this)), baseOptions_(baseOptions) {}
 
     /*
      * Data

--- a/src/keywords/nodevector.cpp
+++ b/src/keywords/nodevector.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/nodevector.h"
+#include "keywords/node.h"
+#include "procedure/nodes/node.h"
+
+NodeVectorKeyword::NodeVectorKeyword(ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope,
+                                     std::vector<const ProcedureNode *> nodes)
+    : NodeKeywordBase(parentNode, nodeType, onlyInScope), KeywordData<std::vector<const ProcedureNode *>>(nodes)
+{
+}
+
+NodeVectorKeyword::NodeVectorKeyword(ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope,
+                                     std::vector<const ProcedureNode *> nodes)
+    : NodeKeywordBase(parentNode, nodeClass, onlyInScope), KeywordData<std::vector<const ProcedureNode *>>(nodes)
+{
+}
+
+/*
+ * Arguments
+ */
+
+// Return minimum number of arguments accepted
+int NodeVectorKeyword::minArguments() const { return 1; }
+
+// Return maximum number of arguments accepted
+int NodeVectorKeyword::maxArguments() const { return 99; }
+
+// Parse arguments from supplied LineParser, starting at given argument offset
+bool NodeVectorKeyword::read(LineParser &parser, int startArg, const CoreData &coreData)
+{
+    if (!parentNode())
+        return Messenger::error("Can't read keyword {} since the parent ProcedureNode has not been set.\n", name());
+
+    // Loop over arguments
+    for (auto n = startArg; n < parser.nArgs(); ++n)
+    {
+        // Locate the named node - don't prune by type yet (we'll check that in setNode())
+        auto *node = onlyInScope() ? parentNode()->nodeInScope(parser.argsv(n)) : parentNode()->nodeExists(parser.argsv(n));
+        if (!node)
+            return Messenger::error("Node '{}' given to keyword {} doesn't exist.\n", parser.argsv(n), name());
+
+        if (!validNode(node, nodeType_, nodeClass_, name()))
+            return false;
+
+        data_.push_back(node);
+    }
+
+    return true;
+}
+
+// Write keyword data to specified LineParser
+bool NodeVectorKeyword::write(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
+{
+    if (data_.empty())
+        return true;
+
+    std::string nodes;
+    for (auto *node : data_)
+        nodes += fmt::format("  '{}'", node->name());
+
+    if (!parser.writeLineF("{}{}  {}\n", prefix, name(), nodes))
+        return false;
+
+    return true;
+}
+
+/*
+ * Object Management
+ */
+
+// Prune any references to the supplied ProcedureNode in the contained data
+void NodeVectorKeyword::removeReferencesTo(ProcedureNode *node)
+{
+    // Check the node type
+    if (node->type() != nodeType())
+        return;
+
+    data_.erase(std::remove(data_.begin(), data_.end(), node), data_.end());
+}

--- a/src/keywords/nodevector.h
+++ b/src/keywords/nodevector.h
@@ -14,11 +14,11 @@ class NodeVectorKeywordBase : public NodeKeywordUnderlay, public KeywordBase
 {
     public:
     NodeVectorKeywordBase(ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope)
-        : NodeKeywordUnderlay(parentNode, nodeType, onlyInScope), KeywordBase(typeid(this), KeywordBase::NodeVectorData)
+        : NodeKeywordUnderlay(parentNode, nodeType, onlyInScope), KeywordBase(typeid(this))
     {
     }
     NodeVectorKeywordBase(ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope)
-        : NodeKeywordUnderlay(parentNode, nodeClass, onlyInScope), KeywordBase(typeid(this), KeywordBase::NodeVectorData)
+        : NodeKeywordUnderlay(parentNode, nodeClass, onlyInScope), KeywordBase(typeid(this))
     {
     }
     ~NodeVectorKeywordBase() override = default;

--- a/src/keywords/procedure.cpp
+++ b/src/keywords/procedure.cpp
@@ -6,7 +6,7 @@
 #include "classes/configuration.h"
 #include "classes/species.h"
 
-ProcedureKeyword::ProcedureKeyword(Procedure &data) : KeywordBase(typeid(this), KeywordBase::ProcedureData), data_(data) {}
+ProcedureKeyword::ProcedureKeyword(Procedure &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/range.cpp
+++ b/src/keywords/range.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 
 RangeKeyword::RangeKeyword(Range &data, Vec3Labels::LabelType labelType)
-    : KeywordBase(typeid(this), KeywordBase::RangeData), data_(data), labelType_(labelType)
+    : KeywordBase(typeid(this)), data_(data), labelType_(labelType)
 {
 }
 

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -6,7 +6,7 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 
-SpeciesKeyword::SpeciesKeyword(const Species *&data) : KeywordBase(typeid(this), KeywordBase::SpeciesData), data_(data) {}
+SpeciesKeyword::SpeciesKeyword(const Species *&data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/speciessite.cpp
+++ b/src/keywords/speciessite.cpp
@@ -7,7 +7,7 @@
 #include "classes/species.h"
 
 SpeciesSiteKeyword::SpeciesSiteKeyword(const SpeciesSite *&data, bool axesRequired)
-    : KeywordBase(typeid(this), KeywordBase::SpeciesSiteData), data_(data), axesRequired_(axesRequired)
+    : KeywordBase(typeid(this)), data_(data), axesRequired_(axesRequired)
 {
 }
 

--- a/src/keywords/speciessitevector.cpp
+++ b/src/keywords/speciessitevector.cpp
@@ -8,7 +8,7 @@
 #include "classes/species.h"
 
 SpeciesSiteVectorKeyword::SpeciesSiteVectorKeyword(std::vector<const SpeciesSite *> &data, bool axesRequired)
-    : KeywordBase(typeid(this), KeywordBase::SpeciesSiteVectorData), data_(data), axesRequired_(axesRequired)
+    : KeywordBase(typeid(this)), data_(data), axesRequired_(axesRequired)
 {
 }
 

--- a/src/keywords/speciesvector.cpp
+++ b/src/keywords/speciesvector.cpp
@@ -7,7 +7,7 @@
 #include "classes/species.h"
 
 SpeciesVectorKeyword::SpeciesVectorKeyword(std::vector<const Species *> &data)
-    : KeywordBase(typeid(this), KeywordBase::SpeciesVectorData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
 }
 

--- a/src/keywords/speciesvector.cpp
+++ b/src/keywords/speciesvector.cpp
@@ -6,10 +6,7 @@
 #include "classes/coredata.h"
 #include "classes/species.h"
 
-SpeciesVectorKeyword::SpeciesVectorKeyword(std::vector<const Species *> &data)
-    : KeywordBase(typeid(this)), data_(data)
-{
-}
+SpeciesVectorKeyword::SpeciesVectorKeyword(std::vector<const Species *> &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/stdstring.cpp
+++ b/src/keywords/stdstring.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 
-StringKeyword::StringKeyword(std::string &data) : KeywordBase(typeid(this), KeywordBase::StringData), data_(data) {}
+StringKeyword::StringKeyword(std::string &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/valuestore.cpp
+++ b/src/keywords/valuestore.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 #include "classes/valuestore.h"
 
-ValueStoreKeyword::ValueStoreKeyword(ValueStore &data) : KeywordBase(typeid(this), KeywordBase::ValueStoreData), data_(data) {}
+ValueStoreKeyword::ValueStoreKeyword(ValueStore &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/vec3double.cpp
+++ b/src/keywords/vec3double.cpp
@@ -5,14 +5,14 @@
 #include "base/lineparser.h"
 
 Vec3DoubleKeyword::Vec3DoubleKeyword(Vec3<double> &data, Vec3Labels::LabelType labelType)
-    : KeywordBase(typeid(this), KeywordBase::Vec3DoubleData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
     labelType_ = labelType;
 }
 
 Vec3DoubleKeyword::Vec3DoubleKeyword(Vec3<double> &data, std::optional<Vec3<double>> minValue,
                                      std::optional<Vec3<double>> maxValue, Vec3Labels::LabelType labelType)
-    : KeywordBase(typeid(this), KeywordBase::Vec3DoubleData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
     labelType_ = labelType;
     minimumLimit_ = minValue;

--- a/src/keywords/vec3double.h
+++ b/src/keywords/vec3double.h
@@ -16,6 +16,7 @@ class Vec3DoubleKeyword : public KeywordBase
     explicit Vec3DoubleKeyword(Vec3<double> &data, std::optional<Vec3<double>> minValue = std::nullopt,
                                std::optional<Vec3<double>> maxValue = std::nullopt,
                                Vec3Labels::LabelType labelType = Vec3Labels::NoLabels);
+
     ~Vec3DoubleKeyword() override = default;
 
     /*

--- a/src/keywords/vec3integer.cpp
+++ b/src/keywords/vec3integer.cpp
@@ -6,7 +6,7 @@
 
 Vec3IntegerKeyword::Vec3IntegerKeyword(Vec3<int> &data, std::optional<Vec3<int>> minValue, std::optional<Vec3<int>> maxValue,
                                        Vec3Labels::LabelType labelType)
-    : KeywordBase(typeid(this), KeywordBase::Vec3DoubleData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
     labelType_ = labelType;
     minimumLimit_ = minValue;

--- a/src/keywords/vec3nodevalue.cpp
+++ b/src/keywords/vec3nodevalue.cpp
@@ -6,7 +6,7 @@
 #include "procedure/nodes/node.h"
 
 Vec3NodeValueKeyword::Vec3NodeValueKeyword(Vec3<NodeValue> &data, ProcedureNode *parentNode, Vec3Labels::LabelType labelType)
-    : KeywordBase(typeid(this), KeywordBase::Vec3NodeValueData), data_(data), parentNode_(parentNode), labelType_(labelType)
+    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode), labelType_(labelType)
 {
 }
 

--- a/src/keywords/vector_intdouble.cpp
+++ b/src/keywords/vector_intdouble.cpp
@@ -8,7 +8,7 @@
 IntegerDoubleVectorKeyword::IntegerDoubleVectorKeyword::IntegerDoubleVectorKeyword(IntegerDoubleVectorKeywordData &data,
                                                                                    int nRequiredIntegers,
                                                                                    std::optional<int> nRequiredValues)
-    : KeywordBase(typeid(this), KeywordBase::VectorIntegerDoubleData), data_(data), nRequiredIntegers_(nRequiredIntegers),
+    : KeywordBase(typeid(this)), data_(data), nRequiredIntegers_(nRequiredIntegers),
       nRequiredValues_(nRequiredValues)
 {
 }

--- a/src/keywords/vector_intdouble.cpp
+++ b/src/keywords/vector_intdouble.cpp
@@ -8,8 +8,7 @@
 IntegerDoubleVectorKeyword::IntegerDoubleVectorKeyword::IntegerDoubleVectorKeyword(IntegerDoubleVectorKeywordData &data,
                                                                                    int nRequiredIntegers,
                                                                                    std::optional<int> nRequiredValues)
-    : KeywordBase(typeid(this)), data_(data), nRequiredIntegers_(nRequiredIntegers),
-      nRequiredValues_(nRequiredValues)
+    : KeywordBase(typeid(this)), data_(data), nRequiredIntegers_(nRequiredIntegers), nRequiredValues_(nRequiredValues)
 {
 }
 

--- a/src/keywords/vector_intstring.cpp
+++ b/src/keywords/vector_intstring.cpp
@@ -7,8 +7,7 @@
 
 IntegerStringVectorKeyword::IntegerStringVectorKeyword(IntegerStringVectorKeywordData &data, int nRequiredIntegers,
                                                        std::optional<int> nRequiredValues)
-    : KeywordBase(typeid(this)), data_(data), nRequiredIntegers_(nRequiredIntegers),
-      nRequiredValues_(nRequiredValues)
+    : KeywordBase(typeid(this)), data_(data), nRequiredIntegers_(nRequiredIntegers), nRequiredValues_(nRequiredValues)
 {
 }
 

--- a/src/keywords/vector_intstring.cpp
+++ b/src/keywords/vector_intstring.cpp
@@ -7,7 +7,7 @@
 
 IntegerStringVectorKeyword::IntegerStringVectorKeyword(IntegerStringVectorKeywordData &data, int nRequiredIntegers,
                                                        std::optional<int> nRequiredValues)
-    : KeywordBase(typeid(this), KeywordBase::VectorIntegerStringData), data_(data), nRequiredIntegers_(nRequiredIntegers),
+    : KeywordBase(typeid(this)), data_(data), nRequiredIntegers_(nRequiredIntegers),
       nRequiredValues_(nRequiredValues)
 {
 }

--- a/src/keywords/vector_stringdouble.cpp
+++ b/src/keywords/vector_stringdouble.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 
 StringDoubleVectorKeyword::StringDoubleVectorKeyword(StringDoubleVectorKeywordData &data)
-    : KeywordBase(typeid(this), KeywordBase::VectorDoublePairData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
 }
 

--- a/src/keywords/vector_stringpair.cpp
+++ b/src/keywords/vector_stringpair.cpp
@@ -4,10 +4,7 @@
 #include "keywords/vector_stringpair.h"
 #include "base/lineparser.h"
 
-StringPairVectorKeyword::StringPairVectorKeyword(StringPairVectorKeywordData &data)
-    : KeywordBase(typeid(this)), data_(data)
-{
-}
+StringPairVectorKeyword::StringPairVectorKeyword(StringPairVectorKeywordData &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data

--- a/src/keywords/vector_stringpair.cpp
+++ b/src/keywords/vector_stringpair.cpp
@@ -5,7 +5,7 @@
 #include "base/lineparser.h"
 
 StringPairVectorKeyword::StringPairVectorKeyword(StringPairVectorKeywordData &data)
-    : KeywordBase(typeid(this), KeywordBase::VectorStringPairData), data_(data)
+    : KeywordBase(typeid(this)), data_(data)
 {
 }
 


### PR DESCRIPTION
#### This PR is based on #854, and should not be merged ahead of that PR.

This PR builds on #854 and moves keyword widget production to a producer-style mechanism, rather than an endless series of `if`/`else` clauses. It also removes the redundant `KeywordBase::KeywordDataType` enum.