### PR TITLE
Request Catalina for build.

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -34,7 +34,7 @@ stages:
         displayName: 'OSX, Threads, CLI/GUI'
         timeoutInMinutes: 120
         pool:
-          vmImage: 'macos-latest' 
+          vmImage: 'macOS-10.15'
         steps:
           - checkout: self
             fetchDepth: 1

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -59,7 +59,7 @@ stages:
         displayName: "OSX, Threads, CLI/GUI"
         timeoutInMinutes: 120
         pool:
-          vmImage: "macos-latest"
+          vmImage: "macOS-10.15"
         steps:
           - checkout: self
             fetchDepth: 1

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -17,7 +17,7 @@ stages:
         displayName: 'OSX, Threads, CLI/GUI'
         timeoutInMinutes: 120
         pool:
-          vmImage: 'macos-latest'
+          vmImage: 'macOS-10.15'
         steps:
           - checkout: self
             fetchDepth: 1


### PR DESCRIPTION
The Python `dmgbuild` package is a little bit broken on OSX Big Sur since the `flatten` and `unflatten` verbs have been removed from `hdiutil` in this release, and thus breaks `dmgbuild`.

Pipelines in the CI need to be reverted to use only Catalina instead of the latest OSX version available, until a fix for (or alternative to) `dmbguild` is available.