### PR TITLE
Fix ExponentialSpin widget

### DIFF
--- a/src/gui/forcefieldtab.ui
+++ b/src/gui/forcefieldtab.ui
@@ -202,9 +202,6 @@
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="suffix">
-               <string/>
-              </property>
               <property name="decimals">
                <number>4</number>
               </property>
@@ -237,9 +234,6 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
-              </property>
-              <property name="suffix">
-               <string/>
               </property>
               <property name="decimals">
                <number>4</number>
@@ -307,9 +301,6 @@
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
-              </property>
-              <property name="suffix">
-               <string/>
               </property>
               <property name="decimals">
                <number>2</number>

--- a/src/gui/keywordwidgets/double_funcs.cpp
+++ b/src/gui/keywordwidgets/double_funcs.cpp
@@ -9,9 +9,9 @@ DoubleKeywordWidget::DoubleKeywordWidget(QWidget *parent, DoubleKeyword *keyword
 {
     // Set minimum and maximum values
     if (keyword_->validationMin())
-        setMinimumLimit(keyword_->validationMin().value());
+        setMinimum(keyword_->validationMin().value());
     if (keyword_->validationMax())
-        setMaximumLimit(keyword_->validationMax().value());
+        setMaximum(keyword_->validationMax().value());
 
     // Set current value
     setValue(keyword_->data());

--- a/src/gui/keywordwidgets/vec3double_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3double_funcs.cpp
@@ -16,15 +16,15 @@ Vec3DoubleKeywordWidget::Vec3DoubleKeywordWidget(QWidget *parent, Vec3DoubleKeyw
     // Set minimum and maximum values for each component
     if (keyword_->validationMin())
     {
-        ui_.Spin1->setMinimumLimit(keyword_->validationMin().value().x);
-        ui_.Spin2->setMinimumLimit(keyword_->validationMin().value().y);
-        ui_.Spin3->setMinimumLimit(keyword_->validationMin().value().z);
+        ui_.Spin1->setMinimum(keyword_->validationMin().value().x);
+        ui_.Spin2->setMinimum(keyword_->validationMin().value().y);
+        ui_.Spin3->setMinimum(keyword_->validationMin().value().z);
     }
     if (keyword_->validationMax())
     {
-        ui_.Spin1->setMaximumLimit(keyword_->validationMax().value().x);
-        ui_.Spin2->setMaximumLimit(keyword_->validationMax().value().y);
-        ui_.Spin3->setMaximumLimit(keyword_->validationMax().value().z);
+        ui_.Spin1->setMaximum(keyword_->validationMax().value().x);
+        ui_.Spin2->setMaximum(keyword_->validationMax().value().y);
+        ui_.Spin3->setMaximum(keyword_->validationMax().value().z);
     }
 
     // Set current values

--- a/src/gui/widgets/exponentialspin.hui
+++ b/src/gui/widgets/exponentialspin.hui
@@ -3,41 +3,70 @@
 
 #pragma once
 
-#include <QDoubleSpinBox>
+#include "math/doubleexp.h"
+#include <QAbstractSpinBox>
 
-// Real-Value Spinbox with Exponential Notation
-class ExponentialSpin : public QDoubleSpinBox
+// Spinbox with Exponential Notation
+class ExponentialSpin : public QAbstractSpinBox
 {
     Q_OBJECT
 
     public:
-    ExponentialSpin(QWidget *parent = 0);
+    explicit ExponentialSpin(QWidget *parent = 0);
 
     /*
      * Data
      */
     private:
+    // Current value
+    DoubleExp value_;
+    // Text representation of current value
+    QString valueText_;
+    // Threshold (10^[+/-]n) for switching to exponential notation
+    const int exponentFormatThreshold_{3};
+    // Value step size
+    double stepSize_{0.1};
+    // Number of decimals for text representation
+    int nDecimals_{3};
     // Validator for line edit
     QDoubleValidator validator_;
-    // Whether limits are enabled
-    bool limitMinValue_, limitMaxValue_;
+    // Limiting values
+    std::optional<double> minimumValue_, maximumValue_;
 
     public:
-    // Set minimum limit
-    void setMinimumLimit(double value);
-    // Set maximum limit
-    void setMaximumLimit(double value);
+    // Set value
+    void setValue(double value);
+    // Return current value
+    double value() const;
+    // Set value step size
+    void setSingleStep(double stepSize);
+    // Set number of decimals for text representation
+    void setDecimals(int n);
+    // Set minimum value
+    void setMinimum(double value);
+    // Set maximum value
+    void setMaximum(double value);
+    // Set allowed value range
+    void setRange(double minValue, double maxValue);
     // Remove range limits
     void removeLimits();
+
+    /*
+     * Signals / Slots
+     */
+    private slots:
+    // Line edit editing finished
+    void valueEditingFinished();
+
+    signals:
+    void valueChanged(double);
 
     /*
      * Reimplementations
      */
     public:
-    // Convert supplied value to text
-    QString textFromValue(double value) const;
-    // Validate supplied text
-    QValidator::State validate(QString &text, int &pos) const;
-    // Interpret text into value
-    double valueFromText(const QString &text) const;
+    // Step value by specified number of increments
+    void stepBy(int steps) override;
+    // Return whether stepping is currently available
+    QAbstractSpinBox::StepEnabled stepEnabled() const override;
 };

--- a/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
+++ b/src/modules/calculate_sdf/gui/modulewidget_funcs.cpp
@@ -21,9 +21,9 @@ CalculateSDFModuleWidget::CalculateSDFModuleWidget(QWidget *parent, const Generi
     refreshing_ = true;
 
     // Set limits and step sizes in spin widgets
-    ui_.LowerCutoffSpin->setMinimumLimit(0.0);
+    ui_.LowerCutoffSpin->setMinimum(0.0);
     ui_.LowerCutoffSpin->setSingleStep(0.01);
-    ui_.UpperCutoffSpin->setMinimumLimit(0.0);
+    ui_.UpperCutoffSpin->setMinimum(0.0);
     ui_.UpperCutoffSpin->setSingleStep(0.01);
 
     // Set up SDF graph


### PR DESCRIPTION
This PR address issues with the `ExponentialSpin` captured in #888. Essentially, values were not converted/set correctly in the underlying data since they were limited by the minimum representable value dictated by the number of decimals.

Here we base `ExponentialSpin` off `QAbstractSpinBox` rather than `QDoubleSpinBox`, allowing these issues to be resolved.

Closes #888.