### PR TITLE
Bugfix 03/12/21 Layer Creation

### DIFF
--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -212,16 +212,16 @@ void DissolveWindow::on_LayerCreateCalculateRDFNeutronAction_triggered(bool chec
                                                        : std::vector<Configuration *>{dissolve_.configurations().front().get()};
 
     // Add the RDF module
-    auto *rdfModule = dynamic_cast<RDFModule *>(ModuleRegistry::create("RDF", newLayer));
+    auto *rdfModule = ModuleRegistry::create("RDF", newLayer);
     rdfModule->keywords().set("Configuration", firstCfg);
 
     // Add a plain structure factor module
     auto *sqModule = dynamic_cast<SQModule *>(ModuleRegistry::create("SQ", newLayer));
-    sqModule->keywords().set<const RDFModule *>("SourceRDFs", rdfModule);
+    sqModule->keywords().set<const Module *>("SourceRDFs", rdfModule);
 
     // Add a NeutronSQ module
     Module *module = ModuleRegistry::create("NeutronSQ", newLayer);
-    module->keywords().set<const SQModule *>("SourceSQs", sqModule);
+    module->keywords().set<const Module *>("SourceSQs", sqModule);
 
     // Run set-up stages for modules
     newLayer->setUpAll(dissolve_, dissolve_.worldPool());
@@ -241,20 +241,20 @@ void DissolveWindow::on_LayerCreateCalculateRDFNeutronXRayAction_triggered(bool 
                                                        : std::vector<Configuration *>{dissolve_.configurations().front().get()};
 
     // Add the RDF module
-    auto *rdfModule = dynamic_cast<RDFModule *>(ModuleRegistry::create("RDF", newLayer));
+    auto *rdfModule = ModuleRegistry::create("RDF", newLayer);
     rdfModule->keywords().set("Configuration", firstCfg);
 
     // Add a plain structure factor module
-    auto *sqModule = dynamic_cast<SQModule *>(ModuleRegistry::create("SQ", newLayer));
-    sqModule->keywords().set<const RDFModule *>("SourceRDFs", rdfModule);
+    auto *sqModule = ModuleRegistry::create("SQ", newLayer);
+    sqModule->keywords().set<const Module *>("SourceRDFs", rdfModule);
 
     // Add a NeutronSQ module
-    Module *module = ModuleRegistry::create("NeutronSQ", newLayer);
-    module->keywords().set<const SQModule *>("SourceSQs", sqModule);
+    auto *module = ModuleRegistry::create("NeutronSQ", newLayer);
+    module->keywords().set<const Module *>("SourceSQs", sqModule);
 
     // Add an XRaySQ module
     module = ModuleRegistry::create("XRaySQ", newLayer);
-    module->keywords().set<const SQModule *>("SourceSQs", sqModule);
+    module->keywords().set<const Module *>("SourceSQs", sqModule);
 
     // Run set-up stages for modules
     newLayer->setUpAll(dissolve_, dissolve_.worldPool());
@@ -269,17 +269,15 @@ void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(dissolve_.uniqueProcessingLayerName("Analyse RDF/CN"));
 
-    Module *module;
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add the CalculateRDF module
-    auto *calcRDFModule = dynamic_cast<CalculateRDFModule *>(ModuleRegistry::create("CalculateRDF", newLayer));
+    auto *calcRDFModule = ModuleRegistry::create("CalculateRDF", newLayer);
     calcRDFModule->keywords().set("Configuration", firstCfg);
 
     // Add a CalculateCN module
-    module = ModuleRegistry::create("CalculateCN", newLayer);
-    module->keywords().set<const CalculateRDFModule *>("SourceRDF", calcRDFModule);
+    auto *module = ModuleRegistry::create("CalculateCN", newLayer);
+    module->keywords().set<const Module *>("SourceRDF", calcRDFModule);
 
     // Run set-up stages for modules
     newLayer->setUpAll(dissolve_, dissolve_.worldPool());
@@ -294,12 +292,10 @@ void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(dissolve_.uniqueProcessingLayerName("Analyse AvgMol/SDF"));
 
-    Module *module;
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add the CalculateAvgMol module
-    module = ModuleRegistry::create("CalculateAvgMol", newLayer);
+    auto *module = ModuleRegistry::create("CalculateAvgMol", newLayer);
     module->keywords().set("Configuration", firstCfg);
 
     // Add a CalculateSDF module

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -201,6 +201,9 @@ void ModuleControlWidget::keywordDataModified() { emit(dataModified()); }
 // Target keyword data changed
 void ModuleControlWidget::targetKeywordDataChanged(int flags)
 {
+    if (refreshLock_.isLocked())
+        return;
+
     // Always emit the 'dataModified' signal
     emit(dataModified());
 

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -31,6 +31,9 @@ KeywordTypeMap::KeywordTypeMap()
     registerDirectMapping<std::shared_ptr<SelectProcedureNode>, NodeKeyword<SelectProcedureNode>>();
     registerDirectMapping<std::vector<std::shared_ptr<const SelectProcedureNode>>, NodeVectorKeyword<SelectProcedureNode>>();
     registerDirectMapping<std::vector<Module *>, ModuleVectorKeyword>();
+    registerDirectMapping<const Module *, ModuleKeywordBase>(
+        [](ModuleKeywordBase *keyword, const Module *module) { return keyword->setData(module); },
+        [](ModuleKeywordBase *keyword) { return keyword->module(); });
     registerDirectMapping<Configuration *, ConfigurationKeyword>();
     registerDirectMapping<std::vector<Configuration *>, ConfigurationVectorKeyword>();
 

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -64,6 +64,22 @@ class KeywordTypeMap
             return k->data();
         };
     }
+    // Register direct setter for specific keyword / data type pair, with specific data setter and getter on the keyword
+    template <class D, class K>
+    void registerDirectMapping(std::function<bool(K *keyword, const D data)> setFunction,
+                               std::function<const std::any(K *keyword)> getFunction)
+    {
+        directMapSetter_[typeid(D)] = [setFunction](KeywordBase *keyword, const std::any &data) {
+            auto *k = dynamic_cast<K *>(keyword);
+            assert(k);
+            return setFunction(k, std::any_cast<D>(data));
+        };
+        directMapGetter_[typeid(D)] = [getFunction](KeywordBase *keyword) {
+            auto *k = dynamic_cast<K *>(keyword);
+            assert(k);
+            return getFunction(k);
+        };
+    }
 
     public:
     // Set keyword data

--- a/src/modules/calculate_avgmol/avgmol.h
+++ b/src/modules/calculate_avgmol/avgmol.h
@@ -21,7 +21,7 @@ class CalculateAvgMolModule : public Module
     // Target configuration
     Configuration *targetConfiguration_{nullptr};
     // Target site
-    const SpeciesSite *targetSite_;
+    const SpeciesSite *targetSite_{nullptr};
     // Species targeted by module (derived from selected site)
     const Species *targetSpecies_{nullptr};
     // Local Species representing average of targeted Species


### PR DESCRIPTION
A PR to address some issues discovered whilst add pre-defined layers to a simulation in the GUI. Root cause of the problem was that a keyword setter had not been registered for the specific module types - a general setter and getter working on the `KeywordModuleBase` class is implemented rather than having to define derived-class setters for each module type.
