### PR TITLE
Roll back to Nixos 21.05

### DIFF
--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -40,6 +40,8 @@ steps:
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
+      nix-channel --add https://nixos.org/channels/nixos-21.11 nixos
+      nix-channel --update
       mkdir -p .config/cachix
       nix-env -iA cachix -f https://cachix.org/api/v1/install
       nix-env -iA nixos.jq

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -32,15 +32,11 @@ steps:
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
-      cp /usr/bin/env ./
-      ls /
-      sudo rm -rf /usr/lib*
       sudo rm -rf /usr/local*
       sudo rm -rf /usr/share*
       sudo rm -rf /usr/src*
-      sudo mkdir -p /usr/bin
-      sudo cp ./env /usr/bin/env
-    displayName: 'Remove redundant ubuntu executables'
+    displayName: 'Remove redundant ubuntu data'
+    condition: eq( '${{ parameters.export }}', 'true' )
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -33,7 +33,9 @@ steps:
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
       cp /usr/bin/env ./
-      rm -rf /usr/*
+      sudo rm -rf /usr/local*
+      sudo rm -rf /usr/src*
+      sudo rm -rf /usr/share*
       mkdir -p /usr/bin
       cp ./env /usr/bin/env
     displayName: 'Remove redundant ubuntu executables'

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -33,6 +33,7 @@ steps:
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
       cp /usr/bin/env ./
+      du -sh /usr/*
       sudo rm -rf /usr/local*
       sudo rm -rf /usr/src*
       sudo rm -rf /usr/share*

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -33,10 +33,11 @@ steps:
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
       cp /usr/bin/env ./
-      du -sh /usr/*
+      ls /
+      sudo rm -rf /usr/lib*
       sudo rm -rf /usr/local*
-      sudo rm -rf /usr/src*
       sudo rm -rf /usr/share*
+      sudo rm -rf /usr/src*
       sudo mkdir -p /usr/bin
       sudo cp ./env /usr/bin/env
     displayName: 'Remove redundant ubuntu executables'

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -32,6 +32,14 @@ steps:
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh
+      cp /usr/bin/env ./
+      rm -rf /usr/*
+      mkdir -p /usr/bin
+      cp ./env /usr/bin/env
+    displayName: 'Remove redundant ubuntu executables'
+  - bash: |
+      set -ex
+      source ~/.nix-profile/etc/profile.d/nix.sh
       mkdir -p .config/cachix
       nix-env -iA cachix -f https://cachix.org/api/v1/install
       nix-env -iA nixos.jq
@@ -43,14 +51,6 @@ steps:
       nix build -L .#${{ parameters.package }}
       nix build --json .#${{ parameters.package }} > archive.json
     displayName: 'Build'
-  - bash: |
-      set -ex
-      source ~/.nix-profile/etc/profile.d/nix.sh
-      cp /usr/bin/env ./
-      rm -rf /usr/*
-      mkdir -p /usr/bin
-      cp ./env /usr/bin/env
-    displayName: 'Remove redundant ubuntu executables'
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -19,7 +19,7 @@ steps:
       set -ex
       # -- General
       sudo apt-get update -q
-      sudo apt-get install curl gpg jq
+      sudo apt-get install curl gpg
       curl -o install-nix${{ parameters.nix_version }} https://releases.nixos.org/nix/nix-${{ parameters.nix_version }}/install
       curl -o install-nix${{ parameters.nix_version }}.asc https://releases.nixos.org/nix/nix-${{ parameters.nix_version }}/install.asc
       gpg2 --keyserver hkps://keyserver.ubuntu.com --recv-keys B541D55301270E0BCF15CA5D8170B4726D7198DE
@@ -34,6 +34,7 @@ steps:
       source ~/.nix-profile/etc/profile.d/nix.sh
       mkdir -p .config/cachix
       nix-env -iA cachix -f https://cachix.org/api/v1/install
+      nix-env -iA jq
       cachix use dissolve-nix
     displayName: 'Install Cachix'
   - bash: |
@@ -42,6 +43,14 @@ steps:
       nix build -L .#${{ parameters.package }}
       nix build --json .#${{ parameters.package }} > archive.json
     displayName: 'Build'
+  - bash: |
+      set -ex
+      source ~/.nix-profile/etc/profile.d/nix.sh
+      cp /usr/bin/env ./
+      rm -rf /usr/*
+      mkdir -p /usr/bin
+      cp ./env /usr/bin/env
+    displayName: 'Remove redundant ubuntu executables'
   - bash: |
       set -ex
       source ~/.nix-profile/etc/profile.d/nix.sh

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -34,7 +34,7 @@ steps:
       source ~/.nix-profile/etc/profile.d/nix.sh
       mkdir -p .config/cachix
       nix-env -iA cachix -f https://cachix.org/api/v1/install
-      nix-env -iA jq
+      nix-env -iA nixos.jq
       cachix use dissolve-nix
     displayName: 'Install Cachix'
   - bash: |

--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -36,8 +36,8 @@ steps:
       sudo rm -rf /usr/local*
       sudo rm -rf /usr/src*
       sudo rm -rf /usr/share*
-      mkdir -p /usr/bin
-      cp ./env /usr/bin/env
+      sudo mkdir -p /usr/bin
+      sudo cp ./env /usr/bin/env
     displayName: 'Remove redundant ubuntu executables'
   - bash: |
       set -ex

--- a/.azure-pipelines/templates/package-linux.yml
+++ b/.azure-pipelines/templates/package-linux.yml
@@ -21,6 +21,7 @@ stages:
             displayName: "Publish Linux GUI Artifacts"
       - job: "linux_singularity"
         displayName: "Ubuntu, Threads, CLI/GUI, Singularity"
+        timeoutInMinutes: 120
         pool:
           vmImage: "ubuntu-latest"
         steps:
@@ -60,6 +61,7 @@ stages:
             displayName: "Publish Linux CLI Artifacts"
       - job: "linux_serial_singularity"
         displayName: "Ubuntu, Serial, CLI, Singularity"
+        timeoutInMinutes: 120
         pool:
           vmImage: "ubuntu-latest"
         steps:
@@ -102,6 +104,7 @@ stages:
             displayName: "Publish MPI Artifacts"
       - job: "linux_mpi_singularity"
         displayName: "Ubuntu, MPI, CLI, Singularity"
+        timeoutInMinutes: 120
         pool:
           vmImage: "ubuntu-latest"
         steps:

--- a/flake.lock
+++ b/flake.lock
@@ -53,16 +53,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1638371214,
-        "narHash": "sha256-0kE6KhgH7n0vyuX4aUoGsGIQOqjIx2fJavpCWtn73rc=",
+        "lastModified": 1641229786,
+        "narHash": "sha256-WPPcLNbVu6ryj772GooUpF285LOvRHdOo/UNJgPnFYI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a640d8394f34714578f3e6335fc767d0755d78f9",
+        "rev": "88579effa7e88c25087faf6de6388d0cd1738dc0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-21.11",
+        "ref": "nixos-21.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.05";
     flake-utils.url = "github:numtide/flake-utils";
     flake-utils.inputs.nixpkgs.follows = "nixpkgs";
     bundler.url = "github:matthewbauer/nix-bundle";


### PR DESCRIPTION
This should take us back off of qemu 6.0.0, which has been having virtualisation issues.  Hopefully, by the time that 22.05 comes out, those issues will be patched.