### PR TITLE
Short-range Parameter Names

### DIFF
--- a/src/base/lineparser.cpp
+++ b/src/base/lineparser.cpp
@@ -819,7 +819,7 @@ bool LineParser::commitCache()
 int LineParser::nArgs() const { return arguments_.size(); }
 
 // Returns the specified argument as a string
-std::string LineParser::args(int i)
+std::string LineParser::args(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {
@@ -830,7 +830,7 @@ std::string LineParser::args(int i)
 }
 
 // Returns the specified argument as a character string view
-std::string_view LineParser::argsv(int i)
+std::string_view LineParser::argsv(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {
@@ -841,7 +841,7 @@ std::string_view LineParser::argsv(int i)
 }
 
 // Returns the specified argument as an integer
-int LineParser::argi(int i)
+int LineParser::argi(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {
@@ -852,7 +852,7 @@ int LineParser::argi(int i)
 }
 
 // Returns the specified argument as a long integer
-long int LineParser::argli(int i)
+long int LineParser::argli(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {
@@ -863,7 +863,7 @@ long int LineParser::argli(int i)
 }
 
 // Returns the specified argument as a double
-double LineParser::argd(int i)
+double LineParser::argd(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {
@@ -895,7 +895,7 @@ double LineParser::argd(int i)
 }
 
 // Returns the specified argument as a bool
-bool LineParser::argb(int i)
+bool LineParser::argb(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {
@@ -906,7 +906,7 @@ bool LineParser::argb(int i)
 }
 
 // Return the specified and next two arguments as a Vec3<int>
-Vec3<int> LineParser::arg3i(int i)
+Vec3<int> LineParser::arg3i(int i) const
 {
     if ((i < 0) || (i >= (nArgs() - 2)))
     {
@@ -917,7 +917,7 @@ Vec3<int> LineParser::arg3i(int i)
 }
 
 // Return the specified and next two arguments as a Vec3<double>
-Vec3<double> LineParser::arg3d(int i)
+Vec3<double> LineParser::arg3d(int i) const
 {
     if ((i < 0) || (i >= (nArgs() - 2)))
     {
@@ -928,7 +928,7 @@ Vec3<double> LineParser::arg3d(int i)
 }
 
 // Return a vector of double parameters, starting from the specified argument
-std::vector<double> LineParser::argvd(int i)
+std::vector<double> LineParser::argvd(int i) const
 {
     if ((i < 0) || (i >= nArgs()))
     {

--- a/src/base/lineparser.h
+++ b/src/base/lineparser.h
@@ -220,23 +220,23 @@ class LineParser
     // Returns number of arguments grabbed from last parse
     int nArgs() const;
     // Returns the specified argument as a string
-    std::string args(int i);
+    std::string args(int i) const;
     // Returns the specified argument as a string view
-    std::string_view argsv(int i);
+    std::string_view argsv(int i) const;
     // Returns the specified argument as an integer
-    int argi(int i);
+    int argi(int i) const;
     // Returns the specified argument as a long integer
-    long int argli(int i);
+    long int argli(int i) const;
     // Returns the specified argument as a double
-    double argd(int i);
+    double argd(int i) const;
     // Returns the specified argument as a bool
-    bool argb(int i);
+    bool argb(int i) const;
     // Return the specified and next two arguments as a Vec3<int>
-    Vec3<int> arg3i(int i);
+    Vec3<int> arg3i(int i) const;
     // Return the specified and next two arguments as a Vec3<double>
-    Vec3<double> arg3d(int i);
+    Vec3<double> arg3d(int i) const;
     // Return a vector of double parameters, starting from the specified argument
-    std::vector<double> argvd(int i);
+    std::vector<double> argvd(int i) const;
     // Returns whether the specified argument exists
     bool hasArg(int i) const;
 };

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(
   empiricalformula.h
   energykernel.h
   forcekernel.h
+  interactionpotential.h
   isotopedata.h
   isotopologue.h
   isotopologues.h

--- a/src/classes/atomtype.h
+++ b/src/classes/atomtype.h
@@ -3,8 +3,29 @@
 
 #pragma once
 
+#include "base/enumoptions.h"
+#include "classes/interactionpotential.h"
 #include "data/elements.h"
-#include "data/ff/ff.h"
+
+// Short-range functional forms
+class ShortRangeFunctions
+{
+    public:
+    enum class Form
+    {
+        None,                 /* No short-range dispersive forces */
+        LennardJones,         /* Lennard-Jones 12-6 form with Lorentz-Berthelot combination rules */
+        LennardJonesGeometric /* Lennard-Jones 12-6 form with Geometric combination rules */
+    };
+    // Return enum options for form
+    static EnumOptions<Form> forms();
+    // Return parameters for specified form
+    static const std::vector<std::string> &parameters(Form form);
+    // Return nth parameter for the given form
+    static std::string parameter(Form form, int n);
+    // Return index of parameter in the given form
+    static std::optional<int> parameterIndex(Form form, std::string_view name);
+};
 
 // AtomType Definition
 class AtomType
@@ -36,26 +57,17 @@ class AtomType
      * Interaction Parameters
      */
     private:
-    // Short-range interaction type
-    Forcefield::ShortRangeType shortRangeType_{Forcefield::ShortRangeType::Undefined};
-    // Vector of parameters for short-range potential
-    std::vector<double> parameters_;
+    // Short-range interaction potential
+    InteractionPotential<ShortRangeFunctions> interactionPotential_;
     // Atomic charge
     double charge_{0.0};
     // Index of this type in the master type index
     int index_{-1};
 
     public:
-    // Set short-range interaction type
-    void setShortRangeType(Forcefield::ShortRangeType srType);
-    // Return short-range interaction type
-    Forcefield::ShortRangeType shortRangeType() const;
-    // Set short-range parameters vector
-    void setShortRangeParameters(const std::vector<double> &parameters);
-    // Set single short-range parameter
-    void setShortRangeParameter(int index, double parameter);
-    // Return short-range parameters vector
-    const std::vector<double> &shortRangeParameters() const;
+    // Return short-range interaction potential
+    InteractionPotential<ShortRangeFunctions> &interactionPotential();
+    const InteractionPotential<ShortRangeFunctions> &interactionPotential() const;
     // Set atomic charge
     void setCharge(double q);
     // Return atomic charge

--- a/src/classes/interactionpotential.h
+++ b/src/classes/interactionpotential.h
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/lineparser.h"
+#include "base/messenger.h"
+#include "base/sysfunc.h"
+#include "templates/algorithms.h"
+#include <string>
+#include <vector>
+
+// Interaction Potential Storage
+template <class Functions> class InteractionPotential
+{
+    public:
+    explicit InteractionPotential(typename Functions::Form form) : form_(form){};
+    virtual ~InteractionPotential() = default;
+    InteractionPotential(const InteractionPotential &source) { (*this) = source; }
+    InteractionPotential(InteractionPotential &&source) = delete;
+    InteractionPotential &operator=(const InteractionPotential &source)
+    {
+        parameters_.clear();
+        parameters_.resize(source.parameters_.size());
+        std::copy(source.parameters_.begin(), source.parameters_.end(), parameters_.begin());
+        form_ = source.form_;
+
+        return *this;
+    }
+    InteractionPotential &operator=(InteractionPotential &&source) = delete;
+
+    /*
+     * Parameter Data
+     */
+    protected:
+    // Functional form of interaction
+    typename Functions::Form form_;
+    // InteractionPotential for interaction
+    std::vector<double> parameters_;
+
+    public:
+    // Set functional form of interaction
+    void setForm(typename Functions::Form form) { form_ = form; }
+    // Return functional form of interaction
+    typename Functions::Form form() const { return form_; }
+    // Parse supplied vector of terms
+    bool parseParameters(std::vector<std::string> terms)
+    {
+        // Do we have a suitable number of parameters
+        if (!Functions::forms().validNArgs(form(), terms.size()))
+            return false;
+
+        // We allow either a set of plain values or a set of name=value assignments - we don't allow mixing of the two
+        auto nAssigned =
+            std::count_if(terms.begin(), terms.end(), [](const auto &s) { return s.find('=') != std::string::npos; });
+        if (nAssigned == 0)
+        {
+            // Plain values
+            parameters_.resize(terms.size(), 0.0);
+            std::transform(terms.begin(), terms.end(), parameters_.begin(), [](const auto &term) { return std::stod(term); });
+        }
+        else if (nAssigned == terms.size())
+        {
+            // Name = value assignments
+            // The parameters may not have been given in the expected order, so maintain/resize a value vector
+            parameters_.clear();
+            for (const auto &term : terms)
+            {
+                // Split the string into name and value parts
+                auto name = DissolveSys::beforeChar(term, '=');
+                if (name.empty())
+                    return Messenger::error("Bad assignment found in parameters - no name present in '{}'.\n", term);
+                auto value = DissolveSys::afterChar(term, '=');
+                if (value.empty())
+                    return Messenger::error("Bad assignment found in parameters - no value present in '{}'.\n", term);
+
+                // Get the index of the named parameter
+                auto index = Functions::parameterIndex(form(), name);
+                if (!index)
+                    return Messenger::error(
+                        "Bad assignment found in parameters - '{}' is not a valid parameter for this interaction.\n", name);
+
+                // Resize vector if necessary
+                if (index.value() >= parameters_.size())
+                    parameters_.resize(index.value() + 1, 0.0);
+                parameters_[index.value()] = std::stod(std::string(value));
+            }
+        }
+        else
+            return Messenger::error(
+                "Failed to parse parameters string - provide either plain values or name=value, but don't mix both.\n");
+
+        return true;
+    }
+    // Parse parameters from current line
+    bool parseParameters(const LineParser &parser, int startArg)
+    {
+        // Construct a vector of all remaining arguments on the line, starting from the argument offset
+        std::vector<std::string> terms;
+        for (auto n = startArg; n < parser.nArgs(); ++n)
+            terms.emplace_back(parser.args(n));
+        return parseParameters(terms);
+    }
+    // Set form and parameters
+    void setFormAndParameters(typename Functions::Form form, const std::vector<double> &params)
+    {
+        form_ = form;
+        parameters_ = params;
+    }
+    bool setFormAndParameters(typename Functions::Form form, std::string paramString)
+    {
+        form_ = form;
+        std::vector<std::string> terms{DissolveSys::splitString(paramString)};
+        return parseParameters(terms);
+    }
+    // Return number of parameters defined
+    int nParameters() const { return parameters_.size(); }
+    // Return array of parameters
+    const std::vector<double> &parameters() const { return parameters_; }
+    // Return parameters as name=value string
+    std::string parametersAsString() const
+    {
+        auto id = 0;
+        return joinStrings(parameters(), " ",
+                           [&](const auto &value) { return fmt::format("{}={}", Functions::parameter(form(), id++), value); });
+    }
+};

--- a/src/classes/interactionpotential.h
+++ b/src/classes/interactionpotential.h
@@ -16,17 +16,9 @@ template <class Functions> class InteractionPotential
     public:
     explicit InteractionPotential(typename Functions::Form form) : form_(form){};
     virtual ~InteractionPotential() = default;
-    InteractionPotential(const InteractionPotential &source) { (*this) = source; }
+    InteractionPotential(const InteractionPotential &source) = default;
     InteractionPotential(InteractionPotential &&source) = delete;
-    InteractionPotential &operator=(const InteractionPotential &source)
-    {
-        parameters_.clear();
-        parameters_.resize(source.parameters_.size());
-        std::copy(source.parameters_.begin(), source.parameters_.end(), parameters_.begin());
-        form_ = source.form_;
-
-        return *this;
-    }
+    InteractionPotential &operator=(const InteractionPotential &source) = default;
     InteractionPotential &operator=(InteractionPotential &&source) = delete;
 
     /*
@@ -92,6 +84,8 @@ template <class Functions> class InteractionPotential
 
         return true;
     }
+    // Parse parameters from specified string
+    bool parseParameters(std::string paramString) { return parseParameters(DissolveSys::splitString(paramString)); }
     // Parse parameters from current line
     bool parseParameters(const LineParser &parser, int startArg)
     {
@@ -110,8 +104,7 @@ template <class Functions> class InteractionPotential
     bool setFormAndParameters(typename Functions::Form form, std::string paramString)
     {
         form_ = form;
-        std::vector<std::string> terms{DissolveSys::splitString(paramString)};
-        return parseParameters(terms);
+        return parseParameters(paramString);
     }
     // Return number of parameters defined
     int nParameters() const { return parameters_.size(); }

--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -219,7 +219,7 @@ double PairPotential::chargeJ() const { return chargeJ_; }
  */
 
 // Return analytic short range potential energy
-double PairPotential::analyticShortRangeEnergy(double r, PairPotential::ShortRangeTruncationScheme truncation)
+double PairPotential::analyticShortRangeEnergy(double r, PairPotential::ShortRangeTruncationScheme truncation) const
 {
     auto &params = interactionPotential_.parameters();
 
@@ -265,7 +265,7 @@ double PairPotential::analyticShortRangeEnergy(double r, PairPotential::ShortRan
 }
 
 // Return analytic short range force
-double PairPotential::analyticShortRangeForce(double r, PairPotential::ShortRangeTruncationScheme truncation)
+double PairPotential::analyticShortRangeForce(double r, PairPotential::ShortRangeTruncationScheme truncation) const
 {
     auto &params = interactionPotential_.parameters();
 
@@ -455,7 +455,7 @@ double PairPotential::energy(double r)
 }
 
 // Return analytic potential at specified r, including Coulomb term from local atomtype charges
-double PairPotential::analyticEnergy(double r)
+double PairPotential::analyticEnergy(double r) const
 {
     if (r > range_)
         return 0.0;
@@ -470,7 +470,7 @@ double PairPotential::analyticEnergy(double r)
 }
 
 // Return analytic potential at specified r, including Coulomb term from supplied charge product
-double PairPotential::analyticEnergy(double qiqj, double r, PairPotential::CoulombTruncationScheme truncation)
+double PairPotential::analyticEnergy(double qiqj, double r, PairPotential::CoulombTruncationScheme truncation) const
 {
     if (r > range_)
         return 0.0;
@@ -499,7 +499,7 @@ double PairPotential::force(double r)
 }
 
 // Return analytic force at specified r
-double PairPotential::analyticForce(double r)
+double PairPotential::analyticForce(double r) const
 {
     if (r > range_)
         return 0.0;
@@ -514,7 +514,7 @@ double PairPotential::analyticForce(double r)
 }
 
 // Return analytic force at specified r, including Coulomb term from supplied charge product
-double PairPotential::analyticForce(double qiqj, double r, PairPotential::CoulombTruncationScheme truncation)
+double PairPotential::analyticForce(double qiqj, double r, PairPotential::CoulombTruncationScheme truncation) const
 {
     if (r > range_)
         return 0.0;

--- a/src/classes/pairpotential.h
+++ b/src/classes/pairpotential.h
@@ -139,11 +139,10 @@ class PairPotential
     private:
     // Return analytic short range potential energy
     double analyticShortRangeEnergy(
-        double r, PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme());
+        double r, PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme()) const;
     // Return analytic short range force
-    double
-    analyticShortRangeForce(double r,
-                            PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme());
+    double analyticShortRangeForce(
+        double r, PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme()) const;
     // Calculate full potential
     void calculateUFull();
     // Calculate derivative of potential
@@ -163,10 +162,10 @@ class PairPotential
     // Return potential at specified r
     double energy(double r);
     // Return analytic potential at specified r, including Coulomb term from local atomtype charges
-    double analyticEnergy(double r);
+    double analyticEnergy(double r) const;
     // Return analytic potential at specified r, including Coulomb term from supplied charge product
     double analyticEnergy(double qiqj, double r,
-                          PairPotential::CoulombTruncationScheme truncation = PairPotential::coulombTruncationScheme());
+                          PairPotential::CoulombTruncationScheme truncation = PairPotential::coulombTruncationScheme()) const;
     // Return analytic coulomb potential energy of specified charge product
     double
     analyticCoulombEnergy(double qiqj, double r,
@@ -174,10 +173,10 @@ class PairPotential
     // Return derivative of potential at specified r
     double force(double r);
     // Return analytic force at specified r, including Coulomb term from local atomtype charges
-    double analyticForce(double r);
+    double analyticForce(double r) const;
     // Return analytic force at specified r, including Coulomb term from supplied charge product
     double analyticForce(double qiqj, double r,
-                         PairPotential::CoulombTruncationScheme truncation = PairPotential::coulombTruncationScheme());
+                         PairPotential::CoulombTruncationScheme truncation = PairPotential::coulombTruncationScheme()) const;
     // Return analytic coulomb force of specified charge product
     double
     analyticCoulombForce(double qiqj, double r,

--- a/src/classes/pairpotential.h
+++ b/src/classes/pairpotential.h
@@ -79,10 +79,8 @@ class PairPotential
     private:
     // Original source AtomTypes
     std::shared_ptr<AtomType> atomTypeI_, atomTypeJ_;
-    // Parameters for short-range potential
-    std::vector<double> parameters_;
-    // Short range type (determined from AtomTypes)
-    Forcefield::ShortRangeType shortRangeType_{Forcefield::ShortRangeType::Undefined};
+    // Interaction potential
+    InteractionPotential<ShortRangeFunctions> interactionPotential_;
     // Charge on I (taken from AtomType)
     double chargeI_{0.0};
     // Charge on J (taken from AtomType)
@@ -95,10 +93,9 @@ class PairPotential
     public:
     // Set up PairPotential parameters from specified AtomTypes
     bool setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ);
-    // Set short-ranged type
-    void setShortRangeType(Forcefield::ShortRangeType srType);
-    // Return short-ranged type
-    Forcefield::ShortRangeType shortRangeType() const;
+    // Return interaction potential
+    InteractionPotential<ShortRangeFunctions> &interactionPotential();
+    const InteractionPotential<ShortRangeFunctions> &interactionPotential() const;
     // Return first AtomType name
     std::string_view atomTypeNameI() const;
     // Return second AtomType name
@@ -107,14 +104,6 @@ class PairPotential
     std::shared_ptr<AtomType> atomTypeI() const;
     // Return second source AtomType
     std::shared_ptr<AtomType> atomTypeJ() const;
-    // Set parameter specified
-    void setParameter(int index, double value);
-    // Set parameters vector
-    void setParameters(std::vector<double> parameters);
-    // Return parameters vector
-    const std::vector<double> &parameters() const;
-    // Return short-range parameter specified
-    double parameter(int index) const;
     // Set charge I
     void setChargeI(double value);
     // Return charge I
@@ -150,11 +139,10 @@ class PairPotential
     private:
     // Return analytic short range potential energy
     double analyticShortRangeEnergy(
-        double r, Forcefield::ShortRangeType type,
-        PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme());
+        double r, PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme());
     // Return analytic short range force
     double
-    analyticShortRangeForce(double r, Forcefield::ShortRangeType type,
+    analyticShortRangeForce(double r,
                             PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme());
     // Calculate full potential
     void calculateUFull();

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -157,8 +157,8 @@ void Species::print() const
         Messenger::print("    ---------------------------------------------------------------------------------\n");
         for (const auto &bond : bonds_)
             Messenger::print("   {:4d}  {:4d}    {}{:<12}  {}\n", bond.indexI() + 1, bond.indexJ() + 1,
-                             bond.masterTerm() ? '@' : ' ', BondFunctions::forms().keyword(bond.form()),
-                             bond.parametersAsString());
+                             bond.masterTerm() ? '@' : ' ', BondFunctions::forms().keyword(bond.interactionForm()),
+                             bond.interactionPotential().parametersAsString());
     }
 
     if (nAngles() > 0)
@@ -168,8 +168,9 @@ void Species::print() const
         Messenger::print("    ---------------------------------------------------------------------------------------\n");
         for (const auto &angle : angles_)
             Messenger::print("   {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", angle.indexI() + 1, angle.indexJ() + 1,
-                             angle.indexK() + 1, angle.masterTerm() ? '@' : ' ', AngleFunctions::forms().keyword(angle.form()),
-                             angle.parametersAsString());
+                             angle.indexK() + 1, angle.masterTerm() ? '@' : ' ',
+                             AngleFunctions::forms().keyword(angle.interactionForm()),
+                             angle.interactionPotential().parametersAsString());
     }
 
     if (nTorsions() > 0)
@@ -181,7 +182,8 @@ void Species::print() const
         for (const auto &torsion : torsions())
             Messenger::print("   {:4d}  {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", torsion.indexI() + 1, torsion.indexJ() + 1,
                              torsion.indexK() + 1, torsion.indexL() + 1, torsion.masterTerm() ? '@' : ' ',
-                             TorsionFunctions::forms().keyword(torsion.form()), torsion.parametersAsString());
+                             TorsionFunctions::forms().keyword(torsion.interactionForm()),
+                             torsion.interactionPotential().parametersAsString());
     }
 
     if (nImpropers() > 0)
@@ -193,7 +195,8 @@ void Species::print() const
         for (auto &improper : impropers())
             Messenger::print("   {:4d}  {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", improper.indexI() + 1, improper.indexJ() + 1,
                              improper.indexK() + 1, improper.indexL() + 1, improper.masterTerm() ? '@' : ' ',
-                             TorsionFunctions::forms().keyword(improper.form()), improper.parametersAsString());
+                             TorsionFunctions::forms().keyword(improper.interactionForm()),
+                             improper.interactionPotential().parametersAsString());
     }
 }
 

--- a/src/classes/species_ff.cpp
+++ b/src/classes/species_ff.cpp
@@ -42,13 +42,13 @@ void Species::clearForcefieldTerms(bool nullifyAtomTypes)
         clearAtomTypes();
 
     for (auto &b : bonds_)
-        b.setFormAndParameters(BondFunctions::Form::None, std::vector<double>());
+        b.setInteractionFormAndParameters(BondFunctions::Form::None, std::vector<double>());
 
     for (auto &a : angles_)
-        a.setFormAndParameters(AngleFunctions::Form::None, std::vector<double>());
+        a.setInteractionFormAndParameters(AngleFunctions::Form::None, std::vector<double>());
 
     for (auto &t : torsions_)
-        t.setFormAndParameters(TorsionFunctions::Form::None, std::vector<double>());
+        t.setInteractionFormAndParameters(TorsionFunctions::Form::None, std::vector<double>());
 
     impropers_.clear();
 }

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -547,10 +547,11 @@ void generateMasterTerm(Intra &term, std::string_view termName,
     {
         // Are the parameters the same as our local term?
         const Master &master = optMaster->get();
-        if (master.form() != term.form() || master.nParameters() != term.nParameters())
+        if (master.interactionForm() != term.interactionForm() ||
+            master.interactionParameters().size() != term.interactionParameters().size())
             continue;
         else
-            for (auto &&[localValue, masterValue] : zip(term.parameters(), master.parameters()))
+            for (auto &&[localValue, masterValue] : zip(term.interactionParameters(), master.interactionParameters()))
                 if (fabs(localValue - masterValue) > 1.0e-8)
                     optMaster = std::nullopt;
 
@@ -565,8 +566,7 @@ void generateMasterTerm(Intra &term, std::string_view termName,
     if (!optMaster)
     {
         optMaster = termCreator(index == 0 ? termName : fmt::format("{}_{}", termName, index));
-        optMaster->get().setForm(term.form());
-        optMaster->get().setParameters(term.parameters());
+        optMaster->get().setInteractionFormAndParameters(term.interactionForm(), term.interactionParameters());
     }
 
     term.setMasterTerm(&optMaster->get());

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -161,7 +161,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                  * '@' it is a reference to master parameters
                  */
                 if (parser.nArgs() == 4)
-                    a->get().setForm(AngleFunctions::Form::None);
+                    a->get().setInteractionForm(AngleFunctions::Form::None);
                 else if (parser.argsv(4)[0] == '@')
                 {
                     // Search through master Angle parameters to see if this name exists
@@ -184,7 +184,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                         break;
                     }
                     af = AngleFunctions::forms().enumeration(parser.argsv(4));
-                    a->get().setForm(af);
+                    a->get().setInteractionForm(af);
 
                     // Check number of args provided
                     if (!AngleFunctions::forms().validNArgs(af, parser.nArgs() - 5))
@@ -194,7 +194,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!a->get().setParameters(parser, 5))
+                    if (!a->get().setInteractionParameters(parser, 5))
                     {
                         error = true;
                         break;
@@ -256,7 +256,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                  * '@' it is a reference to master parameters
                  */
                 if (parser.nArgs() == 3)
-                    b->get().setForm(BondFunctions::Form::None);
+                    b->get().setInteractionForm(BondFunctions::Form::None);
                 else if (parser.argsv(3)[0] == '@')
                 {
                     // Search through master Bond parameters to see if this name exists
@@ -280,7 +280,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                         break;
                     }
                     bf = BondFunctions::forms().enumeration(parser.argsv(3));
-                    b->get().setForm(bf);
+                    b->get().setInteractionForm(bf);
 
                     // Check number of args provided
                     if (!BondFunctions::forms().validNArgs(bf, parser.nArgs() - 4))
@@ -290,7 +290,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!b->get().setParameters(parser, 4))
+                    if (!b->get().setInteractionParameters(parser, 4))
                     {
                         error = true;
                         break;
@@ -445,7 +445,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                         break;
                     }
                     tf = TorsionFunctions::forms().enumeration(parser.argsv(5));
-                    imp->get().setForm(tf);
+                    imp->get().setInteractionForm(tf);
 
                     // Check number of args provided
                     if (!TorsionFunctions::forms().validNArgs(tf, parser.nArgs() - 6))
@@ -455,7 +455,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!imp->get().setParameters(parser, 6))
+                    if (!imp->get().setInteractionParameters(parser, 6))
                     {
                         error = true;
                         break;
@@ -590,7 +590,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                  * '@' it is a reference to master parameters
                  */
                 if (parser.nArgs() == 5)
-                    torsion->get().setForm(TorsionFunctions::Form::None);
+                    torsion->get().setInteractionForm(TorsionFunctions::Form::None);
                 else if (parser.argsv(5)[0] == '@')
                 {
                     // Search through master Torsion parameters to see if this name exists
@@ -614,7 +614,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                         break;
                     }
                     tf = TorsionFunctions::forms().enumeration(parser.argsv(5));
-                    torsion->get().setForm(tf);
+                    torsion->get().setInteractionForm(tf);
 
                     // Check number of args provided
                     if (!TorsionFunctions::forms().validNArgs(tf, parser.nArgs() - 6))
@@ -624,7 +624,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!torsion->get().setParameters(parser, 6))
+                    if (!torsion->get().setInteractionParameters(parser, 6))
                     {
                         error = true;
                         break;
@@ -698,7 +698,8 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             }
             else if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {} {}\n", newPrefix,
                                         keywords().keyword(Species::SpeciesKeyword::Bond), bond.indexI() + 1, bond.indexJ() + 1,
-                                        BondFunctions::forms().keyword(bond.form()), bond.parametersAsString()))
+                                        BondFunctions::forms().keyword(bond.interactionForm()),
+                                        bond.interactionPotential().parametersAsString()))
                 return false;
 
             // Add the bond to the reference vector based on its indicated bond type (unless it is a SingleBond,
