### PR TITLE
Yet more packaging

### DIFF
--- a/.azure-pipelines/templates/create-release.yml
+++ b/.azure-pipelines/templates/create-release.yml
@@ -20,8 +20,43 @@ jobs:
           buildType: 'current'
           specificBuildWithTriggering: true
           downloadType: 'single'
-          artifactName: 'linux-GUI-artifacts'
-        displayName: 'Download Linux Artifacts'
+          artifactName: 'linux-cli-artifacts'
+        displayName: 'Download Linux CLI Artifacts'
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          specificBuildWithTriggering: true
+          downloadType: 'single'
+          artifactName: 'linux-gui-artifacts'
+        displayName: 'Download Linux GUI Artifacts'
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          specificBuildWithTriggering: true
+          downloadType: 'single'
+          artifactName: 'linux-mpi-artifacts'
+        displayName: 'Download Linux MPI Artifacts'
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          specificBuildWithTriggering: true
+          downloadType: 'single'
+          artifactName: 'singularity-cli-artifacts'
+        displayName: 'Download Singularity CLI Artifacts'
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          specificBuildWithTriggering: true
+          downloadType: 'single'
+          artifactName: 'singularity-gui-artifacts'
+        displayName: 'Download Singularity GUI Artifacts'
+      - task: DownloadBuildArtifacts@0
+        inputs:
+          buildType: 'current'
+          specificBuildWithTriggering: true
+          downloadType: 'single'
+          artifactName: 'singularity-mpi-artifacts'
+        displayName: 'Download Singularity MPI Artifacts'
       - task: DownloadBuildArtifacts@0
         inputs:
           buildType: 'current'
@@ -45,7 +80,7 @@ jobs:
       - bash: |
           set -ex
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-          ./update-release -r disorderedmaterials/dissolve -t ${VERSION} -n "${VERSION}" -f ReleaseNotes.md $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-GUI-artifacts/* $(System.ArtifactsDirectory)/mpi-artifacts/*    $(System.ArtifactsDirectory)/mpi-singularity/*    $(System.ArtifactsDirectory)/cli-singularity/*    $(System.ArtifactsDirectory)/gui-singularity/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
+          ./update-release -r disorderedmaterials/dissolve -t ${VERSION} -n "${VERSION}" -f ReleaseNotes.md $(System.ArtifactsDirectory)/linux-*-artifacts/* $(System.ArtifactsDirectory)/singularity-*-artifacts/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
         condition: eq('${{ parameters.continuous }}', false)
         env:
           GITHUB_TOKEN: $(REPO_SECRET)
@@ -55,7 +90,7 @@ jobs:
           SHORTHASH=`git rev-parse --short HEAD`
           DATE=`date`
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-          ./update-release -r disorderedmaterials/dissolve -t continuous -n "Continuous Build (${VERSION} @ ${SHORTHASH})" -b "Continuous release from current \`develop\` branch at ${SHORTHASH}. Built ${DATE}." -p -e -u $(System.ArtifactsDirectory)/linux-cli-artifacts/* $(System.ArtifactsDirectory)/linux-GUI-artifacts/* $(System.ArtifactsDirectory)/mpi-artifacts/*    $(System.ArtifactsDirectory)/mpi-singularity/*    $(System.ArtifactsDirectory)/cli-singularity/*    $(System.ArtifactsDirectory)/gui-singularity/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
+          ./update-release -r disorderedmaterials/dissolve -t continuous -n "Continuous Build (${VERSION} @ ${SHORTHASH})" -b "Continuous release from current \`develop\` branch at ${SHORTHASH}. Built ${DATE}." -p -e -u $(System.ArtifactsDirectory)/linux-*-artifacts/* $(System.ArtifactsDirectory)/singularity-*-artifacts/* $(System.ArtifactsDirectory)/windows-artifacts/*.exe $(System.ArtifactsDirectory)/windows-artifacts/*.zip $(System.ArtifactsDirectory)/osx-artifacts/*dmg examples/*zip examples/*.tar.gz
         condition: eq('${{ parameters.continuous }}', true)
         env:
           GITHUB_TOKEN: $(REPO_SECRET)

--- a/.azure-pipelines/templates/package-linux.yml
+++ b/.azure-pipelines/templates/package-linux.yml
@@ -17,7 +17,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "packages/"
-              ArtifactName: "linux-GUI-artifacts"
+              ArtifactName: "linux-gui-artifacts"
             displayName: "Publish Linux GUI Artifacts"
       - job: "linux_singularity"
         displayName: "Ubuntu, Threads, CLI/GUI, Singularity"
@@ -36,7 +36,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "singularity/"
-              ArtifactName: "gui-singularity"
+              ArtifactName: "singularity-gui-artifacts"
             displayName: "Publish Linux GUI Singularity"
       - job: "linux_serial"
         displayName: "Ubuntu, Serial, CLI, Exe"
@@ -79,7 +79,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "singularity/"
-              ArtifactName: "cli-singularity"
+              ArtifactName: "singularity-cli-artifacts"
             displayName: "Publish Linux CLI Singularity"
       - job: "linux_mpi"
         displayName: "Ubuntu, MPI, CLI, Exe"
@@ -100,8 +100,8 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "packages/"
-              ArtifactName: "mpi-artifacts"
-            displayName: "Publish MPI Artifacts"
+              ArtifactName: "linux-mpi-artifacts"
+            displayName: "Publish Linux MPI Artifacts"
       - job: "linux_mpi_singularity"
         displayName: "Ubuntu, MPI, CLI, Singularity"
         timeoutInMinutes: 120
@@ -122,5 +122,5 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: "singularity/"
-              ArtifactName: "mpi-singularity"
+              ArtifactName: "singularity-mpi-artifacts"
             displayName: "Publish Linux MPI Singularity"


### PR DESCRIPTION
Following #937 this PR harmonises the naming of published artifact archives, and updates the `create-release.yml` template to download all necessary artifacts.