### PR TITLE
Keyword Signals

### DIFF
--- a/src/gui/charts/procedurenode.h
+++ b/src/gui/charts/procedurenode.h
@@ -111,7 +111,7 @@ class ProcedureChartNodeBlock : public QWidget, public ChartBlock
      */
     private slots:
     // Keyword data for node has been modified
-    void keywordDataModified();
+    void nodeKeywordChanged(int signalMask);
 
     signals:
     // Notify that the node's keyword data has been modified

--- a/src/gui/charts/procedurenode_funcs.cpp
+++ b/src/gui/charts/procedurenode_funcs.cpp
@@ -33,7 +33,7 @@ ProcedureChartNodeBlock::ProcedureChartNodeBlock(QWidget *parent, NodeRef node, 
 
     // Set up our keywords widget
     ui_.NodeKeywordsWidget->setUp(node->keywords(), coreData);
-    connect(ui_.NodeKeywordsWidget, SIGNAL(dataModified()), this, SLOT(keywordDataModified()));
+    connect(ui_.NodeKeywordsWidget, SIGNAL(keywordChanged(int)), this, SLOT(nodeKeywordChanged(int)));
 
     // Update our controls
     ui_.TopLabel->setText(QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(node_->type()))));
@@ -190,4 +190,4 @@ void ProcedureChartNodeBlock::enableSensitiveControls()
  */
 
 // Keyword data for node has been modified
-void ProcedureChartNodeBlock::keywordDataModified() { emit(dataModified()); }
+void ProcedureChartNodeBlock::nodeKeywordChanged(int signalMask) { emit(dataModified()); }

--- a/src/gui/keywordwidgets/atomtypevector.h
+++ b/src/gui/keywordwidgets/atomtypevector.h
@@ -43,8 +43,8 @@ class AtomTypeVectorKeywordWidget : public KeywordDropDown, public KeywordWidget
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -40,7 +40,7 @@ void AtomTypeVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, c
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/bool.hui
+++ b/src/gui/keywordwidgets/bool.hui
@@ -30,8 +30,8 @@ class BoolKeywordWidget : public QCheckBox, public KeywordWidgetBase
     void checkBoxClicked(bool checked);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/bool_funcs.cpp
+++ b/src/gui/keywordwidgets/bool_funcs.cpp
@@ -25,7 +25,7 @@ void BoolKeywordWidget::checkBoxClicked(bool checked)
 
     keyword_->setData(checked);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/configuration.hui
+++ b/src/gui/keywordwidgets/configuration.hui
@@ -33,8 +33,8 @@ class ConfigurationKeywordWidget : public QComboBox, public KeywordWidgetBase
     void comboIndexChanged(int index);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/configuration_funcs.cpp
+++ b/src/gui/keywordwidgets/configuration_funcs.cpp
@@ -34,7 +34,7 @@ void ConfigurationKeywordWidget::comboIndexChanged(int index)
     Configuration *sp = (index == -1 ? nullptr : VariantPointer<Configuration>(itemData(index, Qt::UserRole)));
     keyword_->data() = sp;
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/configurationvector.h
+++ b/src/gui/keywordwidgets/configurationvector.h
@@ -41,8 +41,8 @@ class ConfigurationVectorKeywordWidget : public KeywordDropDown, public KeywordW
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/configurationvector_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationvector_funcs.cpp
@@ -36,7 +36,7 @@ void ConfigurationVectorKeywordWidget::modelDataChanged(const QModelIndex &topLe
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/dialog.h
+++ b/src/gui/keywordwidgets/dialog.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "gui/keywordwidgets/ui_dialog.h"
+#include "keywords/signals.h"
 #include <QDialog>
 
 // Forward Declarations
@@ -17,7 +18,7 @@ class KeywordsDialog : public QDialog
 
     public:
     KeywordsDialog(QWidget *parent, KeywordStore &keywords, const CoreData &coreData);
-    ~KeywordsDialog();
+    ~KeywordsDialog() = default;
 
     private:
     // Main form declaration
@@ -26,22 +27,21 @@ class KeywordsDialog : public QDialog
     const CoreData &coreData_;
     // Whether any keywords have been modified in the current 'show'
     bool keywordsModified_;
-    // Whether any set-up needs to be re-run following keyword modification
-    bool setUpRequired_;
+    // Combined signal mask for all keyword changes
+    KeywordSignals keywordSignalMask_;
 
     public:
     // Run the dialog
     void showOptions();
     // Return whether any keywords have been modified in the current 'show'
     bool keywordsModified() const;
-    // Return whether any set-up needs to be re-run following keyword modification
-    bool isSetUpRequired() const;
+    // Return combined signal mask for all keyword changes
+    KeywordSignals keywordSignalMask() const;
 
     /*
      * Slots
      */
     private slots:
-    void keywordChanged();
-    void setUpRequired();
+    void keywordChanged(int signalMask);
     void on_OKButton_clicked(bool checked);
 };

--- a/src/gui/keywordwidgets/dialog_funcs.cpp
+++ b/src/gui/keywordwidgets/dialog_funcs.cpp
@@ -12,20 +12,16 @@ KeywordsDialog::KeywordsDialog(QWidget *parent, KeywordStore &keywords, const Co
 
     ui_.Keywords->setUp(keywords, coreData);
 
-    connect(ui_.Keywords, SIGNAL(dataModified()), this, SLOT(keywordChanged()));
-    connect(ui_.Keywords, SIGNAL(setUpRequired()), this, SLOT(setUpRequired()));
+    connect(ui_.Keywords, SIGNAL(keywordChanged(int)), this, SLOT(keywordChanged(int)));
 
     keywordsModified_ = false;
-    setUpRequired_ = false;
 }
-
-KeywordsDialog::~KeywordsDialog() {}
 
 // Run the dialog
 void KeywordsDialog::showOptions()
 {
     keywordsModified_ = false;
-    setUpRequired_ = false;
+    keywordSignalMask_ = 0;
 
     exec();
 }
@@ -33,15 +29,17 @@ void KeywordsDialog::showOptions()
 // Return whether any keywords have been modified in the current 'show'
 bool KeywordsDialog::keywordsModified() const { return keywordsModified_; }
 
-// Return whether any set-up needs to be re-run following keyword modification
-bool KeywordsDialog::isSetUpRequired() const { return setUpRequired_; }
+// Return combined signal mask for all keyword changes
+KeywordSignals KeywordsDialog::keywordSignalMask() const { return keywordSignalMask_; }
 
 /*
  * Slots
  */
 
-void KeywordsDialog::keywordChanged() { keywordsModified_ = true; }
-
-void KeywordsDialog::setUpRequired() { setUpRequired_ = true; }
+void KeywordsDialog::keywordChanged(int signalMask)
+{
+    keywordsModified_ = true;
+    keywordSignalMask_ += signalMask;
+}
 
 void KeywordsDialog::on_OKButton_clicked(bool checked) { accept(); }

--- a/src/gui/keywordwidgets/double.hui
+++ b/src/gui/keywordwidgets/double.hui
@@ -30,8 +30,8 @@ class DoubleKeywordWidget : public ExponentialSpin, public KeywordWidgetBase
     void spinBoxValueChanged(double newValue);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/double_funcs.cpp
+++ b/src/gui/keywordwidgets/double_funcs.cpp
@@ -35,7 +35,7 @@ void DoubleKeywordWidget::spinBoxValueChanged(double newValue)
         return;
 
     if (keyword_->setData(newValue))
-        emit(keywordValueChanged(keyword_->optionMask()));
+        emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/enumoptions.hui
+++ b/src/gui/keywordwidgets/enumoptions.hui
@@ -30,8 +30,8 @@ class EnumOptionsKeywordWidget : public QComboBox, public KeywordWidgetBase
     void comboBoxIndexChanged(int index);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/enumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/enumoptions_funcs.cpp
@@ -44,7 +44,7 @@ void EnumOptionsKeywordWidget::comboBoxIndexChanged(int index)
     // keyword structure that it has been modified
     keyword_->setEnumerationByIndex(index);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/expressionvariablevector.h
