### PR TITLE
ExpressionVariable Model

### DIFF
--- a/src/expression/ExpressionVisitor.cpp
+++ b/src/expression/ExpressionVisitor.cpp
@@ -45,7 +45,7 @@ void ExpressionVisitor::create(
 
 antlrcpp::Any ExpressionVisitor::visitParentheses(ExpressionParser::ParenthesesContext *ctx)
 {
-    auto node = std::make_shared<ExpressionRootNode>();
+    auto node = std::make_shared<ExpressionRootNode>(true);
 
     currentContext()->addChild(node);
 

--- a/src/expression/binary.cpp
+++ b/src/expression/binary.cpp
@@ -81,3 +81,33 @@ std::optional<ExpressionValue> ExpressionBinaryOperatorNode::evaluate() const
 
     return result;
 }
+
+// Return string representation of node
+std::string ExpressionBinaryOperatorNode::asString() const
+{
+    // Must be two child nodes
+    if (children_.size() != 2)
+        return "";
+
+    // Evaluate LHS and RHS nodes
+    auto lhs = children_[0]->asString();
+    auto rhs = children_[1]->asString();
+
+    switch (operator_)
+    {
+        case (OperatorAdd):
+            return fmt::format("{}+{}", lhs, rhs);
+        case (OperatorDivide):
+            return fmt::format("{}/{}", lhs, rhs);
+        case (OperatorSubtract):
+            return fmt::format("{}-{}", lhs, rhs);
+        case (OperatorPow):
+            return fmt::format("{}^{}", lhs, rhs);
+        case (OperatorMultiply):
+            return fmt::format("{}*{}", lhs, rhs);
+        default:
+            throw(std::runtime_error(fmt::format("ExpressionBinaryOperatorNode - unhandled operator {}.\n", operator_)));
+    }
+
+    return "";
+}

--- a/src/expression/binary.h
+++ b/src/expression/binary.h
@@ -41,4 +41,6 @@ class ExpressionBinaryOperatorNode : public ExpressionNode
     public:
     // Evaluate node
     std::optional<ExpressionValue> evaluate() const override;
+    // Return string representation of node
+    std::string asString() const override;
 };

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -15,13 +15,13 @@
 
 Expression::Expression(std::string_view expressionText) : rootNode_(nullptr) { create(expressionText); }
 
