### PR TITLE
Species Editor Modifications

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -247,6 +247,8 @@ class Species
     std::shared_ptr<Forcefield> forcefield() const;
     // Apply terms from source Forcefield
     bool applyForcefieldTerms(CoreData &coreData);
+    // Clear forcefield terms
+    void clearForcefieldTerms(bool nullifyAtomTypes = true);
 
     /*
      * Isotopologues

--- a/src/classes/species_ff.cpp
+++ b/src/classes/species_ff.cpp
@@ -34,3 +34,21 @@ bool Species::applyForcefieldTerms(CoreData &coreData)
 
     return true;
 }
+
+// Clear forcefield terms
+void Species::clearForcefieldTerms(bool nullifyAtomTypes)
+{
+    if (nullifyAtomTypes)
+        clearAtomTypes();
+
+    for (auto &b : bonds_)
+        b.setFormAndParameters(SpeciesBond::BondFunction::NoForm, {});
+
+    for (auto &a : angles_)
+        a.setFormAndParameters(SpeciesAngle::AngleFunction::NoForm, {});
+
+    for (auto &t : torsions_)
+        t.setFormAndParameters(SpeciesTorsion::TorsionFunction::NoForm, {});
+
+    impropers_.clear();
+}

--- a/src/gui/render/renderablespecies.cpp
+++ b/src/gui/render/renderablespecies.cpp
@@ -392,7 +392,7 @@ void RenderableSpecies::recreateDrawInteractionPrimitive(SpeciesAtom *fromAtom, 
 
         // Draw the temporary bond between the atoms
         interactionAssembly_.createCylinderBond(bondPrimitive_, fromAtom->r(), j.r(), j.r() - fromAtom->r(),
-                                                ElementColours::colour(fromAtom->Z()), ElementColours::colour(j.Z()), true,
+                                                ElementColours::colour(j.Z()), ElementColours::colour(fromAtom->Z()), true,
                                                 spheresBondRadius_);
     }
 }

--- a/src/gui/specieseditor.h
+++ b/src/gui/specieseditor.h
@@ -16,7 +16,7 @@ class SpeciesEditor : public QWidget
 
     public:
     SpeciesEditor(QWidget *parent = 0);
-    ~SpeciesEditor();
+    ~SpeciesEditor() = default;
 
     private:
     // Main Dissolve pointer

--- a/src/gui/specieseditor.ui
+++ b/src/gui/specieseditor.ui
@@ -81,7 +81,7 @@
          <string/>
         </property>
         <property name="pixmap">
-         <pixmap resource="../main.qrc">:/viewer_toolbar/icons/viewer_toolbar_interaction.svg</pixmap>
+         <pixmap resource="main.qrc">:/viewer_toolbar/icons/viewer_toolbar_interaction.svg</pixmap>
         </property>
         <property name="scaledContents">
          <bool>true</bool>
@@ -109,7 +109,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_interact.svg</normaloff>
           <normalon>:/viewer/icons/viewer_interact_on.svg</normalon>:/viewer/icons/viewer_interact.svg</iconset>
         </property>
@@ -123,7 +123,7 @@
          <bool>true</bool>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="autoExclusive">
          <bool>false</bool>
@@ -164,7 +164,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_edit.svg</normaloff>
           <normalon>:/viewer/icons/viewer_edit_on.svg</normalon>:/viewer/icons/viewer_edit.svg</iconset>
         </property>
@@ -178,7 +178,7 @@
          <bool>true</bool>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="autoExclusive">
          <bool>false</bool>
@@ -238,7 +238,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_delete.svg</normaloff>:/viewer/icons/viewer_delete.svg</iconset>
         </property>
         <property name="iconSize">
@@ -289,7 +289,7 @@
          <string/>
         </property>
         <property name="pixmap">
-         <pixmap resource="../main.qrc">:/viewer_toolbar/icons/viewer_toolbar_view.svg</pixmap>
+         <pixmap resource="main.qrc">:/viewer_toolbar/icons/viewer_toolbar_view.svg</pixmap>
         </property>
         <property name="scaledContents">
          <bool>true</bool>
@@ -317,7 +317,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_reset.svg</normaloff>:/viewer/icons/viewer_reset.svg</iconset>
         </property>
         <property name="iconSize">
@@ -358,7 +358,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_spheres.svg</normaloff>
           <normalon>:/viewer/icons/viewer_spheres_on.svg</normalon>:/viewer/icons/viewer_spheres.svg</iconset>
         </property>
@@ -400,7 +400,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_axes.svg</normaloff>
           <normalon>:/viewer/icons/viewer_axes_on.svg</normalon>:/viewer/icons/viewer_axes.svg</iconset>
         </property>
@@ -442,7 +442,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_snapshot.svg</normaloff>:/viewer/icons/viewer_snapshot.svg</iconset>
         </property>
         <property name="iconSize">
@@ -493,7 +493,7 @@
          <string/>
         </property>
         <property name="pixmap">
-         <pixmap resource="../main.qrc">:/viewer_toolbar/icons/viewer_toolbar_tools.svg</pixmap>
+         <pixmap resource="main.qrc">:/viewer_toolbar/icons/viewer_toolbar_tools.svg</pixmap>
         </property>
         <property name="scaledContents">
          <bool>true</bool>
@@ -521,7 +521,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_calculatebonds.svg</normaloff>:/viewer/icons/viewer_calculatebonds.svg</iconset>
         </property>
         <property name="iconSize">
@@ -562,7 +562,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="../main.qrc">
+         <iconset resource="main.qrc">
           <normaloff>:/viewer/icons/viewer_medic.svg</normaloff>:/viewer/icons/viewer_medic.svg</iconset>
         </property>
         <property name="iconSize">
@@ -660,7 +660,7 @@
     <widget class="QFrame" name="InfoFrame">
      <property name="font">
       <font>
-       <pointsize>8</pointsize>
+       <pointsize>10</pointsize>
       </font>
      </property>
      <property name="frameShape">
@@ -724,6 +724,7 @@
         </property>
         <property name="font">
          <font>
+          <pointsize>10</pointsize>
           <weight>75</weight>
           <bold>true</bold>
          </font>
@@ -775,6 +776,7 @@
         </property>
         <property name="font">
          <font>
+          <pointsize>10</pointsize>
           <weight>75</weight>
           <bold>true</bold>
          </font>
@@ -817,6 +819,7 @@
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="main.qrc"/>
   <include location="../main.qrc"/>
  </resources>
  <connections/>

--- a/src/gui/specieseditor.ui
+++ b/src/gui/specieseditor.ui
@@ -103,7 +103,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>View mode</string>
+         <string>Rotate, translate, and zoom the view</string>
         </property>
         <property name="text">
          <string/>
@@ -158,7 +158,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Draw mode</string>
+         <string>Draw atoms and bonds</string>
         </property>
         <property name="text">
          <string/>
@@ -206,6 +206,9 @@
           <bold>true</bold>
          </font>
         </property>
+        <property name="toolTip">
+         <string>Current draw element</string>
+        </property>
         <property name="text">
          <string>C</string>
         </property>
@@ -232,7 +235,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Delete mode</string>
+         <string>Delete atoms and bonds</string>
         </property>
         <property name="text">
          <string/>
@@ -515,7 +518,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Add missing bonds to the species</string>
+         <string>Detect bonds between atoms</string>
         </property>
         <property name="text">
          <string/>
@@ -556,7 +559,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Fix the geometry, minimising the energy of the current structure according to its forcefield</string>
+         <string>Clean the geometry of the species using the Universal ForceField</string>
         </property>
         <property name="text">
          <string/>
@@ -820,7 +823,7 @@
  </customwidgets>
  <resources>
   <include location="main.qrc"/>
-  <include location="../main.qrc"/>
+  <include location="main.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/gui/specieseditor_funcs.cpp
+++ b/src/gui/specieseditor_funcs.cpp
@@ -3,11 +3,13 @@
 
 #include "classes/empiricalformula.h"
 #include "classes/species.h"
+#include "data/ff/library.h"
 #include "gui/specieseditor.h"
 #include "gui/widgets/elementselector.hui"
 #include "main/dissolve.h"
 #include "modules/geomopt/geomopt.h"
 #include <QButtonGroup>
+#include <QMessageBox>
 
 SpeciesEditor::SpeciesEditor(QWidget *parent) : QWidget(parent)
 {
@@ -17,10 +19,11 @@ SpeciesEditor::SpeciesEditor(QWidget *parent) : QWidget(parent)
     ui_.setupUi(this);
 
     // Create a button group for the interaction modes
-    QButtonGroup *group = new QButtonGroup;
+    auto *group = new QButtonGroup;
     group->addButton(ui_.InteractionViewButton);
     group->addButton(ui_.InteractionDrawButton);
     group->addButton(ui_.InteractionDeleteButton);
+    speciesViewer()->setInteractionMode(SpeciesViewer::InteractionMode::Draw);
 
     // Connect signals / slots
     connect(ui_.SpeciesView, SIGNAL(dataModified()), this, SLOT(notifyDataModified()));
@@ -32,8 +35,6 @@ SpeciesEditor::SpeciesEditor(QWidget *parent) : QWidget(parent)
     updateToolbar();
     updateStatusBar();
 }
-
-SpeciesEditor::~SpeciesEditor() {}
 
 // Set main Dissolve pointer
 void SpeciesEditor::setDissolve(Dissolve *dissolve) { dissolve_ = dissolve; }
@@ -201,19 +202,38 @@ void SpeciesEditor::on_ToolsMinimiseButton_clicked(bool checked)
     if (!sp)
         return;
 
-    // Apply forcefield terms now?
-    if (sp->forcefield())
-        sp->applyForcefieldTerms(dissolve_->coreData());
+    // Get the pointer to the UFF, and create some temporary objects
+    auto uff = ForcefieldLibrary::forcefield("UFF");
+    if (!uff)
+        throw(std::runtime_error("Couldn't locate UFF to perform minimisation.\n"));
+    CoreData coreData;
+    Dissolve dissolve(coreData);
+
+    // Clear any old forcefield terms from the species, and recreate higher-order intramolecular terms
+    sp->clearForcefieldTerms();
+    sp->updateIntramolecularTerms();
+
+    // Apply new forcefield terms
+    if (uff->assignAtomTypes(sp, coreData, Forcefield::TypeAll, false) != 0 || !uff->assignIntramolecular(sp))
+    {
+        QMessageBox::critical(this, "Error", "Failed to apply UFF to the species - molecule clean-up is not possible.");
+        return;
+    }
 
     // Check that the Species set up is valid
     if (!sp->checkSetUp())
         return;
 
+    // Create a temporary potential map
+    dissolve.regeneratePairPotentials();
     GeometryOptimisationModule optimiser;
-    optimiser.optimiseSpecies(dissolve_->potentialMap(), dissolve_->worldPool(), sp);
+    optimiser.optimiseSpecies(dissolve.potentialMap(), dissolve.worldPool(), sp);
 
     // Centre the Species back at the origin
     sp->centreAtOrigin();
+
+    // Clear the forcefield terms from the species
+    sp->clearForcefieldTerms();
 
     // Need to update the SpeciesViewer, and signal that the data shown has been modified
     speciesViewer()->view().showAllData();

--- a/src/gui/speciesviewer_funcs.cpp
+++ b/src/gui/speciesviewer_funcs.cpp
@@ -15,7 +15,7 @@ SpeciesViewer::SpeciesViewer(QWidget *parent) : BaseViewer(parent)
     // Interaction
     setInteractionMode(SpeciesViewer::InteractionMode::Select);
     transientInteractionMode_ = SpeciesViewer::TransientInteractionMode::None;
-    drawElement_ = Elements::H;
+    drawElement_ = Elements::C;
 
     // Set up the view
     view_.setViewType(View::NormalView);


### PR DESCRIPTION
Here we make a few adjustments and improvements to the `SpeciesEditor`, namely:

1. Add in a UFF-based minimisation tool for cleaning-up geometries "mid-draw"
2. Update tooltips
3. Fix bond colouring.

Closes #214 by obfuscation.
Closes #858.