+++ b/src/gui/keywordwidgets/expressionvariablevector.h
@@ -44,8 +44,8 @@ class ExpressionVariableVectorKeywordWidget : public QWidget, public KeywordWidg
     void on_VariablesTable_itemChanged(QTableWidgetItem *item);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -126,7 +126,7 @@ void ExpressionVariableVectorKeywordWidget::on_VariablesTable_itemChanged(QTable
             break;
     }
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/fileandformat.h
+++ b/src/gui/keywordwidgets/fileandformat.h
@@ -41,8 +41,8 @@ class FileAndFormatKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_OptionsButton_clicked(bool checked);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/fileandformat_funcs.cpp
+++ b/src/gui/keywordwidgets/fileandformat_funcs.cpp
@@ -45,7 +45,7 @@ void FileAndFormatKeywordWidget::on_FileEdit_editingFinished()
 
     checkFileValidity();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void FileAndFormatKeywordWidget::on_FileEdit_returnPressed()
@@ -57,7 +57,7 @@ void FileAndFormatKeywordWidget::on_FileEdit_returnPressed()
 
     checkFileValidity();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void FileAndFormatKeywordWidget::on_FileSelectButton_clicked(bool checked)
@@ -88,7 +88,7 @@ void FileAndFormatKeywordWidget::on_FileSelectButton_clicked(bool checked)
         ui_.FileEdit->setText(fileInfo.dir().relativeFilePath(filename));
         updateKeywordData();
         updateWidgetValues(coreData_);
-        emit(keywordValueChanged(keyword_->optionMask()));
+        emit(keywordDataChanged(keyword_->signalMask()));
     }
 }
 
@@ -99,7 +99,7 @@ void FileAndFormatKeywordWidget::on_FormatCombo_currentIndexChanged(int index)
 
     updateKeywordData();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void FileAndFormatKeywordWidget::on_OptionsButton_clicked(bool checked)
@@ -109,7 +109,7 @@ void FileAndFormatKeywordWidget::on_OptionsButton_clicked(bool checked)
     optionsDialog.showOptions();
 
     if (optionsDialog.keywordsModified())