-Expression::~Expression() { clear(); }
+Expression::~Expression() { clearNodes(); }
 
 Expression::Expression(const Expression &source) { (*this) = source; }
 
 void Expression::operator=(const Expression &source)
 {
-    clear();
+    clearNodes();
 
     expressionString_ = source.expressionString_;
 
@@ -33,11 +33,9 @@ void Expression::operator=(const Expression &source)
  * Data
  */
 
-// Clear data
-void Expression::clear()
+// Clear node data
+void Expression::clearNodes()
 {
-    expressionString_ = "";
-
     if (rootNode_)
         rootNode_->clear();
 
@@ -51,7 +49,7 @@ bool Expression::isValid() const { return rootNode_ != nullptr; }
 bool Expression::create(std::string_view expressionString,
                         OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> externalVariables)
 {
-    clear();
+    clearNodes();
 
     expressionString_ = expressionString;
 
@@ -61,7 +59,7 @@ bool Expression::create(std::string_view expressionString,
 
     rootNode_ = std::make_shared<ExpressionRootNode>();
 
-    // Create string stream and set up ANTLR input strem
+    // Create string stream and set up ANTLR input stream
     std::stringstream stream;
     stream << expressionString_;
     antlr4::ANTLRInputStream input(stream);
@@ -75,7 +73,7 @@ bool Expression::create(std::string_view expressionString,
     // Generate tokens from input stream
     antlr4::CommonTokenStream tokens(&lexer);
 
-    // Create ANTLR parser and set-up error listenres
+    // Create ANTLR parser and set-up error listeners
     ExpressionParser parser(&tokens);
     ExpressionParserErrorListener parserErrorListener(*this);
     parser.removeErrorListeners();
@@ -92,6 +90,7 @@ bool Expression::create(std::string_view expressionString,
     catch (ExpressionExceptions::ExpressionSyntaxException &ex)
     {
         fmt::print(ex.what());
+        clearNodes();
         return Messenger::error(ex.what());
     };
 
@@ -104,6 +103,7 @@ bool Expression::create(std::string_view expressionString,
     catch (ExpressionExceptions::ExpressionSyntaxException &ex)
     {
         fmt::print(ex.what());
+        clearNodes();
         return Messenger::error(ex.what());
     }
 

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -113,6 +113,9 @@ bool Expression::create(std::string_view expressionString,
 // Return original generating string
 std::string_view Expression::expressionString() const { return expressionString_; }
 
+// Set generating string from current nodes
+void Expression::setExpressionStringFromNodes() { expressionString_ = rootNode_ ? rootNode_->asString() : ""; }
+
 // Return root node for the expression
 std::shared_ptr<ExpressionNode> Expression::rootNode() { return rootNode_; }
 

--- a/src/expression/expression.h
+++ b/src/expression/expression.h
@@ -38,6 +38,8 @@ class Expression
            OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> externalVariables = std::nullopt);
     // Return original generating string
     std::string_view expressionString() const;
+    // Set generating string from current nodes
+    void setExpressionStringFromNodes();
     // Return root node for the expression
     std::shared_ptr<ExpressionNode> rootNode();
 

--- a/src/expression/expression.h
+++ b/src/expression/expression.h
@@ -28,8 +28,8 @@ class Expression
     std::shared_ptr<ExpressionNode> rootNode_;
 
     public:
-    // Clear data
-    void clear();
+    // Clear node data
+    void clearNodes();
     // Return whether current expression is valid (contains at least one node)
     bool isValid() const;
     // Create expression from supplied string, with optional external variables

--- a/src/expression/function.cpp
+++ b/src/expression/function.cpp
@@ -103,3 +103,24 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
 
     return result;
 }
+
+// Return string representation of node
+std::string ExpressionFunctionNode::asString() const
+{
+    // Number of required child nodes depends on the function
+    const auto nArgs = internalFunctions().minArgs(function_);
+    if (children_.size() != nArgs)
+        return "";
+
+    // Evaluate the arguments
+    std::vector<std::string> args;
+    for (auto n = 0; n < nArgs; ++n)
+    {
+        auto optArg = children_[n]->asString();
+        if (optArg.empty())
+            return "";
+        args.emplace_back(optArg);
+    }
+
+    return fmt::format("{}({})", internalFunctions().keyword(function_), args[0]);
+}

--- a/src/expression/function.h
+++ b/src/expression/function.h
@@ -49,4 +49,6 @@ class ExpressionFunctionNode : public ExpressionNode
     public:
     // Evaluate node
     std::optional<ExpressionValue> evaluate() const override;
+    // Return string representation of node
+    std::string asString() const override;
 };

--- a/src/expression/node.h
+++ b/src/expression/node.h
@@ -11,7 +11,7 @@
 // Forward Declarations
 class Expression;
 
-// NETA Node
+// Expression Node
 class ExpressionNode
 {
     public:
@@ -41,4 +41,6 @@ class ExpressionNode
     public:
     // Evaluate node
     virtual std::optional<ExpressionValue> evaluate() const = 0;
+    // Return string representation of node
+    virtual std::string asString() const = 0;
 };

--- a/src/expression/number.cpp
+++ b/src/expression/number.cpp
@@ -29,3 +29,6 @@ std::optional<ExpressionValue> ExpressionNumberNode::evaluate() const
 
     return value_;
 }
+
+// Return string representation of node
+std::string ExpressionNumberNode::asString() const { return value_.asString(); }

--- a/src/expression/number.h
+++ b/src/expression/number.h
@@ -35,4 +35,6 @@ class ExpressionNumberNode : public ExpressionNode
     public:
     // Evaluate node
     std::optional<ExpressionValue> evaluate() const override;
+    // Return string representation of node
+    std::string asString() const override;
 };

--- a/src/expression/reference.cpp
+++ b/src/expression/reference.cpp
@@ -28,9 +28,15 @@ std::shared_ptr<ExpressionNode> ExpressionReferenceNode::duplicate()
 // Evaluate node
 std::optional<ExpressionValue> ExpressionReferenceNode::evaluate() const
 {
-    // Must have a valid pointer
-    if (!variable_)
-        return std::nullopt;
+    assert(variable_);
 
     return (variable_->value());
+}
+
+// Return string representation of node
+std::string ExpressionReferenceNode::asString() const
+{
+    assert(variable_);
+
+    return std::string(variable_->name());
 }

--- a/src/expression/reference.h
+++ b/src/expression/reference.h
@@ -35,4 +35,6 @@ class ExpressionReferenceNode : public ExpressionNode
     public:
     // Evaluate node
     std::optional<ExpressionValue> evaluate() const override;
+    // Return string representation of node
+    std::string asString() const override;
 };

--- a/src/expression/root.cpp
+++ b/src/expression/root.cpp
@@ -3,7 +3,9 @@
 
 #include "expression/root.h"
 
-ExpressionRootNode::ExpressionRootNode() : ExpressionNode() {}
+ExpressionRootNode::ExpressionRootNode(bool parenthesesEnclosed) : ExpressionNode(), parenthesesEnclosed_(parenthesesEnclosed)
+{
+}
 
 /*
  * Nodes
@@ -31,4 +33,12 @@ std::optional<ExpressionValue> ExpressionRootNode::evaluate() const
         return std::nullopt;
 
     return children_[0]->evaluate();
+}
+
+// Return string representation of node
+std::string ExpressionRootNode::asString() const
+{
+    if (children_.size() == 0)
+        return "";
+    return parenthesesEnclosed_ ? fmt::format("({})", children_[0]->asString()) : children_[0]->asString();
 }

--- a/src/expression/root.h
+++ b/src/expression/root.h
@@ -9,8 +9,15 @@
 class ExpressionRootNode : public ExpressionNode
 {
     public:
-    ExpressionRootNode();
+    explicit ExpressionRootNode(bool parenthesesEnclosed = false);
     ~ExpressionRootNode() override = default;
+
+    /*
+     * Data
+     */
+    private:
+    // Whether parentheses surround the nodes
+    bool parenthesesEnclosed_;
 
     /*
      * Nodes
@@ -25,4 +32,6 @@ class ExpressionRootNode : public ExpressionNode
     public:
     // Evaluate node
     std::optional<ExpressionValue> evaluate() const override;
+    // Return string representation of node
+    std::string asString() const override;
 };

--- a/src/expression/unary.cpp
+++ b/src/expression/unary.cpp
@@ -31,14 +31,14 @@ std::optional<ExpressionValue> ExpressionUnaryOperatorNode::evaluate() const
     if (children_.size() != 1)
         return std::nullopt;
 
-    // Evaluate LHS node
-    auto optl = children_[0]->evaluate();
-    if (!optl)
+    // Evaluate RHS node
+    auto optr = children_[0]->evaluate();
+    if (!optr)
         return std::nullopt;
 
     // Perform the operation
     ExpressionValue result;
-    auto rhs = (*optl);
+    auto rhs = (*optr);
     switch (operator_)
     {
         case (OperatorNegate):
@@ -52,4 +52,25 @@ std::optional<ExpressionValue> ExpressionUnaryOperatorNode::evaluate() const
     }
 
     return result;
+}
+
+// Return string representation of node
+std::string ExpressionUnaryOperatorNode::asString() const
+{
+    // Must be a single child node
+    if (children_.size() != 1)
+        return "";
+
+    // Evaluate RHS node
+    auto rhs = children_[0]->asString();
+
+    switch (operator_)
+    {
+        case (OperatorNegate):
+            return fmt::format("-{}", rhs);
+        default:
+            throw(std::runtime_error(fmt::format("ExpressionUnaryOperatorNode - unhandled operator {}.\n", operator_)));
+    }
+
+    return "";
 }

--- a/src/expression/unary.h
+++ b/src/expression/unary.h
@@ -37,4 +37,6 @@ class ExpressionUnaryOperatorNode : public ExpressionNode
     public:
     // Evaluate node
     std::optional<ExpressionValue> evaluate() const override;
+    // Return string representation of node
+    std::string asString() const override;
 };

--- a/src/gui/delegates/exponentialspin.hui
+++ b/src/gui/delegates/exponentialspin.hui
@@ -14,11 +14,11 @@ class ExponentialSpinDelegate : public QItemDelegate
 
     private:
     // Parameters for ExponentialSpin
-    double min_, max_, step_, nDecimals_;
+    double min_, max_, step_;
+    int nDecimals_;
 
     public:
-    ExponentialSpinDelegate(QObject *parent = 0, double vmin = -1e6, double vmax = 1e6, double vstep = 1.0,
-                            double nDecimals = 5);
+    ExponentialSpinDelegate(QObject *parent = 0, double vmin = -1e6, double vmax = 1e6, double vstep = 1.0, int nDecimals = 5);
     // Reimplemented virtual function to create editing widget
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     // Set the data to appear when the editor is called

--- a/src/gui/delegates/exponentialspin_funcs.cpp
+++ b/src/gui/delegates/exponentialspin_funcs.cpp
@@ -4,7 +4,7 @@
 #include "gui/delegates/exponentialspin.hui"
 #include <stdio.h>
 
-ExponentialSpinDelegate::ExponentialSpinDelegate(QObject *parent, double vmin, double vmax, double vstep, double nDecimals)
+ExponentialSpinDelegate::ExponentialSpinDelegate(QObject *parent, double vmin, double vmax, double vstep, int nDecimals)
     : QItemDelegate(parent)
 {
     // Private variables
@@ -43,9 +43,7 @@ void ExponentialSpinDelegate::setModelData(QWidget *editor, QAbstractItemModel *
 {
     auto *spinBox = static_cast<ExponentialSpin *>(editor);
 
-    double value = spinBox->value();
-
-    model->setData(index, value, Qt::EditRole);
+    model->setData(index, spinBox->value(), Qt::EditRole);
 }
 
 // Update widget geometry

--- a/src/gui/keywordwidgets/expressionvariablevector.h
+++ b/src/gui/keywordwidgets/expressionvariablevector.h
@@ -5,10 +5,8 @@
 
 #include "gui/keywordwidgets/base.h"
 #include "gui/keywordwidgets/ui_expressionvariablevector.h"
+#include "gui/models/expressionVariableVectorModel.h"
 #include "keywords/expressionvariablevector.h"
-#include "procedure/nodes/node.h"
-
-Q_DECLARE_METATYPE(ExpressionNode *);
 
 // Forward Declarations
 class QWidget;
@@ -34,14 +32,11 @@ class ExpressionVariableVectorKeywordWidget : public QWidget, public KeywordWidg
     private:
     // Main form declaration
     Ui::ExpressionVariableVectorWidget ui_;
-
-    private:
-    // Variable table update function
-    void updateVariableTableRow(int row, std::shared_ptr<ExpressionVariable> variable, bool createItem);
+    // Model for table
+    ExpressionVariableVectorModel variableModel_;
 
     private slots:
-    // Variables table item changed
-    void on_VariablesTable_itemChanged(QTableWidgetItem *item);
+    void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
     // Keyword data changed

--- a/src/gui/keywordwidgets/expressionvariablevector.ui
+++ b/src/gui/keywordwidgets/expressionvariablevector.ui
@@ -35,7 +35,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QTableWidget" name="VariablesTable">
+    <widget class="QTableView" name="VariablesTable">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
@@ -51,39 +51,6 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::SingleSelection</enum>
      </property>
-     <property name="rowCount">
-      <number>0</number>
-     </property>
-     <property name="columnCount">
-      <number>3</number>
-     </property>
-     <attribute name="horizontalHeaderVisible">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderStretchLastSection">
-      <bool>false</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Type</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Value</string>
-      </property>
-     </column>
     </widget>
    </item>
   </layout>

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -4,16 +4,7 @@
 #include "classes/coredata.h"
 #include "expression/variable.h"
 #include "gui/delegates/exponentialspin.hui"
-#include "gui/delegates/integerspin.hui"
-#include "gui/helpers/tablewidgetupdater.h"
 #include "gui/keywordwidgets/expressionvariablevector.h"
-#include "procedure/nodes/node.h"
-#include <QComboBox>
-#include <QHBoxLayout>
-#include <QString>
-
-Q_DECLARE_SMART_POINTER_METATYPE(std::shared_ptr)
-Q_DECLARE_METATYPE(std::shared_ptr<ExpressionVariable>)
 
 ExpressionVariableVectorKeywordWidget::ExpressionVariableVectorKeywordWidget(QWidget *parent,
                                                                              ExpressionVariableVectorKeyword *keyword,
@@ -23,8 +14,13 @@ ExpressionVariableVectorKeywordWidget::ExpressionVariableVectorKeywordWidget(QWi
     // Create and set up the UI for our widget
     ui_.setupUi(this);
 
-    // Set current information
-    updateValue();
+    // Set up model
+    variableModel_.setData(keyword->data(), keyword->parentNode());
+    ui_.VariablesTable->setModel(&variableModel_);
+
+    // Connect signals / slots
+    connect(&variableModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
+            SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
 
     // Add suitable delegate to the table
     ui_.VariablesTable->setItemDelegateForColumn(2, new ExponentialSpinDelegate(this));
@@ -34,114 +30,14 @@ ExpressionVariableVectorKeywordWidget::ExpressionVariableVectorKeywordWidget(QWi
  * Widgets
  */
 
-// Variable table update function
-void ExpressionVariableVectorKeywordWidget::updateVariableTableRow(int row, std::shared_ptr<ExpressionVariable> variable,
-                                                                   bool createItem)
-{
-    QTableWidgetItem *item;
-
-    // Name
-    if (createItem)
-    {
-        item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, QVariant::fromValue(variable));
-        ui_.VariablesTable->setItem(row, 0, item);
-    }
-    else
-        item = ui_.VariablesTable->item(row, 0);
-    item->setText(QString::fromStdString(std::string(variable->name())));
-
-    // Type
-    if (createItem)
-    {
-        item = new QTableWidgetItem;
-        item->setFlags(Qt::ItemIsSelectable);
-        item->setData(Qt::UserRole, QVariant::fromValue(variable));
-        ui_.VariablesTable->setItem(row, 1, item);
-    }
-    else
-        item = ui_.VariablesTable->item(row, 1);
-    item->setText(variable->value().type() == ExpressionValue::ValueType::Integer ? "int" : "double");
-
-    // Value
-    if (createItem)
-    {
-        item = new QTableWidgetItem;
-        item->setData(Qt::UserRole, QVariant::fromValue(variable));
-        ui_.VariablesTable->setItem(row, 2, item);
-    }
-    else
-        item = ui_.VariablesTable->item(row, 2);
-    item->setText(QString::fromStdString(variable->value().asString()));
-}
-
 // Variable data changed
-void ExpressionVariableVectorKeywordWidget::on_VariablesTable_itemChanged(QTableWidgetItem *w)
+void ExpressionVariableVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
     if (refreshing_)
         return;
 
-    // Get the widget's data (our ExpressionVariable)
-    std::shared_ptr<ExpressionVariable> variable = w->data(Qt::UserRole).value<std::shared_ptr<ExpressionVariable>>();
-    if (!variable)
-        return;
-
-    // Check column of the item to see what we need to do
-    switch (w->column())
-    {
-        // Variable name
-        case (0):
-            // Check that the name is not currently in use anywhere in the Procedure
-            if (keyword_->parentNode()->parameterExists(qPrintable(w->text()), variable))
-            {
-                Messenger::error("A Node with name '{}' already exists elsewhere in the Procedure.\n", qPrintable(w->text()));
-                w->setText(QString::fromStdString(std::string(variable->name())));
-                return;
-            }
-            else
-                variable->setName(qPrintable(w->text()));
-            break;
-        // Variable value
-        case (2):
-            // Determine the type of the new value so we can convert and set accordingly
-            bool isFloatingPoint = false,
-                 originalFloatingPoint = variable->value().type() == ExpressionValue::ValueType::Double;
-            if (DissolveSys::isNumber(qPrintable(w->text()), isFloatingPoint))
-            {
-                if (isFloatingPoint)
-                    variable->setValue(w->text().toDouble());
-                else
-                    variable->setValue(w->text().toInt());
-
-                // Update the type?
-                if (isFloatingPoint != originalFloatingPoint)
-                {
-                    auto *item = ui_.VariablesTable->item(w->row(), 1);
-                    if (item)
-                        item->setText(isFloatingPoint ? "double" : "int");
-                }
-            }
-            else
-                Messenger::error("Invalid input - not a number.\n");
-            break;
-    }
-
     emit(keywordDataChanged(keyword_->signalMask()));
 }
 
