### PR TITLE
Switch to completion in Data Manager Dialog

### DIFF
--- a/src/gui/datamanagerdialog.h
+++ b/src/gui/datamanagerdialog.h
@@ -44,8 +44,6 @@ class DataManagerDialog : public QDialog
     Ui::DataManagerDialog ui_;
 
     private:
-    // Update the specified table of GenericItems, optionally filtering them by name and description
-    void filterTable(QString filterText);
     // Update ReferencePoint table row
     void referencePointRowUpdate(int row, const ReferencePoint *refPoint, bool createItems);
     // Return currently-selected ReferencePoint
@@ -54,8 +52,6 @@ class DataManagerDialog : public QDialog
     void updateControls();
 
     private slots:
-    // Simulation Data
-    void on_SimulationDataFilterEdit_textChanged(const QString &text);
     // Reference Points
     void on_ReferencePointRemoveButton_clicked(bool checked);
     void on_ReferencePointCreateButton_clicked(bool checked);

--- a/src/gui/datamanagerdialog_funcs.cpp
+++ b/src/gui/datamanagerdialog_funcs.cpp
@@ -30,8 +30,7 @@ DataManagerDialog::DataManagerDialog(QWidget *parent, Dissolve &dissolve, std::v
 
     connect(completer, QOverload<const QString &>::of(&QCompleter::activated),
             // [=](const QModelIndex &index)
-            [&](const QString &text)
-            {
+            [&](const QString &text) {
                 int row = 0;
                 while (simProxy_.data(simProxy_.index(row, 0)) != text)
                     row++;


### PR DESCRIPTION
This removes the regex from the Data Manager Dialog and, instead, causes the dialog to pop up suggestions as you type.  Selecting one of the suggestions selects the item in the table.

If we don't like this setup, we may just stick with the regex and close #723.