-        emit(keywordValueChanged(keyword_->optionMask()));
+        emit(keywordDataChanged(optionsDialog.keywordSignalMask() + keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/function1d.h
+++ b/src/gui/keywordwidgets/function1d.h
@@ -40,8 +40,8 @@ class Function1DKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     void parameterSpin_valueChanged(double value);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/function1d_funcs.cpp
+++ b/src/gui/keywordwidgets/function1d_funcs.cpp
@@ -68,7 +68,7 @@ void Function1DKeywordWidget::functionCombo_currentIndexChanged(int index)
 
     updateWidgetValues(coreData_);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Parameter value changed
@@ -81,7 +81,7 @@ void Function1DKeywordWidget::parameterSpin_valueChanged(double value)
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/integer.hui
+++ b/src/gui/keywordwidgets/integer.hui
@@ -30,8 +30,8 @@ class IntegerKeywordWidget : public QSpinBox, public KeywordWidgetBase
     void spinBoxValueChanged(int newValue);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/integer_funcs.cpp
+++ b/src/gui/keywordwidgets/integer_funcs.cpp
@@ -34,7 +34,7 @@ void IntegerKeywordWidget::spinBoxValueChanged(int newValue)
 
     keyword_->setData(newValue);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/isotopologueset.h
+++ b/src/gui/keywordwidgets/isotopologueset.h
@@ -49,8 +49,8 @@ class IsotopologueSetKeywordWidget : public KeywordDropDown, public KeywordWidge
     void currentItemChanged();
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -67,7 +67,7 @@ void IsotopologueSetKeywordWidget::modelDataChanged(const QModelIndex &topLeft, 
 {
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void IsotopologueSetKeywordWidget::addSpeciesButton_clicked(bool checked) { setModel_.addMissingSpecies(coreData_.species()); }

--- a/src/gui/keywordwidgets/module.h
+++ b/src/gui/keywordwidgets/module.h
@@ -40,8 +40,8 @@ class ModuleKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_ModuleCombo_currentIndexChanged(int index);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/module_funcs.cpp
+++ b/src/gui/keywordwidgets/module_funcs.cpp
@@ -41,7 +41,7 @@ void ModuleKeywordWidget::on_ModuleCombo_currentIndexChanged(int index)
     else
         keyword_->setData(ui_.ModuleCombo->currentData(Qt::UserRole).value<Module *>());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -43,8 +43,8 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
     void modelDataChanged(const QModelIndex &, const QModelIndex &);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -41,7 +41,7 @@ void ModuleVectorKeywordWidget::modelDataChanged(const QModelIndex &, const QMod
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/node.h
+++ b/src/gui/keywordwidgets/node.h
@@ -39,8 +39,8 @@ class NodeKeywordWidget : public QWidget, public KeywordWidgetBase
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/node_funcs.cpp
+++ b/src/gui/keywordwidgets/node_funcs.cpp
@@ -43,7 +43,7 @@ void NodeKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const QMode
 
     keyword_->setData(allowedNodes_[ui_.NodeCombo->currentIndex()]);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/nodeandinteger.h
+++ b/src/gui/keywordwidgets/nodeandinteger.h
@@ -40,8 +40,8 @@ class NodeAndIntegerKeywordWidget : public QWidget, public KeywordWidgetBase
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
+++ b/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
@@ -47,7 +47,7 @@ void NodeAndIntegerKeywordWidget::on_IntegerSpin_valueChanged(int value)
 
     keyword_->setIndex(value);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void NodeAndIntegerKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
@@ -57,7 +57,7 @@ void NodeAndIntegerKeywordWidget::modelDataChanged(const QModelIndex &topLeft, c
 
     keyword_->setNode(allowedNodes_[ui_.NodeCombo->currentIndex()]);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/nodevalue.h
+++ b/src/gui/keywordwidgets/nodevalue.h
@@ -36,8 +36,8 @@ class NodeValueKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_ValueEdit_returnPressed();
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalue_funcs.cpp
@@ -30,7 +30,7 @@ void NodeValueKeywordWidget::on_ValueEdit_editingFinished()
     keyword_->setData(qPrintable(ui_.ValueEdit->text()));
     checkValueValidity();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void NodeValueKeywordWidget::on_ValueEdit_returnPressed()
@@ -41,7 +41,7 @@ void NodeValueKeywordWidget::on_ValueEdit_returnPressed()
     keyword_->setData(qPrintable(ui_.ValueEdit->text()));
     checkValueValidity();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/nodevalueenumoptions.h
+++ b/src/gui/keywordwidgets/nodevalueenumoptions.h
@@ -37,8 +37,8 @@ class NodeValueEnumOptionsKeywordWidget : public QWidget, public KeywordWidgetBa
     void on_OptionsCombo_currentIndexChanged(int index);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
@@ -46,7 +46,7 @@ void NodeValueEnumOptionsKeywordWidget::on_ValueEdit_editingFinished()
     keyword_->setValue(qPrintable(ui_.ValueEdit->text()));
     ui_.ValueValidIndicator->setOK(keyword_->value().isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void NodeValueEnumOptionsKeywordWidget::on_ValueEdit_returnPressed()
@@ -57,7 +57,7 @@ void NodeValueEnumOptionsKeywordWidget::on_ValueEdit_returnPressed()
     keyword_->setValue(qPrintable(ui_.ValueEdit->text()));
     ui_.ValueValidIndicator->setOK(keyword_->value().isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void NodeValueEnumOptionsKeywordWidget::on_OptionsCombo_currentIndexChanged(int index)
@@ -67,7 +67,7 @@ void NodeValueEnumOptionsKeywordWidget::on_OptionsCombo_currentIndexChanged(int 
 
     keyword_->setEnumeration(index);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/nodevector.h
+++ b/src/gui/keywordwidgets/nodevector.h
@@ -40,8 +40,8 @@ class NodeVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/nodevector_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevector_funcs.cpp
@@ -40,7 +40,7 @@ void NodeVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/optionaldouble.hui
+++ b/src/gui/keywordwidgets/optionaldouble.hui
@@ -32,8 +32,8 @@ class OptionalDoubleKeywordWidget : public ExponentialSpin, public KeywordWidget
     void spinBoxValueNullified();
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/optionaldouble_funcs.cpp
+++ b/src/gui/keywordwidgets/optionaldouble_funcs.cpp
@@ -40,7 +40,7 @@ void OptionalDoubleKeywordWidget::spinBoxValueChanged(double newValue)
         return;
 
     if (keyword_->setData(newValue))
-        emit(keywordValueChanged(keyword_->optionMask()));
+        emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value nullified
@@ -50,7 +50,7 @@ void OptionalDoubleKeywordWidget::spinBoxValueNullified()
         return;
 
     keyword_->setData(std::nullopt);
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/optionalint.hui
+++ b/src/gui/keywordwidgets/optionalint.hui
@@ -32,8 +32,8 @@ class OptionalIntegerKeywordWidget : public ExponentialSpin, public KeywordWidge
     void spinBoxValueNullified();
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/optionalint_funcs.cpp
+++ b/src/gui/keywordwidgets/optionalint_funcs.cpp
@@ -41,7 +41,7 @@ void OptionalIntegerKeywordWidget::spinBoxValueChanged(int newValue)
         return;
 
     if (keyword_->setData(newValue))
-        emit(keywordValueChanged(keyword_->optionMask()));
+        emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value nullified
@@ -51,7 +51,7 @@ void OptionalIntegerKeywordWidget::spinBoxValueNullified()
         return;
 
     keyword_->setData(std::nullopt);
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/producers.h
+++ b/src/gui/keywordwidgets/producers.h
@@ -5,6 +5,7 @@
 
 #include "keywords/base.h"
 #include <any>
+#include <cassert>
 #include <functional>
 #include <string>
 #include <typeindex>

--- a/src/gui/keywordwidgets/range.h
+++ b/src/gui/keywordwidgets/range.h
@@ -35,8 +35,8 @@ class RangeKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_Spin2_valueChanged(double value);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/range_funcs.cpp
+++ b/src/gui/keywordwidgets/range_funcs.cpp
@@ -41,7 +41,7 @@ void RangeKeywordWidget::on_Spin1_valueChanged(double value)
 
     keyword_->data().setMinimum(value);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value changed
@@ -52,7 +52,7 @@ void RangeKeywordWidget::on_Spin2_valueChanged(double value)
 
     keyword_->data().setMaximum(value);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/species.hui
+++ b/src/gui/keywordwidgets/species.hui
@@ -33,8 +33,8 @@ class SpeciesKeywordWidget : public QComboBox, public KeywordWidgetBase
     void comboBoxIndexChanged(int index);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/species_funcs.cpp
+++ b/src/gui/keywordwidgets/species_funcs.cpp
@@ -34,7 +34,7 @@ void SpeciesKeywordWidget::comboBoxIndexChanged(int index)
     Species *sp = (index == -1 ? nullptr : VariantPointer<Species>(itemData(index, Qt::UserRole)));
     keyword_->data() = sp;
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/speciessite.h
+++ b/src/gui/keywordwidgets/speciessite.h
@@ -38,8 +38,8 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
     void siteRadioButton_clicked(bool checked);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -43,7 +43,7 @@ void SpeciesSiteKeywordWidget::siteRadioButton_clicked(bool checked)
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/speciessitevector.h
+++ b/src/gui/keywordwidgets/speciessitevector.h
@@ -45,8 +45,8 @@ class SpeciesSiteVectorKeywordWidget : public KeywordDropDown, public KeywordWid
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -35,7 +35,7 @@ void SpeciesSiteVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/speciesvector.h
+++ b/src/gui/keywordwidgets/speciesvector.h
@@ -41,8 +41,8 @@ class SpeciesVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetB
     void modelDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/speciesvector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesvector_funcs.cpp
@@ -34,7 +34,7 @@ void SpeciesVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, co
 
     updateSummaryText();
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/stdstring.hui
+++ b/src/gui/keywordwidgets/stdstring.hui
@@ -30,8 +30,8 @@ class StringKeywordWidget : public QLineEdit, public KeywordWidgetBase
     void lineEditTextChanged(const QString &text);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/stdstring_funcs.cpp
+++ b/src/gui/keywordwidgets/stdstring_funcs.cpp
@@ -24,7 +24,7 @@ void StringKeywordWidget::lineEditTextChanged(const QString &text)
 
     keyword_->data() = qPrintable(text);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/vec3double.h
+++ b/src/gui/keywordwidgets/vec3double.h
@@ -36,8 +36,8 @@ class Vec3DoubleKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_Spin3_valueChanged(double value);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/vec3double_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3double_funcs.cpp
@@ -60,7 +60,7 @@ void Vec3DoubleKeywordWidget::on_Spin1_valueChanged(double value)
     newVec.x = value;
     keyword_->setData(newVec);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value changed
@@ -73,7 +73,7 @@ void Vec3DoubleKeywordWidget::on_Spin2_valueChanged(double value)
     newVec.y = value;
     keyword_->setData(newVec);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value changed
@@ -86,7 +86,7 @@ void Vec3DoubleKeywordWidget::on_Spin3_valueChanged(double value)
     newVec.z = value;
     keyword_->setData(newVec);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/vec3integer.h
+++ b/src/gui/keywordwidgets/vec3integer.h
@@ -37,8 +37,8 @@ class Vec3IntegerKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_Spin3_valueChanged(int value);
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/vec3integer_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3integer_funcs.cpp
@@ -54,7 +54,7 @@ void Vec3IntegerKeywordWidget::on_Spin1_valueChanged(int value)
     newVec.x = value;
     keyword_->setData(newVec);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value changed
@@ -67,7 +67,7 @@ void Vec3IntegerKeywordWidget::on_Spin2_valueChanged(int value)
     newVec.y = value;
     keyword_->setData(newVec);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 // Spin box value changed
@@ -80,7 +80,7 @@ void Vec3IntegerKeywordWidget::on_Spin3_valueChanged(int value)
     newVec.z = value;
     keyword_->setData(newVec);
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 /*
  * Update

--- a/src/gui/keywordwidgets/vec3nodevalue.h
+++ b/src/gui/keywordwidgets/vec3nodevalue.h
@@ -40,8 +40,8 @@ class Vec3NodeValueKeywordWidget : public QWidget, public KeywordWidgetBase
     void on_ValueCEdit_returnPressed();
 
     signals:
-    // Keyword value changed
-    void keywordValueChanged(int flags);
+    // Keyword data changed
+    void keywordDataChanged(int flags);
 
     /*
      * Update

--- a/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
@@ -34,7 +34,7 @@ void Vec3NodeValueKeywordWidget::on_ValueAEdit_editingFinished()
     keyword_->setData(0, qPrintable(ui_.ValueAEdit->text()));
     ui_.ValueAValidIndicator->setOK(keyword_->data().x.isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void Vec3NodeValueKeywordWidget::on_ValueAEdit_returnPressed()
@@ -45,7 +45,7 @@ void Vec3NodeValueKeywordWidget::on_ValueAEdit_returnPressed()
     keyword_->setData(0, qPrintable(ui_.ValueAEdit->text()));
     ui_.ValueAValidIndicator->setOK(keyword_->data().x.isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void Vec3NodeValueKeywordWidget::on_ValueBEdit_editingFinished()
@@ -56,7 +56,7 @@ void Vec3NodeValueKeywordWidget::on_ValueBEdit_editingFinished()
     keyword_->setData(1, qPrintable(ui_.ValueBEdit->text()));
     ui_.ValueBValidIndicator->setOK(keyword_->data().y.isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void Vec3NodeValueKeywordWidget::on_ValueBEdit_returnPressed()
@@ -67,7 +67,7 @@ void Vec3NodeValueKeywordWidget::on_ValueBEdit_returnPressed()
     keyword_->setData(1, qPrintable(ui_.ValueBEdit->text()));
     ui_.ValueBValidIndicator->setOK(keyword_->data().y.isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void Vec3NodeValueKeywordWidget::on_ValueCEdit_editingFinished()
@@ -78,7 +78,7 @@ void Vec3NodeValueKeywordWidget::on_ValueCEdit_editingFinished()
     keyword_->setData(2, qPrintable(ui_.ValueCEdit->text()));
     ui_.ValueCValidIndicator->setOK(keyword_->data().z.isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 void Vec3NodeValueKeywordWidget::on_ValueCEdit_returnPressed()
@@ -89,7 +89,7 @@ void Vec3NodeValueKeywordWidget::on_ValueCEdit_returnPressed()
     keyword_->setData(2, qPrintable(ui_.ValueCEdit->text()));
     ui_.ValueCValidIndicator->setOK(keyword_->data().z.isValid());
 
-    emit(keywordValueChanged(keyword_->optionMask()));
+    emit(keywordDataChanged(keyword_->signalMask()));
 }
 
 /*

--- a/src/gui/keywordwidgets/widget.hui
+++ b/src/gui/keywordwidgets/widget.hui
@@ -39,11 +39,9 @@ class KeywordsWidget : public QToolBox
      */
     private slots:
     // Keyword data changed
-    void keywordDataChanged(int flags);
+    void keywordDataChanged(int keywordSignalMask);
 
     signals:
-    // Displayed keyword widget value / data changed
-    void dataModified();
-    // Set-up in encompassing class required after keyword change
-    void setUpRequired();
+    // Keyword has been modified
+    void keywordChanged(int keywordSignalMask);
 };

--- a/src/gui/keywordwidgets/widget_funcs.cpp
+++ b/src/gui/keywordwidgets/widget_funcs.cpp
@@ -46,7 +46,7 @@ void KeywordsWidget::setUp(KeywordStore &keywords, const CoreData &coreData)
             }
 
             // Connect signals
-            connect(widget, SIGNAL(keywordValueChanged(int)), this, SLOT(keywordDataChanged(int)));
+            connect(widget, SIGNAL(keywordDataChanged(int)), this, SLOT(keywordDataChanged(int)));
 
             // Create a label and add it and the widget to our layout
             auto *nameLabel = new QLabel(QString::fromStdString(std::string(keyword->name())));
@@ -79,12 +79,4 @@ void KeywordsWidget::updateControls()
  */
 
 // Keyword data changed
-void KeywordsWidget::keywordDataChanged(int flags)
-{
-    // Always emit the 'dataModified' signal
-    emit(dataModified());
-
-    // Set-up of encompassing class required?
-    if (flags & KeywordBase::ModificationRequiresSetUpOption)
-        emit(setUpRequired());
-}
+void KeywordsWidget::keywordDataChanged(int keywordSignalMask) { emit(keywordChanged(keywordSignalMask)); }

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -39,10 +39,6 @@ class ModuleControlWidget : public QWidget
     // Associated Module
     Module *module_;
 
-    private slots:
-    // Run the set-up stage of the associated Module
-    void setUpModule();
-
     public:
     // Set target Module to display
     void setModule(Module *module, Dissolve *dissolve);
@@ -76,10 +72,7 @@ class ModuleControlWidget : public QWidget
     void on_ModuleOutputButton_clicked(bool checked);
     void on_EnabledButton_clicked(bool checked);
     void on_FrequencySpin_valueChanged(int value);
-    // Keyword data for Module has been modified
-    void keywordDataModified();
-    // Target keyword data changed
-    void targetKeywordDataChanged(int flags);
+    void moduleKeywordChanged(int signalMask);
 
     signals:
     // Notify that the Module's data has been modified in some way

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -21,8 +21,7 @@ ModuleControlWidget::ModuleControlWidget(QWidget *parent)
     moduleWidget_ = nullptr;
 
     // Connect signals from keywords widget
-    connect(ui_.ModuleKeywordsWidget, SIGNAL(dataModified()), this, SLOT(keywordDataModified()));
-    connect(ui_.ModuleKeywordsWidget, SIGNAL(setUpRequired()), this, SLOT(setUpModule()));
+    connect(ui_.ModuleKeywordsWidget, SIGNAL(keywordChanged(int)), this, SLOT(moduleKeywordChanged(int)));
 
     // Set event filtering so that we do not blindly accept mouse wheel events in the frequency spin (problematic since we
     // will exist in a QScrollArea)
@@ -57,7 +56,7 @@ void ModuleControlWidget::setModule(Module *module, Dissolve *dissolve)
                 throw(std::runtime_error(fmt::format("No widget created for keyword '{}'.\n", keyword->name())));
 
             // Connect it up
-            connect(widget, SIGNAL(keywordValueChanged(int)), this, SLOT(targetKeywordDataChanged(int)));
+            connect(widget, SIGNAL(keywordDataChanged(int)), this, SLOT(moduleKeywordChanged(int)));
 
             // Create the label
             auto *nameLabel = new QLabel(QString::fromStdString(std::string(keyword->name())));
@@ -91,19 +90,6 @@ void ModuleControlWidget::setModule(Module *module, Dissolve *dissolve)
 
 // Return target Module for the widget
 Module *ModuleControlWidget::module() const { return module_; }
-
-// Run the set-up stage of the associated Module
-void ModuleControlWidget::setUpModule()
-{
-    if ((!module_) || (!dissolve_))
-        return;
-
-    // Run the Module's set-up stage
-    module_->setUp(*dissolve_, dissolve_->worldPool());
-
-    if (moduleWidget_)
-        moduleWidget_->updateControls(ModuleWidget::UpdateType::Normal);
-}
 
 /*
  * Update
@@ -195,11 +181,8 @@ void ModuleControlWidget::on_FrequencySpin_valueChanged(int value)
     emit(dataModified());
 }
 
-// Keyword data for Module has been modified
-void ModuleControlWidget::keywordDataModified() { emit(dataModified()); }
-
 // Target keyword data changed
-void ModuleControlWidget::targetKeywordDataChanged(int flags)
+void ModuleControlWidget::moduleKeywordChanged(int signalMask)
 {
     if (refreshLock_.isLocked())
         return;
@@ -207,7 +190,13 @@ void ModuleControlWidget::targetKeywordDataChanged(int flags)
     // Always emit the 'dataModified' signal
     emit(dataModified());
 
-    // Set-up of encompassing class required?
-    if (flags & KeywordBase::ModificationRequiresSetUpOption)
-        setUpModule();
+    // If we have a signal mask set, call the module's setUp() function with it
+    if (signalMask > 0)
+    {
+        module_->setUp(*dissolve_, dissolve_->worldPool(), KeywordSignals(signalMask));
+        if (moduleWidget_)
+            moduleWidget_->updateControls(signalMask & KeywordSignals::RecreateRenderables
+                                              ? ModuleWidget::UpdateType::RecreateRenderables
+                                              : ModuleWidget::UpdateType::Normal);
+    }
 }

--- a/src/keywords/CMakeLists.txt
+++ b/src/keywords/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   optionalint.cpp
   procedure.cpp
   range.cpp
+  signals.cpp
   species.cpp
   speciessite.cpp
   speciessitevector.cpp
@@ -72,6 +73,7 @@ add_library(
   optionalint.h
   procedure.h
   range.h
+  signals.h
   species.h
   speciessite.h
   speciessitevector.h

--- a/src/keywords/base.cpp
+++ b/src/keywords/base.cpp
@@ -20,20 +20,11 @@ void KeywordBase::setBaseInfo(std::string_view name, std::string_view descriptio
 // Return typeindex for the keyword
 const std::type_index KeywordBase::typeIndex() const { return typeIndex_; }
 
-// Set option mask
-void KeywordBase::setOptionMask(int optionMask) { optionMask_ = optionMask; }
-
 // Return keyword name
 std::string_view KeywordBase::name() const { return name_; }
 
 // Return keyword description
 std::string_view KeywordBase::description() const { return description_; }
-
-// Return keyword option mask
-int KeywordBase::optionMask() const { return optionMask_; }
-
-// Return whether specified option is set
-bool KeywordBase::isOptionSet(KeywordOption opt) const { return (optionMask_ & opt); }
 
 /*
  * Arguments

--- a/src/keywords/base.cpp
+++ b/src/keywords/base.cpp
@@ -48,6 +48,16 @@ bool KeywordBase::validNArgs(int nArgsProvided) const
 }
 
 /*
+ * GUI Signalling
+ */
+
+// Set signals to be emitted (via Qt) when editing this keyword in the GUI
+void KeywordBase::setSignalMask(int mask) { signals_ = mask; }
+
+// Return signals to be emitted (via Qt) when editing this keyword in the GUI
+KeywordSignals KeywordBase::signalMask() const { return signals_; }
+
+/*
  * Object Management
  */
 

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -7,6 +7,7 @@
 #include "procedure/nodes/aliases.h"
 #include <memory>
 #include <optional>
+#include <string>
 #include <typeindex>
 #include <vector>
 

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -48,8 +48,6 @@ class KeywordBase
     std::string name_;
     // Description of keyword, if any
     std::string description_;
-    // Keyword option mask
-    int optionMask_{NoOptions};
 
     public:
     // Set base keyword information
@@ -62,10 +60,6 @@ class KeywordBase
     std::string_view name() const;
     // Return keyword description
     std::string_view description() const;
-    // Return keyword option mask
-    int optionMask() const;
-    // Return whether specified option is set
-    bool isOptionSet(KeywordOption opt) const;
 
     /*
      * Arguments

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
+#include "keywords/signals.h"
 #include "procedure/nodes/aliases.h"
-#include "templates/reflist.h"
-#include "templates/vector3.h"
 #include <memory>
 #include <optional>
 #include <typeindex>
+#include <vector>
 
 // Forward Declarations
 class AtomType;
@@ -31,16 +31,6 @@ class KeywordBase
     /*
      * Keyword Description
      */
-    public:
-    // Keyword Options
-    enum KeywordOption
-    {
-        NoOptions = 0,           /* Keyword has no options set */
-        InRestartFileOption = 1, /* Keyword should have its data written to the restart file */
-        ModificationRequiresSetUpOption =
-            2 /* Modifying the keyword's data requires that the owning object requires setting up */
-    };
-
     private:
     // Type index of derived class
     const std::type_index typeIndex_;
@@ -87,6 +77,19 @@ class KeywordBase
         Failed = 0,
         Success = 1
     };
+
+    /*
+     * GUI Signalling
+     */
+    private:
+    // Signals to be emitted (via Qt) when editing this keyword in the GUI
+    KeywordSignals signals_;
+
+    public:
+    // Set signals to be emitted (via Qt) when editing this keyword in the GUI
+    void setSignalMask(int signalMask);
+    // Return signals to be emitted (via Qt) when editing this keyword in the GUI
+    KeywordSignals signalMask() const;
 
     /*
      * Object Management

--- a/src/keywords/enumoptions.h
+++ b/src/keywords/enumoptions.h
@@ -32,13 +32,6 @@ class EnumOptionsBaseKeyword : public KeywordBase
     virtual int enumerationByIndex() const = 0;
     // Set new option index, informing KeywordBase
     virtual void setEnumerationByIndex(int optionIndex) = 0;
-
-    /*
-     * Access to KeywordBase
-     */
-    public:
-    // Return option mask for keyword
-    virtual int optionMask() const = 0;
 };
 
 // Keyword based on EnumOptions
@@ -112,11 +105,4 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword
     };
     // Set new option index
     void setEnumerationByIndex(int optionIndex) override { data_ = optionData_.enumerationByIndex(optionIndex); }
-
-    /*
-     * Access to KeywordBase
-     */
-    public:
-    // Return option mask for keyword
-    int optionMask() const override { return KeywordBase::optionMask(); }
 };

--- a/src/keywords/signals.cpp
+++ b/src/keywords/signals.cpp
@@ -17,10 +17,13 @@ KeywordSignals &KeywordSignals::operator=(int signalMask)
 
 void KeywordSignals::operator+=(int signalMask) { signalMask_ |= signalMask; }
 
-KeywordSignals::operator int() const { return signalMask_; }
+KeywordSignals::operator int() const { return signalMask_.to_ulong(); }
 
 // Return true if the specified signal is set
-bool KeywordSignals::set(KeywordSignal keywordSignal) const { return signalMask_ & keywordSignal; }
+bool KeywordSignals::set(KeywordSignal keywordSignal) const { return signalMask_.test(keywordSignal); }
 
 // Return true if the specified signal is set, or if none are set at all
-bool KeywordSignals::setOrNull(KeywordSignal keywordSignal) const { return signalMask_ == 0 || (signalMask_ & keywordSignal); }
+bool KeywordSignals::setOrNone(KeywordSignal keywordSignal) const
+{
+    return signalMask_.none() || signalMask_.test(keywordSignal);
+}

--- a/src/keywords/signals.cpp
+++ b/src/keywords/signals.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#include "keywords/signals.h"
+
+KeywordSignals::KeywordSignals() : signalMask_(0) {}
+
+KeywordSignals::KeywordSignals(int signalMask) : signalMask_(signalMask) {}
+
+KeywordSignals::KeywordSignals(const KeywordSignals &source) { signalMask_ = source.signalMask_; }
+
+KeywordSignals &KeywordSignals::operator=(int signalMask)
+{
+    signalMask_ = signalMask;
+    return *this;
+}
+
+void KeywordSignals::operator+=(int signalMask) { signalMask_ |= signalMask; }
+
+KeywordSignals::operator int() const { return signalMask_; }
+
+// Return true if the specified signal is set
+bool KeywordSignals::set(KeywordSignal keywordSignal) const { return signalMask_ & keywordSignal; }
+
+// Return true if the specified signal is set, or if none are set at all
+bool KeywordSignals::setOrNull(KeywordSignal keywordSignal) const { return signalMask_ == 0 || (signalMask_ & keywordSignal); }

--- a/src/keywords/signals.h
+++ b/src/keywords/signals.h
@@ -3,33 +3,36 @@
 
 #pragma once
 
+#include <bitset>
+
 // Keyword Signals
 class KeywordSignals
 {
     public:
     KeywordSignals();
+    ~KeywordSignals() = default;
     explicit KeywordSignals(int signalMask);
     KeywordSignals(const KeywordSignals &source);
     KeywordSignals &operator=(int signalMask);
     void operator+=(int signalMask);
     operator int() const;
-    ~KeywordSignals() = default;
 
     public:
     enum KeywordSignal
     {
-        ClearData = 1,
-        RecreateRenderables = 2,
-        ReloadExternalData = 4
+        ClearData,
+        RecreateRenderables,
+        ReloadExternalData,
+        nKeywordSignals
     };
 
     private:
     // Signals to be emitted (via Qt) when editing this keyword in the GUI
-    int signalMask_{0};
+    std::bitset<nKeywordSignals> signalMask_;
 
     public:
     // Return true if the specified signal is set
     bool set(KeywordSignal keywordSignal) const;
     // Return true if the specified signal is set, or if none are set at all
-    bool setOrNull(KeywordSignal keywordSignal) const;
+    bool setOrNone(KeywordSignal keywordSignal) const;
 };

--- a/src/keywords/signals.h
+++ b/src/keywords/signals.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Team Dissolve and contributors
+
+#pragma once
+
+// Keyword Signals
+class KeywordSignals
+{
+    public:
+    KeywordSignals();
+    explicit KeywordSignals(int signalMask);
+    KeywordSignals(const KeywordSignals &source);
+    KeywordSignals &operator=(int signalMask);
+    void operator+=(int signalMask);
+    operator int() const;
+    ~KeywordSignals() = default;
+
+    public:
+    enum KeywordSignal
+    {
+        ClearData = 1,
+        RecreateRenderables = 2,
+        ReloadExternalData = 4
+    };
+
+    private:
+    // Signals to be emitted (via Qt) when editing this keyword in the GUI
+    int signalMask_{0};
+
+    public:
+    // Return true if the specified signal is set
+    bool set(KeywordSignal keywordSignal) const;
+    // Return true if the specified signal is set, or if none are set at all
+    bool setOrNull(KeywordSignal keywordSignal) const;
+};

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -85,13 +85,16 @@ const KeywordBase *KeywordStore::find(std::string_view name) const
 }
 
 // Return keywords
-const std::map<std::string_view, KeywordBase *> KeywordStore::keywords() const { return keywords_; }
+const std::map<std::string_view, KeywordBase *> &KeywordStore::keywords() const { return keywords_; }
 
 // Return "Target" group keywords
-const std::vector<KeywordBase *> KeywordStore::targetsGroup() const { return targetsGroup_; }
+const std::vector<KeywordBase *> &KeywordStore::targetsGroup() const { return targetsGroup_; }
+
+// Return restartable keywords
+const std::vector<KeywordBase *> &KeywordStore::restartables() const { return restartables_; }
 
 // Return keyword group mappings
-const std::vector<std::pair<std::string_view, std::vector<KeywordBase *>>> KeywordStore::displayGroups() const
+const std::vector<std::pair<std::string_view, std::vector<KeywordBase *>>> &KeywordStore::displayGroups() const
 {
     return displayGroups_;
 };

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -124,6 +124,8 @@ class KeywordStore
     std::vector<KeywordBase *> targetsGroup_;
     // Keyword group mappings
     std::vector<std::pair<std::string_view, std::vector<KeywordBase *>>> displayGroups_;
+    // Keywords to be stored in the restart file
+    std::vector<KeywordBase *> restartables_;
 
     public:
     // Add keyword (no group)
@@ -145,14 +147,11 @@ class KeywordStore
         return k;
     }
     // Add target keyword
-    template <class K, typename... Args>
-    KeywordBase *addTarget(std::string_view name, std::string_view description, Args &&... args)
+    template <class K, typename... Args> void addTarget(std::string_view name, std::string_view description, Args &&... args)
     {
         auto *k = addKeyword<K>(name, description, args...);
 
         targetsGroup_.push_back(k);
-
-        return k;
     }
     // Add keyword (displaying in named group)
     template <class K, typename... Args>
@@ -169,15 +168,24 @@ class KeywordStore
 
         return k;
     }