-/*
- * Update
- */
-
 // Update value displayed in widget
-void ExpressionVariableVectorKeywordWidget::updateValue()
-{
-    refreshing_ = true;
-
-    // Update the variables list against that contained in the keyword's data
-    ConstTableWidgetUpdater<ExpressionVariableVectorKeywordWidget, ExpressionVariable, std::shared_ptr<ExpressionVariable>>
-        tableUpdater(ui_.VariablesTable, keyword_->data(), this,
-                     &ExpressionVariableVectorKeywordWidget::updateVariableTableRow);
-
-    refreshing_ = false;
-}
+void ExpressionVariableVectorKeywordWidget::updateValue() {}

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -46,6 +46,7 @@ set(models_SRCS
     dataManagerReferencePointModel.cpp
     dataManagerSimulationModel.cpp
     enumOptionsModel.cpp
+    expressionVariableVectorModel.cpp
     isotopologueSetModel.cpp
     masterTermModel.cpp
     moduleLayerModel.cpp
@@ -82,6 +83,7 @@ qt_wrap_cpp(
   dataManagerReferencePointModel.h
   dataManagerSimulationModel.h
   enumOptionsModel.h
+  expressionVariableVectorModel.h
   isotopologueSetModel.h
   pairPotentialModel.h
   speciesModel.h

--- a/src/gui/models/expressionVariableVectorModel.cpp
+++ b/src/gui/models/expressionVariableVectorModel.cpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/models/expressionVariableVectorModel.h"
+#include "procedure/nodes/node.h"
+
+// Set source variable data
+void ExpressionVariableVectorModel::setData(std::vector<std::shared_ptr<ExpressionVariable>> &variables,
+                                            const ProcedureNode *parentNode)
+{
+    beginResetModel();
+    variables_ = variables;
+    parentNode_ = parentNode;
+    endResetModel();
+}
+
+int ExpressionVariableVectorModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return variables_ ? variables_->get().size() : 0;
+}
+int ExpressionVariableVectorModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return 0;
+    return 3;
+}
+
+Qt::ItemFlags ExpressionVariableVectorModel::flags(const QModelIndex &index) const
+{
+    if (index.column() == 1)
+        return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    else
+        return Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable;
+}
+
+QVariant ExpressionVariableVectorModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole)
+        return {};
+
+    if (orientation == Qt::Horizontal)
+        switch (section)
+        {
+            case 0:
+                return "Name";
+            case 1:
+                return "Type";
+            case 2:
+                return "Value";
+            default:
+                return {};
+        }
+
+    return {};
+}
+
+// Bond model
+QVariant ExpressionVariableVectorModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || !variables_)
+        return {};
+
+    auto &vars = variables_->get();
+
+    if (index.row() >= vars.size() || index.row() < 0)
+        return {};
+
+    if (role != Qt::DisplayRole && role != Qt::EditRole)
+        return {};
+
+    auto &var = vars[index.row()];
+
+    switch (index.column())
+    {
+        // Name
+        case 0:
+            return QString::fromStdString(std::string(var->name()));
+        case 1:
+            return var->value().type() == ExpressionValue::ValueType::Integer ? "Int" : "Real";
+        case 2:
+            return QString::fromStdString(var->value().asString());
+        default:
+            return {};
+    }
+
+    return {};
+}
+
+bool ExpressionVariableVectorModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    if (role != Qt::EditRole || !variables_ || index.column() == 1)
+        return false;
+
+    auto &var = variables_->get()[index.row()];
+
+    if (index.column() == 0)
+    {
+        // Name - must check for existing var in scope with the same name
+        auto p = parentNode_->parameterExists(value.toString().toStdString());
+        if (p && p != var)
+            return false;
+        var->setName(value.toString().toStdString());
+    }
+    else if (index.column() == 2)
+    {
+        // Value - need to check type (int vs double)
+        auto varValue = value.toString().toStdString();
+        bool isFloatingPoint = false;
+        if (DissolveSys::isNumber(varValue, isFloatingPoint))
+        {
+            if (isFloatingPoint)
+                var->setValue(value.toDouble());
+            else
+                var->setValue(value.toInt());
+        }
+        else
+            return Messenger::error("Value '{}' provided for variable '{}' doesn't appear to be a number.\n", varValue,
+                                    var->name());
+    }
+
+    emit dataChanged(index, index);
+    return true;
+}