@@ -745,8 +746,9 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             }
             else if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {}  {}\n", newPrefix,
                                         keywords().keyword(Species::SpeciesKeyword::Angle), angle.indexI() + 1,
-                                        angle.indexJ() + 1, angle.indexK() + 1, AngleFunctions::forms().keyword(angle.form()),
-                                        angle.parametersAsString()))
+                                        angle.indexJ() + 1, angle.indexK() + 1,
+                                        AngleFunctions::forms().keyword(angle.interactionForm()),
+                                        angle.interactionPotential().parametersAsString()))
                 return false;
         }
     }
@@ -772,8 +774,8 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             else if (!parser.writeLineF(fmt::format("{}{}  {:3d}  {:3d}  {:3d}  {:3d}  {}  {}\n", newPrefix,
                                                     keywords().keyword(Species::SpeciesKeyword::Torsion), torsion.indexI() + 1,
                                                     torsion.indexJ() + 1, torsion.indexK() + 1, torsion.indexL() + 1,
-                                                    TorsionFunctions::forms().keyword(torsion.form()),
-                                                    torsion.parametersAsString())))
+                                                    TorsionFunctions::forms().keyword(torsion.interactionForm()),
+                                                    torsion.interactionPotential().parametersAsString())))
                 return false;
         }
     }