+    // Add keyword (displaying in named group) and capture in restart file
+    template <class K, typename... Args>
+    KeywordBase *addRestartable(std::string_view displayGroup, std::string_view name, std::string_view description,
+                                Args &&... args)
+    {
+        return restartables_.emplace_back(add<K>(displayGroup, name, description, args...));
+    }
     // Find named keyword
     KeywordBase *find(std::string_view name);
     const KeywordBase *find(std::string_view name) const;
     // Return keywords
-    const std::map<std::string_view, KeywordBase *> keywords() const;
+    const std::map<std::string_view, KeywordBase *> &keywords() const;
     // Return "Target" group keywords
-    const std::vector<KeywordBase *> targetsGroup() const;
+    const std::vector<KeywordBase *> &targetsGroup() const;
+    // Return restartable keywords
+    const std::vector<KeywordBase *> &restartables() const;
     // Return keyword group mappings
-    const std::vector<std::pair<std::string_view, std::vector<KeywordBase *>>> displayGroups() const;
+    const std::vector<std::pair<std::string_view, std::vector<KeywordBase *>>> &displayGroups() const;
 
     /*
      * Set / Get

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -602,15 +602,9 @@ bool Dissolve::saveRestart(std::string_view filename)
     // Module Keyword Data
     for (const auto *module : Module::instances())
     {
-        for (auto &[name, keyword] : module->keywords().keywords())
-        {
-            // If the keyword is not flagged to be saved in the restart file, skip it
-            if (!keyword->isOptionSet(KeywordBase::InRestartFileOption))
-                continue;
-
-            if (!keyword->serialise(parser, fmt::format("Keyword  {}  {}  ", module->uniqueName(), name)))
+        for (auto &keyword : module->keywords().restartables())
+            if (!keyword->serialise(parser, fmt::format("Keyword  {}  {}  ", module->uniqueName(), keyword->name())))
                 return false;
-        }
     }
 
     // Processing Module Data

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -101,7 +101,7 @@ bool Module::isDisabled() const { return !enabled_; }
 bool Module::process(Dissolve &dissolve, ProcessPool &procPool) { return false; }
 
 // Run set-up stage
-bool Module::setUp(Dissolve &dissolve, ProcessPool &procPool) { return true; }
+bool Module::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) { return true; }
 
 // Run main processing stage
 bool Module::executeProcessing(Dissolve &dissolve, ProcessPool &procPool)

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -88,7 +88,7 @@ class Module
 
     public:
     // Run set-up stage
-    virtual bool setUp(Dissolve &dissolve, ProcessPool &procPool);
+    virtual bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals = {});
     // Run main processing stage
     bool executeProcessing(Dissolve &dissolve, ProcessPool &procPool);
 

--- a/src/modules/atomshake/atomshake.cpp
+++ b/src/modules/atomshake/atomshake.cpp
@@ -19,8 +19,8 @@ AtomShakeModule::AtomShakeModule() : Module("AtomShake")
         "Interatomic cutoff distance to use for energy calculation (0.0 to use pair potential range)", cutoffDistance_, 0.0,
         std::nullopt, 0.1, "Use PairPotential Range");
     keywords_.add<IntegerKeyword>("Control", "ShakesPerAtom", "Number of shakes to attempt per atom", nShakesPerAtom_, 1);
-    keywords_.add<DoubleKeyword>("Control", "StepSize", "Step size in Angstroms to use in Monte Carlo moves", stepSize_, 0.001)
-        ->setOptionMask(KeywordBase::InRestartFileOption);
+    keywords_.addRestartable<DoubleKeyword>("Control", "StepSize", "Step size in Angstroms to use in Monte Carlo moves",
+                                            stepSize_, 0.001);
     keywords_.add<DoubleKeyword>("Control", "StepSizeMax", "Maximum allowed value for step size, in Angstroms", stepSizeMax_,
                                  0.01);
     keywords_.add<DoubleKeyword>("Control", "StepSizeMin", "Minimum allowed value for step size, in Angstroms", stepSizeMin_,

--- a/src/modules/calculate_angle/angle.h
+++ b/src/modules/calculate_angle/angle.h
@@ -79,7 +79,7 @@ class CalculateAngleModule : public Module
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -9,7 +9,7 @@
 #include "procedure/nodes/select.h"
 
 // Run set-up stage
-bool CalculateAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { return true; }
+bool CalculateAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) { return true; }
 
 // Run main processing
 bool CalculateAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)

--- a/src/modules/calculate_avgmol/avgmol.cpp
+++ b/src/modules/calculate_avgmol/avgmol.cpp
@@ -12,7 +12,7 @@ CalculateAvgMolModule::CalculateAvgMolModule() : Module("CalculateAvgMol")
     keywords_
         .add<SpeciesSiteKeyword>("Control", "Site", "Target site about which to calculate average species geometry",
                                  targetSite_, true)
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
 
     targetSpecies_ = nullptr;
 }

--- a/src/modules/calculate_avgmol/avgmol.h
+++ b/src/modules/calculate_avgmol/avgmol.h
@@ -47,7 +47,7 @@ class CalculateAvgMolModule : public Module
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -7,7 +7,7 @@
 #include "templates/algorithms.h"
 
 // Run set-up stage
-bool CalculateAvgMolModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
+bool CalculateAvgMolModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
     // Clear species
     averageSpecies_.clear();

--- a/src/modules/calculate_axisangle/axisangle.h
+++ b/src/modules/calculate_axisangle/axisangle.h
@@ -57,7 +57,7 @@ class CalculateAxisAngleModule : public Module
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -9,7 +9,7 @@
 #include "procedure/nodes/select.h"
 
 // Run set-up stage
-bool CalculateAxisAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { return true; }
+bool CalculateAxisAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) { return true; }
 
 // Run main processing
 bool CalculateAxisAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)

--- a/src/modules/calculate_dangle/dangle.h
+++ b/src/modules/calculate_dangle/dangle.h
@@ -59,7 +59,7 @@ class CalculateDAngleModule : public Module
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -9,7 +9,7 @@
 #include "procedure/nodes/select.h"
 
 // Run set-up stage
-bool CalculateDAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { return true; }
+bool CalculateDAngleModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) { return true; }
 
 // Run main processing
 bool CalculateDAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)

--- a/src/modules/calculate_rdf/process.cpp
+++ b/src/modules/calculate_rdf/process.cpp
@@ -9,7 +9,7 @@
 #include "procedure/nodes/sequence.h"
 
 // Run set-up stage
-bool CalculateRDFModule::setUp(Dissolve &dissolve, ProcessPool &procPool) { return true; }
+bool CalculateRDFModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) { return true; }
 
 // Run main processing
 bool CalculateRDFModule::process(Dissolve &dissolve, ProcessPool &procPool)

--- a/src/modules/calculate_rdf/rdf.h
+++ b/src/modules/calculate_rdf/rdf.h
@@ -53,7 +53,7 @@ class CalculateRDFModule : public Module
      */
     private:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 };

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -84,5 +84,5 @@ class EnergyModule : public Module
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 };

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -11,7 +11,7 @@
 #include "modules/energy/energy.h"
 
 // Run set-up stage