--- a/src/gui/models/expressionVariableVectorModel.h
+++ b/src/gui/models/expressionVariableVectorModel.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+#include "expression/variable.h"
+#include "templates/optionalref.h"
+#include <QAbstractTableModel>
+#include <QModelIndex>
+#include <vector>
+
+// Forward Declarations
+class ProcedureNode;
+
+// Expression Variable Vector Model
+class ExpressionVariableVectorModel : public QAbstractTableModel
+{
+    Q_OBJECT
+
+    private:
+    // Source variable data
+    OptionalReferenceWrapper<std::vector<std::shared_ptr<ExpressionVariable>>> variables_;
+    // Parent procedure node (to enable parameter search)
+    const ProcedureNode *parentNode_{nullptr};
+
+    public:
+    // Set source variable data
+    void setData(std::vector<std::shared_ptr<ExpressionVariable>> &variables, const ProcedureNode *parentNode);
+
+    int rowCount(const QModelIndex &parent) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+};

--- a/src/gui/widgets/exponentialspin_funcs.cpp
+++ b/src/gui/widgets/exponentialspin_funcs.cpp
@@ -104,7 +104,11 @@ void ExponentialSpin::valueEditingFinished()
     setValue(lineEdit()->text().toDouble());
 }
 
-void ExponentialSpin::returnPressed() { lineEdit()->selectAll(); }
+void ExponentialSpin::returnPressed()
+{
+    lineEdit()->selectAll();
+    valueEditingFinished();
+}
 
 /*
  * Reimplementations

--- a/src/keywords/expressionvariablevector.cpp
+++ b/src/keywords/expressionvariablevector.cpp
@@ -19,6 +19,7 @@ ExpressionVariableVectorKeyword::ExpressionVariableVectorKeyword(std::vector<std
  */
 
 // Return reference to vector of data
