### PR TITLE
Package Naming

### DIFF
--- a/.azure-pipelines/templates/build-linux.yml
+++ b/.azure-pipelines/templates/build-linux.yml
@@ -67,8 +67,10 @@ steps:
       source ~/.nix-profile/etc/profile.d/nix.sh
       cachix use dissolve-nix
       nix bundle -L .#${{ parameters.package }}
+      # Get program version and move/rename artifact
+      DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
       mkdir -p packages
-      cp ${{ parameters.package }} packages/${{ parameters.package }}
+      cp ${{ parameters.package }} packages/${{ parameters.package }}-${DISSOLVE_VERSION}
       rm ${{ parameters.package }}
     displayName: 'Package Executable'
     condition: and(eq( '${{ parameters.export }}', 'true' ), eq( '${{ parameters.exportExe }}', 'true' ))
@@ -77,7 +79,9 @@ steps:
       source ~/.nix-profile/etc/profile.d/nix.sh
       cachix use dissolve-nix
       nix build -L .#${{ parameters.singularity }}
+      # Get program version and move/rename artifact
+      DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
       mkdir -p singularity
-      cp result singularity/${{ parameters.package }}.sif
+      cp result singularity/${{ parameters.package }}-${DISSOLVE_VERSION}.sif
     displayName: 'Package Singularity'
     condition: and(eq( '${{ parameters.export }}', 'true' ), eq( '${{ parameters.exportSingularity }}', 'true' ))

--- a/.azure-pipelines/templates/create-release.yml
+++ b/.azure-pipelines/templates/create-release.yml
@@ -45,7 +45,7 @@ jobs:
       - bash: |
           set -ex
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-          ./update-release -r disorderedmaterials/dissolve -t ${VERSION} -n "${VERSION}" -f ReleaseNotes.md $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-GUI-artifacts/* $(System.ArtifactsDirectory)/mpi-artifacts/*    $(System.ArtifactsDirectory)/mpi-singularity/*    $(System.ArtifactsDirectory)/cli-singularity/*    $(System.ArtifactsDirectory)/gui-singularity/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
+          ./update-release -r disorderedmaterials/dissolve -t ${VERSION} -n "${VERSION}" -f ReleaseNotes.md $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-GUI-artifacts/* $(System.ArtifactsDirectory)/mpi-artifacts/* $(System.ArtifactsDirectory)/mpi-singularity/* $(System.ArtifactsDirectory)/cli-singularity/* $(System.ArtifactsDirectory)/gui-singularity/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
         condition: eq('${{ parameters.continuous }}', false)
         env:
           GITHUB_TOKEN: $(REPO_SECRET)
@@ -55,7 +55,7 @@ jobs:
           SHORTHASH=`git rev-parse --short HEAD`
           DATE=`date`
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-          ./update-release -r disorderedmaterials/dissolve -t continuous -n "Continuous Build (${VERSION} @ ${SHORTHASH})" -b "Continuous release from current \`develop\` branch at ${SHORTHASH}. Built ${DATE}." -p -e -u $(System.ArtifactsDirectory)/linux-artifacts/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
+          ./update-release -r disorderedmaterials/dissolve -t continuous -n "Continuous Build (${VERSION} @ ${SHORTHASH})" -b "Continuous release from current \`develop\` branch at ${SHORTHASH}. Built ${DATE}." -p -e -u $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-GUI-artifacts/* $(System.ArtifactsDirectory)/mpi-artifacts/* $(System.ArtifactsDirectory)/mpi-singularity/* (System.ArtifactsDirectory)/cli-singularity/* $(System.ArtifactsDirectory)/gui-singularity/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
         condition: eq('${{ parameters.continuous }}', true)
         env:
           GITHUB_TOKEN: $(REPO_SECRET)


### PR DESCRIPTION
Following on from #933, this is a quick PR to fix publication of continuous artifacts and rename linux objects to include version in the hope of getting the continuous build published again (last time this was successful was November last year!).

The website needs to be updated to reflect the new linux packages, but this is left until the release is ready and is captured in #859.