### PR TITLE
Bugfix 15/11/21 Tab Management

### DIFF
--- a/src/gui/configurationtab.h
+++ b/src/gui/configurationtab.h
@@ -21,7 +21,7 @@ class ConfigurationTab : public QWidget, public MainTab
     public:
     ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                      Configuration *cfg);
-    ~ConfigurationTab();
+    ~ConfigurationTab() = default;
 
     /*
      * UI

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -39,12 +39,6 @@ ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dis
     connect(ui_.ProcedureWidget, SIGNAL(dataModified()), dissolveWindow, SLOT(setModified()));
 }
 
-ConfigurationTab::~ConfigurationTab()
-{
-    // Remove the Configuration represented in this tab
-    dissolve_.removeConfiguration(configuration_);
-}
-
 /*
  * MainTab Reimplementations
  */

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -241,6 +241,8 @@ class DissolveWindow : public QMainWindow
     void enableSensitiveControls();
     // All iterations requested are complete
     void iterationsComplete();
+    // Specified tab (indicated by page widget) has been closed, and relevant data should be deleted accordingly
+    void closeTab(QWidget *page);
 
     signals:
     void iterate(int);

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -41,6 +41,7 @@ DissolveWindow::DissolveWindow(Dissolve &dissolve)
     // Connect signals from our main tab widget
     connect(ui_.MainTabs, SIGNAL(dataModified()), this, SLOT(setModified()));
     connect(ui_.MainTabs, SIGNAL(dataModified()), this, SLOT(fullUpdate()));
+    connect(ui_.MainTabs, SIGNAL(tabClosed(QWidget *)), this, SLOT(closeTab(QWidget *)));
 
     refreshing_ = false;
     modified_ = false;

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -83,3 +83,35 @@ void DissolveWindow::on_MainTabs_currentChanged(int index)
 
 // Return list of all current tabs
 const std::vector<MainTab *> DissolveWindow::allTabs() const { return ui_.MainTabs->allTabs(); }
+
+void DissolveWindow::closeTab(QWidget *page)
+{
+    auto *tab = ui_.MainTabs->findTab(page);
+    if (!tab)
+        return;
+
+    // Determine what we need to delete...
+    if (tab->type() == MainTab::TabType::Configuration)
+    {
+        auto *cfg = dynamic_cast<ConfigurationTab *>(tab)->configuration();
+        ui_.MainTabs->removeByPage(page);
+        dissolve_.removeConfiguration(cfg);
+    }
+    else if (tab->type() == MainTab::TabType::Layer)
+    {
+        auto *layer = dynamic_cast<LayerTab *>(tab)->moduleLayer();
+        ui_.MainTabs->removeByPage(page);
+        dissolve_.removeProcessingLayer(layer);
+    }
+    else if (tab->type() == MainTab::TabType::Species)
+    {
+        auto *sp = dynamic_cast<SpeciesTab *>(tab)->species();
+        ui_.MainTabs->removeByPage(page);
+        dissolve_.removeSpecies(sp);
+    }
+    else
+        return;
+
+    setModified();
+    fullUpdate();
+}

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -19,7 +19,7 @@ class LayerTab : public QWidget, public MainTab
     public:
     LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
              ModuleLayer *layer);
-    ~LayerTab();
+    ~LayerTab() = default;
 
     /*
      * UI

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -23,8 +23,6 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
     ui_.ModuleListPanel->setUp(dissolveWindow, moduleLayer_);
 }
 
-LayerTab::~LayerTab() { dissolve_.removeProcessingLayer(moduleLayer_); }
-
 /*
  * MainTab Reimplementations
  */

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -79,6 +79,8 @@ class MainTabsWidget : public QTabWidget
     QPointer<WorkspaceTab> workspaceTab(QWidget *page);
     // Find tab with title specified
     MainTab *findTab(const QString title);
+    // Find tab displaying specified page
+    MainTab *findTab(const QWidget *page);
     // Generate unique tab name with base name provided
     const QString uniqueTabName(const QString base);
 
@@ -116,8 +118,6 @@ class MainTabsWidget : public QTabWidget
     public:
     // Update all tabs
     void updateAllTabs();
-    // Update all Species tabs
-    void updateSpeciesTabs();
     // Disable sensitive controls in all tabs
     void disableSensitiveControls();
     // Enable sensitive controls in all tabs

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -198,7 +198,7 @@ void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
         return;
 
     // Check that we really want to delete the Configuration
-    if (!cfgTab->close())
+    if (!cfgTab->canClose())
         return;
 
     // Update the GUI

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -201,8 +201,9 @@ void DissolveWindow::on_ConfigurationDeleteAction_triggered(bool checked)
     if (!cfgTab->canClose())
         return;
 
-    // Update the GUI
     ui_.MainTabs->removeByPage(cfgTab->page());
+    dissolve_.removeConfiguration(cfgTab->configuration());
+
     setModified();
     fullUpdate();
 }

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -312,7 +312,7 @@ void DissolveWindow::on_LayerDeleteAction_triggered(bool checked)
         return;
 
     // Check that we really want to delete the layer
-    if (!layerTab->close())
+    if (!layerTab->canClose())
         return;
 
     // Update the GUI

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -315,8 +315,9 @@ void DissolveWindow::on_LayerDeleteAction_triggered(bool checked)
     if (!layerTab->canClose())
         return;
 
-    // Update the GUI
     ui_.MainTabs->removeByPage(layerTab->page());
+    dissolve_.removeProcessingLayer(layerTab->moduleLayer());
+
     setModified();
     fullUpdate();
 }

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -130,7 +130,7 @@ void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
         return;
 
     // Check that we really want to delete the Species
-    if (!spTab->close())
+    if (!spTab->canClose())
         return;
 
     // Update the GUI

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -133,8 +133,9 @@ void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
     if (!spTab->canClose())
         return;
 
-    // Update the GUI
     ui_.MainTabs->removeByPage(spTab->page());
+    dissolve_.removeSpecies(spTab->species());
+
     setModified();
     fullUpdate();
 }

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -31,7 +31,7 @@ class SpeciesTab : public QWidget, public MainTab
     public:
     SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                Species *species);
-    ~SpeciesTab();
+    ~SpeciesTab() = default;
 
     /*
      * UI

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -114,12 +114,6 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
     connect(ui_.IsotopologueAddButton, SIGNAL(clicked()), &isos_, SLOT(addIso()));
 }
 
-SpeciesTab::~SpeciesTab()
-{
-    // Remove the Species represented in this tab
-    dissolve_.removeSpecies(species_);
-}
-
 /*
  * UI
  */


### PR DESCRIPTION
A PR to finally address the tab (mis)management in the GUI.  At some point in the past, the ability to delete a tab was lost - all mechanisms worked correctly, but since the `MainTab`-derived class contained a `shared_ptr` to the content (`Species`, `Configuration`, or `ModuleLayer`), and Qt garbage collection isn't immediate, the data always persisted.

This tab moves responsibility for the deletion of relevant data on to the main GUI.

Closes #830.
Closes #839.