+std::vector<std::shared_ptr<ExpressionVariable>> &ExpressionVariableVectorKeyword::data() { return data_; }
 const std::vector<std::shared_ptr<ExpressionVariable>> &ExpressionVariableVectorKeyword::data() const { return data_; }
 
 // Return parent ProcedureNode

--- a/src/keywords/expressionvariablevector.h
+++ b/src/keywords/expressionvariablevector.h
@@ -28,6 +28,7 @@ class ExpressionVariableVectorKeyword : public KeywordBase
 
     public:
     // Return reference to vector of data
+    std::vector<std::shared_ptr<ExpressionVariable>> &data();
     const std::vector<std::shared_ptr<ExpressionVariable>> &data() const;
     // Return parent ProcedureNode
     const ProcedureNode *parentNode() const;

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -228,8 +228,8 @@ std::shared_ptr<SequenceProcedureNode> ProcedureNode::branch() { return nullptr;
  * Parameters
  */
 
-// Return whether this node has the named parameter specified
-std::shared_ptr<ExpressionVariable> ProcedureNode::hasParameter(std::string_view name,
+// Return the named parameter (if it exists)
+std::shared_ptr<ExpressionVariable> ProcedureNode::getParameter(std::string_view name,
                                                                 std::shared_ptr<ExpressionVariable> excludeParameter)
 {
     return nullptr;

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -181,8 +181,8 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
      * Parameters
      */
     public:
-    // Return whether this node has the named parameter specified
-    virtual std::shared_ptr<ExpressionVariable> hasParameter(std::string_view name,
+    // Return the named parameter (if it exists)
+    virtual std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
                                                              std::shared_ptr<ExpressionVariable> excludeParameter = nullptr);
     // Return references to all parameters for this node
     virtual OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const;

--- a/src/procedure/nodes/parameters.cpp
+++ b/src/procedure/nodes/parameters.cpp
@@ -33,8 +33,8 @@ void ParametersProcedureNode::addParameter(std::string_view name, ExpressionValu
     parameters_.push_back(std::make_shared<ExpressionVariable>(name, initialValue));
 }
 
-// Return whether this node has the named parameter specified
-std::shared_ptr<ExpressionVariable> ParametersProcedureNode::hasParameter(std::string_view name,
+// Return the named parameter (if it exists)
+std::shared_ptr<ExpressionVariable> ParametersProcedureNode::getParameter(std::string_view name,
                                                                           std::shared_ptr<ExpressionVariable> excludeParameter)
 {
     for (auto var : parameters_)

--- a/src/procedure/nodes/parameters.h
+++ b/src/procedure/nodes/parameters.h
@@ -35,8 +35,8 @@ class ParametersProcedureNode : public ProcedureNode
     public:
     // Add new parameter
     void addParameter(std::string_view name, ExpressionValue initialValue);
-    // Return whether this node has the named parameter specified
-    std::shared_ptr<ExpressionVariable> hasParameter(std::string_view name,
+    // Return the named parameter (if it exists)
+    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
                                                      std::shared_ptr<ExpressionVariable> excludeParameter) override;
     // Return vector of all parameters for this node
     OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -107,7 +107,7 @@ SequenceProcedureNode::searchParameters(std::string_view name,
     for (auto node : sequence_)
     {
         // Does this node have a parameter by this name?
-        auto result = node->hasParameter(name, excludeParameter);
+        auto result = node->getParameter(name, excludeParameter);
         if (result)
             return result;
 
@@ -270,7 +270,7 @@ SequenceProcedureNode::parameterInScope(NodeRef queryingNode, std::string_view n
 
     for (auto node : range)
     {
-        auto param = node->hasParameter(name, excludeParameter);
+        auto param = node->getParameter(name, excludeParameter);
         if (param)
             return param;
     }

--- a/unit/gui/CMakeLists.txt
+++ b/unit/gui/CMakeLists.txt
@@ -1,6 +1,7 @@
 dissolve_unit_test(datamanager.cpp)
 dissolve_unit_test(forcefieldTab.cpp)
 dissolve_unit_test(isotopologeSetModel.cpp exchangeable)
+dissolve_unit_test(expressionVariableVectorModel.cpp)
 dissolve_unit_test(masterTerms.cpp)
 dissolve_unit_test(optionalDouble.cpp)
 dissolve_unit_test(speciestab.cpp)

--- a/unit/gui/expressionVariableVectorModel.cpp
+++ b/unit/gui/expressionVariableVectorModel.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "gui/models/expressionVariableVectorModel.h"
+#include "main/dissolve.h"
+#include "procedure/nodes/parameters.h"
+#include "procedure/procedure.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+TEST(ExpressionVariableVectorModelTest, Basic)
+{
+    CoreData coreData;
+    Dissolve dissolve(coreData);
+
+    // Create a simple procedure with a parameters node
+    Procedure procedure(ProcedureNode::AnalysisContext);
+    auto parameters = std::make_shared<ParametersProcedureNode>();
+    procedure.addRootSequenceNode(parameters);
+    parameters->addParameter("Alpha", 1.2345);
+    parameters->addParameter("Beta", 99);
+    parameters->addParameter("Gamma", -10);
+
+    // Create a second set of data since we can't get the ParametersProcedureNode data non-const
+    std::vector<std::shared_ptr<ExpressionVariable>> data;
+    data.push_back(std::make_shared<ExpressionVariable>("alf", 5.4321));
+    data.push_back(std::make_shared<ExpressionVariable>("bert", 1));
+    data.push_back(std::make_shared<ExpressionVariable>("gemma", 10));
+
+    // Set up the model, supplying our mutable data and the parameters node as the parent
+    ExpressionVariableVectorModel model;
+    model.setData(data, parameters.get());
+
+    // Size
+    EXPECT_EQ(model.columnCount(QModelIndex()), 3);
+    EXPECT_EQ(model.rowCount(QModelIndex()), 3);
+    EXPECT_EQ(model.columnCount(model.index(0, 0)), 0);
+    EXPECT_EQ(model.rowCount(model.index(0, 0)), 0);
+
+    // Data
+    EXPECT_EQ(model.data(model.index(0, 0), Qt::DisplayRole).toString().toStdString(), "alf");
+    EXPECT_EQ(model.data(model.index(0, 1), Qt::DisplayRole).toString().toStdString(), "Real");
+    EXPECT_DOUBLE_EQ(model.data(model.index(0, 2), Qt::DisplayRole).toDouble(), 5.4321);
+
+    // Set
+    EXPECT_TRUE(model.setData(model.index(0, 0), "colin", Qt::EditRole));
+    EXPECT_EQ(model.data(model.index(0, 0), Qt::DisplayRole).toString().toStdString(), "colin");
+    EXPECT_FALSE(model.setData(model.index(0, 1), "Anything", Qt::EditRole));
+    EXPECT_TRUE(model.setData(model.index(0, 2), 4.567, Qt::EditRole));
+    EXPECT_DOUBLE_EQ(model.data(model.index(0, 2), Qt::DisplayRole).toDouble(), 4.567);
+    EXPECT_TRUE(model.setData(model.index(0, 2), 50, Qt::EditRole));
+    EXPECT_EQ(model.data(model.index(0, 2), Qt::DisplayRole).toInt(), 50);
+    EXPECT_DOUBLE_EQ(model.data(model.index(0, 2), Qt::DisplayRole).toDouble(), 50.0);
+    EXPECT_FALSE(model.setData(model.index(1, 0), "Alpha", Qt::EditRole));
+    EXPECT_FALSE(model.setData(model.index(1, 0), "Beta", Qt::EditRole));
+    EXPECT_FALSE(model.setData(model.index(1, 0), "Gamma", Qt::EditRole));
+    EXPECT_TRUE(model.setData(model.index(1, 0), "Gemma", Qt::EditRole));
+}
+
+} // namespace UnitTest

--- a/unit/math/expression.cpp
+++ b/unit/math/expression.cpp
@@ -4,6 +4,7 @@
 #include "expression/expression.h"
 #include "expression/reference.h"
 #include "expression/variable.h"
+#include "math/mathfunc.h"
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <string_view>
@@ -24,16 +25,17 @@ class ExpressionTest : public ::testing::Test
         variables.emplace_back(std::make_shared<ExpressionVariable>("bee", 100.0));
     }
 
-    void exprTest(std::string_view expr, const ExpressionValue &val, bool fail)
+    private:
+    void checkExpr(std::string_view expr, const ExpressionValue &val, bool shouldFail)
     {
         auto generationResult = expression.create(expr, variables);
-        ASSERT_NE(bool(generationResult), fail);
-        if (fail)
+        ASSERT_NE(bool(generationResult), shouldFail);
+        if (shouldFail)
             return;
         auto optResult = expression.evaluate();
         ASSERT_TRUE(optResult);
         auto result = (*optResult);
-        ASSERT_EQ(result.type(), val.type());
+        ASSERT_TRUE(result.type() == val.type());
         switch (val.type())
         {
             case (ExpressionValue::ValueType::Double):
@@ -43,6 +45,20 @@ class ExpressionTest : public ::testing::Test
                 EXPECT_EQ(result.asInteger(), val.asInteger());
                 break;
         }
+    }
+
+    protected:
+    void exprTest(std::string_view expr, const ExpressionValue &val, bool shouldFail)
+    {
+        // Test expression
+        checkExpr(expr, val, shouldFail);
+        if (shouldFail)
+            return;
+
+        // Regenerate expression string from nodes and re-test
+        expression.setExpressionStringFromNodes();
+        EXPECT_EQ(expr, expression.expressionString());
+        checkExpr(expression.expressionString(), val, shouldFail);
     }
 
     std::vector<std::shared_ptr<ExpressionVariable>> variables;
@@ -63,9 +79,9 @@ TEST_F(ExpressionTest, BasicIntegerMath)
 
 TEST_F(ExpressionTest, BasicFloatMath)
 {
-    exprTest("1.0+24*3.4", 1.0 + 24 * 3.4, false);
+    exprTest("1+24*3.4", 1.0 + 24 * 3.4, false);
     exprTest("(9.231-4*89.4)/76.92+7", (9.231 - 4 * 89.4) / 76.92 + 7, false);
-    exprTest("-3.0^3", pow(-3.0, 3), false);
+    exprTest("-3^3", DissolveMath::power(-3, 3), false);
     exprTest("cos(45)", cos(M_PI_4), false);
     exprTest("exp(cos(45))", exp(cos(M_PI_4)), false);
     exprTest("sqrt(sin(78.9)*cos(45))", sqrt(sin(78.9 * M_PI / 180.0) * cos(M_PI_4)), false);
@@ -78,8 +94,7 @@ TEST_F(ExpressionTest, Variables)
     auto a = variables[0];
     auto bee = variables[1];
     exprTest("a/5", a->value().asDouble() / 5, false);
-    exprTest("a + sqrt(bee)", a->value().asDouble() + sqrt(bee->value().asDouble()), false);
+    exprTest("a+sqrt(bee)", a->value().asDouble() + sqrt(bee->value().asDouble()), false);
     exprTest("1.8*wasp", 0, true);
-};
-
+}
 } // namespace UnitTest


### PR DESCRIPTION
This PR adds a model and accompanying unit test for `std::vector<ExpressionVariable>`, as used by the `Parameters` procedure node. It also fixes a couple of issues with expression validity detection, and the `ExponentialSpin` delegate class.

We also add in the ability to regenerate `Expression`s from the constituent nodes, allowing variable names etc. to be updated (this will happen in a subsequent PR. Unit testing has been extended to cover this feature.

The model currently lacks the ability to add/remove data, but this is left until refactoring work moving `Procedure` display away from custom charts is completed (#871).
