### PR TITLE
ETA Calculation

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -82,6 +82,12 @@ class DissolveWindow : public QMainWindow
     // Label for simulation ETA (when using RunFor)
     QLabel *etaLabel_;
 
+    private:
+    // Add text label to status bar
+    QLabel *addStatusBarLabel(QString text);
+    // Add text label to status bar
+    QLabel *addStatusBarIcon(QString resource);
+
     /*
      * File
      */

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -4,10 +4,8 @@
 #include "base/lineparser.h"
 #include "base/messenger.h"
 #include "gui/configurationtab.h"
-#include "gui/forcefieldtab.h"
 #include "gui/gui.h"
 #include "gui/layertab.h"
-#include "gui/speciestab.h"
 #include "gui/workspacetab.h"
 #include "main/dissolve.h"
 #include "main/version.h"
@@ -16,7 +14,6 @@
 #include <QDirIterator>
 #include <QFileInfo>
 #include <QFontDatabase>
-#include <QLCDNumber>
 #include <QMdiSubWindow>
 #include <QMessageBox>
 #include <QSettings>
@@ -49,26 +46,13 @@ DissolveWindow::DissolveWindow(Dissolve &dissolve)
     dissolveState_ = NoState;
 
     // Create statusbar widgets
-    localSimulationIndicator_ = new QLabel;
-    localSimulationIndicator_->setPixmap(QPixmap(":/general/icons/general_local.svg"));
-    localSimulationIndicator_->setMaximumSize(QSize(20, 20));
-    localSimulationIndicator_->setScaledContents(true);
-    restartFileIndicator_ = new QLabel;
-    restartFileIndicator_->setPixmap(QPixmap(":/general/icons/general_restartfile.svg"));
-    restartFileIndicator_->setMaximumSize(QSize(20, 20));
-    restartFileIndicator_->setScaledContents(true);
-    heartbeatFileIndicator_ = new QLabel;
-    heartbeatFileIndicator_->setPixmap(QPixmap(":/general/icons/general_heartbeat.svg"));
-    heartbeatFileIndicator_->setMaximumSize(QSize(20, 20));
-    heartbeatFileIndicator_->setScaledContents(true);
-    iterationLabel_ = new QLabel("00000");
-    etaLabel_ = new QLabel("ETA: --:--:--");
 
-    statusBar()->addPermanentWidget(iterationLabel_);
-    statusBar()->addPermanentWidget(etaLabel_);
-    statusBar()->addPermanentWidget(heartbeatFileIndicator_);
-    statusBar()->addPermanentWidget(restartFileIndicator_);
-    statusBar()->addPermanentWidget(localSimulationIndicator_);
+    iterationLabel_ = addStatusBarLabel("00000");
+    addStatusBarIcon(":/general/icons/general_clock.svg");
+    etaLabel_ = addStatusBarLabel("--:--:--");
+    heartbeatFileIndicator_ = addStatusBarIcon(":/general/icons/general_heartbeat.svg");
+    restartFileIndicator_ = addStatusBarIcon(":/general/icons/general_restartfile.svg");
+    localSimulationIndicator_ = addStatusBarIcon(":/general/icons/general_local.svg");
 
     updateWindowTitle();
     updateStatusBar();
@@ -124,6 +108,30 @@ void DissolveWindow::setModified()
 Dissolve &DissolveWindow::dissolve() { return dissolve_; }
 
 const Dissolve &DissolveWindow::dissolve() const { return dissolve_; }