-bool EnergyModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
+bool EnergyModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
     // For each Configuration target, add a flag to its moduleData (which is *not* stored in the restart file) that we are
     // targeting it

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -165,5 +165,5 @@ class EPSRModule : public Module
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 };

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -28,7 +28,7 @@
 #include <functional>
 
 // Run set-up stage
-bool EPSRModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
+bool EPSRModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
     // Check for exactly one Configuration referenced through target modules
     targetConfiguration_ = nullptr;

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -49,7 +49,7 @@ class ForcesModule : public Module
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 
     /*
      * Functions

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -11,7 +11,7 @@
 #include "modules/import_trajectory/importtraj.h"
 
 // Run set-up stage
-bool ForcesModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
+bool ForcesModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
     if (referenceForces_.hasFilename())
     {

--- a/src/modules/intrashake/intrashake.cpp
+++ b/src/modules/intrashake/intrashake.cpp
@@ -27,9 +27,8 @@ IntraShakeModule::IntraShakeModule() : Module("IntraShake")
 
     // Bonds
     keywords_.add<BoolKeyword>("Bonds", "AdjustBonds", "Whether Bonds in the molecule should be shaken", adjustBonds_);
-    keywords_
-        .add<DoubleKeyword>("Bonds", "BondStepSize", "Step size for Bond adjustments (Angstroms)", bondStepSize_, 0.001, 1.0)
-        ->setOptionMask(KeywordBase::InRestartFileOption);
+    keywords_.addRestartable<DoubleKeyword>("Bonds", "BondStepSize", "Step size for Bond adjustments (Angstroms)",
+                                            bondStepSize_, 0.001, 1.0);
     keywords_.add<DoubleKeyword>("Bonds", "BondStepSizeMin", "Minimum step size for Bond adjustments (Angstroms)",
                                  bondStepSizeMin_, 0.001, 1.0);
     keywords_.add<DoubleKeyword>("Bonds", "BondStepSizeMax", "Maximum step size for Bond adjustments (Angstroms)",
@@ -37,9 +36,8 @@ IntraShakeModule::IntraShakeModule() : Module("IntraShake")
 
     // Angles
     keywords_.add<BoolKeyword>("Angles", "AdjustAngles", "Whether Angles in the molecule should be shaken", adjustAngles_);
-    keywords_
-        .add<DoubleKeyword>("Angles", "AngleStepSize", "Step size for Angle adjustments (degrees)", angleStepSize_, 0.01, 45.0)
-        ->setOptionMask(KeywordBase::InRestartFileOption);
+    keywords_.addRestartable<DoubleKeyword>("Angles", "AngleStepSize", "Step size for Angle adjustments (degrees)",
+                                            angleStepSize_, 0.01, 45.0);
     keywords_.add<DoubleKeyword>("Angles", "AngleStepSizeMin", "Minimum step size for Angle adjustments (degrees)",
                                  angleStepSizeMin_, 0.01, 45.0);
     keywords_.add<DoubleKeyword>("Angles", "AngleStepSizeMax", "Maximum step size for Angle adjustments (degrees)",
@@ -48,10 +46,8 @@ IntraShakeModule::IntraShakeModule() : Module("IntraShake")
     // Torsions
     keywords_.add<BoolKeyword>("Torsions", "AdjustTorsions", "Whether Torsions in the molecule should be shaken",
                                adjustTorsions_);
-    keywords_
-        .add<DoubleKeyword>("Torsions", "TorsionStepSize", "Step size for Torsion adjustments (degrees)", torsionStepSize_,
-                            0.01, 45.0)
-        ->setOptionMask(KeywordBase::InRestartFileOption);
+    keywords_.addRestartable<DoubleKeyword>("Torsions", "TorsionStepSize", "Step size for Torsion adjustments (degrees)",
+                                            torsionStepSize_, 0.01, 45.0);
     keywords_.add<DoubleKeyword>("Torsions", "TorsionStepSizeMin", "Minimum step size for Torsion adjustments (degrees)",
                                  torsionStepSizeMin_, 0.01, 45.0);
     keywords_.add<DoubleKeyword>("Torsions", "TorsionStepSizeMax", "Maximum step size for Torsion adjustments (degrees)",

--- a/src/modules/molshake/molshake.cpp
+++ b/src/modules/molshake/molshake.cpp
@@ -23,20 +23,16 @@ MolShakeModule::MolShakeModule() : Module("MolShake")
                                   nShakesPerMolecule_, 1);
     keywords_.add<DoubleKeyword>("Control", "TargetAcceptanceRate", "Target acceptance rate for Monte Carlo moves",
                                  targetAcceptanceRate_, 0.001);
-    keywords_
-        .add<DoubleKeyword>("Control", "RotationStepSize",
-                            "Step size in degrees to use for the rotational component of the Monte Carlo moves",
-                            rotationStepSize_)
-        ->setOptionMask(KeywordBase::InRestartFileOption);
+    keywords_.addRestartable<DoubleKeyword>("Control", "RotationStepSize",
+                                            "Step size in degrees to use for the rotational component of the Monte Carlo moves",
+                                            rotationStepSize_);
     keywords_.add<DoubleKeyword>("Control", "RotationStepSizeMin", "Minimum step size for rotations (degrees)",
                                  rotationStepSizeMin_, 0.001, 180.0);
     keywords_.add<DoubleKeyword>("Control", "RotationStepSizeMax", "Maximum step size for rotations (degrees)",
                                  rotationStepSizeMax_, 0.001, 180.0);
-    keywords_
-        .add<DoubleKeyword>("Control", "TranslationStepSize",
-                            "Step size in Angstroms for the translational component of the Monte Carlo moves",
-                            translationStepSize_, 0.0001, 100.0)
-        ->setOptionMask(KeywordBase::InRestartFileOption);
+    keywords_.addRestartable<DoubleKeyword>("Control", "TranslationStepSize",
+                                            "Step size in Angstroms for the translational component of the Monte Carlo moves",
+                                            translationStepSize_, 0.0001, 100.0);
     keywords_.add<DoubleKeyword>("Control", "TranslationStepSizeMin", "Minimum step size for translations (Angstroms)",
                                  translationStepSizeMin_, 0.0001);
     keywords_.add<DoubleKeyword>("Control", "TranslationStepSizeMax", "Maximum step size for translations (Angstroms)",

--- a/src/modules/neutronsq/neutronsq.cpp
+++ b/src/modules/neutronsq/neutronsq.cpp
@@ -28,27 +28,32 @@ NeutronSQModule::NeutronSQModule() : Module("NeutronSQ")
 
     // Reference Data
     keywords_.add<FileAndFormatKeyword>("Reference Data", "Reference", "F(Q) reference data", referenceFQ_, "EndReference")
-        ->setSignalMask(KeywordSignals::ReloadExternalData);
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
     keywords_
         .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
             "Reference Data", "ReferenceNormalisation", "Normalisation to remove from reference data before use",
             referenceNormalisation_, StructureFactors::normalisationTypes())
-        ->setSignalMask(KeywordSignals::ReloadExternalData);
-    keywords_.add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMin",
-                                         "Minimum Q value to use when Fourier-transforming reference data (0.0 for no minimum)",
-                                         referenceFTQMin_, 0.0, std::nullopt, 0.1, "No Minimum Limit");
-    keywords_.add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMax",
-                                         "Maximum Q value to use when Fourier-transforming reference data (0.0 for no maximum)",
-                                         referenceFTQMax_, 0.0, std::nullopt, 0.1, "No Maximum Limit");
-    keywords_.add<DoubleKeyword>("Reference Data", "ReferenceFTDeltaR",
-                                 "Spacing in r to use when generating the Fourier-transformed data", referenceFTDeltaR_, 1.0e-4,
-                                 1.0);
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
+    keywords_
+        .add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMin",
+                                    "Minimum Q value to use when Fourier-transforming reference data (0.0 for no minimum)",
+                                    referenceFTQMin_, 0.0, std::nullopt, 0.1, "No Minimum Limit")
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
+    keywords_
+        .add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMax",
+                                    "Maximum Q value to use when Fourier-transforming reference data (0.0 for no maximum)",
+                                    referenceFTQMax_, 0.0, std::nullopt, 0.1, "No Maximum Limit")
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
+    keywords_
+        .add<DoubleKeyword>("Reference Data", "ReferenceFTDeltaR",
+                            "Spacing in r to use when generating the Fourier-transformed data", referenceFTDeltaR_, 1.0e-4, 1.0)
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
     keywords_
         .add<EnumOptionsKeyword<WindowFunction::Form>>(
             "Reference Data", "ReferenceWindowFunction",
             "Window function to apply when Fourier-transforming reference S(Q) to g(r)", referenceWindowFunction_,
             WindowFunction::forms())
-        ->setSignalMask(KeywordSignals::ReloadExternalData);
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
 
     // Export
     keywords_.add<BoolKeyword>("Export", "SaveGR", "Save weighted g(r) and G(r)", saveGR_);

--- a/src/modules/neutronsq/neutronsq.cpp
+++ b/src/modules/neutronsq/neutronsq.cpp
@@ -28,12 +28,12 @@ NeutronSQModule::NeutronSQModule() : Module("NeutronSQ")
 
     // Reference Data
     keywords_.add<FileAndFormatKeyword>("Reference Data", "Reference", "F(Q) reference data", referenceFQ_, "EndReference")
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
     keywords_
         .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
             "Reference Data", "ReferenceNormalisation", "Normalisation to remove from reference data before use",
             referenceNormalisation_, StructureFactors::normalisationTypes())
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
     keywords_.add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMin",
                                          "Minimum Q value to use when Fourier-transforming reference data (0.0 for no minimum)",
                                          referenceFTQMin_, 0.0, std::nullopt, 0.1, "No Minimum Limit");
@@ -48,7 +48,7 @@ NeutronSQModule::NeutronSQModule() : Module("NeutronSQ")
             "Reference Data", "ReferenceWindowFunction",
             "Window function to apply when Fourier-transforming reference S(Q) to g(r)", referenceWindowFunction_,
             WindowFunction::forms())
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
 
     // Export
     keywords_.add<BoolKeyword>("Export", "SaveGR", "Save weighted g(r) and G(r)", saveGR_);

--- a/src/modules/neutronsq/neutronsq.h
+++ b/src/modules/neutronsq/neutronsq.h
@@ -84,5 +84,5 @@ class NeutronSQModule : public Module
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 };

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -14,12 +14,12 @@
 #include "modules/sq/sq.h"
 
 // Run set-up stage
-bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
+bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
     /*
      * Load and set up reference data (if a file/format was given)
      */
