### PR TITLE
Fix FreeType on Windows

### DIFF
--- a/.azure-pipelines/templates/build-windows.yml
+++ b/.azure-pipelines/templates/build-windows.yml
@@ -25,6 +25,8 @@ steps:
       $ErrorActionPreference = 'Stop'
       cd $(Build.BinariesDirectory)
       git clone ${{ parameters.ftrepo }} freetype-latest
+      # Hack on a file...
+      (Get-Content freetype-latest\src\gzip\zutil.h).replace('#ifdef Z_SOLO', '#ifdef Z_SOLO_NO') | Set-Content freetype-latest\src\gzip\zutil.h
       mkdir freetype-build
       cd freetype-build
       cmake -G "Visual Studio 16 2019" -A "x64" ../freetype-latest -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install

--- a/.azure-pipelines/templates/build-windows.yml
+++ b/.azure-pipelines/templates/build-windows.yml
@@ -4,7 +4,7 @@ parameters:
   - name: qtver
     default: 6.1.1
   - name: ftrepo
-    default: git://git.sv.nongnu.org/freetype/freetype2.git
+    default: https://gitlab.freedesktop.org/freetype/freetype.git
   - name: ftglrepo
     default: https://github.com/frankheckenbach/ftgl.git
   - name: threading


### PR DESCRIPTION
Current Windows builds fail with:

```
D:\a\1\b\freetype-latest\src\gzip\zutil.h(33,17): error C2371: 'ptrdiff_t': redefinition; different basic types [D:\a\1\b\freetype-build\freetype.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30133\include\vcruntime.h(194): message : see declaration of 'ptrdiff_t' [D:\a\1\b\freetype-build\freetype.vcxproj]
```