@@ -798,7 +800,8 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             else if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {:3d}  {}  {}\n", newPrefix,
                                         keywords().keyword(Species::SpeciesKeyword::Improper), imp.indexI() + 1,
                                         imp.indexJ() + 1, imp.indexK() + 1, imp.indexL() + 1,
-                                        TorsionFunctions::forms().keyword(imp.form()), imp.parametersAsString()))
+                                        TorsionFunctions::forms().keyword(imp.interactionForm()),
+                                        imp.interactionPotential().parametersAsString()))
                 return false;
         }
     }

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -63,7 +63,7 @@ SpeciesAngle::SpeciesAngle(SpeciesAngle &&source) noexcept : SpeciesIntra(source
 
     // Copy data
     assign(source.i_, source.j_, source.k_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
 
     // Reset source data
@@ -76,7 +76,7 @@ SpeciesAngle &SpeciesAngle::operator=(const SpeciesAngle &source)
 {
     // Copy data
     assign(source.i_, source.j_, source.k_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -91,7 +91,7 @@ SpeciesAngle &SpeciesAngle::operator=(SpeciesAngle &&source) noexcept
 
     // Copy data
     assign(source.i_, source.j_, source.k_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -213,10 +213,11 @@ void SpeciesAngle::detach()
 double SpeciesAngle::fundamentalFrequency(double reducedMass) const
 {
     // Get pointer to relevant parameters array
-    const auto &params = parameters();
+    const auto &params = interactionParameters();
+    const auto angleForm = interactionForm();
 
     double k = 0.0;
-    if (form() == AngleFunctions::Form::Harmonic)
+    if (angleForm == AngleFunctions::Form::Harmonic)
         k = params[0];
     else
     {
@@ -241,11 +242,12 @@ double SpeciesAngle::fundamentalFrequency(double reducedMass) const
 double SpeciesAngle::energy(double angleInDegrees) const
 {
     // Get pointer to relevant parameters array
-    const auto &params = parameters();
+    const auto &params = interactionParameters();
+    const auto angleForm = interactionForm();
 
-    if (form() == AngleFunctions::Form::None)
+    if (angleForm == AngleFunctions::Form::None)
         return 0.0;
-    else if (form() == AngleFunctions::Form::Harmonic)
+    else if (angleForm == AngleFunctions::Form::Harmonic)
     {
         /*
          * U(theta) = 0.5 * forcek * (theta - eq)**2
@@ -257,7 +259,7 @@ double SpeciesAngle::energy(double angleInDegrees) const
         const auto delta = (angleInDegrees - params[1]) / DEGRAD;
         return 0.5 * params[0] * delta * delta;
     }
-    else if (form() == AngleFunctions::Form::Cosine)
+    else if (angleForm == AngleFunctions::Form::Cosine)
     {
         /*
          * U(theta) = forcek * (1 + s * cos(n*theta - eq))
@@ -270,7 +272,7 @@ double SpeciesAngle::energy(double angleInDegrees) const
          */
         return params[0] * (1.0 + params[3] * cos(params[1] * angleInDegrees / DEGRAD - params[2] / DEGRAD));
     }
-    else if (form() == AngleFunctions::Form::Cos2)
+    else if (angleForm == AngleFunctions::Form::Cos2)
     {
         /*
          * U(theta) = forcek * (C0 + C1 * cos(theta) + C2 * cos(2*theta))
@@ -305,14 +307,15 @@ double SpeciesAngle::force(double angleInDegrees) const
      */
 
     // Get pointer to relevant parameters array
-    const auto &params = parameters();
+    const auto &params = interactionParameters();
+    const auto angleForm = interactionForm();
 
     // Convert angle to radians
     const auto angleInRadians = angleInDegrees / DEGRAD;
 
-    if (form() == AngleFunctions::Form::None)
+    if (angleForm == AngleFunctions::Form::None)
         return 0.0;
-    else if (form() == AngleFunctions::Form::Harmonic)
+    else if (angleForm == AngleFunctions::Form::Harmonic)
     {
         /*
          * dU/dTheta = k * (theta - eq)
@@ -324,7 +327,7 @@ double SpeciesAngle::force(double angleInDegrees) const
 
         return params[0] * ((angleInDegrees - params[1]) / DEGRAD) / sin(angleInRadians);
     }
-    else if (form() == AngleFunctions::Form::Cosine)
+    else if (angleForm == AngleFunctions::Form::Cosine)
     {
         /*
          * dU/dTheta = -k * n * s * sin(n*theta - eq)
@@ -338,7 +341,7 @@ double SpeciesAngle::force(double angleInDegrees) const
 
         return -params[0] * params[1] * params[3] * sin(params[1] * angleInRadians - params[2] / DEGRAD) / sin(angleInRadians);
     }
-    else if (form() == AngleFunctions::Form::Cos2)
+    else if (angleForm == AngleFunctions::Form::Cos2)
     {
         /*
          * dU/dTheta = -k * (c1 * sin(theta) + 2 * c2 * sin(2*theta))

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -287,8 +287,8 @@ double SpeciesAngle::energy(double angleInDegrees) const
         return params[0] * (params[1] + params[2] * cos(angleInRadians) + params[3] * cos(2.0 * angleInRadians));
     }
 
-    Messenger::error("Functional form of SpeciesAngle term not accounted for, so can't calculate energy.\n");
-    return 0.0;
+    throw(std::runtime_error(fmt::format("Angle functional form '{}' not accounted for, so can't calculate energy.\n",
+                                         AngleFunctions::forms().keyword(angleForm))));
 }
 
 // Return force multiplier for specified angle
@@ -357,6 +357,6 @@ double SpeciesAngle::force(double angleInDegrees) const
                sin(angleInRadians);
     }
 
-    Messenger::error("Functional form of SpeciesAngle term not accounted for, so can't calculate force.\n");
-    return 0.0;
+    throw(std::runtime_error(fmt::format("Angle functional form '{}' not accounted for, so can't calculate force.\n",
+                                         AngleFunctions::forms().keyword(angleForm))));
 }

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -292,8 +292,8 @@ double SpeciesBond::energy(double distance) const
         return params[0] * delta * delta / (params[1] / sqrt((massI + massJ) / (massI * massJ)));
     }
 
-    Messenger::error("Functional form of SpeciesBond term not accounted for, so can't calculate energy.\n");
-    return 0.0;
+    throw(std::runtime_error(fmt::format("Bond functional form '{}' not accounted for, so can't calculate energy.\n",
+                                         BondFunctions::forms().keyword(bondForm))));
 }
 
 // Return force multiplier for specified distance
@@ -330,6 +330,6 @@ double SpeciesBond::force(double distance) const
         return -2.0 * params[0] * (distance - params[1]) / (params[1] / sqrt((massI + massJ) / (massI * massJ)));
     }
 
-    Messenger::error("Functional form of SpeciesBond term not accounted for, so can't calculate force.\n");
-    return 0.0;
+    throw(std::runtime_error(fmt::format("Bond functional form '{}' not accounted for, so can't calculate force.\n",
+                                         BondFunctions::forms().keyword(bondForm))));
 }

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -59,7 +59,7 @@ SpeciesBond::SpeciesBond(SpeciesBond &&source) noexcept : SpeciesIntra(source)
     // Copy data
     assign(source.i_, source.j_);
     bondType_ = source.bondType_;
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
 
     // Reset source data
@@ -72,7 +72,7 @@ SpeciesBond &SpeciesBond::operator=(const SpeciesBond &source)
     // Copy data
     assign(source.i_, source.j_);
     bondType_ = source.bondType_;
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -88,7 +88,7 @@ SpeciesBond &SpeciesBond::operator=(SpeciesBond &&source) noexcept
     // Copy data
     assign(source.i_, source.j_);
     bondType_ = source.bondType_;
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -228,12 +228,13 @@ double SpeciesBond::bondOrder() const { return SpeciesBond::bondOrder(bondType_)
 double SpeciesBond::fundamentalFrequency(double reducedMass) const
 {
     // Get pointer to relevant parameters array
-    const auto &params = parameters();
+    const auto &params = interactionParameters();
+    const auto bondForm = interactionForm();
 
     double k = 0.0;
-    if (form() == BondFunctions::Form::Harmonic)
+    if (bondForm == BondFunctions::Form::Harmonic)
         k = params[0];
-    else if (form() == BondFunctions::Form::EPSR)
+    else if (bondForm == BondFunctions::Form::EPSR)
         k = params[0];
     else
     {
@@ -258,11 +259,12 @@ double SpeciesBond::fundamentalFrequency(double reducedMass) const
 double SpeciesBond::energy(double distance) const
 {
     // Get pointer to relevant parameters array
-    const auto &params = parameters();
+    const auto &params = interactionParameters();
+    const auto bondForm = interactionForm();
 
-    if (form() == BondFunctions::Form::None)
+    if (bondForm == BondFunctions::Form::None)
         return 0.0;
-    else if (form() == BondFunctions::Form::Harmonic)
+    else if (bondForm == BondFunctions::Form::Harmonic)
     {
         /*
          * Parameters:
@@ -272,7 +274,7 @@ double SpeciesBond::energy(double distance) const
         auto delta = distance - params[1];
         return 0.5 * params[0] * delta * delta;
     }
-    else if (form() == BondFunctions::Form::EPSR)
+    else if (bondForm == BondFunctions::Form::EPSR)
     {
         /*
          * Basically a harmonic oscillator metered by the mass of the atoms
@@ -298,11 +300,12 @@ double SpeciesBond::energy(double distance) const
 double SpeciesBond::force(double distance) const
 {
     // Get pointer to relevant parameters array
-    const auto &params = parameters();
+    const auto &params = interactionParameters();
+    const auto bondForm = interactionForm();
 
-    if (form() == BondFunctions::Form::None)
+    if (bondForm == BondFunctions::Form::None)
         return 0.0;
-    else if (form() == BondFunctions::Form::Harmonic)
+    else if (bondForm == BondFunctions::Form::Harmonic)
     {
         /*
          * V = -k * (r - eq)
@@ -313,7 +316,7 @@ double SpeciesBond::force(double distance) const
          */
         return -params[0] * (distance - params[1]);
     }
-    else if (form() == BondFunctions::Form::EPSR)
+    else if (bondForm == BondFunctions::Form::EPSR)
     {
         /*
          * Basically a harmonic oscillator metered by the mass of the atoms

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -28,7 +28,7 @@ SpeciesImproper::SpeciesImproper(SpeciesImproper &&source) noexcept : SpeciesInt
 
     // Copy data
     assign(source.i_, source.j_, source.k_, source.l_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
 
     // Reset source data
@@ -43,7 +43,7 @@ SpeciesImproper::~SpeciesImproper() { detach(); }
 SpeciesImproper &SpeciesImproper::operator=(const SpeciesImproper &source)
 {
     assign(source.i_, source.j_, source.k_, source.l_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -56,7 +56,7 @@ SpeciesImproper &SpeciesImproper::operator=(SpeciesImproper &&source) noexcept
         detach();
 
     assign(source.i_, source.j_, source.k_, source.l_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -215,11 +215,11 @@ double SpeciesImproper::fundamentalFrequency(double reducedMass) const
 // Return energy for specified angle
 double SpeciesImproper::energy(double angleInDegrees) const
 {
-    return SpeciesTorsion::energy(angleInDegrees, form(), parameters());
+    return SpeciesTorsion::energy(angleInDegrees, interactionForm(), interactionParameters());
 }
 
 // Return force multiplier for specified angle
 double SpeciesImproper::force(double angleInDegrees) const
 {
-    return SpeciesTorsion::force(angleInDegrees, form(), parameters());
+    return SpeciesTorsion::force(angleInDegrees, interactionForm(), interactionParameters());
 }

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -76,7 +76,6 @@ template <class Intra, class Functions> class SpeciesIntra
     }
     bool setInteractionParameters(LineParser &parser, int startArg)
     {
-        // Does this intramolecular interaction reference a set of master parameters?
         if (masterTerm_)
             return Messenger::error("Refused to set intramolecular parameters since master parameters are referenced.\n");
 
@@ -85,17 +84,17 @@ template <class Intra, class Functions> class SpeciesIntra
     // Set form and parameters
     void setInteractionFormAndParameters(typename Functions::Form form, const std::vector<double> &params)
     {
-        if (!masterTerm_)
-            interactionPotential_.setFormAndParameters(form, params);
-        else
+        if (masterTerm_)
             Messenger::error("Refused to set intramolecular parameter since master parameters are referenced.\n");
+
+        return interactionPotential_.setFormAndParameters(form, params);
     }
     bool setInteractionFormAndParameters(typename Functions::Form form, std::string params)
     {
-        if (!masterTerm_)
-            interactionPotential_.setFormAndParameters(form, params);
-        else
+        if (masterTerm_)
             return Messenger::error("Refused to set intramolecular parameter since master parameters are referenced.\n");
+
+        return interactionPotential_.setFormAndParameters(form, params);
     }
     // Return array of parameters
     const std::vector<double> &interactionParameters() const

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -124,7 +124,7 @@ SpeciesTorsion::SpeciesTorsion(SpeciesTorsion &&source) noexcept : SpeciesIntra(
 
     // Copy data
     assign(source.i_, source.j_, source.k_, source.l_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
 
     // Reset source data
@@ -139,7 +139,7 @@ SpeciesTorsion::~SpeciesTorsion() { detach(); }
 SpeciesTorsion &SpeciesTorsion::operator=(const SpeciesTorsion &source)
 {
     assign(source.i_, source.j_, source.k_, source.l_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -153,7 +153,7 @@ SpeciesTorsion &SpeciesTorsion::operator=(SpeciesTorsion &&source) noexcept
 
     // Copy data
     assign(source.i_, source.j_, source.k_, source.l_);
-    form_ = source.form_;
+    interactionPotential_ = source.interactionPotential_;
     masterTerm_ = source.masterTerm_;
     SpeciesIntra::operator=(source);
 
@@ -427,7 +427,7 @@ double SpeciesTorsion::energy(double angleInDegrees, TorsionFunctions::Form form
 // Return energy for specified angle
 double SpeciesTorsion::energy(double angleInDegrees) const
 {
-    return SpeciesTorsion::energy(angleInDegrees, form(), parameters());
+    return SpeciesTorsion::energy(angleInDegrees, interactionForm(), interactionParameters());
 }
 
 // Return force multiplier for specified angle and functional form, given supplied parameters
@@ -590,5 +590,5 @@ double SpeciesTorsion::force(double angleInDegrees, TorsionFunctions::Form form,
 // Return force multiplier for specified angle
 double SpeciesTorsion::force(double angleInDegrees) const
 {
-    return SpeciesTorsion::force(angleInDegrees, form(), parameters());
+    return SpeciesTorsion::force(angleInDegrees, interactionForm(), interactionParameters());
 }

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -420,8 +420,8 @@ double SpeciesTorsion::energy(double angleInDegrees, TorsionFunctions::Form form
         return U;
     }
 
-    Messenger::error("Functional form of torsion / improper term not accounted for, so can't calculate energy.\n");
-    return 0.0;
+    throw(std::runtime_error(fmt::format("Torsion functional form '{}' not accounted for, so can't calculate energy.\n",
+                                         TorsionFunctions::forms().keyword(form))));
 }
 
 // Return energy for specified angle
@@ -583,8 +583,8 @@ double SpeciesTorsion::force(double angleInDegrees, TorsionFunctions::Form form,
         return -dU_dphi * dphi_dcosphi;
     }
 
-    Messenger::error("Functional form of torsion / improper term not accounted for, so can't calculate force.\n");
-    return 0.0;
+    throw(std::runtime_error(fmt::format("Torsion functional form '{}' not accounted for, so can't calculate force.\n",
+                                         TorsionFunctions::forms().keyword(form))));
 }
 
 // Return force multiplier for specified angle

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -379,8 +379,7 @@ bool Forcefield::assignBondTermParameters(SpeciesBond &bond, bool determineTypes
                                 atomTypes[0].get().equivalentName(), atomTypes[1].get().equivalentName());
     const ForcefieldBondTerm &term = *optTerm;
 
-    bond.setForm(term.form());
-    bond.setParameters(term.parameters());
+    bond.setInteractionFormAndParameters(term.form(), term.parameters());
 
     return true;
 }
@@ -404,8 +403,7 @@ bool Forcefield::assignAngleTermParameters(SpeciesAngle &angle, bool determineTy
                                 atomTypes[2].get().equivalentName());
     const ForcefieldAngleTerm &term = *optTerm;
 
-    angle.setForm(term.form());
-    angle.setParameters(term.parameters());
+    angle.setInteractionFormAndParameters(term.form(), term.parameters());
 
     return true;
 }
@@ -431,8 +429,7 @@ bool Forcefield::assignTorsionTermParameters(SpeciesTorsion &torsion, bool deter
                                 atomTypes[3].get().equivalentName());
     const ForcefieldTorsionTerm &term = *optTerm;
 
-    torsion.setForm(term.form());
-    torsion.setParameters(term.parameters());
+    torsion.setInteractionFormAndParameters(term.form(), term.parameters());
 
     return true;
 }
@@ -547,8 +544,7 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                             optImproper = sp->addImproper(&i, j, k, l);
                         SpeciesImproper &improper = *optImproper;
 
-                        improper.setForm(improperTerm.form());
-                        improper.setParameters(improperTerm.parameters());
+                        improper.setInteractionFormAndParameters(improperTerm.form(), improperTerm.parameters());
                     }
                 }
             }

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -41,20 +41,6 @@ bool Forcefield::prepare()
 }
 
 /*
- * Definition
- */
-
-// Return enum options for ShortRangeType
-EnumOptions<Forcefield::ShortRangeType> Forcefield::shortRangeTypes()
-{
-    return EnumOptions<Forcefield::ShortRangeType>("ShortRangeType",
-                                                   {{Forcefield::ShortRangeType::Undefined, "Undefined"},
-                                                    {Forcefield::ShortRangeType::NoInteraction, "None"},
-                                                    {Forcefield::ShortRangeType::LennardJones, "LJ", 2, 2},
-                                                    {Forcefield::ShortRangeType::LennardJonesGeometric, "LJGeometric", 2, 2}});
-}
-
-/*
  * Atom Type Data
  */
 
@@ -349,9 +335,8 @@ void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, C
     // This is to avoid copying e.g. generator data (stored after the short range parameters) and causing issues elsewhere
     std::vector<double> params;
     params.insert(params.begin(), ffa.parameters().begin(),
-                  ffa.parameters().begin() + Forcefield::shortRangeTypes().minArgs(shortRangeType()).value_or(0));
-    at->setShortRangeParameters(params);
-    at->setShortRangeType(shortRangeType());
+                  ffa.parameters().begin() + ShortRangeFunctions::forms().minArgs(shortRangeForm()).value_or(0));
+    at->interactionPotential().setFormAndParameters(shortRangeForm(), params);
     at->setCharge(ffa.charge());
 
     // Set the charge on the SpeciesAtom if requested

--- a/src/data/ff/ff.h
+++ b/src/data/ff/ff.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "classes/atomtype.h"
 #include "classes/speciesangle.h"
 #include "classes/speciesbond.h"
 #include "classes/speciesimproper.h"
@@ -49,22 +50,12 @@ class Forcefield
      * Definition
      */
     public:
-    // ShortRange Interaction Type
-    enum class ShortRangeType
-    {
-        Undefined,            /* Undefined short-range type */
-        NoInteraction,        /* No short-range dispersive forces */
-        LennardJones,         /* Lennard-Jones 12-6 form with Lorentz-Berthelot combination rules */
-        LennardJonesGeometric /* Lennard-Jones 12-6 form with Geometric combination rules */
-    };
-    // Return enum options for ShortRangeType
-    static EnumOptions<ShortRangeType> shortRangeTypes();
     // Return name of Forcefield
     virtual std::string_view name() const = 0;
     // Return description of Forcefield
     virtual std::string_view description() const = 0;
     // Return short-range interaction style for AtomTypes
-    virtual ShortRangeType shortRangeType() const = 0;
+    virtual ShortRangeFunctions::Form shortRangeForm() const = 0;
 
     /*
      * Atom Type Data

--- a/src/data/ff/kulmala2010/kulmala2010.cpp
+++ b/src/data/ff/kulmala2010/kulmala2010.cpp
@@ -116,4 +116,4 @@ std::string_view Forcefield_Kulmala2010::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_Kulmala2010::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_Kulmala2010::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/kulmala2010/kulmala2010.h
+++ b/src/data/ff/kulmala2010/kulmala2010.h
@@ -28,5 +28,5 @@ class Forcefield_Kulmala2010 : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/data/ff/ludwig/ntf2.cpp
+++ b/src/data/ff/ludwig/ntf2.cpp
@@ -74,4 +74,4 @@ std::string_view Forcefield_Ludwig_NTf2::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_Ludwig_NTf2::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_Ludwig_NTf2::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/ludwig/ntf2.h
+++ b/src/data/ff/ludwig/ntf2.h
@@ -28,5 +28,5 @@ class Forcefield_Ludwig_NTf2 : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/data/ff/ludwig/py4oh.cpp
+++ b/src/data/ff/ludwig/py4oh.cpp
@@ -118,4 +118,4 @@ std::string_view Forcefield_Ludwig_Py4OH::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_Ludwig_Py4OH::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_Ludwig_Py4OH::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/ludwig/py4oh.h
+++ b/src/data/ff/ludwig/py4oh.h
@@ -28,5 +28,5 @@ class Forcefield_Ludwig_Py4OH : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/data/ff/ludwig/py5.cpp
+++ b/src/data/ff/ludwig/py5.cpp
@@ -119,4 +119,4 @@ std::string_view Forcefield_Ludwig_Py5::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_Ludwig_Py5::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_Ludwig_Py5::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/ludwig/py5.h
+++ b/src/data/ff/ludwig/py5.h
@@ -28,5 +28,5 @@ class Forcefield_Ludwig_Py5 : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/data/ff/oplsaa2005/base.cpp
+++ b/src/data/ff/oplsaa2005/base.cpp
@@ -12,7 +12,7 @@ OPLSAA2005BaseForcefield::~OPLSAA2005BaseForcefield() = default;
  */
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType OPLSAA2005BaseForcefield::shortRangeType() const
+ShortRangeFunctions::Form OPLSAA2005BaseForcefield::shortRangeForm() const
 {
-    return Forcefield::ShortRangeType::LennardJonesGeometric;
+    return ShortRangeFunctions::Form::LennardJonesGeometric;
 }

--- a/src/data/ff/oplsaa2005/base.h
+++ b/src/data/ff/oplsaa2005/base.h
@@ -20,7 +20,7 @@ class OPLSAA2005BaseForcefield : public Forcefield
     // Return formatted publication references
     std::string_view publicationReferences() const;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 
     /*
      * Atom Type Data

--- a/src/data/ff/pcl2019/base.cpp
+++ b/src/data/ff/pcl2019/base.cpp
@@ -62,7 +62,7 @@ PCL2019BaseForcefield::~PCL2019BaseForcefield() = default;
 std::string_view PCL2019BaseForcefield::publicationReferences() const { return "TODO!"; }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType PCL2019BaseForcefield::shortRangeType() const
+ShortRangeFunctions::Form PCL2019BaseForcefield::shortRangeForm() const
 {
-    return Forcefield::ShortRangeType::LennardJonesGeometric;
+    return ShortRangeFunctions::Form::LennardJonesGeometric;
 }

--- a/src/data/ff/pcl2019/base.h
+++ b/src/data/ff/pcl2019/base.h
@@ -20,7 +20,7 @@ class PCL2019BaseForcefield : public Forcefield
     // Return formatted publication references
     std::string_view publicationReferences() const;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 
     /*
      * Atom Type Data

--- a/src/data/ff/spcfw/spcfw.cpp
+++ b/src/data/ff/spcfw/spcfw.cpp
@@ -57,4 +57,4 @@ std::string_view Forcefield_SPCFw::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_SPCFw::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_SPCFw::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/spcfw/spcfw.h
+++ b/src/data/ff/spcfw/spcfw.h
@@ -28,5 +28,5 @@ class Forcefield_SPCFw : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/data/ff/strader2002/dmso.cpp
+++ b/src/data/ff/strader2002/dmso.cpp
@@ -66,4 +66,4 @@ std::string_view Forcefield_Strader2002::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_Strader2002::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_Strader2002::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/strader2002/dmso.h
+++ b/src/data/ff/strader2002/dmso.h
@@ -28,5 +28,5 @@ class Forcefield_Strader2002 : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/data/ff/uff/uff.cpp
+++ b/src/data/ff/uff/uff.cpp
@@ -279,7 +279,7 @@ std::string_view Forcefield_UFF::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_UFF::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_UFF::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }
 
 /*
  * Atom Type Data

--- a/src/data/ff/uff/uff.h
+++ b/src/data/ff/uff/uff.h
@@ -37,7 +37,7 @@ class Forcefield_UFF : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 
     /*
      * Atom Type Data

--- a/src/data/ff/xml/base.cpp
+++ b/src/data/ff/xml/base.cpp
@@ -21,4 +21,4 @@ std::string_view Forcefield_XML::description() const { return "Whatever forcefie
 std::string_view Forcefield_XML::publicationReferences() const { return "I have no idea"; }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_XML::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_XML::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/xml/base.h
+++ b/src/data/ff/xml/base.h
@@ -32,7 +32,7 @@ class Forcefield_XML : public Forcefield
     // Return formatted publication references
     std::string_view publicationReferences() const;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 
     /*
      * Atom Type Data

--- a/src/data/ff/zhang2013/zhang2013.cpp
+++ b/src/data/ff/zhang2013/zhang2013.cpp
@@ -87,4 +87,4 @@ std::string_view Forcefield_Zhang2013::description() const
 }
 
 // Return short-range interaction style for AtomTypes
-Forcefield::ShortRangeType Forcefield_Zhang2013::shortRangeType() const { return Forcefield::ShortRangeType::LennardJones; }
+ShortRangeFunctions::Form Forcefield_Zhang2013::shortRangeForm() const { return ShortRangeFunctions::Form::LennardJones; }

--- a/src/data/ff/zhang2013/zhang2013.h
+++ b/src/data/ff/zhang2013/zhang2013.h
@@ -28,5 +28,5 @@ class Forcefield_Zhang2013 : public Forcefield
     // Return description for Forcefield
     std::string_view description() const override;
     // Return short-range interaction style for AtomTypes
-    Forcefield::ShortRangeType shortRangeType() const override;
+    ShortRangeFunctions::Form shortRangeForm() const override;
 };

--- a/src/gui/addforcefieldtermsdialog_funcs.cpp
+++ b/src/gui/addforcefieldtermsdialog_funcs.cpp
@@ -211,8 +211,7 @@ void AddForcefieldTermsDialog::finalise()
         // Overwrite existing parameters?
         if (ui_.AtomTypesOverwriteParametersCheck->isChecked())
         {
-            original.atomType()->setShortRangeParameters(modified.atomType()->shortRangeParameters());
-            original.atomType()->setShortRangeType(modified.atomType()->shortRangeType());
+            original.atomType()->interactionPotential() = modified.atomType()->interactionPotential();
             original.atomType()->setCharge(modified.atomType()->charge());
             dissolve_.coreData().bumpAtomTypesVersion();
         }

--- a/src/gui/copyspeciestermsdialog_funcs.cpp
+++ b/src/gui/copyspeciestermsdialog_funcs.cpp
@@ -65,7 +65,7 @@ void CopySpeciesTermsDialog::findTermsToCopy(std::vector<std::pair<Intra *, cons
         // Only selected and/or unassigned terms?
         if (onlySelected && !targetTerm.isSelected())
             continue;
-        if (onlyUnassigned && targetTerm.form() != unassignedForm)
+        if (onlyUnassigned && targetTerm.interactionForm() != unassignedForm)
             continue;
 
         // Check for a suitable term in the target species
@@ -99,7 +99,7 @@ template <class I> void CopySpeciesTermsDialog::copyTerms(const std::vector<std:
         else
         {
             target->detachFromMasterTerm();
-            target->setFormAndParameters(source->form(), source->parameters());
+            target->setInteractionFormAndParameters(source->interactionForm(), source->interactionParameters());
         }
     }
 }

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -75,7 +75,7 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
     // Set item delegates for tables
     // -- Short Range Functional Forms
     ui_.AtomTypesTable->setItemDelegateForColumn(
-        3, new ComboListDelegate(this, new ComboEnumOptionsItems<Forcefield::ShortRangeType>(Forcefield::shortRangeTypes())));
+        3, new ComboListDelegate(this, new ComboEnumOptionsItems<ShortRangeFunctions::Form>(ShortRangeFunctions::forms())));
 
     // Ensure fonts for table headers are set correctly and the headers themselves are visible
     ui_.AtomTypesTable->horizontalHeader()->setFont(font());

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -70,10 +70,11 @@ QVariant AtomTypeModel::data(const QModelIndex &index, int role) const
                 return QString::number(rawData(index)->charge());
             // Short Range Form
             case (3):
-                return QString::fromStdString(Forcefield::shortRangeTypes().keyword(rawData(index)->shortRangeType()));
+                return QString::fromStdString(
+                    ShortRangeFunctions::forms().keyword(rawData(index)->interactionPotential().form()));
             // Short Range Parameters
             case (4):
-                return QString::fromStdString(joinStrings(rawData(index)->shortRangeParameters()));
+                return QString::fromStdString(rawData(index)->interactionPotential().parametersAsString());
             default:
                 return {};
         }
@@ -127,14 +128,14 @@ bool AtomTypeModel::setData(const QModelIndex &index, const QVariant &value, int
                 break;
             // Short Range Form
             case (3):
-                atomType->setShortRangeType(Forcefield::shortRangeTypes().enumeration(value.toString().toStdString()));
+                atomType->interactionPotential().setForm(
+                    ShortRangeFunctions::forms().enumeration(value.toString().toStdString()));
                 break;
             // Short Range Parameters
             case (4):
-                values = DissolveSys::splitStringToDoubles(value.toString().toStdString());
-                if (!Forcefield::shortRangeTypes().validNArgs(atomType->shortRangeType(), values.size()))
+                if (!atomType->interactionPotential().parseParameters(value.toString().toStdString()))
                     return false;
-                atomType->setShortRangeParameters(values);
+                break;
             default:
                 return false;
         }

--- a/src/gui/models/masterTermModel.cpp
+++ b/src/gui/models/masterTermModel.cpp
@@ -100,9 +100,9 @@ QVariant MasterTermBondModel::getTermData(int index, MasterTermModelData::DataTy
         case (MasterTermModelData::DataType::Name):
             return QString::fromStdString(std::string(masterBond->name()));
         case (MasterTermModelData::DataType::Form):
-            return QString::fromStdString(std::string(BondFunctions::forms().keyword(masterBond->form())));
+            return QString::fromStdString(std::string(BondFunctions::forms().keyword(masterBond->interactionForm())));
         case (MasterTermModelData::DataType::Parameters):
-            return QString::fromStdString(masterBond->parametersAsString());
+            return QString::fromStdString(masterBond->interactionPotential().parametersAsString());
         default:
             return {};
     }
@@ -123,7 +123,7 @@ bool MasterTermBondModel::setTermData(int index, MasterTermModelData::DataType d
             try
             {
                 auto bf = BondFunctions::forms().enumeration(value.toString().toStdString());
-                masterBond->setForm(bf);
+                masterBond->setInteractionForm(bf);
             }
             catch (std::runtime_error &e)
             {
@@ -131,7 +131,7 @@ bool MasterTermBondModel::setTermData(int index, MasterTermModelData::DataType d
             }
             break;
         case (MasterTermModelData::DataType::Parameters):
-            if (!masterBond->setParameters(value.toString().toStdString()))
+            if (!masterBond->setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:
@@ -165,9 +165,9 @@ QVariant MasterTermAngleModel::getTermData(int index, MasterTermModelData::DataT
         case (MasterTermModelData::DataType::Name):
             return QString::fromStdString(std::string(masterAngle->name()));
         case (MasterTermModelData::DataType::Form):
-            return QString::fromStdString(std::string(AngleFunctions::forms().keyword(masterAngle->form())));
+            return QString::fromStdString(std::string(AngleFunctions::forms().keyword(masterAngle->interactionForm())));
         case (MasterTermModelData::DataType::Parameters):
-            return QString::fromStdString(masterAngle->parametersAsString());
+            return QString::fromStdString(masterAngle->interactionPotential().parametersAsString());
         default:
             return {};
     }
@@ -188,7 +188,7 @@ bool MasterTermAngleModel::setTermData(int index, MasterTermModelData::DataType 
             try
             {
                 auto af = AngleFunctions::forms().enumeration(value.toString().toStdString());
-                masterAngle->setForm(af);
+                masterAngle->setInteractionForm(af);
             }
             catch (std::runtime_error &e)
             {
@@ -196,7 +196,7 @@ bool MasterTermAngleModel::setTermData(int index, MasterTermModelData::DataType 
             }
             break;
         case (MasterTermModelData::DataType::Parameters):
-            if (!masterAngle->setParameters(value.toString().toStdString()))
+            if (!masterAngle->setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:
@@ -231,9 +231,9 @@ QVariant MasterTermTorsionModel::getTermData(int index, MasterTermModelData::Dat
         case (MasterTermModelData::DataType::Name):
             return QString::fromStdString(std::string(masterTorsion->name()));
         case (MasterTermModelData::DataType::Form):
-            return QString::fromStdString(std::string(TorsionFunctions::forms().keyword(masterTorsion->form())));
+            return QString::fromStdString(std::string(TorsionFunctions::forms().keyword(masterTorsion->interactionForm())));
         case (MasterTermModelData::DataType::Parameters):
-            return QString::fromStdString(masterTorsion->parametersAsString());
+            return QString::fromStdString(masterTorsion->interactionPotential().parametersAsString());
         default:
             return {};
     }
@@ -254,7 +254,7 @@ bool MasterTermTorsionModel::setTermData(int index, MasterTermModelData::DataTyp
             try
             {
                 auto tf = TorsionFunctions::forms().enumeration(value.toString().toStdString());
-                masterTorsion->setForm(tf);
+                masterTorsion->setInteractionForm(tf);
             }
             catch (std::runtime_error &e)
             {
@@ -262,7 +262,7 @@ bool MasterTermTorsionModel::setTermData(int index, MasterTermModelData::DataTyp
             }
             break;
         case (MasterTermModelData::DataType::Parameters):
-            if (!masterTorsion->setParameters(value.toString().toStdString()))
+            if (!masterTorsion->setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:
@@ -297,9 +297,9 @@ QVariant MasterTermImproperModel::getTermData(int index, MasterTermModelData::Da
         case (MasterTermModelData::DataType::Name):
             return QString::fromStdString(std::string(masterImproper->name()));
         case (MasterTermModelData::DataType::Form):
-            return QString::fromStdString(std::string(TorsionFunctions::forms().keyword(masterImproper->form())));
+            return QString::fromStdString(std::string(TorsionFunctions::forms().keyword(masterImproper->interactionForm())));
         case (MasterTermModelData::DataType::Parameters):
-            return QString::fromStdString(masterImproper->parametersAsString());
+            return QString::fromStdString(masterImproper->interactionPotential().parametersAsString());
         default:
             return {};
     }
@@ -320,7 +320,7 @@ bool MasterTermImproperModel::setTermData(int index, MasterTermModelData::DataTy
             try
             {
                 auto tf = TorsionFunctions::forms().enumeration(value.toString().toStdString());
-                masterImproper->setForm(tf);
+                masterImproper->setInteractionForm(tf);
             }
             catch (std::runtime_error &e)
             {
@@ -328,7 +328,7 @@ bool MasterTermImproperModel::setTermData(int index, MasterTermModelData::DataTy
             }
             break;
         case (MasterTermModelData::DataType::Parameters):
-            if (!masterImproper->setParameters(value.toString().toStdString()))
+            if (!masterImproper->setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:

--- a/src/gui/models/pairPotentialModel.cpp
+++ b/src/gui/models/pairPotentialModel.cpp
@@ -42,14 +42,14 @@ QVariant PairPotentialModel::data(const QModelIndex &index, int role) const
             // Charge
             case (2):
                 return QString::fromStdString(
-                    std::string(Forcefield::shortRangeTypes().keyword(rawData(index)->shortRangeType())));
+                    ShortRangeFunctions::forms().keyword(rawData(index)->interactionPotential().form()));
             // Short Range Parameters
             case (3):
                 return QString::number(rawData(index)->chargeI());
             case (4):
                 return QString::number(rawData(index)->chargeJ());
             case (5):
-                return QString::fromStdString(joinStrings(rawData(index)->parameters()));
+                return QString::fromStdString(rawData(index)->interactionPotential().parametersAsString());
             default:
                 return {};
         }
@@ -85,14 +85,8 @@ bool PairPotentialModel::setData(const QModelIndex &index, const QVariant &value
             break;
         // Short Range Parameters
         case (5):
-            values = DissolveSys::splitStringToDoubles(value.toString().toStdString());
-            if (values.size() != pair->parameters().size())
+            if (!pair->interactionPotential().parseParameters(value.toString().toStdString()))
                 return false;
-            {
-                int idx = 0;
-                for (auto v : values)
-                    pair->setParameter(idx++, v);
-            }
             break;
         default:
             return false;

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -48,7 +48,9 @@ QVariant SpeciesAngleModel::data(const QModelIndex &index, int role) const
                 return angle.masterTerm() ? QString::fromStdString("@" + std::string(angle.masterTerm()->name()))
                                           : QString::fromStdString(AngleFunctions::forms().keyword(angle.interactionForm()));
             case 4:
-                return QString::fromStdString(angle.interactionPotential().parametersAsString());
+                return angle.masterTerm()
+                           ? QString::fromStdString(angle.masterTerm()->interactionPotential().parametersAsString())
+                           : QString::fromStdString(angle.interactionPotential().parametersAsString());
             default:
                 return {};
         }

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -46,9 +46,9 @@ QVariant SpeciesAngleModel::data(const QModelIndex &index, int role) const
                 return angle.index(index.column()) + 1;
             case 3:
                 return angle.masterTerm() ? QString::fromStdString("@" + std::string(angle.masterTerm()->name()))
-                                          : QString::fromStdString(AngleFunctions::forms().keyword(angle.form()));
+                                          : QString::fromStdString(AngleFunctions::forms().keyword(angle.interactionForm()));
             case 4:
-                return QString::fromStdString(angle.parametersAsString());
+                return QString::fromStdString(angle.interactionPotential().parametersAsString());
             default:
                 return {};
         }
@@ -110,7 +110,7 @@ bool SpeciesAngleModel::setData(const QModelIndex &index, const QVariant &value,
                 {
                     auto af = AngleFunctions::forms().enumeration(value.toString().toStdString());
                     angle.detachFromMasterTerm();
-                    angle.setForm(af);
+                    angle.setInteractionForm(af);
                 }
                 catch (std::runtime_error &e)
                 {
@@ -119,7 +119,7 @@ bool SpeciesAngleModel::setData(const QModelIndex &index, const QVariant &value,
             }
             break;
         case 4:
-            if (!angle.setParameters(value.toString().toStdString()))
+            if (!angle.setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -45,7 +45,9 @@ QVariant SpeciesBondModel::data(const QModelIndex &index, int role) const
                            ? QString::fromStdString("@" + std::string(bond.masterTerm()->name()))
                            : QString::fromStdString(std::string(BondFunctions::forms().keyword(bond.interactionForm())));
             case 3:
-                return QString::fromStdString(bond.interactionPotential().parametersAsString());
+                return bond.masterTerm()
+                           ? QString::fromStdString(bond.masterTerm()->interactionPotential().parametersAsString())
+                           : QString::fromStdString(bond.interactionPotential().parametersAsString());
             default:
                 return {};
         }

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -41,10 +41,11 @@ QVariant SpeciesBondModel::data(const QModelIndex &index, int role) const
             case 1:
                 return bond.index(index.column()) + 1;
             case 2:
-                return bond.masterTerm() ? QString::fromStdString("@" + std::string(bond.masterTerm()->name()))
-                                         : QString::fromStdString(std::string(BondFunctions::forms().keyword(bond.form())));
+                return bond.masterTerm()
+                           ? QString::fromStdString("@" + std::string(bond.masterTerm()->name()))
+                           : QString::fromStdString(std::string(BondFunctions::forms().keyword(bond.interactionForm())));
             case 3:
-                return QString::fromStdString(bond.parametersAsString());
+                return QString::fromStdString(bond.interactionPotential().parametersAsString());
             default:
                 return {};
         }
@@ -103,7 +104,7 @@ bool SpeciesBondModel::setData(const QModelIndex &index, const QVariant &value, 
                 {
                     auto bf = BondFunctions::forms().enumeration(value.toString().toStdString());
                     bond.detachFromMasterTerm();
-                    bond.setForm(bf);
+                    bond.setInteractionForm(bf);
                 }
                 catch (std::runtime_error &e)
                 {
@@ -112,7 +113,7 @@ bool SpeciesBondModel::setData(const QModelIndex &index, const QVariant &value, 
             }
             break;
         case 3:
-            if (!bond.setParameters(value.toString().toStdString()))
+            if (!bond.setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -50,7 +50,9 @@ QVariant SpeciesImproperModel::data(const QModelIndex &index, int role) const
                            ? QString::fromStdString("@" + std::string(improper.masterTerm()->name()))
                            : QString::fromStdString(TorsionFunctions::forms().keyword(improper.interactionForm()));
             case 5:
-                return QString::fromStdString(improper.interactionPotential().parametersAsString());
+                return improper.masterTerm()
+                           ? QString::fromStdString(improper.masterTerm()->interactionPotential().parametersAsString())
+                           : QString::fromStdString(improper.interactionPotential().parametersAsString());
             default:
                 return {};
         }

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -46,10 +46,11 @@ QVariant SpeciesImproperModel::data(const QModelIndex &index, int role) const
             case 3:
                 return improper.index(index.column()) + 1;
             case 4:
-                return improper.masterTerm() ? QString::fromStdString("@" + std::string(improper.masterTerm()->name()))
-                                             : QString::fromStdString(TorsionFunctions::forms().keyword(improper.form()));
+                return improper.masterTerm()
+                           ? QString::fromStdString("@" + std::string(improper.masterTerm()->name()))
+                           : QString::fromStdString(TorsionFunctions::forms().keyword(improper.interactionForm()));
             case 5:
-                return QString::fromStdString(improper.parametersAsString());
+                return QString::fromStdString(improper.interactionPotential().parametersAsString());
             default:
                 return {};
         }
@@ -117,7 +118,7 @@ bool SpeciesImproperModel::setData(const QModelIndex &index, const QVariant &val
                 {
                     auto tf = TorsionFunctions::forms().enumeration(value.toString().toStdString());
                     improper.detachFromMasterTerm();
-                    improper.setForm(tf);
+                    improper.setInteractionForm(tf);
                 }
                 catch (std::runtime_error &e)
                 {
@@ -126,7 +127,7 @@ bool SpeciesImproperModel::setData(const QModelIndex &index, const QVariant &val
             }
             break;
         case 5:
-            if (!improper.setParameters(value.toString().toStdString()))
+            if (!improper.setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -46,10 +46,11 @@ QVariant SpeciesTorsionModel::data(const QModelIndex &index, int role) const
             case 3:
                 return torsion.index(index.column()) + 1;
             case 4:
-                return torsion.masterTerm() ? QString::fromStdString("@" + std::string(torsion.masterTerm()->name()))
-                                            : QString::fromStdString(TorsionFunctions::forms().keyword(torsion.form()));
+                return torsion.masterTerm()
+                           ? QString::fromStdString("@" + std::string(torsion.masterTerm()->name()))
+                           : QString::fromStdString(TorsionFunctions::forms().keyword(torsion.interactionForm()));
             case 5:
-                return QString::fromStdString(torsion.parametersAsString());
+                return QString::fromStdString(torsion.interactionPotential().parametersAsString());
             default:
                 return {};
         }
@@ -117,7 +118,7 @@ bool SpeciesTorsionModel::setData(const QModelIndex &index, const QVariant &valu
                 {
                     auto tf = TorsionFunctions::forms().enumeration(value.toString().toStdString());
                     torsion.detachFromMasterTerm();
-                    torsion.setForm(tf);
+                    torsion.setInteractionForm(tf);
                 }
                 catch (std::runtime_error &e)
                 {
@@ -126,7 +127,7 @@ bool SpeciesTorsionModel::setData(const QModelIndex &index, const QVariant &valu
             }
             break;
         case 5:
-            if (!torsion.setParameters(value.toString().toStdString()))
+            if (!torsion.setInteractionParameters(value.toString().toStdString()))
                 return false;
             break;
         default:

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -50,7 +50,9 @@ QVariant SpeciesTorsionModel::data(const QModelIndex &index, int role) const
                            ? QString::fromStdString("@" + std::string(torsion.masterTerm()->name()))
                            : QString::fromStdString(TorsionFunctions::forms().keyword(torsion.interactionForm()));
             case 5:
-                return QString::fromStdString(torsion.interactionPotential().parametersAsString());
+                return torsion.masterTerm()
+                           ? QString::fromStdString(torsion.masterTerm()->interactionPotential().parametersAsString())
+                           : QString::fromStdString(torsion.interactionPotential().parametersAsString());
             default:
                 return {};
         }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -186,22 +186,26 @@ bool Dissolve::saveInput(std::string_view filename)
 
         for (auto &b : coreData_.masterBonds())
             if (!parser.writeLineF("  {}  '{}'  {}  {}\n", MasterBlock::keywords().keyword(MasterBlock::BondKeyword), b->name(),
-                                   BondFunctions::forms().keyword(b->form()), b->parametersAsString()))
+                                   BondFunctions::forms().keyword(b->interactionForm()),
+                                   b->interactionPotential().parametersAsString()))
                 return false;
 
         for (auto &a : coreData_.masterAngles())
             if (!parser.writeLineF("  {}  '{}'  {}  {}\n", MasterBlock::keywords().keyword(MasterBlock::AngleKeyword),
-                                   a->name(), AngleFunctions::forms().keyword(a->form()), a->parametersAsString()))
+                                   a->name(), AngleFunctions::forms().keyword(a->interactionForm()),
+                                   a->interactionPotential().parametersAsString()))
                 return false;
 
         for (auto &t : coreData_.masterTorsions())
             if (!parser.writeLineF("  {}  '{}'  {}  {}\n", MasterBlock::keywords().keyword(MasterBlock::TorsionKeyword),
-                                   t->name(), TorsionFunctions::forms().keyword(t->form()), t->parametersAsString()))
+                                   t->name(), TorsionFunctions::forms().keyword(t->interactionForm()),
+                                   t->interactionPotential().parametersAsString()))
                 return false;
 
         for (auto &imp : coreData_.masterImpropers())
             if (!parser.writeLineF("  {}  '{}'  {}  {}\n", MasterBlock::keywords().keyword(MasterBlock::ImproperKeyword),
-                                   imp->name(), TorsionFunctions::forms().keyword(imp->form()), imp->parametersAsString()))
+                                   imp->name(), TorsionFunctions::forms().keyword(imp->interactionForm()),
+                                   imp->interactionPotential().parametersAsString()))
                 return false;
 
         // Done with the master terms

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -233,16 +233,12 @@ bool Dissolve::saveInput(std::string_view filename)
     if (!parser.writeLineF("  # Atom Type Parameters\n"))
         return false;
     for (const auto &atomType : atomTypes())
-    {
-        std::string line = fmt::format("  {}  {}  {}  {:12.6e}  {}",
-                                       PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::ParametersKeyword),
-                                       atomType->name(), Elements::symbol(atomType->Z()), atomType->charge(),
-                                       Forcefield::shortRangeTypes().keyword(atomType->shortRangeType()));
-        for (auto x : atomType->shortRangeParameters())
-            line += fmt::format("  {:12.6e}", x);
-        if (!parser.writeLine(line))
+        if (!parser.writeLineF("  {}  {}  {}  {:12.6e}  {}  {}\n",
+                               PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::ParametersKeyword),
+                               atomType->name(), Elements::symbol(atomType->Z()), atomType->charge(),
+                               ShortRangeFunctions::forms().keyword(atomType->interactionPotential().form()),
+                               atomType->interactionPotential().parametersAsString()))
             return false;
-    }
 
     if (!parser.writeLineF("  {}  {}\n", PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::RangeKeyword),
                            pairPotentialRange_))

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -58,7 +58,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 try
                 {
                     auto &masterAngle = coreData.addMasterAngle(parser.argsv(1));
-                    masterAngle.setForm(af);
+                    masterAngle.setInteractionForm(af);
 
                     // Check number of args provided
                     if (!AngleFunctions::forms().validNArgs(af, parser.nArgs() - 3))
@@ -68,15 +68,15 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!masterAngle.setParameters(parser, 3))
+                    if (!masterAngle.setInteractionParameters(parser, 3))
                     {
                         error = true;
                         break;
                     }
 
                     Messenger::printVerbose("Defined master angle term: {:<10}  {:<12}  {}\n", masterAngle.name(),
-                                            AngleFunctions::forms().keyword(masterAngle.form()),
-                                            masterAngle.parametersAsString());
+                                            AngleFunctions::forms().keyword(masterAngle.interactionForm()),
+                                            masterAngle.interactionPotential().parametersAsString());
                 }
                 catch (const std::runtime_error &e)
                 {
@@ -98,7 +98,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 try
                 {
                     auto &masterBond = coreData.addMasterBond(parser.argsv(1));
-                    masterBond.setForm(bf);
+                    masterBond.setInteractionForm(bf);
 
                     // Check number of args provided
                     if (!BondFunctions::forms().validNArgs(bf, parser.nArgs() - 3))
@@ -108,14 +108,15 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!masterBond.setParameters(parser, 3))
+                    if (!masterBond.setInteractionParameters(parser, 3))
                     {
                         error = true;
                         break;
                     }
 
                     Messenger::printVerbose("Defined master bond term: {:<10}  {:<12}  {}\n", masterBond.name(),
-                                            BondFunctions::forms().keyword(masterBond.form()), masterBond.parametersAsString());
+                                            BondFunctions::forms().keyword(masterBond.interactionForm()),
+                                            masterBond.interactionPotential().parametersAsString());
                 }
                 catch (const std::runtime_error &e)
                 {
@@ -141,7 +142,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 try
                 {
                     auto &masterImproper = coreData.addMasterImproper(parser.argsv(1));
-                    masterImproper.setForm(tf);
+                    masterImproper.setInteractionForm(tf);
 
                     // Check number of args provided
                     if (!TorsionFunctions::forms().validNArgs(tf, parser.nArgs() - 3))
@@ -151,15 +152,15 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!masterImproper.setParameters(parser, 3))
+                    if (!masterImproper.setInteractionParameters(parser, 3))
                     {
                         error = true;
                         break;
                     }
 
                     Messenger::printVerbose("Defined master improper term: {:<10}  {:<12}  {}\n", masterImproper.name(),
-                                            TorsionFunctions::forms().keyword(masterImproper.form()),
-                                            masterImproper.parametersAsString());
+                                            TorsionFunctions::forms().keyword(masterImproper.interactionForm()),
+                                            masterImproper.interactionPotential().parametersAsString());
                 }
                 catch (const std::runtime_error &e)
                 {
@@ -181,7 +182,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 try
                 {
                     auto &masterTorsion = coreData.addMasterTorsion(parser.argsv(1));
-                    masterTorsion.setForm(tf);
+                    masterTorsion.setInteractionForm(tf);
 
                     // Check number of args provided
                     if (!TorsionFunctions::forms().validNArgs(tf, parser.nArgs() - 3))
@@ -191,15 +192,15 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     }
 
                     // Set parameters
-                    if (!masterTorsion.setParameters(parser, 3))
+                    if (!masterTorsion.setInteractionParameters(parser, 3))
                     {
                         error = true;
                         break;
                     }
 
                     Messenger::printVerbose("Defined master torsion term: {:<10}  {:<12}  {}\n", masterTorsion.name(),
-                                            TorsionFunctions::forms().keyword(masterTorsion.form()),
-                                            masterTorsion.parametersAsString());
+                                            TorsionFunctions::forms().keyword(masterTorsion.interactionForm()),
+                                            masterTorsion.interactionPotential().parametersAsString());
                 }
                 catch (const std::runtime_error &e)
                 {

--- a/src/main/keywords_pairpotentials.cpp
+++ b/src/main/keywords_pairpotentials.cpp
@@ -31,7 +31,6 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
     std::shared_ptr<AtomType> at1;
     auto blockDone = false, error = false;
     Elements::Element Z;
-    std::vector<double> parameters;
 
     while (!parser.eofOrBlank())
     {
@@ -110,19 +109,18 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 at1->setCharge(parser.argd(3));
 
                 // Get short-range type
-                if (!Forcefield::shortRangeTypes().isValid(parser.argsv(4)))
+                if (!ShortRangeFunctions::forms().isValid(parser.argsv(4)))
                 {
-                    Forcefield::shortRangeTypes().errorAndPrintValid(parser.argsv(4));
+                    ShortRangeFunctions::forms().errorAndPrintValid(parser.argsv(4));
                     error = true;
                     break;
                 }
-                at1->setShortRangeType(Forcefield::shortRangeTypes().enumeration(parser.argsv(4)));
-
-                // Get interaction parameters
-                parameters.clear();
-                for (int n = 5; n < parser.nArgs(); ++n)
-                    parameters.push_back(parser.argd(n));
-                at1->setShortRangeParameters(parameters);
+                at1->interactionPotential().setForm(ShortRangeFunctions::forms().enumeration(parser.argsv(4)));
+                if (!at1->interactionPotential().parseParameters(parser, 5))
+                {
+                    error = true;
+                    break;
+                }
                 break;
             case (PairPotentialsBlock::RangeKeyword):
                 dissolve->setPairPotentialRange(parser.argd(1));

--- a/src/main/pairpotentials.cpp
+++ b/src/main/pairpotentials.cpp
@@ -146,9 +146,7 @@ bool Dissolve::generatePairPotentials(const std::shared_ptr<AtomType> &onlyInvol
             }
 
             // Check the implied short-range form of the potential
-            if (pot->shortRangeType() == Forcefield::ShortRangeType::Undefined)
-                ++nUndefined;
-            else if (!pot->tabulate(pairPotentialRange_, pairPotentialDelta_, atomTypeChargeSource_))
+            if (!pot->tabulate(pairPotentialRange_, pairPotentialDelta_, atomTypeChargeSource_))
                 return false;
 
             // Retrieve additional potential from the processing module data, if present
@@ -161,5 +159,5 @@ bool Dissolve::generatePairPotentials(const std::shared_ptr<AtomType> &onlyInvol
 
     pairPotentialAtomTypeVersion_ = coreData_.atomTypesVersion();
 
-    return (nUndefined == 0);
+    return true;
 }

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -69,12 +69,12 @@ void Dissolve::copySpeciesBond(const SpeciesBond &source, SpeciesBond &dest)
         if (!master)
         {
             master = coreData_.addMasterBond(source.masterTerm()->name());
-            master->get().setFormAndParameters(source.form(), source.parameters());
+            master->get().setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
         }
         dest.setMasterTerm(&master->get());
     }
     else
-        dest.setFormAndParameters(source.form(), source.parameters());
+        dest.setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
 }
 void Dissolve::copySpeciesAngle(const SpeciesAngle &source, SpeciesAngle &dest)
 {
@@ -84,12 +84,12 @@ void Dissolve::copySpeciesAngle(const SpeciesAngle &source, SpeciesAngle &dest)
         if (!master)
         {
             master = coreData_.addMasterAngle(source.masterTerm()->name());
-            master->get().setFormAndParameters(source.form(), source.parameters());
+            master->get().setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
         }
         dest.setMasterTerm(&master->get());
     }
     else
-        dest.setFormAndParameters(source.form(), source.parameters());
+        dest.setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
 }
 void Dissolve::copySpeciesTorsion(const SpeciesTorsion &source, SpeciesTorsion &dest)
 {
@@ -99,12 +99,12 @@ void Dissolve::copySpeciesTorsion(const SpeciesTorsion &source, SpeciesTorsion &
         if (!master)
         {
             master = coreData_.addMasterTorsion(source.masterTerm()->name());
-            master->get().setFormAndParameters(source.form(), source.parameters());
+            master->get().setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
         }
         dest.setMasterTerm(&master->get());
     }
     else
-        dest.setFormAndParameters(source.form(), source.parameters());
+        dest.setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
 }
 void Dissolve::copySpeciesImproper(const SpeciesImproper &source, SpeciesImproper &dest)
 {
@@ -114,12 +114,12 @@ void Dissolve::copySpeciesImproper(const SpeciesImproper &source, SpeciesImprope
         if (!master)
         {
             master = coreData_.addMasterImproper(source.masterTerm()->name());
-            master->get().setFormAndParameters(source.form(), source.parameters());
+            master->get().setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
         }
         dest.setMasterTerm(&master->get());
     }
     else
-        dest.setFormAndParameters(source.form(), source.parameters());
+        dest.setInteractionFormAndParameters(source.interactionForm(), source.interactionParameters());
 }
 
 // Copy Species from supplied instance

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -53,8 +53,7 @@ void Dissolve::copyAtomType(const SpeciesAtom *sourceAtom, SpeciesAtom *destAtom
     {
         at = addAtomType(sourceAtom->Z());
         at->setName(sourceAtom->atomType()->name());
-        at->setShortRangeParameters(sourceAtom->atomType()->shortRangeParameters());
-        at->setShortRangeType(sourceAtom->atomType()->shortRangeType());
+        at->interactionPotential() = sourceAtom->atomType()->interactionPotential();
     }
 
     destAtom->setAtomType(at);

--- a/src/modules/checkspecies/checkspecies.h
+++ b/src/modules/checkspecies/checkspecies.h
@@ -57,7 +57,7 @@ class CheckSpeciesModule : public Module
             return Messenger::error("No {} {} exists in the species.", intraType, indexString);
 
         const T &intra = *term;
-        const auto &sourceParams = intra.parameters();
+        const auto &sourceParams = intra.interactionParameters();
 
         // Check parameter values
         auto result = true;

--- a/tests/energyforce3/py4oh-ntf2.txt
+++ b/tests/energyforce3/py4oh-ntf2.txt
@@ -354,28 +354,28 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  C  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  S  S     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  N  N      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  F  F      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  O  O      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  nc  N     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ca_o  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ca_m  C      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ca_p  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ha_o  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ha_m  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ha_p  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_1  C      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_2  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_1  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_3  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_2  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_4  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_3  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  oh  O      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_4  H      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ho  H     0.0       LJ  0.0  0.0  0.0  0.0
+  Parameters  C  C     0.0       LJ  0.0  0.0
+  Parameters  S  S     0.0       LJ  0.0  0.0
+  Parameters  N  N      0.0       LJ  0.0  0.0
+  Parameters  F  F      0.0       LJ  0.0  0.0
+  Parameters  O  O      0.0       LJ  0.0  0.0
+  Parameters  nc  N     0.0       LJ  0.0  0.0
+  Parameters  ca_o  C     0.0       LJ  0.0  0.0
+  Parameters  ca_m  C      0.0       LJ  0.0  0.0
+  Parameters  ca_p  C     0.0       LJ  0.0  0.0
+  Parameters  ha_o  H     0.0       LJ  0.0  0.0
+  Parameters  ha_m  H     0.0       LJ  0.0  0.0
+  Parameters  ha_p  H     0.0       LJ  0.0  0.0
+  Parameters  ct_1  C      0.0       LJ  0.0  0.0
+  Parameters  ct_2  C     0.0       LJ  0.0  0.0
+  Parameters  hc_1  H     0.0       LJ  0.0  0.0
+  Parameters  ct_3  C     0.0       LJ  0.0  0.0
+  Parameters  hc_2  H     0.0       LJ  0.0  0.0
+  Parameters  ct_4  C     0.0       LJ  0.0  0.0
+  Parameters  hc_3  H     0.0       LJ  0.0  0.0
+  Parameters  oh  O      0.0       LJ  0.0  0.0
+  Parameters  hc_4  H      0.0       LJ  0.0  0.0
+  Parameters  ho  H     0.0       LJ  0.0  0.0
   Range  9.000000
   Delta  0.005000
   IncludeCoulomb  False

--- a/tests/energyforce4/py4oh-ntf2.txt
+++ b/tests/energyforce4/py4oh-ntf2.txt
@@ -277,28 +277,28 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  C  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  S  S     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  N  N      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  F  F      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  O  O      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  nc  N     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ca_o  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ca_m  C      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ca_p  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ha_o  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ha_m  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ha_p  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_1  C      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_2  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_1  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_3  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_2  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ct_4  C     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_3  H     0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  oh  O      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  hc_4  H      0.0       LJ  0.0  0.0  0.0  0.0
-  Parameters  ho  H     0.0       LJ  0.0  0.0  0.0  0.0
+  Parameters  C  C     0.0       LJ  0.0  0.0
+  Parameters  S  S     0.0       LJ  0.0  0.0
+  Parameters  N  N      0.0       LJ  0.0  0.0
+  Parameters  F  F      0.0       LJ  0.0  0.0
+  Parameters  O  O      0.0       LJ  0.0  0.0
+  Parameters  nc  N     0.0       LJ  0.0  0.0
+  Parameters  ca_o  C     0.0       LJ  0.0  0.0
+  Parameters  ca_m  C      0.0       LJ  0.0  0.0
+  Parameters  ca_p  C     0.0       LJ  0.0  0.0
+  Parameters  ha_o  H     0.0       LJ  0.0  0.0
+  Parameters  ha_m  H     0.0       LJ  0.0  0.0
+  Parameters  ha_p  H     0.0       LJ  0.0  0.0
+  Parameters  ct_1  C      0.0       LJ  0.0  0.0
+  Parameters  ct_2  C     0.0       LJ  0.0  0.0
+  Parameters  hc_1  H     0.0       LJ  0.0  0.0
+  Parameters  ct_3  C     0.0       LJ  0.0  0.0
+  Parameters  hc_2  H     0.0       LJ  0.0  0.0
+  Parameters  ct_4  C     0.0       LJ  0.0  0.0
+  Parameters  hc_3  H     0.0       LJ  0.0  0.0
+  Parameters  oh  O      0.0       LJ  0.0  0.0
+  Parameters  hc_4  H      0.0       LJ  0.0  0.0
+  Parameters  ho  H     0.0       LJ  0.0  0.0
   Range  9.000000
   Delta  0.005000
   IncludeCoulomb  False

--- a/tests/epsr/water-neutron-xray.txt
+++ b/tests/epsr/water-neutron-xray.txt
@@ -53,8 +53,8 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  OW  O  -8.200000e-01  LJ  6.503000e-01  3.165492e+00  0.000000e+00  0.000000e+00
-  Parameters  HW  H  4.100000e-01  LJ  0.000000e+00  0.000000e+00  0.000000e+00  0.000000e+00
+  Parameters  OW  O  -8.200000e-01  LJ  6.503000e-01  3.165492e+00
+  Parameters  HW  H  4.100000e-01  LJ  0.000000e+00  0.000000e+00
   Range  15.000000
   Delta  0.005000
   CoulombTruncation  Shifted

--- a/tests/inputs/benzene.txt
+++ b/tests/inputs/benzene.txt
@@ -110,8 +110,8 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00  0.000000e+00  0.000000e+00
-  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00  0.000000e+00  0.000000e+00
+  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00
+  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00
   Range  12.000000
   Delta  0.005000
   IncludeCoulomb  True

--- a/tests/md/benzene.txt
+++ b/tests/md/benzene.txt
@@ -110,8 +110,8 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00  0.000000e+00  0.000000e+00
-  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00  0.000000e+00  0.000000e+00
+  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00
+  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00
   Range  12.000000
   Delta  0.005000
   CoulombTruncation  Shifted

--- a/tests/molshake/benzene.txt
+++ b/tests/molshake/benzene.txt
@@ -110,8 +110,8 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00  0.000000e+00  0.000000e+00
-  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00  0.000000e+00  0.000000e+00
+  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00
+  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00
   Range  12.000000
   Delta  0.005000
   IncludeCoulomb  True

--- a/tests/restart/benzene.txt
+++ b/tests/restart/benzene.txt
@@ -110,8 +110,8 @@ EndSpecies
 
 PairPotentials
   # Atom Type Parameters
-  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00  0.000000e+00  0.000000e+00
-  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00  0.000000e+00  0.000000e+00
+  Parameters  CA  C  -1.150000e-01  LJGeometric  2.928800e-01  3.550000e+00
+  Parameters  HA  H  1.150000e-01  LJGeometric  1.255200e-01  2.420000e+00
   Range  12.000000
   Delta  0.005000
   IncludeCoulomb  True

--- a/unit/classes/cells.cpp
+++ b/unit/classes/cells.cpp
@@ -26,24 +26,21 @@ TEST(CellsTest, Basic)
     // Add atom types and LJ pair potentials (only one real one - between Ar and OW
     auto arType = dissolve.addAtomType(Elements::Ar);
     arType->setName("Ar");
-    arType->setShortRangeType(Forcefield::ShortRangeType::LennardJones);
-    arType->setShortRangeParameters({0.0, 0.0});
+    arType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
     auto hType = dissolve.addAtomType(Elements::H);
     hType->setName("HW");
-    hType->setShortRangeType(Forcefield::ShortRangeType::LennardJones);
-    hType->setShortRangeParameters({0.0, 0.0});
+    hType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
     auto oType = dissolve.addAtomType(Elements::O);
     oType->setName("OW");
-    oType->setShortRangeType(Forcefield::ShortRangeType::LennardJones);
-    oType->setShortRangeParameters({0.0, 0.0});
-    dissolve.addPairPotential(arType, arType)->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
-    dissolve.addPairPotential(hType, hType)->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
-    dissolve.addPairPotential(oType, oType)->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
-    dissolve.addPairPotential(hType, oType)->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
-    dissolve.addPairPotential(arType, hType)->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
+    oType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
+
+    dissolve.addPairPotential(arType, arType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    dissolve.addPairPotential(hType, hType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    dissolve.addPairPotential(oType, oType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    dissolve.addPairPotential(hType, oType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    dissolve.addPairPotential(arType, hType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
     auto *pp = dissolve.addPairPotential(arType, oType);
-    pp->setShortRangeType(Forcefield::ShortRangeType::LennardJones);
-    pp->setParameters({0.0, 0.0});
+    pp->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
     // Set up pseudo-species
     auto *argon = dissolve.addSpecies();
@@ -73,10 +70,9 @@ TEST(CellsTest, Basic)
         i.setCoordinates(r);
     cfg->updateCellContents();
 
-    // Prepare the main simulation, and re-generate our specific Ar-OW parameters
+    // Prepare the main simulation, and re-generate our specific Ar-OW potential
     EXPECT_TRUE(dissolve.prepare());
-    pp->setShortRangeType(Forcefield::ShortRangeType::LennardJones);
-    pp->setParameters({0.35, 2.166});
+    pp->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.35 sigma=2.166");
     pp->tabulate(dissolve.pairPotentialRange(), dissolve.pairPotentialDelta(), false);
 
     // Test consistency of energy calculation with DL_POLY reference energies

--- a/unit/classes/neta.cpp
+++ b/unit/classes/neta.cpp
@@ -248,7 +248,7 @@ TEST_F(NETATest, Forcefield)
         }
         std::string_view name() const override { return "Test Forcefield for NETA."; }
         std::string_view description() const override { return "Test Forcefield for NETA."; }
-        ShortRangeType shortRangeType() const override { return Forcefield::ShortRangeType::LennardJones; }
+        ShortRangeFunctions::Form shortRangeForm() const override { return ShortRangeFunctions::Form::LennardJones; }
     };
 
     Forcefield_TEST testFF;

--- a/unit/gui/forcefieldTab.cpp
+++ b/unit/gui/forcefieldTab.cpp
@@ -46,14 +46,14 @@ TEST_F(ForcefieldTabTest, PairPotentials)
     EXPECT_EQ(pairs.data(pairs.index(0, 2)).toString().toStdString(), "LJGeometric");
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 3)).toDouble(), -0.115);
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 4)).toDouble(), -0.115);
-    EXPECT_EQ(pairs.data(pairs.index(0, 5)).toString().toStdString(), "0.29288, 3.55");
+    EXPECT_EQ(pairs.data(pairs.index(0, 5)).toString().toStdString(), "epsilon=0.29288 sigma=3.55");
 
     EXPECT_EQ(pairs.data(pairs.index(2, 0)).toString().toStdString(), "HA");
     EXPECT_EQ(pairs.data(pairs.index(2, 1)).toString().toStdString(), "HA");
     EXPECT_EQ(pairs.data(pairs.index(2, 2)).toString().toStdString(), "LJGeometric");
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, 3)).toDouble(), 0.115);
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, 4)).toDouble(), 0.115);
-    EXPECT_EQ(pairs.data(pairs.index(2, 5)).toString().toStdString(), "0.12552, 2.42");
+    EXPECT_EQ(pairs.data(pairs.index(2, 5)).toString().toStdString(), "epsilon=0.12552 sigma=2.42");
 
     // Currently, we do not support the user changing the values, but
     // I've added the option for the future
@@ -66,6 +66,6 @@ TEST_F(ForcefieldTabTest, PairPotentials)
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 4)).toDouble(), -3);
     EXPECT_TRUE(pairs.setData(pairs.index(0, 5), "4.0, -5.0"));
     EXPECT_THAT(pairs.data(pairs.index(0, 5)).toString().toStdString(),
-                testing::AnyOf(testing::Eq("4.0, -5.0"), testing::Eq("4, -5")));
+                testing::AnyOf(testing::Eq("epsilon=4.0 sigma=-5.0"), testing::Eq("epsilon=4 sigma=-5")));
 }
 } // namespace UnitTest

--- a/unit/gui/masterTerms.cpp
+++ b/unit/gui/masterTerms.cpp
@@ -26,9 +26,9 @@ TEST_F(MasterTermsTableModelTest, MasterBonds)
 {
     std::vector<std::shared_ptr<MasterBond>> masterBonds;
     auto &b1 = masterBonds.emplace_back(std::make_shared<MasterBond>("CA-CA"));
-    b1->setFormAndParameters(BondFunctions::Form::Harmonic, "k=3924.590   eq=1.400");
+    b1->setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=3924.590   eq=1.400");
     auto &b2 = masterBonds.emplace_back(std::make_shared<MasterBond>("CA-HA"));
-    b2->setFormAndParameters(BondFunctions::Form::Harmonic, "k=3071.060   eq=1.080");
+    b2->setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=3071.060   eq=1.080");
 
     MasterTermBondModel model;
     model.setSourceData(masterBonds);
@@ -69,9 +69,9 @@ TEST_F(MasterTermsTableModelTest, MasterAngles)
 {
     std::vector<std::shared_ptr<MasterAngle>> masterAngles;
     auto &a1 = masterAngles.emplace_back(std::make_shared<MasterAngle>("CA-CA-CA"));
-    a1->setFormAndParameters(AngleFunctions::Form::Harmonic, "k=527.184   eq=120.000");
+    a1->setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=527.184   eq=120.000");
     auto &a2 = masterAngles.emplace_back(std::make_shared<MasterAngle>("CA-CA-HA"));
-    a2->setFormAndParameters(AngleFunctions::Form::Harmonic, "k=292.880   eq=120.000");
+    a2->setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=292.880   eq=120.000");
 
     MasterTermAngleModel model;
     model.setSourceData(masterAngles);
@@ -113,11 +113,11 @@ TEST_F(MasterTermsTableModelTest, MasterTorsions)
 {
     std::vector<std::shared_ptr<MasterTorsion>> masterTorsions;
     auto &t1 = masterTorsions.emplace_back(std::make_shared<MasterTorsion>("CA-CA-CA-CA"));
-    t1->setFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     0.000");
+    t1->setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     0.000");
     auto &t2 = masterTorsions.emplace_back(std::make_shared<MasterTorsion>("CA-CA-CA-HA"));
-    t2->setFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     1.000");
+    t2->setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     1.000");
     auto &t3 = masterTorsions.emplace_back(std::make_shared<MasterTorsion>("HA-CA-CA-HA"));
-    t3->setFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     2.000");
+    t3->setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     2.000");
 
     MasterTermTorsionModel model;
     model.setSourceData(masterTorsions);

--- a/unit/io/intraParameterParse.cpp
+++ b/unit/io/intraParameterParse.cpp
@@ -16,8 +16,8 @@ template <class I> double testParameters(I &intra, double testValue)
     auto refForce = intra.force(testValue);
 
     // Get the parameters from the term as a string, re-set and compare values
-    auto params = intra.parametersAsString();
-    intra.setFormAndParameters(intra.form(), params);
+    auto params = intra.interactionPotential().parametersAsString();
+    intra.setInteractionFormAndParameters(intra.interactionForm(), params);
 
     EXPECT_DOUBLE_EQ(refEnergy, intra.energy(testValue));
     EXPECT_DOUBLE_EQ(refForce, intra.force(testValue));
@@ -29,62 +29,62 @@ TEST(IntraParameters, Syntax)
 {
     SpeciesBond b;
     // Valid String
-    EXPECT_TRUE(b.setFormAndParameters(BondFunctions::Form::None, ""));
-    EXPECT_TRUE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.0"));
-    EXPECT_TRUE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0   eq=1.0"));
+    EXPECT_TRUE(b.setInteractionFormAndParameters(BondFunctions::Form::None, ""));
+    EXPECT_TRUE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.0"));
+    EXPECT_TRUE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0   eq=1.0"));
     // Just values
-    EXPECT_TRUE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "4000.0 1.0"));
-    EXPECT_TRUE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "4000 1"));
+    EXPECT_TRUE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "4000.0 1.0"));
+    EXPECT_TRUE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "4000 1"));
     // Too many values
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "4000.0 1.0 99"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "4000.0 1.0 99"));
     // Missing parameter
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0"));
     // Comma, not space
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0,eq=1.0"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0,eq=1.0"));
     // Missing value
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "k= eq=1.0"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k= eq=1.0"));
     // Missing name
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "=4000.0 eq=1.0"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "=4000.0 eq=1.0"));
     // Mixing values and assignments
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "4000.0 eq=1.0"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "4000.0 eq=1.0"));
     // Unknown parameter
-    EXPECT_FALSE(b.setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 X=1.0"));
+    EXPECT_FALSE(b.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 X=1.0"));
 
     SpeciesAngle a1, a2;
     // Valid string
-    EXPECT_TRUE(a1.setFormAndParameters(AngleFunctions::Form::Cos2, "k=100.0 C0=1 C1=2 C2=3"));
-    EXPECT_TRUE(a1.setFormAndParameters(AngleFunctions::Form::Cos2, "K=100.0 c0=1 c1=2 C2=3"));
+    EXPECT_TRUE(a1.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "k=100.0 C0=1 C1=2 C2=3"));
+    EXPECT_TRUE(a1.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "K=100.0 c0=1 c1=2 C2=3"));
     // Missing parameter
-    EXPECT_FALSE(a1.setFormAndParameters(AngleFunctions::Form::Cos2, "K=100.0 c0=1 c1=2"));
+    EXPECT_FALSE(a1.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "K=100.0 c0=1 c1=2"));
     // Wrong parameters
-    EXPECT_FALSE(a2.setFormAndParameters(AngleFunctions::Form::Cos2, "eq=1.0 k=4000.0"));
+    EXPECT_FALSE(a2.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "eq=1.0 k=4000.0"));
 
     SpeciesTorsion t;
     // Valid String
-    EXPECT_TRUE(t.setFormAndParameters(TorsionFunctions::Form::Cosine, "k=5.0 eq=1.0 n=3 s=1"));
+    EXPECT_TRUE(t.setInteractionFormAndParameters(TorsionFunctions::Form::Cosine, "k=5.0 eq=1.0 n=3 s=1"));
     // Parameter jumping
-    EXPECT_TRUE(t.setFormAndParameters(TorsionFunctions::Form::CosN, "k6=9.0"));
+    EXPECT_TRUE(t.setInteractionFormAndParameters(TorsionFunctions::Form::CosN, "k6=9.0"));
 }
 
 TEST(IntraParameters, Ordering)
 {
     SpeciesBond b1, b2;
-    EXPECT_TRUE(b1.setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.0"));
-    EXPECT_TRUE(b2.setFormAndParameters(BondFunctions::Form::Harmonic, "eq=1.0 k=4000.0"));
+    EXPECT_TRUE(b1.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.0"));
+    EXPECT_TRUE(b2.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "eq=1.0 k=4000.0"));
     EXPECT_DOUBLE_EQ(testParameters(b1, 1.05), testParameters(b2, 1.05));
 
     SpeciesAngle a1, a2;
-    EXPECT_TRUE(a1.setFormAndParameters(AngleFunctions::Form::Cos2, "k=100.0 C0=1 C1=2 C2=3"));
-    EXPECT_TRUE(a2.setFormAndParameters(AngleFunctions::Form::Cos2, "C0=1 k=100.0 C2=3 C1=2"));
+    EXPECT_TRUE(a1.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "k=100.0 C0=1 C1=2 C2=3"));
+    EXPECT_TRUE(a2.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "C0=1 k=100.0 C2=3 C1=2"));
     EXPECT_DOUBLE_EQ(testParameters(a1, 100.5), testParameters(a2, 100.5));
-    EXPECT_TRUE(a1.setFormAndParameters(AngleFunctions::Form::Cos2, "C2=3 k=100.0 C1=2 C0=1"));
+    EXPECT_TRUE(a1.setInteractionFormAndParameters(AngleFunctions::Form::Cos2, "C2=3 k=100.0 C1=2 C0=1"));
     EXPECT_DOUBLE_EQ(testParameters(a1, 100.5), testParameters(a2, 100.5));
 
     SpeciesTorsion t1, t2;
-    EXPECT_TRUE(t1.setFormAndParameters(TorsionFunctions::Form::CosN, "k6=9.0"));
-    EXPECT_TRUE(t2.setFormAndParameters(TorsionFunctions::Form::CosN, "k1=0.0 k3=0.0 k6=9.0"));
+    EXPECT_TRUE(t1.setInteractionFormAndParameters(TorsionFunctions::Form::CosN, "k6=9.0"));
+    EXPECT_TRUE(t2.setInteractionFormAndParameters(TorsionFunctions::Form::CosN, "k1=0.0 k3=0.0 k6=9.0"));
     EXPECT_DOUBLE_EQ(testParameters(t1, 100.5), testParameters(t2, 100.5));
-    EXPECT_TRUE(t2.setFormAndParameters(TorsionFunctions::Form::CosN, "k6=9.0 k1=0.0 k3=0.0"));
+    EXPECT_TRUE(t2.setInteractionFormAndParameters(TorsionFunctions::Form::CosN, "k6=9.0 k1=0.0 k3=0.0"));
     EXPECT_DOUBLE_EQ(testParameters(t1, 100.5), testParameters(t2, 100.5));
 }
 

--- a/unit/math/derivatives.cpp
+++ b/unit/math/derivatives.cpp
@@ -39,8 +39,7 @@ class DerivativesTest : public ::testing::Test
     void intraTest(Intra &intraTerm, Form form, const std::vector<double> &params, double xMin, double xMax, double xDelta,
                    bool angular = false)
     {
-        intraTerm.setForm(form);
-        intraTerm.setParameters(params);
+        intraTerm.setInteractionFormAndParameters(form, params);
 
         auto x = xMin;
         const auto dx = xDelta / 100.0;

--- a/unit/math/geometryMin.cpp
+++ b/unit/math/geometryMin.cpp
@@ -31,9 +31,9 @@ TEST(GeometryMinimisationTest, Water)
     water.atom(0).setAtomType(atH);
     water.atom(1).setAtomType(atO);
     water.atom(2).setAtomType(atH);
-    water.addBond(0, 1).setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.0");
-    water.addBond(1, 2).setFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.2");
-    water.addAngle(0, 1, 2).setFormAndParameters(AngleFunctions::Form::Harmonic, "k=4000.0 eq=123.45");
+    water.addBond(0, 1).setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.0");
+    water.addBond(1, 2).setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=4000.0 eq=1.2");
+    water.addAngle(0, 1, 2).setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=4000.0 eq=123.45");
 
     // Run the geometry optimisation
     GeometryOptimisationModule geomOpt;

--- a/unit/math/geometryMin.cpp
+++ b/unit/math/geometryMin.cpp
@@ -14,9 +14,9 @@ TEST(GeometryMinimisationTest, Water)
     // Set up CoreData
     CoreData coreData;
     auto atO = coreData.addAtomType(Elements::O);
-    atO->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
+    atO->interactionPotential().setForm(ShortRangeFunctions::Form::None);
     auto atH = coreData.addAtomType(Elements::H);
-    atH->setShortRangeType(Forcefield::ShortRangeType::NoInteraction);
+    atH->interactionPotential().setForm(ShortRangeFunctions::Form::None);
     std::vector<std::unique_ptr<PairPotential>> pairPotentials;
     pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atO, atO);
     pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atH, atH);


### PR DESCRIPTION
This PR breaks out the parameter name parsing from `SpeciesIntra` into an independent `InteractionPotential` template and extends its use to short-range (van der Waals) parameter naming.