-    if (referenceFQ_.hasFilename())
+    if (referenceFQ_.hasFilename() && actionSignals.setOrNull(KeywordSignals::ReloadExternalData))
     {
         // Load the data
         Data1D referenceData;

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -19,7 +19,7 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSi
     /*
      * Load and set up reference data (if a file/format was given)
      */
-    if (referenceFQ_.hasFilename() && actionSignals.setOrNull(KeywordSignals::ReloadExternalData))
+    if (referenceFQ_.hasFilename() && actionSignals.setOrNone(KeywordSignals::ReloadExternalData))
     {
         // Load the data
         Data1D referenceData;

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -20,7 +20,7 @@ bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSigna
     /*
      * Load and set up reference data (if a file/format was given)
      */
-    if (referenceFQ_.hasFilename() && actionSignals.setOrNull(KeywordSignals::ReloadExternalData))
+    if (referenceFQ_.hasFilename() && actionSignals.setOrNone(KeywordSignals::ReloadExternalData))
     {
         // Load the data
         Data1D referenceData;

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -15,12 +15,12 @@
 #include "templates/algorithms.h"
 
 // Run set-up stage
-bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool)
+bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
     /*
      * Load and set up reference data (if a file/format was given)
      */
-    if (referenceFQ_.hasFilename())
+    if (referenceFQ_.hasFilename() && actionSignals.setOrNull(KeywordSignals::ReloadExternalData))
     {
         // Load the data
         Data1D referenceData;

--- a/src/modules/xraysq/xraysq.cpp
+++ b/src/modules/xraysq/xraysq.cpp
@@ -26,27 +26,33 @@ XRaySQModule::XRaySQModule() : Module("XRaySQ")
 
     // Reference Data
     keywords_.add<FileAndFormatKeyword>("Reference Data", "Reference", "F(Q) reference data", referenceFQ_, "EndReference")
-        ->setSignalMask(KeywordSignals::ReloadExternalData);
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
     keywords_
         .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
             "Reference Data", "ReferenceNormalisation", "Normalisation to remove from reference data before use",
             referenceNormalisation_, StructureFactors::normalisationTypes())
-        ->setSignalMask(KeywordSignals::ReloadExternalData);
-    keywords_.add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMin",
-                                         "Minimum Q value to use when Fourier-transforming reference data (0.0 for no minimum)",
-                                         referenceFTQMin_, 0.0, std::nullopt, 0.01, "No Minimum Limit");
-    keywords_.add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMax",
-                                         "Maximum Q value to use when Fourier-transforming reference data (0.0 for no maximum)",
-                                         referenceFTQMax_, 0.0, std::nullopt, 0.01, "No Maximum Limit");
-    keywords_.add<DoubleKeyword>("Reference Data", "ReferenceFTDeltaR",
-                                 "Set the spacing in r to use when generating the Fourier-transformed data", referenceFTDeltaR_,
-                                 1.0e-4, 1.0);
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
+    keywords_
+        .add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMin",
+                                    "Minimum Q value to use when Fourier-transforming reference data (0.0 for no minimum)",
+                                    referenceFTQMin_, 0.0, std::nullopt, 0.01, "No Minimum Limit")
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
+    keywords_
+        .add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMax",
+                                    "Maximum Q value to use when Fourier-transforming reference data (0.0 for no maximum)",
+                                    referenceFTQMax_, 0.0, std::nullopt, 0.01, "No Maximum Limit")
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
+    keywords_
+        .add<DoubleKeyword>("Reference Data", "ReferenceFTDeltaR",
+                            "Set the spacing in r to use when generating the Fourier-transformed data", referenceFTDeltaR_,
+                            1.0e-4, 1.0)
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
     keywords_
         .add<EnumOptionsKeyword<WindowFunction::Form>>(
             "Reference Data", "ReferenceWindowFunction",
             "Window function to apply when Fourier-transforming reference S(Q) to g(r)", referenceWindowFunction_,
             WindowFunction::forms())