+
+/*
+ * Statusbar
+ */
+
+// Add text label to status bar
+QLabel *DissolveWindow::addStatusBarLabel(QString text)
+{
+    auto *label = new QLabel(text);
+    statusBar()->addPermanentWidget(label);
+    return label;
+}
+
+// Add text label to status bar
+QLabel *DissolveWindow::addStatusBarIcon(QString resource)
+{
+
+    auto *label = new QLabel;
+    label->setPixmap(QPixmap(resource));
+    label->setMaximumSize(QSize(20, 20));
+    label->setScaledContents(true);
+    statusBar()->addPermanentWidget(label);
+    return label;
+}
 
 /*
  * File

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -124,10 +124,10 @@ QLabel *DissolveWindow::addStatusBarLabel(QString text)
 // Add text label to status bar
 QLabel *DissolveWindow::addStatusBarIcon(QString resource)
 {
-
+    const auto iconSize = statusBar()->font().pointSize() * 1.75;
     auto *label = new QLabel;
     label->setPixmap(QPixmap(resource));
-    label->setMaximumSize(QSize(20, 20));
+    label->setMaximumSize(QSize(iconSize, iconSize));
     label->setScaledContents(true);
     statusBar()->addPermanentWidget(label);
     return label;

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -422,10 +422,12 @@ void DissolveWindow::updateWhileRunning(int iterationsRemaining)
 
     // Set ETA text if we can
     if (iterationsRemaining == -1)
-        etaLabel_->setText("ETA: --:--:--");
+        etaLabel_->setText("--:--:--");
     else
-        etaLabel_->setText(QStringLiteral("ETA: %1").arg(
-            QString::fromStdString(Timer::etaString(iterationsRemaining * dissolve_.iterationTime()))));
+    {
+        auto estimatedTime = dissolve_.estimateRequiredTime(iterationsRemaining);
+        etaLabel_->setText(estimatedTime ? QString::fromStdString(Timer::etaString(estimatedTime.value())) : "??:??:??");
+    }
 
     // Enable data access in Renderables, and update all tabs.
     Renderable::setSourceDataAccessEnabled(true);

--- a/src/gui/icons/general_clock.svg
+++ b/src/gui/icons/general_clock.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100"
+   height="100"
+   viewBox="0 0 100 100"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="general_clock.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="2.1071429"
+     inkscape:cx="-82.246039"
+     inkscape:cy="34.770059"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     showguides="false" />
+  <circle
+     style="opacity:1;fill:#ffffeb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.24566929;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path925"
+     cx="50"
+     cy="50"
+     r="37.966103" />
+  <g
+     id="g939"
+     transform="translate(1.9287111,2.4335939)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path2"
+       d="m 52.237954,47.566356 c 0,1.145867 -0.407987,2.126767 -1.22396,2.9427 -0.815967,0.816 -1.796867,1.224 -2.9427,1.224 -1.145833,0 -2.126737,-0.408 -2.94271,-1.224 -0.815973,-0.815933 -1.22396,-1.796833 -1.22396,-2.9427 0,-1.1458 0.407987,-2.1267 1.22396,-2.9427 0.815973,-0.815933 1.796877,-1.2239 2.94271,-1.2239 1.145833,0 2.126733,0.407967 2.9427,1.2239 0.815973,0.816 1.22396,1.7969 1.22396,2.9427 z"
+       style="opacity:1;fill:#310049;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path816"
+       d="M 48.070312,5.5351561 A 42.030907,42.030907 0 0 0 6.0410158,47.566406 42.030907,42.030907 0 0 0 48.070312,89.597656 42.030907,42.030907 0 0 0 90.101562,47.566406 42.030907,42.030907 0 0 0 48.070312,5.5351561 Z m 0,7.1308599 A 34.899914,34.899914 0 0 1 82.970703,47.566406 34.899914,34.899914 0 0 1 48.070312,82.466797 34.899914,34.899914 0 0 1 13.171875,47.566406 34.899914,34.899914 0 0 1 48.070312,12.666016 Z"
+       style="opacity:1;fill:#310049;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.24566928;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       style="opacity:1"
+       transform="translate(-0.0982012,0.0070838)"
+       id="g902">
+      <g
+         id="g873"
+         transform="translate(0,-0.4745768)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path2-6"
+           d="m 17.692088,48.033849 c 0,1.145867 -0.407987,2.126767 -1.22396,2.9427 -0.815967,0.816 -1.796867,1.224 -2.9427,1.224 -1.145833,0 -2.126737,-0.408 -2.94271,-1.224 -0.8159726,-0.815933 -1.2239596,-1.796833 -1.2239596,-2.9427 0,-1.1458 0.407987,-2.1267 1.2239596,-2.9427 0.815973,-0.815933 1.796877,-1.2239 2.94271,-1.2239 1.145833,0 2.126733,0.407967 2.9427,1.2239 0.815973,0.816 1.22396,1.7969 1.22396,2.9427 z"
+           style="fill:#310049;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2-6-7"
+           d="m 86.980222,48.03385 c 0,1.145867 -0.407987,2.126767 -1.22396,2.9427 -0.815967,0.816 -1.796867,1.223999 -2.9427,1.223999 -1.145833,0 -2.126737,-0.408 -2.94271,-1.223999 -0.815973,-0.815933 -1.22396,-1.796833 -1.22396,-2.9427 0,-1.145801 0.407987,-2.1267 1.22396,-2.942701 0.815973,-0.815933 1.796877,-1.2239 2.94271,-1.2239 1.145833,0 2.126733,0.407967 2.9427,1.2239 0.815973,0.816001 1.22396,1.7969 1.22396,2.942701 z"
+           style="fill:#310049;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      </g>
+      <g
+         transform="rotate(90,48.406779,47.796611)"
+         id="g873-5">
+        <path
+           inkscape:connector-curvature="0"
+           id="path2-6-3"
+           d="m 17.692088,48.033849 c 0,1.145867 -0.407987,2.126767 -1.22396,2.9427 -0.815967,0.816 -1.796867,1.224 -2.9427,1.224 -1.145833,0 -2.126737,-0.408 -2.94271,-1.224 -0.8159726,-0.815933 -1.2239596,-1.796833 -1.2239596,-2.9427 0,-1.1458 0.407987,-2.1267 1.2239596,-2.9427 0.815973,-0.815933 1.796877,-1.2239 2.94271,-1.2239 1.145833,0 2.126733,0.407967 2.9427,1.2239 0.815973,0.816 1.22396,1.7969 1.22396,2.9427 z"
+           style="fill:#310049;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path2-6-7-5"
+           d="m 86.980222,48.03385 c 0,1.145867 -0.407987,2.126767 -1.22396,2.9427 -0.815967,0.816 -1.796867,1.223999 -2.9427,1.223999 -1.145833,0 -2.126737,-0.408 -2.94271,-1.223999 -0.815973,-0.815933 -1.22396,-1.796833 -1.22396,-2.9427 0,-1.145801 0.407987,-2.1267 1.22396,-2.942701 0.815973,-0.815933 1.796877,-1.2239 2.94271,-1.2239 1.145833,0 2.126733,0.407967 2.9427,1.2239 0.815973,0.816001 1.22396,1.7969 1.22396,2.942701 z"
+           style="fill:#310049;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       style="opacity:1;fill:#310049;fill-opacity:1"
+       id="g923">
+      <rect
+         style="opacity:1;fill:#310049;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.24566928;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect904"
+         width="4.2711864"
+         height="27.894726"
+         x="45.935696"
+         y="19.837324" />
+      <rect
+         style="opacity:1;fill:#310049;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.24566926;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect904-6"
+         width="4.2711864"
+         height="16.569033"
+         x="-11.749693"
+         y="68.040794"
+         transform="rotate(-53.439479)" />
+    </g>
+  </g>
+</svg>

--- a/src/gui/main.qrc
+++ b/src/gui/main.qrc
@@ -100,6 +100,7 @@
     <file>icons/general_edit.svg</file>
     <file>icons/general_screen.svg</file>
     <file>icons/general_monitor.svg</file>
+    <file>icons/general_clock.svg</file>
     <file>icons/general_heartbeat.svg</file>
     <file>icons/general_local.svg</file>
     <file>icons/general_movemodule.svg</file>

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -234,8 +234,8 @@ class Dissolve
     void resetIterationCounter();
     // Return current simulation step
     int iteration() const;
-    // Return per-iteration time in seconds
-    double iterationTime() const;
+    // Estimate time in seconds required to perform next n steps (if possible to determine)
+    std::optional<double> estimateRequiredTime(int nIterations);
     // Print timing information
     void printTiming();
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -307,8 +307,43 @@ void Dissolve::resetIterationCounter() { iteration_ = 0; }
 // Return current simulation step
 int Dissolve::iteration() const { return iteration_; }
 
-// Return per-iteration time in seconds
-double Dissolve::iterationTime() const { return iterationTime_.value(); }
+// Estimate time in seconds required to perform next n steps (if possible to determine)
+std::optional<double> Dissolve::estimateRequiredTime(int nIterations)
+{
+    auto seconds = 0.0;
+    auto n = 0;
+
+    for (const auto &layer : processingLayers_)
+    {
+        if (!layer->isEnabled())
+            continue;
+
+        // Determine how many times this layer will run in the provided number of iterations
+        auto nLayer = ((iteration_ % layer->frequency()) + nIterations) / layer->frequency();
+        if (nLayer == 0)
+            continue;
+
+        // Determine the iteration count of the layer
+        auto layerIteration = iteration_ / layer->frequency();
+
+        // For each module in the layer, determine how many times it will run in the number of layer iterations
+        for (const auto &module : layer->modules())
+        {
+            auto nModule = ((layerIteration % module->frequency()) + nLayer) / module->frequency();
+            if (nModule == 0)
+                continue;
+
+            // Do we have valid timing information for the module?
+            if (module->processTimes().count() > 0)
+            {
+                ++n;
+                seconds += nModule * module->processTimes();
+            }
+        }
+    }
+
+    return n > 0 ? std::optional<double>(seconds) : std::optional<double>();
+}
 
 // Print timing information
 void Dissolve::printTiming()


### PR DESCRIPTION
This PR updates the estimated time calculation, as well as improving the construction of the status bar widgets.

Previously, estimated timings were based on the duration of a single averaged iteration time, which is grossly inaccurate given the frequencies of modules as well as layers. Here, the ETA is calculated by considering frequencies explicitly.

Closes #150.
Closes #861.