### PR TITLE
Display population in tab

### DIFF
--- a/src/gui/configurationtab.h
+++ b/src/gui/configurationtab.h
@@ -44,6 +44,8 @@ class ConfigurationTab : public QWidget, public MainTab
     bool canChangeTitle() const;
     // Return whether the tab can be closed (after any necessary user querying, etc.)
     bool canClose() const;
+    // Return title of tab
+    const QString title() const;
 
     /*
      * Configuration Target

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -37,6 +37,7 @@ ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dis
     // Set target for ProcedureEditor, and connect signals
     ui_.ProcedureWidget->setUp(&configuration_->generator(), dissolve.coreData());
     connect(ui_.ProcedureWidget, SIGNAL(dataModified()), dissolveWindow, SLOT(setModified()));
+    connect(ui_.GeneratorRegenerateButton, SIGNAL(clicked()), parent, SLOT(updateTabNames()));
 }
 
 /*

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -69,8 +69,9 @@ QString ConfigurationTab::getNewTitle(bool &ok)
 bool ConfigurationTab::canChangeTitle() const { return true; }
 
 // Return title of tab
-const QString ConfigurationTab::title() const {
-  return QString("%1 (%2/%3)").arg(title_).arg(configuration_->nMolecules()).arg(configuration_->nAtoms());
+const QString ConfigurationTab::title() const
+{
+    return QString("%1 (%2/%3)").arg(title_).arg(configuration_->nMolecules()).arg(configuration_->nAtoms());
 }
 
 // Return whether the tab can be closed (after any necessary user querying, etc.)

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -67,6 +67,11 @@ QString ConfigurationTab::getNewTitle(bool &ok)
 // Return whether the title of the tab can be changed
 bool ConfigurationTab::canChangeTitle() const { return true; }
 
+// Return title of tab
+const QString ConfigurationTab::title() const {
+  return QString("%1 (%2/%3)").arg(title_).arg(configuration_->nMolecules()).arg(configuration_->nAtoms());
+}
+
 // Return whether the tab can be closed (after any necessary user querying, etc.)
 bool ConfigurationTab::canClose() const
 {

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -146,6 +146,8 @@ class MainTabsWidget : public QTabWidget
     void tabCloseButtonClicked(bool);
     // Tab bar double-clicked
     void tabBarDoubleClicked(int index);
+    // Update tab names
+    void updateTabNames();
 
     signals:
     void dataModified();

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -258,7 +258,7 @@ void MainTabsWidget::reconcileTabs(DissolveWindow *dissolveWindow)
                 configurationTabs_.emplace_back(new ConfigurationTab(dissolveWindow, dissolve, this, tabTitle, cfg.get()));
 
             allTabs_.push_back(cfgTab.data());
-            insertTab(baseIndex + currentTabIndex, cfgTab.data(), tabTitle);
+            insertTab(baseIndex + currentTabIndex, cfgTab.data(), cfgTab->title());
             addTabCloseButton(cfgTab->page());
             setTabIcon(cfgTab->page(), QIcon(":/tabs/icons/tabs_configuration.svg"));
         }

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -44,6 +44,18 @@ void MainTabsWidget::setUp(DissolveWindow *dissolveWindow)
     messagesTab_ = new MessagesTab(dissolveWindow, dissolveWindow->dissolve(), this, "Messages");
 }
 
+// Update tab names
+void MainTabsWidget::updateTabNames() {
+  for(int i=0; i < count(); ++i) {
+    // Currently, only the Configuration Tabs will need updates
+    auto *confTab = dynamic_cast<ConfigurationTab*>(widget(i));
+    if (confTab) {
+      setTabText(i, confTab->title());
+      continue;
+    }
+  }
+}
+
 /*
  * Tab Data
  */

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -45,15 +45,18 @@ void MainTabsWidget::setUp(DissolveWindow *dissolveWindow)
 }
 
 // Update tab names
-void MainTabsWidget::updateTabNames() {
-  for(int i=0; i < count(); ++i) {
-    // Currently, only the Configuration Tabs will need updates
-    auto *confTab = dynamic_cast<ConfigurationTab*>(widget(i));
-    if (confTab) {
-      setTabText(i, confTab->title());
-      continue;
+void MainTabsWidget::updateTabNames()
+{
+    for (int i = 0; i < count(); ++i)
+    {
+        // Currently, only the Configuration Tabs will need updates
+        auto *confTab = dynamic_cast<ConfigurationTab *>(widget(i));
+        if (confTab)
+        {
+            setTabText(i, confTab->title());
+            continue;
+        }
     }
-  }
 }
 
 /*


### PR DESCRIPTION
This PR adds the total number of molecules and atoms as extra information to a configuration tab.  This should close #819.

![20211130_17h30m53s_grim](https://user-images.githubusercontent.com/1728853/144097847-aecae91b-c838-4bf2-8032-5e5478fe32c1.png)
