### PR TITLE
Display population in the configuration tab

### DIFF
--- a/src/gui/configurationtab.ui
+++ b/src/gui/configurationtab.ui
@@ -402,6 +402,46 @@
           </property>
          </widget>
         </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_atom_pop">
+          <property name="text">
+           <string>Atoms</string>
+          </property>
+	  <property name="font">
+           <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+	 </widget>
+	</item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="AtomPopulation">
+          <property name="text">
+           <string>0</string>
+          </property>
+	 </widget>
+	</item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_mol_pop">
+          <property name="text">
+	    <string>Molecules</string>
+	  </property>
+	  <property name="font">
+	   <font>
+            <weight>75</weight>
+            <bold>true</bold>
+           </font>
+          </property>
+	 </widget>
+	</item>
+        <item row="6" column="1">
+         <widget class="QLabel" name="MolPopulation">
+          <property name="text">
+           <string>0</string>
+          </property>
+	 </widget>
+	</item>
        </layout>
       </widget>
      </item>

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -118,6 +118,10 @@ void ConfigurationTab::updateControls()
     // Temperature
     ui_.TemperatureSpin->setValue(configuration_->temperature());
 
+    // Populations
+    ui_.AtomPopulation->setText(QString::number(configuration_->nAtoms()));
+    ui_.MolPopulation->setText(QString::number(configuration_->nMolecules()));
+
     // Current Box
     const auto *box = configuration_->box();
     ui_.CurrentBoxTypeLabel->setText(QString::fromStdString(std::string(Box::boxTypes().keyword(box->type()))));


### PR DESCRIPTION
This is a much simpler and cleaner setup for displaying the population of a configuration in the Configuration tab.  This closes #819.

![20211201_13h32m27s_grim](https://user-images.githubusercontent.com/1728853/144399605-82bc12ea-f97d-4b31-89ba-739c7aa5b94d.png)
