### PR TITLE
Bugfix 02/12/21 Intramolecular g(r)

### DIFF
--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -362,21 +362,17 @@ bool RDFModule::calculateGR(GenericList &processingData, ProcessPool &procPool, 
     // This is GitHub issue #562
     for (auto it = cfg->molecules().begin() + offset; it < cfg->molecules().end(); it += nChunks)
     {
-        auto &atoms = (*it)->atoms();
+        const auto &atoms = (*it)->atoms();
 
-        dissolve::for_each_pair(ParallelPolicies::seq, atoms.begin(), atoms.end(),
-                                [box, &cells, &originalgr](int index, auto &i, int jndex, auto &j) {
-                                    // Ignore atom on itself
-                                    if (index == jndex)
-                                        return;
+        dissolve::for_each_pair(
+            ParallelPolicies::seq, atoms.begin(), atoms.end(),
+            [box, &cells, &originalgr](int index, auto &i, int jndex, auto &j) {
+                // Ignore atom on itself
+                if (index == jndex)
+                    return;
 
-                                    double distance;
-                                    if (cells.minimumImageRequired(*i->cell(), *j->cell()))
-                                        distance = box->minimumDistance(i->r(), j->r());
-                                    else
-                                        distance = (i->r() - j->r()).magnitude();
-                                    originalgr.boundHistogram(i->localTypeIndex(), j->localTypeIndex()).bin(distance);
-                                });
+                originalgr.boundHistogram(i->localTypeIndex(), j->localTypeIndex()).bin(box->minimumDistance(i->r(), j->r()));
+            });
     }
 
     timer.stop();


### PR DESCRIPTION
Simple PR to address efficiency issues in the intramolecular g(r) calculation. This was highlighted by a simulation containing a large species (>27k atoms) and which took over 3 minutes to calculate the intramolecular partials for a single molecule. Checking for minimum image by querying the cell array turned out to be the issue, so it has been removed in favour of always calculating the minimum image distance regardless of whether it is required or not.

After this change, the calculation takes 10 seconds.

There may be other places in the code where this is also happening.