-        ->setSignalMask(KeywordSignals::ReloadExternalData);
+        ->setSignalMask(KeywordSignals::ReloadExternalData | KeywordSignals::RecreateRenderables);
 
     // Export
     keywords_.add<BoolKeyword>("Export", "SaveFormFactors",

--- a/src/modules/xraysq/xraysq.cpp
+++ b/src/modules/xraysq/xraysq.cpp
@@ -26,12 +26,12 @@ XRaySQModule::XRaySQModule() : Module("XRaySQ")
 
     // Reference Data
     keywords_.add<FileAndFormatKeyword>("Reference Data", "Reference", "F(Q) reference data", referenceFQ_, "EndReference")
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
     keywords_
         .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
             "Reference Data", "ReferenceNormalisation", "Normalisation to remove from reference data before use",
             referenceNormalisation_, StructureFactors::normalisationTypes())
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
     keywords_.add<OptionalDoubleKeyword>("Reference Data", "ReferenceFTQMin",
                                          "Minimum Q value to use when Fourier-transforming reference data (0.0 for no minimum)",
                                          referenceFTQMin_, 0.0, std::nullopt, 0.01, "No Minimum Limit");
@@ -46,7 +46,7 @@ XRaySQModule::XRaySQModule() : Module("XRaySQ")
             "Reference Data", "ReferenceWindowFunction",
             "Window function to apply when Fourier-transforming reference S(Q) to g(r)", referenceWindowFunction_,
             WindowFunction::forms())
-        ->setOptionMask(KeywordBase::ModificationRequiresSetUpOption);
+        ->setSignalMask(KeywordSignals::ReloadExternalData);
 
     // Export
     keywords_.add<BoolKeyword>("Export", "SaveFormFactors",

--- a/src/modules/xraysq/xraysq.h
+++ b/src/modules/xraysq/xraysq.h
@@ -86,5 +86,5 @@ class XRaySQModule : public Module
 
     public:
     // Run set-up stage
-    bool setUp(Dissolve &dissolve, ProcessPool &procPool) override;
+    bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 };


### PR DESCRIPTION
This PR attempts to introduce a suitable mechanism for "reacting" to modifications to keywords when those modifications affect underlying data. In particular, data that may have already been created and stored in the main processing list.

A simple and extensible "signal" enum and class is added, and whose enumerations can be set on individual keywords in order to promote the desired effect when caught by the parent `Module` or `Procedure` (although full implementation of the latter will not be performed until editing is moved off of the custom chart classes - #871).

Rather than implement all probable / possible uses of signals in this PR, exemplar signalling is made on the `NeutronSQ` and `XRaySQ` modules (closes #913). Future required uses will be added as and when required locally in other work.