### PR TITLE
Set Charges on Atoms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,7 +345,6 @@ if(GUI)
            keywordwidgets
            delegates
            charts
-           components
            models
            gui
            ${NO_WHOLE_ARCHIVE_FLAG}

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -208,6 +208,8 @@ const std::vector<const SpeciesAtom *> Species::selectedAtoms() const
 bool Species::isSelectionSingleElement() const
 {
     auto selection = selectedAtoms();
+    if (selection.empty())
+        return false;
     return std::all_of(selection.begin(), selection.end(), [&](const auto *i) { return i->Z() == selection.front()->Z(); });
 }
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,11 +1,12 @@
 # Don't forget to include output directory, otherwise the UI file won't be wrapped!
 
-# -----------
-# Sub-Windows
-# -----------
+
+# -----------------
+# Main Dissolve GUI
+# -----------------
 
 # Meta-Objects
-set(components_MOC_HDRS
+set(gui_MOC_HDRS
     # Gizmos
     graphgizmo.h
     integrator1dgizmo.h
@@ -45,11 +46,32 @@ set(components_MOC_HDRS
     selectforcefielddialog.h
     selectgenericitemdialog.h
     selectspeciesdialog.h
+    # Editors
+    modulecontrolwidget.h
+    modulelisteditor.h
+    modulewidget.h
+    procedureeditor.h
+    # Main Tabs
+    configurationtab.h
+    forcefieldtab.h
+    layertab.h
+    maintab.h
+    messagestab.h
+    speciestab.h
+    workspacetab.h
+    # Main UI
+    gui.h
+    stockcolours.h
+    outputhandler.hui
+    tmdiarea.hui
+    thread.hui
+    maintabsbar.hui
+    maintabswidget.hui
 )
-qt6_wrap_cpp(components_MOC_SRCS ${components_MOC_HDRS})
+qt6_wrap_cpp(gui_MOC_SRCS ${gui_MOC_HDRS})
 
 # User Interface Files
-set(components_UIS
+set(gui_UIS
     # Gizmos
     graphgizmo.ui
     integrator1dgizmo.ui
@@ -85,11 +107,24 @@ set(components_UIS
     selectforcefielddialog.ui
     selectgenericitemdialog.ui
     selectspeciesdialog.ui
+    # Editors
+    modulecontrolwidget.ui
+    modulelisteditor.ui
+    procedureeditor.ui
+    # Main Tabs
+    configurationtab.ui
+    forcefieldtab.ui
+    layertab.ui
+    messagestab.ui
+    speciestab.ui
+    workspacetab.ui
+    # Main UI
+    gui.ui
 )
-qt6_wrap_ui(components_UIS_H ${components_UIS})
+qt6_wrap_ui(gui_UIS_H ${gui_UIS})
 
 # Source files (not Qt UI files or custom .h [uih])
-set(components_SRCS
+set(gui_SRCS
     # Gizmos
     gizmo.cpp
     graphgizmo_funcs.cpp
@@ -151,67 +186,6 @@ set(components_SRCS
     selectforcefielddialog_funcs.cpp
     selectgenericitemdialog_funcs.cpp
     selectspeciesdialog_funcs.cpp
-)
-
-# Target 'components'
-add_library(components ${components_UIS_H} ${components_SRCS} ${components_MOC_SRCS})
-target_include_directories(
-  components PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${Qt6Widgets_INCLUDE_DIRS} ${FREETYPE_INCLUDE_DIRS}
-                     ${Qt6OpenGLWidgets_INCLUDE_DIRS} ${CONAN_INCLUDE_DIRS_PUGIXML}
-)
-
-target_link_libraries(components widgets base)
-
-# -----------------
-# Main Dissolve GUI
-# -----------------
-
-# Meta-Objects
-set(gui_MOC_HDRS
-    # Editors
-    modulecontrolwidget.h
-    modulelisteditor.h
-    modulewidget.h
-    procedureeditor.h
-    # Main Tabs
-    configurationtab.h
-    forcefieldtab.h
-    layertab.h
-    maintab.h
-    messagestab.h
-    speciestab.h
-    workspacetab.h
-    # Main UI
-    gui.h
-    stockcolours.h
-    outputhandler.hui
-    tmdiarea.hui
-    thread.hui
-    maintabsbar.hui
-    maintabswidget.hui
-)
-qt6_wrap_cpp(gui_MOC_SRCS ${gui_MOC_HDRS})
-
-# User Interface Files
-set(gui_UIS
-    # Editors
-    modulecontrolwidget.ui
-    modulelisteditor.ui
-    procedureeditor.ui
-    # Main Tabs
-    configurationtab.ui
-    forcefieldtab.ui
-    layertab.ui
-    messagestab.ui
-    speciestab.ui
-    workspacetab.ui
-    # Main UI
-    gui.ui
-)
-qt6_wrap_ui(gui_UIS_H ${gui_UIS})
-
-# Source files (not Qt UI files or custom .h [uih])
-set(gui_SRCS
     # Editors
     modulecontrolwidget_funcs.cpp
     modulelisteditor_funcs.cpp
@@ -263,7 +237,6 @@ target_link_libraries(
   charts
   delegates
   widgets
-  components
   models
   base
   Qt6::OpenGL

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -140,7 +140,7 @@ class DissolveWindow : public QMainWindow
     // Clear all data and start new simulation afresh
     void startNew();
 
-    private slots:
+    public slots:
     // File
     void on_FileNewAction_triggered(bool checked);
     void on_FileOpenLocalAction_triggered(bool checked);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -173,6 +173,7 @@ class DissolveWindow : public QMainWindow
     void on_SpeciesCopyTermsAction_triggered(bool checked);
     void on_SpeciesRegenerateIntraFromConnectivityAction_triggered(bool checked);
     void on_SpeciesSetAtomTypesInSelectionAction_triggered(bool checked);
+    void on_SpeciesSetChargesInSelectionAction_triggered(bool checked);
     // Configuration
     void on_ConfigurationCreateEmptyAction_triggered(bool checked);
     void on_ConfigurationCreateSimpleRandomMixAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -224,6 +224,7 @@
     <addaction name="SpeciesCopyTermsAction"/>
     <addaction name="separator"/>
     <addaction name="SpeciesSetAtomTypesInSelectionAction"/>
+    <addaction name="SpeciesSetChargesInSelectionAction"/>
     <addaction name="separator"/>
     <addaction name="SpeciesRegenerateIntraFromConnectivityAction"/>
    </widget>
@@ -839,6 +840,11 @@
   <action name="SpeciesCopyTermsAction">
    <property name="text">
     <string>C&amp;opy Terms From Species...</string>
+   </property>
+  </action>
+  <action name="SpeciesSetChargesInSelectionAction">
+   <property name="text">
+    <string>Set Atom C&amp;harges in Selection...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -363,6 +363,8 @@ void DissolveWindow::updateMenus()
         return;
 
     // Species Menu
+    auto speciesAtomSelection = activeTab->type() == MainTab::TabType::Species ? ui_.MainTabs->currentSpecies()->selectedAtoms()
+                                                                               : std::vector<SpeciesAtom *>();
     ui_.SpeciesRenameAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesDeleteAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesAddForcefieldTermsAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
@@ -371,6 +373,8 @@ void DissolveWindow::updateMenus()
     ui_.SpeciesRegenerateIntraFromConnectivityAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesSetAtomTypesInSelectionAction->setEnabled(activeTab->type() == MainTab::TabType::Species &&
                                                          ui_.MainTabs->currentSpecies()->isSelectionSingleElement());
+    ui_.SpeciesSetChargesInSelectionAction->setEnabled(activeTab->type() == MainTab::TabType::Species &&
+                                                       !ui_.MainTabs->currentSpecies()->selectedAtoms().empty());
 
     // Configuration Menu
     ui_.ConfigurationRenameAction->setEnabled(activeTab->type() == MainTab::TabType::Configuration);

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -12,6 +12,7 @@
 #include "gui/selectelementdialog.h"
 #include "gui/speciestab.h"
 #include <QFileDialog>
+#include <QInputDialog>
 #include <QMessageBox>
 
 void DissolveWindow::on_SpeciesCreateAtomicAction_triggered(bool checked)
@@ -249,6 +250,31 @@ void DissolveWindow::on_SpeciesSetAtomTypesInSelectionAction_triggered(bool chec
     for (auto *i : species->selectedAtoms())
         i->setAtomType(at);
     species->updateAtomTypes();
+
+    setModified();
+
+    fullUpdate();
+}
+
+void DissolveWindow::on_SpeciesSetChargesInSelectionAction_triggered(bool checked)
+{
+    // Get the current Species (if a SpeciesTab is selected)
+    auto species = ui_.MainTabs->currentSpecies();
+    if (!species)
+        return;
+
+    // Check current selection
+    if (species->selectedAtoms().empty())
+        return;
+
+    auto ok = false;
+    auto q = QInputDialog::getDouble(this, "Set atom charges", "Enter the charge (per atom) to apply to the selection", 0.0,
+                                     -100.0, 100.0, 5, &ok);
+    if (!ok)
+        return;
+
+    for (auto *i : species->selectedAtoms())
+        i->setCharge(q);
 
     setModified();
 

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -82,6 +82,7 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
             SLOT(siteSelectionChanged(const QItemSelection &, const QItemSelection &)));
 
     // Set up SpeciesViewer
+    ui_.ViewerWidget->speciesViewer()->setDissolveWindow(dissolveWindow_);
     ui_.ViewerWidget->setDissolve(&dissolve);
     ui_.ViewerWidget->setSpecies(species_);
 

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -93,6 +93,7 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
     // Connect signals / slots
     connect(ui_.ViewerWidget, SIGNAL(dataModified()), this, SLOT(updateControls()));
     connect(ui_.ViewerWidget, SIGNAL(dataModified()), dissolveWindow_, SLOT(setModified()));
+    connect(ui_.ViewerWidget->speciesViewer(), SIGNAL(atomsChanged()), dissolveWindow_, SLOT(updateMenus()));
     connect(ui_.ViewerWidget->speciesViewer(), SIGNAL(atomsChanged()), this, SLOT(updateAtomTableSelection()));
     connect(ui_.SiteViewerWidget, SIGNAL(dataModified()), this, SLOT(updateSitesTab()));
     connect(ui_.SiteViewerWidget, SIGNAL(siteCreatedAndShown()), this, SLOT(setCurrentSiteFromViewer()));

--- a/src/gui/speciesviewer_input.cpp
+++ b/src/gui/speciesviewer_input.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
+#include "gui/gui.h"
 #include "gui/speciesviewer.hui"
 #include "neta/neta.h"
 #include <QtGui/QMouseEvent>
@@ -143,8 +144,10 @@ void SpeciesViewer::contextMenuRequested(QPoint pos)
             setMenu->setFont(font());
             auto *setAtomTypeAction = setMenu->addAction("Atom type...");
             setAtomTypeAction->setEnabled(species_->isSelectionSingleElement());
-            connect(setAtomTypeAction, SIGNAL(triggered(bool)), dissolveWindow_.value(), SLOT(on_SpeciesSetAtomTypesInSelectionAction_triggered(bool)));
-            connect(setMenu->addAction("Charges..."), SIGNAL(triggered(bool)), dissolveWindow_.value(), SLOT(on_SpeciesSetChargesInSelectionAction_triggered(bool)));
+            connect(setAtomTypeAction, SIGNAL(triggered(bool)), dissolveWindow_.value(),
+                    SLOT(on_SpeciesSetAtomTypesInSelectionAction_triggered(bool)));
+            connect(setMenu->addAction("Charges..."), SIGNAL(triggered(bool)), dissolveWindow_.value(),
+                    SLOT(on_SpeciesSetChargesInSelectionAction_triggered(bool)));
         }
     }
 

--- a/src/gui/speciesviewer_input.cpp
+++ b/src/gui/speciesviewer_input.cpp
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Team Dissolve and contributors
 
-#include "classes/species.h"
-#include "gui/render/renderablespecies.h"
 #include "gui/speciesviewer.hui"
 #include "neta/neta.h"
 #include <QtGui/QMouseEvent>
@@ -137,6 +135,17 @@ void SpeciesViewer::contextMenuRequested(QPoint pos)
         }
         else
             selectMenu->setEnabled(false);
+
+        // Set menu (only if DissolveWindow is set)
+        if (dissolveWindow_)
+        {
+            auto *setMenu = menu.addMenu("Set...");
+            setMenu->setFont(font());
+            auto *setAtomTypeAction = setMenu->addAction("Atom type...");
+            setAtomTypeAction->setEnabled(species_->isSelectionSingleElement());
+            connect(setAtomTypeAction, SIGNAL(triggered(bool)), dissolveWindow_.value(), SLOT(on_SpeciesSetAtomTypesInSelectionAction_triggered(bool)));
+            connect(setMenu->addAction("Charges..."), SIGNAL(triggered(bool)), dissolveWindow_.value(), SLOT(on_SpeciesSetChargesInSelectionAction_triggered(bool)));
+        }
     }
 
     // Execute the menu

--- a/src/gui/speciesviewer_input.cpp
+++ b/src/gui/speciesviewer_input.cpp
@@ -110,7 +110,7 @@ void SpeciesViewer::mouseMoved(int dx, int dy)
 void SpeciesViewer::contextMenuRequested(QPoint pos)
 {
     QMenu menu(this);
-    //    menu.setFont(font());
+    menu.setFont(font());
 
     std::map<QAction *, std::string> actionMap;
 
@@ -128,6 +128,7 @@ void SpeciesViewer::contextMenuRequested(QPoint pos)
 
         // Atom select submenu
         auto *selectMenu = menu.addMenu("Select similar atoms...");
+        selectMenu->setFont(font());
         if (nSelected == 1)
         {
             actionMap[selectMenu->addAction("By direct connectivity")] = "SelectDirect";

--- a/src/gui/viewer.hui
+++ b/src/gui/viewer.hui
@@ -3,10 +3,8 @@
 
 #pragma once
 
-#include "base/enumoptions.h"
 #include "base/timer.h"
 #include "gui/render/fontinstance.h"
-#include "gui/render/primitive.h"
 #include "gui/render/renderable.h"
 #include "gui/render/renderablegroupmanager.h"
 #include "gui/render/view.h"
@@ -22,6 +20,7 @@
 #include <vector>
 
 // Forward Declarations
+class DissolveWindow;
 class QOpenGLFramebufferObject;
 
 // Base rendering widget
@@ -30,8 +29,19 @@ class BaseViewer : public QOpenGLWidget, protected QOpenGLFunctions
     Q_OBJECT
 
     public:
-    BaseViewer(QWidget *parent);
-    ~BaseViewer();
+    explicit BaseViewer(QWidget *parent);
+    ~BaseViewer() = default;
+
+    /*
+     * Main UI
+     */
+    protected:
+    // Pointer to DissolveWindow (for optional integrations with main UI)
+    std::optional<DissolveWindow *> dissolveWindow_;
+
+    public:
+    // Set pointer to DissolveWindow (for optional integrations with main UI)
+    void setDissolveWindow(DissolveWindow *dissolveWindow);
 
     /*
      * View

--- a/src/gui/viewer_funcs.cpp
+++ b/src/gui/viewer_funcs.cpp
@@ -41,4 +41,9 @@ BaseViewer::BaseViewer(QWidget *parent) : QOpenGLWidget(parent), view_(renderabl
     setFormat(surfaceFormat);
 }
 
-BaseViewer::~BaseViewer() {}
+/*
+ * Main UI
+ */
+
+// Set pointer to DissolveWindow (for optional integrations with main UI)
+void BaseViewer::setDissolveWindow(DissolveWindow *dissolveWindow) { dissolveWindow_ = dissolveWindow; }


### PR DESCRIPTION
Following on from the `show-species-charge` PR (#851) this PR allows manual setting of charges on selected atoms in a `Species`.

A side-effect of this addition was to introduce a cyclic dependency between the `gui` and `components` libraries - to circumvent, these are now built as one monolithic GUI library object.