### PR TITLE
Automatic targets

### DIFF
--- a/benchmark/common/problems.h
+++ b/benchmark/common/problems.h
@@ -89,7 +89,7 @@ template <ProblemType problem, Population population> struct Problem
     void setUpRDF()
     {
         rdfmodule_ = std::make_unique<RDFModule>();
-        rdfmodule_->keywords().set("Configuration", std::vector<Configuration *>{cfg_});
+        rdfmodule_->keywords().set("Configurations", std::vector<Configuration *>{cfg_});
     }
 
     template <RDFModule::PartialsMethod method> void iterateGR()

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -20,7 +20,7 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
 
     // Set the module list model and connect signals
     ui_.ModulesList->setModel(&moduleLayerModel_);
-    moduleLayerModel_.setData(moduleLayer_);
+    moduleLayerModel_.setData(moduleLayer_, dissolve);
     connect(ui_.ModulesList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
             SLOT(moduleSelectionChanged(const QItemSelection &, const QItemSelection &)));
     connect(&moduleLayerModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
@@ -207,7 +207,7 @@ void LayerTab::updateModuleList()
     std::optional<QModelIndex> selectedIndex;
     if (!ui_.ModulesList->selectionModel()->selection().indexes().empty())
         selectedIndex = ui_.ModulesList->selectionModel()->selection().indexes().front();
-    moduleLayerModel_.setData(moduleLayer_);
+    moduleLayerModel_.reset();
     if (selectedIndex)
         ui_.ModulesList->selectionModel()->select(selectedIndex.value(), QItemSelectionModel::ClearAndSelect);
 }

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -28,8 +28,7 @@ void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checke
     newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (Basic Atomic)"));
 
     Module *module;
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add some Monte Carlo
     module = ModuleRegistry::create("AtomShake", newLayer);
@@ -53,8 +52,7 @@ void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
     newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (Atomic)"));
 
     Module *module;
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add some Monte Carlo
     module = ModuleRegistry::create("AtomShake", newLayer);
@@ -83,8 +81,7 @@ void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
     newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (Standard)"));
 
     Module *module;
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add a Monte Carlo shake (MolShake) module
     module = ModuleRegistry::create("MolShake", newLayer);
@@ -113,8 +110,7 @@ void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
     newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (EPSR)"));
 
     Module *module;
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add some Monte Carlo
     module = ModuleRegistry::create("MolShake", newLayer);
@@ -162,8 +158,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF"));
     newLayer->setFrequency(5);
 
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add the RDF module
     auto *module = ModuleRegistry::create("RDF", newLayer);
@@ -183,8 +178,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggere
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Unweighted S(Q)"));
     newLayer->setFrequency(5);
 
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add the RDF module
     auto *rdfModule = dynamic_cast<RDFModule *>(ModuleRegistry::create("RDF", newLayer));
@@ -208,8 +202,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool c
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Neutron S(Q)"));
     newLayer->setFrequency(5);
 
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add the RDF module
     auto *rdfModule = ModuleRegistry::create("RDF", newLayer);
@@ -237,8 +230,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bo
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Neutron S(Q) / X-Ray S(Q)"));
     newLayer->setFrequency(5);
 
-    auto firstCfg = dissolve_.configurations().empty() ? std::vector<Configuration *>()
-                                                       : std::vector<Configuration *>{dissolve_.configurations().front().get()};
+    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
     // Add the RDF module
     auto *rdfModule = ModuleRegistry::create("RDF", newLayer);

--- a/src/gui/models/moduleLayerModel.h
+++ b/src/gui/models/moduleLayerModel.h
@@ -4,9 +4,13 @@
 #pragma once
 
 #include "module/layer.h"
+#include "templates/optionalref.h"
 #include <QAbstractListModel>
 #include <QMimeData>
 #include <QModelIndex>
+
+// Forward Declarations
+class Dissolve;
 
 class ModuleLayerModel : public QAbstractListModel
 {
@@ -15,12 +19,16 @@ class ModuleLayerModel : public QAbstractListModel
     private:
     // Source ModuleLayer
     ModuleLayer *moduleLayer_{nullptr};
+    // Reference to Dissolve (for Configuration target setting)
+    OptionalReferenceWrapper<Dissolve> dissolve_;
     // Return object represented by specified model index
     Module *rawData(const QModelIndex &index) const;
 
     public:
-    // Set source Species data
-    void setData(ModuleLayer *moduleLayer);
+    // Set source data
+    void setData(ModuleLayer *moduleLayer, Dissolve &dissolve);
+    // Reset model data, forcing update
+    void reset();
 
     /*
      * QAbstractItemModel overrides

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -170,20 +170,21 @@ bool Dissolve::prepare()
     {
         Messenger::print("Generating attached atom lists for required species...");
         for (auto *module : intraShakeModules)
-            for (auto *cfg :
-                 dynamic_cast<IntraShakeModule *>(module)->keywords().get<std::vector<Configuration *>>("Configuration"))
-                for (auto &sp : coreData_.species())
-                    if (cfg->containsSpecies(sp.get()) && !sp->attachedAtomListsGenerated())
-                    {
-                        Messenger::print("Performing one-time generation of attached atom lists for intramolecular "
-                                         "terms in Species '{}'...\n",
-                                         sp->name());
-                        if (sp->nAtoms() > 500)
-                            Messenger::warn("'{}' is a large molecule - this might take a while! Consider using a "
-                                            "different evolution module.\n",
-                                            sp->name());
-                        sp->generateAttachedAtomLists();
-                    }
+        {
+            auto *cfg = dynamic_cast<IntraShakeModule *>(module)->keywords().get<Configuration *>("Configuration");
+            for (auto &sp : coreData_.species())
+                if (cfg->containsSpecies(sp.get()) && !sp->attachedAtomListsGenerated())
+                {
+                    Messenger::print("Performing one-time generation of attached atom lists for intramolecular "
+                                     "terms in Species '{}'...\n",
+                                     sp->name());
+                    if (sp->nAtoms() > 500)
+                        Messenger::warn("'{}' is a large molecule - this might take a while! Consider using a "
+                                        "different evolution module.\n",
+                                        sp->name());
+                    sp->generateAttachedAtomLists();
+                }
+        }
     }
 
     // Set up parallel comms / limits etc.

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -88,6 +88,21 @@ bool ModuleLayer::contains(Module *searchModule) const
 // Return vector of Modules
 std::vector<std::unique_ptr<Module>> &ModuleLayer::modules() { return modules_; }
 
+// Return map of modules in the layer, optionally preceding the specified module
+std::map<std::string, std::vector<const Module *>> ModuleLayer::modulesAsMap(const Module *beforeThis) const
+{
+    std::map<std::string, std::vector<const Module *>> moduleMap;
+
+    for (auto &module : modules_)
+    {
+        if (module.get() == beforeThis)
+            break;
+        moduleMap[std::string(module->type())].emplace_back(module.get());
+    }
+
+    return moduleMap;
+}
+
 /*
  * General Actions
  */

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -53,7 +54,7 @@ class ModuleLayer
      * Modules
      */
     private:
-    // List of Modules
+    // Vector of Modules in the layer
     std::vector<std::unique_ptr<Module>> modules_;
 
     public:
@@ -65,6 +66,8 @@ class ModuleLayer
     bool contains(Module *searchModule) const;
     // Return vector of Modules
     std::vector<std::unique_ptr<Module>> &modules();
+    // Return map of modules in the layer, optionally preceding the specified module
+    std::map<std::string, std::vector<const Module *>> modulesAsMap(const Module *beforeThis = nullptr) const;
 
     /*
      * General Actions

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -100,6 +100,12 @@ bool Module::isDisabled() const { return !enabled_; }
 // Run main processing
 bool Module::process(Dissolve &dissolve, ProcessPool &procPool) { return false; }
 
+// Set target data
+void Module::setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                        const std::map<std::string, std::vector<const Module *>> &moduleMap)
+{
+}
+
 // Run set-up stage
 bool Module::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) { return true; }
 

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -87,6 +87,9 @@ class Module
     virtual bool process(Dissolve &dissolve, ProcessPool &procPool) = 0;
 
     public:
+    // Set target data
+    virtual void setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                            const std::map<std::string, std::vector<const Module *>> &moduleMap);
     // Run set-up stage
     virtual bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals = {});
     // Run main processing stage

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -10,7 +10,7 @@ bool AnalyseModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());

--- a/src/modules/atomshake/atomshake.cpp
+++ b/src/modules/atomshake/atomshake.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "modules/atomshake/atomshake.h"
-#include "keywords/configurationvector.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
@@ -10,8 +10,7 @@
 AtomShakeModule::AtomShakeModule() : Module("AtomShake")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
     keywords_.add<OptionalDoubleKeyword>(

--- a/src/modules/atomshake/atomshake.h
+++ b/src/modules/atomshake/atomshake.h
@@ -17,7 +17,7 @@ class AtomShakeModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Interatomic cutoff distance to use for energy calculation
     std::optional<double> cutoffDistance_;
     // Number of shakes to attempt per atom

--- a/src/modules/atomshake/atomshake.h
+++ b/src/modules/atomshake/atomshake.h
@@ -17,7 +17,7 @@ class AtomShakeModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Interatomic cutoff distance to use for energy calculation
     std::optional<double> cutoffDistance_;
     // Number of shakes to attempt per atom

--- a/src/modules/atomshake/process.cpp
+++ b/src/modules/atomshake/process.cpp
@@ -21,175 +21,170 @@ bool AtomShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+
+    // Retrieve control parameters from Configuration
+    auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
+    const auto termScale = 1.0;
+    const auto rRT = 1.0 / (.008314472 * targetConfiguration_->temperature());
+
+    // Print argument/parameter summary
+    Messenger::print("AtomShake: Cutoff distance is {}\n", rCut);
+    Messenger::print("AtomShake: Performing {} shake(s) per Atom\n", nShakesPerAtom_);
+    Messenger::print("AtomShake: Step size for adjustments is {:.5f} Angstroms (allowed range is {} <= delta <= {}).\n",
+                     stepSize_, stepSizeMin_, stepSizeMax_);
+    Messenger::print("AtomShake: Target acceptance rate is {}.\n", targetAcceptanceRate_);
+    Messenger::print("\n");
+
+    ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();
+
+    // Create a Molecule distributor
+    RegionalDistributor distributor(targetConfiguration_->nMolecules(), targetConfiguration_->cells(), procPool, strategy);
+
+    // Create a local ChangeStore and EnergyKernel
+    ChangeStore changeStore(procPool);
+    EnergyKernel kernel(procPool, targetConfiguration_->box(), targetConfiguration_->cells(), dissolve.potentialMap(), rCut);
+
+    // Initialise the random number buffer so it is suitable for our parallel strategy within the main loop
+    procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
+
+    int shake, n;
+    auto nAttempts = 0, nAccepted = 0;
+    bool accept;
+    double currentEnergy, currentIntraEnergy, newEnergy, newIntraEnergy, delta, totalDelta = 0.0;
+    Vec3<double> rDelta;
+
+    Timer timer;
+    procPool.resetAccumulatedTime();
+    while (distributor.cycle())
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+        // Get next set of Molecule targets from the distributor
+        auto &targetMolecules = distributor.assignedMolecules();
 
-        // Retrieve control parameters from Configuration
-        auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
-        const auto termScale = 1.0;
-        const auto rRT = 1.0 / (.008314472 * cfg->temperature());
-
-        // Print argument/parameter summary
-        Messenger::print("AtomShake: Cutoff distance is {}\n", rCut);
-        Messenger::print("AtomShake: Performing {} shake(s) per Atom\n", nShakesPerAtom_);
-        Messenger::print("AtomShake: Step size for adjustments is {:.5f} Angstroms (allowed range is {} <= delta <= {}).\n",
-                         stepSize_, stepSizeMin_, stepSizeMax_);
-        Messenger::print("AtomShake: Target acceptance rate is {}.\n", targetAcceptanceRate_);
-        Messenger::print("\n");
-
-        ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();
-
-        // Create a Molecule distributor
-        RegionalDistributor distributor(cfg->nMolecules(), cfg->cells(), procPool, strategy);
-
-        // Create a local ChangeStore and EnergyKernel
-        ChangeStore changeStore(procPool);
-        EnergyKernel kernel(procPool, cfg->box(), cfg->cells(), dissolve.potentialMap(), rCut);
-
-        // Initialise the random number buffer so it is suitable for our parallel strategy within the main loop
-        procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
-
-        int shake, n;
-        auto nAttempts = 0, nAccepted = 0;
-        bool accept;
-        double currentEnergy, currentIntraEnergy, newEnergy, newIntraEnergy, delta, totalDelta = 0.0;
-        Vec3<double> rDelta;
-
-        Timer timer;
-        procPool.resetAccumulatedTime();
-        while (distributor.cycle())
+        // Switch parallel strategy if necessary
+        if (distributor.currentStrategy() != strategy)
         {
-            // Get next set of Molecule targets from the distributor
-            auto &targetMolecules = distributor.assignedMolecules();
+            // Set the new strategy
+            strategy = distributor.currentStrategy();
 
-            // Switch parallel strategy if necessary
-            if (distributor.currentStrategy() != strategy)
-            {
-                // Set the new strategy
-                strategy = distributor.currentStrategy();
-
-                // Re-initialise the random buffer
-                procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
-            }
-
-            // Loop over target Molecules
-            for (auto molId : targetMolecules)
-            {
-                /*
-                 * Calculation Begins
-                 */
-
-                // Get Molecule index and pointer
-                std::shared_ptr<Molecule> mol = cfg->molecule(molId);
-
-                // Set current Atom targets in ChangeStore (whole Molecule)
-                changeStore.add(mol);
-
-                n = 0;
-                // Loop over atoms in the Molecule
-                for (const auto &i : mol->atoms())
-                {
-                    // Calculate reference energy for the Atom
-                    currentEnergy = kernel.energy(*i);
-                    currentIntraEnergy = kernel.intramolecularEnergy(*mol, *i) * termScale;
-
-                    // Loop over number of shakes per Atom
-                    for (shake = 0; shake < nShakesPerAtom_; ++shake)
-                    {
-                        // Create a random translation vector
-                        rDelta.set(procPool.randomPlusMinusOne() * stepSize_, procPool.randomPlusMinusOne() * stepSize_,
-                                   procPool.randomPlusMinusOne() * stepSize_);
-
-                        // Translate Atom and update its Cell position
-                        i->translateCoordinates(rDelta);
-                        cfg->updateCellLocation(i);
-
-                        // Calculate new energy
-                        newEnergy = kernel.energy(*i);
-                        newIntraEnergy = kernel.intramolecularEnergy(*mol, *i) * termScale;
-
-                        // Trial the transformed Atom position
-                        delta = (newEnergy + newIntraEnergy) - (currentEnergy + currentIntraEnergy);
-                        accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
-
-                        if (accept)
-                        {
-                            // Accept new (current) position of target Atom
-                            changeStore.updateAtom(n);
-                            currentEnergy = newEnergy;
-                        }
-                        else
-                            changeStore.revert(n);
-
-                        // Increase attempt counters
-                        // The strategy in force at any one time may vary, so use the distributor's
-                        // helper functions.
-                        if (distributor.collectStatistics())
-                        {
-                            if (accept)
-                            {
-                                totalDelta += delta;
-                                ++nAccepted;
-                            }
-                            ++nAttempts;
-                        }
-                        ++n;
-                    }
-                }
-
-                // Store modifications to Atom positions ready for broadcast later
-                changeStore.storeAndReset();
-
-                /*
-                 * Calculation End
-                 */
-            }
-
-            // Now all target Molecules have been processes, broadcast the changes made
-            changeStore.distributeAndApply(cfg);
-            changeStore.reset();
+            // Re-initialise the random buffer
+            procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
         }
 
-        // Collect statistics across all processes
-        if (!procPool.allSum(&nAccepted, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nAttempts, 1, strategy))
-            return false;
-        if (!procPool.allSum(&totalDelta, 1, strategy))
-            return false;
+        // Loop over target Molecules
+        for (auto molId : targetMolecules)
+        {
+            /*
+             * Calculation Begins
+             */
 
-        timer.stop();
+            // Get Molecule index and pointer
+            std::shared_ptr<Molecule> mol = targetConfiguration_->molecule(molId);
 
-        Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
+            // Set current Atom targets in ChangeStore (whole Molecule)
+            changeStore.add(mol);
 
-        // Calculate and print acceptance rate
-        double rate = double(nAccepted) / nAttempts;
-        Messenger::print("Total number of attempted moves was {} ({} work, {} comms)\n", nAttempts, timer.totalTimeString(),
-                         procPool.accumulatedTimeString());
+            n = 0;
+            // Loop over atoms in the Molecule
+            for (const auto &i : mol->atoms())
+            {
+                // Calculate reference energy for the Atom
+                currentEnergy = kernel.energy(*i);
+                currentIntraEnergy = kernel.intramolecularEnergy(*mol, *i) * termScale;
 
-        Messenger::print("Overall acceptance rate was {:4.2f}% ({} of {} attempted moves)\n", 100.0 * rate, nAccepted,
-                         nAttempts);
+                // Loop over number of shakes per Atom
+                for (shake = 0; shake < nShakesPerAtom_; ++shake)
+                {
+                    // Create a random translation vector
+                    rDelta.set(procPool.randomPlusMinusOne() * stepSize_, procPool.randomPlusMinusOne() * stepSize_,
+                               procPool.randomPlusMinusOne() * stepSize_);
 
-        // Update and set translation step size
-        stepSize_ *= (nAccepted == 0) ? 0.8 : rate / targetAcceptanceRate_;
-        if (stepSize_ < stepSizeMin_)
-            stepSize_ = stepSizeMin_;
-        else if (stepSize_ > stepSizeMax_)
-            stepSize_ = stepSizeMax_;
-        keywords_.set("StepSize", stepSize_);
+                    // Translate Atom and update its Cell position
+                    i->translateCoordinates(rDelta);
+                    targetConfiguration_->updateCellLocation(i);
 
-        Messenger::print("Updated step size is {} Angstroms.\n", stepSize_);
+                    // Calculate new energy
+                    newEnergy = kernel.energy(*i);
+                    newIntraEnergy = kernel.intramolecularEnergy(*mol, *i) * termScale;
 
-        // Increase contents version in Configuration
-        if (nAccepted > 0)
-            cfg->incrementContentsVersion();
+                    // Trial the transformed Atom position
+                    delta = (newEnergy + newIntraEnergy) - (currentEnergy + currentIntraEnergy);
+                    accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
+
+                    if (accept)
+                    {
+                        // Accept new (current) position of target Atom
+                        changeStore.updateAtom(n);
+                        currentEnergy = newEnergy;
+                    }
+                    else
+                        changeStore.revert(n);
+
+                    // Increase attempt counters
+                    // The strategy in force at any one time may vary, so use the distributor's
+                    // helper functions.
+                    if (distributor.collectStatistics())
+                    {
+                        if (accept)
+                        {
+                            totalDelta += delta;
+                            ++nAccepted;
+                        }
+                        ++nAttempts;
+                    }
+                    ++n;
+                }
+            }
+
+            // Store modifications to Atom positions ready for broadcast later
+            changeStore.storeAndReset();
+
+            /*
+             * Calculation End
+             */
+        }
+
+        // Now all target Molecules have been processes, broadcast the changes made
+        changeStore.distributeAndApply(targetConfiguration_);
+        changeStore.reset();
     }
+
+    // Collect statistics across all processes
+    if (!procPool.allSum(&nAccepted, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nAttempts, 1, strategy))
+        return false;
+    if (!procPool.allSum(&totalDelta, 1, strategy))
+        return false;
+
+    timer.stop();
+
+    Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
+
+    // Calculate and print acceptance rate
+    double rate = double(nAccepted) / nAttempts;
+    Messenger::print("Total number of attempted moves was {} ({} work, {} comms)\n", nAttempts, timer.totalTimeString(),
+                     procPool.accumulatedTimeString());
+
+    Messenger::print("Overall acceptance rate was {:4.2f}% ({} of {} attempted moves)\n", 100.0 * rate, nAccepted, nAttempts);
+
+    // Update and set translation step size
+    stepSize_ *= (nAccepted == 0) ? 0.8 : rate / targetAcceptanceRate_;
+    if (stepSize_ < stepSizeMin_)
+        stepSize_ = stepSizeMin_;
+    else if (stepSize_ > stepSizeMax_)
+        stepSize_ = stepSizeMax_;
+    keywords_.set("StepSize", stepSize_);
+
+    Messenger::print("Updated step size is {} Angstroms.\n", stepSize_);
+
+    // Increase contents version in Configuration
+    if (nAccepted > 0)
+        targetConfiguration_->incrementContentsVersion();
 
     return true;
 }

--- a/src/modules/atomshake/process.cpp
+++ b/src/modules/atomshake/process.cpp
@@ -14,12 +14,6 @@
 // Run main processing
 bool AtomShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * Perform an Atom shake
-     *
-     * This is a parallel routine, with processes operating in groups.
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/benchmark/benchmark.cpp
+++ b/src/modules/benchmark/benchmark.cpp
@@ -3,13 +3,13 @@
 
 #include "modules/benchmark/benchmark.h"
 #include "keywords/bool.h"
+#include "keywords/configuration.h"
 #include "keywords/integer.h"
 
 BenchmarkModule::BenchmarkModule() : Module("Benchmark")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
     keywords_.add<IntegerKeyword>("Control", "N", "Number of times to run each benchmark in order to form average", nRepeats_,

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -17,7 +17,7 @@ class BenchmarkModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Number of times to run each benchmark in order to form average
     int nRepeats_{5};
     // Whether to save new timings to the restart file

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -17,7 +17,7 @@ class BenchmarkModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Number of times to run each benchmark in order to form average
     int nRepeats_{5};
     // Whether to save new timings to the restart file

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -56,9 +56,4 @@ class BraggModule : public Module
     private:
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
-
-    public:
-    // Set target data
-    void setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
-                    const std::map<std::string, std::vector<const Module *>> &moduleMap) override;
 };

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -56,4 +56,9 @@ class BraggModule : public Module
     private:
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
+
+    public:
+    // Set target data
+    void setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                    const std::map<std::string, std::vector<const Module *>> &moduleMap) override;
 };

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -10,15 +10,6 @@
 #include "modules/bragg/bragg.h"
 #include "templates/algorithms.h"
 
-// Set target data
-void XRaySQModule::setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
-                              const std::map<std::string, std::vector<const Module *>> &moduleMap)
-{
-    auto sqIt = moduleMap.find("SQ");
-    if (sqIt != moduleMap.end())
-        sourceSQ_ = dynamic_cast<const SQModule *>(sqIt->second.front());
-}
-
 // Run main processing
 bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -10,6 +10,15 @@
 #include "modules/bragg/bragg.h"
 #include "templates/algorithms.h"
 
+// Set target data
+void XRaySQModule::setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                              const std::map<std::string, std::vector<const Module *>> &moduleMap)
+{
+    auto sqIt = moduleMap.find("SQ");
+    if (sqIt != moduleMap.end())
+        sourceSQ_ = dynamic_cast<const SQModule *>(sqIt->second.front());
+}
+
 // Run main processing
 bool BraggModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -13,7 +13,7 @@ bool CalculateAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
     selectA_->setDistanceReferenceSite(selectB_);

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -53,7 +53,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Grab Box pointer
     const auto *box = targetConfiguration_->box();

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -13,7 +13,7 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, ProcessPool &procPool
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -13,7 +13,7 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);

--- a/src/modules/calculate_rdf/process.cpp
+++ b/src/modules/calculate_rdf/process.cpp
@@ -13,7 +13,7 @@ bool CalculateRDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);

--- a/src/modules/calculate_sdf/process.cpp
+++ b/src/modules/calculate_sdf/process.cpp
@@ -14,7 +14,7 @@ bool CalculateSDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
     collectVector_->keywords().set("RangeX", rangeX_);

--- a/src/modules/checks/checks.cpp
+++ b/src/modules/checks/checks.cpp
@@ -2,15 +2,14 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "modules/checks/checks.h"
-#include "keywords/configurationvector.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/geometrylist.h"
 
 ChecksModule::ChecksModule() : Module("Checks")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Distance
     keywords_.add<GeometryListKeyword>("Distance", "Distance", "Define a distance between Atoms to be checked", distances_,

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -18,7 +18,7 @@ class ChecksModule : public Module
      */
     private:
     // Target configuration
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Distances to check
     std::vector<Geometry> distances_;
     // Threshold at which distance checks will fail (Angstroms)

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -18,7 +18,7 @@ class ChecksModule : public Module
      */
     private:
     // Target configuration
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Distances to check
     std::vector<Geometry> distances_;
     // Threshold at which distance checks will fail (Angstroms)

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -16,64 +16,61 @@ bool ChecksModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+
+    Messenger::print("Checks: Threshold for distance checks is {} Angstroms\n", distanceThreshold_);
+    Messenger::print("Checks: Threshold for angle checks is {} degrees\n", angleThreshold_);
+
+    auto &atoms = targetConfiguration_->atoms();
+
+    double actual, delta;
+    bool ok;
+
+    /*
+     * Check Distances
+     */
+
+    // Loop over distances to check
+    for (const auto &d : distances_)
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+        actual = targetConfiguration_->box()->minimumDistance(atoms[d.indices(0)].r(), atoms[d.indices(1)].r());
+        delta = fabs(actual - d.value());
+        ok = delta < distanceThreshold_;
+        Messenger::print("Distance between Atoms {} and {} is {} Angstroms, and is {} (delta = {}, tolerance = {}).\n",
+                         d.indices(0) + 1, d.indices(1) + 1, actual, ok ? "OK" : "NOT OK", delta, distanceThreshold_);
 
-        Messenger::print("Checks: Threshold for distance checks is {} Angstroms\n", distanceThreshold_);
-        Messenger::print("Checks: Threshold for angle checks is {} degrees\n", angleThreshold_);
-
-        auto &atoms = cfg->atoms();
-
-        double actual, delta;
-        bool ok;
-
-        /*
-         * Check Distances
-         */
-
-        // Loop over distances to check
-        for (const auto &d : distances_)
+        // Check consistency between processes
+        if (!procPool.allTrue(ok))
         {
-            actual = cfg->box()->minimumDistance(atoms[d.indices(0)].r(), atoms[d.indices(1)].r());
-            delta = fabs(actual - d.value());
-            ok = delta < distanceThreshold_;
-            Messenger::print("Distance between Atoms {} and {} is {} Angstroms, and is {} (delta = {}, tolerance = {}).\n",
-                             d.indices(0) + 1, d.indices(1) + 1, actual, ok ? "OK" : "NOT OK", delta, distanceThreshold_);
-
-            // Check consistency between processes
-            if (!procPool.allTrue(ok))
-            {
-                Messenger::error("Failed consistency check between processes.\n");
-                return false;
-            }
+            Messenger::error("Failed consistency check between processes.\n");
+            return false;
         }
+    }
 
-        /*
-         * Check Angles
-         */
+    /*
+     * Check Angles
+     */
 
-        // Loop over angles to check
-        for (const auto &a : angles_)
+    // Loop over angles to check
+    for (const auto &a : angles_)
+    {
+        actual = targetConfiguration_->box()->angleInDegrees(atoms[a.indices(0)].r(), atoms[a.indices(1)].r(),
+                                                             atoms[a.indices(2)].r());
+        delta = fabs(actual - a.value());
+        ok = delta < angleThreshold_;
+        Messenger::print("Angle between Atoms {}, {} and {} is {} degrees, and is {} (delta = {}, tolerance = {}).\n",
+                         a.indices(0) + 1, a.indices(1) + 1, a.indices(2) + 1, actual, ok ? "OK" : "NOT OK", delta,
+                         angleThreshold_);
+
+        // Check consistency between processes
+        if (!procPool.allTrue(ok))
         {
-            actual = cfg->box()->angleInDegrees(atoms[a.indices(0)].r(), atoms[a.indices(1)].r(), atoms[a.indices(2)].r());
-            delta = fabs(actual - a.value());
-            ok = delta < angleThreshold_;
-            Messenger::print("Angle between Atoms {}, {} and {} is {} degrees, and is {} (delta = {}, tolerance = {}).\n",
-                             a.indices(0) + 1, a.indices(1) + 1, a.indices(2) + 1, actual, ok ? "OK" : "NOT OK", delta,
-                             angleThreshold_);
-
-            // Check consistency between processes
-            if (!procPool.allTrue(ok))
-            {
-                Messenger::error("Failed consistency check between processes.\n");
-                return false;
-            }
+            Messenger::error("Failed consistency check between processes.\n");
+            return false;
         }
     }
 

--- a/src/modules/energy/energy.cpp
+++ b/src/modules/energy/energy.cpp
@@ -3,6 +3,7 @@
 
 #include "modules/energy/energy.h"
 #include "keywords/bool.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
@@ -10,8 +11,7 @@
 EnergyModule::EnergyModule() : Module("Energy")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
     keywords_.add<DoubleKeyword>("Control", "StabilityThreshold",

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -20,7 +20,7 @@ class EnergyModule : public Module
      */
     private:
     // Target configuration
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Save calculated energies to disk, one file per targetted configuration
     bool save_{false};
     // Threshold value at which energy is deemed stable over the defined windowing period

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -20,7 +20,7 @@ class EnergyModule : public Module
      */
     private:
     // Target configuration
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Save calculated energies to disk, one file per targetted configuration
     bool save_{false};
     // Threshold value at which energy is deemed stable over the defined windowing period

--- a/src/modules/energy/gui/energywidget.h
+++ b/src/modules/energy/gui/energywidget.h
@@ -40,10 +40,4 @@ class EnergyModuleWidget : public ModuleWidget
     public:
     // Update controls within widget
     void updateControls(ModuleWidget::UpdateType updateType) override;
-
-    /*
-     * Widgets / Functions
-     */
-    private slots:
-    void on_ConfigurationTargetCombo_currentIndexChanged(int index);
 };

--- a/src/modules/energy/gui/energywidget.ui
+++ b/src/modules/energy/gui/energywidget.ui
@@ -41,9 +41,6 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QComboBox" name="ConfigurationTargetCombo"/>
-   </item>
-   <item>
     <widget class="QFrame" name="PlotWidgetFrame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">

--- a/src/modules/energy/gui/energywidget_funcs.cpp
+++ b/src/modules/energy/gui/energywidget_funcs.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Team Dissolve and contributors
 
-#include "classes/atomtype.h"
 #include "gui/dataviewer.hui"
 #include "gui/helpers/comboboxcontroller.h"
 #include "gui/render/renderabledata1d.h"

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -13,11 +13,11 @@
 // Run set-up stage
 bool EnergyModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {
-    // For each Configuration target, add a flag to its moduleData (which is *not* stored in the restart file) that we are
-    // targeting it
-    for (auto *cfg : targetConfigurations_)
-        dissolve.processingModuleData().realise<bool>("IsEnergyModuleTarget", cfg->niceName(), GenericItem::ProtectedFlag) =
-            true;
+    // For the Configuration target add a flag to its moduleData (which is *not* stored in the restart file) to specify that we
+    // are targeting it
+    if (targetConfiguration_)
+        dissolve.processingModuleData().realise<bool>("IsEnergyModuleTarget", targetConfiguration_->niceName(),
+                                                      GenericItem::ProtectedFlag) = true;
 
     return true;
 }
@@ -32,375 +32,381 @@ bool EnergyModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+    auto strategy = procPool.bestStrategy();
+
+    // Print parameter summary
+    if (test_)
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
-        auto strategy = procPool.bestStrategy();
+        Messenger::print("Energy: All energies will be calculated in serial test mode and compared to "
+                         "production values.\n");
+        if (testAnalytic_)
+            Messenger::print("Energy: Exact, analytical potential will be used in test.");
+        if (testReferenceInter_)
+            Messenger::print("Energy: Reference interatomic energy is {:15.9e} kJ/mol.\n", testReferenceInter_.value());
+        if (testReferenceIntra_)
+            Messenger::print("Energy: Reference intramolecular energy is {:15.9e} kJ/mol.\n", testReferenceIntra_.value());
+    }
 
-        // Print parameter summary
-        if (test_)
+    Messenger::print("\n");
+
+    Messenger::print("Calculating total energy for Configuration '{}'...\n", targetConfiguration_->name());
+    // Calculate the total energy
+    if (test_)
+    {
+        /*
+         * Calculate the total energy of the system using a basic loop on each process, and then compare with
+         * production routines.
+         */
+
+        /*
+         * Test Calculation Begins
+         */
+
+        const PotentialMap &potentialMap = dissolve.potentialMap();
+        auto correctInterEnergy = 0.0, correctIntraEnergy = 0.0, correctSelfEnergy = 0.0;
+
+        double r, angle;
+        Atom *i, *j;
+        Vec3<double> vecji, vecjk, veckl;
+        std::shared_ptr<Molecule> molN, molM;
+        const auto *box = targetConfiguration_->box();
+        double scale;
+        const auto cutoff = dissolve.potentialMap().range();
+
+        Timer testTimer;
+
+        // Calculate interatomic energy in a loop over defined Molecules
+        for (auto n = 0; n < targetConfiguration_->nMolecules(); ++n)
         {
-            Messenger::print("Energy: All energies will be calculated in serial test mode and compared to "
-                             "production values.\n");
-            if (testAnalytic_)
-                Messenger::print("Energy: Exact, analytical potential will be used in test.");
-            if (testReferenceInter_)
-                Messenger::print("Energy: Reference interatomic energy is {:15.9e} kJ/mol.\n", testReferenceInter_.value());
-            if (testReferenceIntra_)
-                Messenger::print("Energy: Reference intramolecular energy is {:15.9e} kJ/mol.\n", testReferenceIntra_.value());
-        }
+            molN = targetConfiguration_->molecule(n);
 
-        Messenger::print("\n");
-
-        Messenger::print("Calculating total energy for Configuration '{}'...\n", cfg->name());
-        // Calculate the total energy
-        if (test_)
-        {
-            /*
-             * Calculate the total energy of the system using a basic loop on each process, and then compare with
-             * production routines.
-             */
-
-            /*
-             * Test Calculation Begins
-             */
-
-            const PotentialMap &potentialMap = dissolve.potentialMap();
-            auto correctInterEnergy = 0.0, correctIntraEnergy = 0.0, correctSelfEnergy = 0.0;
-
-            double r, angle;
-            Atom *i, *j;
-            Vec3<double> vecji, vecjk, veckl;
-            std::shared_ptr<Molecule> molN, molM;
-            const auto *box = cfg->box();
-            double scale;
-            const auto cutoff = dissolve.potentialMap().range();
-
-            Timer testTimer;
-
-            // Calculate interatomic energy in a loop over defined Molecules
-            for (auto n = 0; n < cfg->nMolecules(); ++n)
+            // Molecule self-energy
+            for (auto ii = 0; ii < molN->nAtoms() - 1; ++ii)
             {
-                molN = cfg->molecule(n);
+                i = molN->atom(ii);
 
-                // Molecule self-energy
-                for (auto ii = 0; ii < molN->nAtoms() - 1; ++ii)
+                for (auto jj = ii + 1; jj < molN->nAtoms(); ++jj)
+                {
+                    j = molN->atom(jj);
+
+                    // Get interatomic distance
+                    r = box->minimumDistance(i->r(), j->r());
+                    if (r > cutoff)
+                        continue;
+
+                    // Get intramolecular scaling of atom pair
+                    scale = i->scaling(j);
+                    if (scale < 1.0e-3)
+                        continue;
+
+                    if (testAnalytic_)
+                        correctSelfEnergy += potentialMap.analyticEnergy(i, j, r) * scale;
+                    else
+                        correctSelfEnergy += potentialMap.energy(*i, *j, r) * scale;
+                }
+            }
+
+            // Molecule-molecule energy
+            for (auto m = n + 1; m < targetConfiguration_->nMolecules(); ++m)
+            {
+                molM = targetConfiguration_->molecule(m);
+
+                // Double loop over atoms
+                for (auto ii = 0; ii < molN->nAtoms(); ++ii)
                 {
                     i = molN->atom(ii);
 
-                    for (auto jj = ii + 1; jj < molN->nAtoms(); ++jj)
+                    for (auto jj = 0; jj < molM->nAtoms(); ++jj)
                     {
-                        j = molN->atom(jj);
+                        j = molM->atom(jj);
 
-                        // Get interatomic distance
+                        // Get interatomic distance and check cutoff
                         r = box->minimumDistance(i->r(), j->r());
                         if (r > cutoff)
                             continue;
 
-                        // Get intramolecular scaling of atom pair
-                        scale = i->scaling(j);
-                        if (scale < 1.0e-3)
-                            continue;
-
                         if (testAnalytic_)
-                            correctSelfEnergy += potentialMap.analyticEnergy(i, j, r) * scale;
+                            correctInterEnergy += potentialMap.analyticEnergy(i, j, r);
                         else
-                            correctSelfEnergy += potentialMap.energy(*i, *j, r) * scale;
+                            correctInterEnergy += potentialMap.energy(*i, *j, r);
                     }
                 }
-
-                // Molecule-molecule energy
-                for (auto m = n + 1; m < cfg->nMolecules(); ++m)
-                {
-                    molM = cfg->molecule(m);
-
-                    // Double loop over atoms
-                    for (auto ii = 0; ii < molN->nAtoms(); ++ii)
-                    {
-                        i = molN->atom(ii);
-
-                        for (auto jj = 0; jj < molM->nAtoms(); ++jj)
-                        {
-                            j = molM->atom(jj);
-
-                            // Get interatomic distance and check cutoff
-                            r = box->minimumDistance(i->r(), j->r());
-                            if (r > cutoff)
-                                continue;
-
-                            if (testAnalytic_)
-                                correctInterEnergy += potentialMap.analyticEnergy(i, j, r);
-                            else
-                                correctInterEnergy += potentialMap.energy(*i, *j, r);
-                        }
-                    }
-                }
-
-                // Bond energy
-                for (const auto &bond : molN->species()->bonds())
-                {
-                    r = cfg->box()->minimumDistance(molN->atom(bond.indexI())->r(), molN->atom(bond.indexJ())->r());
-                    correctIntraEnergy += bond.energy(r);
-                }
-
-                // Angle energy
-                for (const auto &angle : molN->species()->angles())
-                {
-                    // Get vectors 'j-i' and 'j-k'
-                    vecji = cfg->box()->minimumVector(molN->atom(angle.indexJ())->r(), molN->atom(angle.indexI())->r());
-                    vecjk = cfg->box()->minimumVector(molN->atom(angle.indexJ())->r(), molN->atom(angle.indexK())->r());
-
-                    // Calculate angle and determine angle energy
-                    vecji.normalise();
-                    vecjk.normalise();
-                    correctIntraEnergy += angle.energy(Box::angleInDegrees(vecji, vecjk));
-                }
-
-                // Torsion energy
-                for (const auto &torsion : molN->species()->torsions())
-                {
-                    // Get vectors 'j-i', 'j-k' and 'k-l'
-                    vecji = cfg->box()->minimumVector(molN->atom(torsion.indexJ())->r(), molN->atom(torsion.indexI())->r());
-                    vecjk = cfg->box()->minimumVector(molN->atom(torsion.indexJ())->r(), molN->atom(torsion.indexK())->r());
-                    veckl = cfg->box()->minimumVector(molN->atom(torsion.indexK())->r(), molN->atom(torsion.indexL())->r());
-
-                    angle = Box::torsionInDegrees(vecji, vecjk, veckl);
-
-                    // Determine Torsion energy
-                    correctIntraEnergy += torsion.energy(angle);
-                }
-
-                // Improper energy
-                for (const auto &imp : molN->species()->impropers())
-                {
-                    // Get vectors 'j-i', 'j-k' and 'k-l'
-                    vecji = cfg->box()->minimumVector(molN->atom(imp.indexJ())->r(), molN->atom(imp.indexI())->r());
-                    vecjk = cfg->box()->minimumVector(molN->atom(imp.indexJ())->r(), molN->atom(imp.indexK())->r());
-                    veckl = cfg->box()->minimumVector(molN->atom(imp.indexK())->r(), molN->atom(imp.indexL())->r());
-
-                    angle = Box::torsionInDegrees(vecji, vecjk, veckl);
-
-                    // Determine improper energy
-                    correctIntraEnergy += imp.energy(angle);
-                }
             }
 
-            // Add the self energy into the total interatomic energy
-            correctInterEnergy += correctSelfEnergy;
-
-            testTimer.stop();
-
-            Messenger::print("Correct interatomic pairpotential energy (total) is {:15.9e} kJ/mol\n", correctInterEnergy);
-            Messenger::print("Correct interatomic pairpotential (within molecules) is {:15.9e} kJ/mol\n", correctSelfEnergy);
-            Messenger::print("Correct intramolecular energy is {:15.9e} kJ/mol\n", correctIntraEnergy);
-            Messenger::print("Correct total energy is {:15.9e} kJ/mol\n", correctInterEnergy + correctIntraEnergy);
-            Messenger::print("Time to do total (test) energy was {}.\n", testTimer.totalTimeString());
-
-            /*
-             * Test Calculation End
-             */
-
-            /*
-             * Production Calculation Begins
-             */
-
-            // Calculate interatomic energy
-            Timer interTimer;
-            auto interEnergy = interAtomicEnergy(procPool, cfg, dissolve.potentialMap());
-            interTimer.stop();
-
-            // Calculate intramolecular energy
-            Timer intraTimer;
-            auto intraEnergy = intraMolecularEnergy(procPool, cfg, dissolve.potentialMap());
-            intraTimer.stop();
-
-            // Calculate total interatomic energy from molecules
-            Timer moleculeTimer;
-            EnergyKernel energyKernel(procPool, cfg->box(), cfg->cells(), dissolve.potentialMap(), cutoff);
-            auto molecularEnergy = 0.0;
-            for (const auto &mol : cfg->molecules())
-                molecularEnergy += energyKernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
-            // In the typical case where there is more than one molecule, our sum will contain double the intermolecular
-            // pairpotential energy, and zero intramolecular energy
-            if (cfg->nMolecules() > 1)
-                molecularEnergy *= 0.5;
-            molecularEnergy += correctSelfEnergy;
-            moleculeTimer.stop();
-
-            Messenger::print("Production interatomic pairpotential energy is {:15.9e} kJ/mol\n", interEnergy);
-            Messenger::print("Production intramolecular energy is {:15.9e} kJ/mol\n", intraEnergy);
-            Messenger::print("Total production energy is {:15.9e} kJ/mol\n", interEnergy + intraEnergy);
-            Messenger::print("Molecular energy (excluding bound terms) is {:15.9e} kJ/mol\n", molecularEnergy);
-            Messenger::print("Time to do interatomic energy was {}.\n", interTimer.totalTimeString());
-            Messenger::print("Time to do intramolecular energy was {}.\n", intraTimer.totalTimeString());
-            Messenger::print("Time to do intermolecular energy was {}.\n", moleculeTimer.totalTimeString());
-
-            /*
-             * Production Calculation Ends
-             */
-
-            // Compare production vs reference values
-            double delta;
-            if (testReferenceInter_)
+            // Bond energy
+            for (const auto &bond : molN->species()->bonds())
             {
-                delta = testReferenceInter_.value() - correctInterEnergy;
-                Messenger::print("Reference interatomic energy delta with correct value is {:15.9e} kJ/mol and "
-                                 "is {} (threshold is {:10.3e} kJ/mol)\n",
-                                 delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-                if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                    return false;
-
-                delta = testReferenceInter_.value() - interEnergy;
-                Messenger::print("Reference interatomic energy delta with production value is {:15.9e} kJ/mol "
-                                 "and is {} (threshold is {:10.3e} kJ/mol)\n",
-                                 delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-                if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                    return false;
+                r = targetConfiguration_->box()->minimumDistance(molN->atom(bond.indexI())->r(),
+                                                                 molN->atom(bond.indexJ())->r());
+                correctIntraEnergy += bond.energy(r);
             }
-            if (testReferenceIntra_)
+
+            // Angle energy
+            for (const auto &angle : molN->species()->angles())
             {
-                delta = testReferenceIntra_.value() - correctIntraEnergy;
-                Messenger::print("Reference intramolecular energy delta with correct value is {:15.9e} kJ/mol "
-                                 "and is {} (threshold is {:10.3e} kJ/mol)\n",
-                                 delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-                if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                    return false;
+                // Get vectors 'j-i' and 'j-k'
+                vecji = targetConfiguration_->box()->minimumVector(molN->atom(angle.indexJ())->r(),
+                                                                   molN->atom(angle.indexI())->r());
+                vecjk = targetConfiguration_->box()->minimumVector(molN->atom(angle.indexJ())->r(),
+                                                                   molN->atom(angle.indexK())->r());
 
-                delta = testReferenceIntra_.value() - intraEnergy;
-                Messenger::print("Reference intramolecular energy delta with production value is {:15.9e} kJ/mol "
-                                 "and is {} (threshold is {:10.3e} kJ/mol)\n",
-                                 delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-                if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                    return false;
+                // Calculate angle and determine angle energy
+                vecji.normalise();
+                vecjk.normalise();
+                correctIntraEnergy += angle.energy(Box::angleInDegrees(vecji, vecjk));
             }
 
-            // Compare production vs 'correct' values
-            auto interDelta = correctInterEnergy - interEnergy;
-            auto intraDelta = correctIntraEnergy - intraEnergy;
-            auto moleculeDelta = correctInterEnergy - molecularEnergy;
-            Messenger::print("Comparing 'correct' with production values...\n");
-            Messenger::print("Interatomic energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
-                             interDelta, fabs(interDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-            Messenger::print("Intramolecular energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
-                             intraDelta, fabs(intraDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-            Messenger::print("Intermolecular energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
-                             moleculeDelta, fabs(moleculeDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+            // Torsion energy
+            for (const auto &torsion : molN->species()->torsions())
+            {
+                // Get vectors 'j-i', 'j-k' and 'k-l'
+                vecji = targetConfiguration_->box()->minimumVector(molN->atom(torsion.indexJ())->r(),
+                                                                   molN->atom(torsion.indexI())->r());
+                vecjk = targetConfiguration_->box()->minimumVector(molN->atom(torsion.indexJ())->r(),
+                                                                   molN->atom(torsion.indexK())->r());
+                veckl = targetConfiguration_->box()->minimumVector(molN->atom(torsion.indexK())->r(),
+                                                                   molN->atom(torsion.indexL())->r());
 
-            // All OK?
-            if (!procPool.allTrue((fabs(interDelta) < testThreshold_) && (fabs(intraDelta) < testThreshold_) &&
-                                  (fabs(moleculeDelta) < testThreshold_)))
+                angle = Box::torsionInDegrees(vecji, vecjk, veckl);
+
+                // Determine Torsion energy
+                correctIntraEnergy += torsion.energy(angle);
+            }
+
+            // Improper energy
+            for (const auto &imp : molN->species()->impropers())
+            {
+                // Get vectors 'j-i', 'j-k' and 'k-l'
+                vecji =
+                    targetConfiguration_->box()->minimumVector(molN->atom(imp.indexJ())->r(), molN->atom(imp.indexI())->r());
+                vecjk =
+                    targetConfiguration_->box()->minimumVector(molN->atom(imp.indexJ())->r(), molN->atom(imp.indexK())->r());
+                veckl =
+                    targetConfiguration_->box()->minimumVector(molN->atom(imp.indexK())->r(), molN->atom(imp.indexL())->r());
+
+                angle = Box::torsionInDegrees(vecji, vecjk, veckl);
+
+                // Determine improper energy
+                correctIntraEnergy += imp.energy(angle);
+            }
+        }
+
+        // Add the self energy into the total interatomic energy
+        correctInterEnergy += correctSelfEnergy;
+
+        testTimer.stop();
+
+        Messenger::print("Correct interatomic pairpotential energy (total) is {:15.9e} kJ/mol\n", correctInterEnergy);
+        Messenger::print("Correct interatomic pairpotential (within molecules) is {:15.9e} kJ/mol\n", correctSelfEnergy);
+        Messenger::print("Correct intramolecular energy is {:15.9e} kJ/mol\n", correctIntraEnergy);
+        Messenger::print("Correct total energy is {:15.9e} kJ/mol\n", correctInterEnergy + correctIntraEnergy);
+        Messenger::print("Time to do total (test) energy was {}.\n", testTimer.totalTimeString());
+
+        /*
+         * Test Calculation End
+         */
+
+        /*
+         * Production Calculation Begins
+         */
+
+        // Calculate interatomic energy
+        Timer interTimer;
+        auto interEnergy = interAtomicEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
+        interTimer.stop();
+
+        // Calculate intramolecular energy
+        Timer intraTimer;
+        auto intraEnergy = intraMolecularEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
+        intraTimer.stop();
+
+        // Calculate total interatomic energy from molecules
+        Timer moleculeTimer;
+        EnergyKernel energyKernel(procPool, targetConfiguration_->box(), targetConfiguration_->cells(), dissolve.potentialMap(),
+                                  cutoff);
+        auto molecularEnergy = 0.0;
+        for (const auto &mol : targetConfiguration_->molecules())
+            molecularEnergy += energyKernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+        // In the typical case where there is more than one molecule, our sum will contain double the intermolecular
+        // pairpotential energy, and zero intramolecular energy
+        if (targetConfiguration_->nMolecules() > 1)
+            molecularEnergy *= 0.5;
+        molecularEnergy += correctSelfEnergy;
+        moleculeTimer.stop();
+
+        Messenger::print("Production interatomic pairpotential energy is {:15.9e} kJ/mol\n", interEnergy);
+        Messenger::print("Production intramolecular energy is {:15.9e} kJ/mol\n", intraEnergy);
+        Messenger::print("Total production energy is {:15.9e} kJ/mol\n", interEnergy + intraEnergy);
+        Messenger::print("Molecular energy (excluding bound terms) is {:15.9e} kJ/mol\n", molecularEnergy);
+        Messenger::print("Time to do interatomic energy was {}.\n", interTimer.totalTimeString());
+        Messenger::print("Time to do intramolecular energy was {}.\n", intraTimer.totalTimeString());
+        Messenger::print("Time to do intermolecular energy was {}.\n", moleculeTimer.totalTimeString());
+
+        /*
+         * Production Calculation Ends
+         */
+
+        // Compare production vs reference values
+        double delta;
+        if (testReferenceInter_)
+        {
+            delta = testReferenceInter_.value() - correctInterEnergy;
+            Messenger::print("Reference interatomic energy delta with correct value is {:15.9e} kJ/mol and "
+                             "is {} (threshold is {:10.3e} kJ/mol)\n",
+                             delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+            if (!procPool.allTrue(fabs(delta) < testThreshold_))
+                return false;
+
+            delta = testReferenceInter_.value() - interEnergy;
+            Messenger::print("Reference interatomic energy delta with production value is {:15.9e} kJ/mol "
+                             "and is {} (threshold is {:10.3e} kJ/mol)\n",
+                             delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+            if (!procPool.allTrue(fabs(delta) < testThreshold_))
                 return false;
         }
-        else
+        if (testReferenceIntra_)
         {
-            /*
-             * Calculates the total energy of the entire system.
-             *
-             * This is a serial routine (subroutines called from within are parallel).
-             */
+            delta = testReferenceIntra_.value() - correctIntraEnergy;
+            Messenger::print("Reference intramolecular energy delta with correct value is {:15.9e} kJ/mol "
+                             "and is {} (threshold is {:10.3e} kJ/mol)\n",
+                             delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+            if (!procPool.allTrue(fabs(delta) < testThreshold_))
+                return false;
 
-            procPool.resetAccumulatedTime();
-
-            // Calculate intermolecular energy
-            Timer interTimer;
-            auto interEnergy = interAtomicEnergy(procPool, cfg, dissolve.potentialMap());
-            interTimer.stop();
-
-            // Calculate intramolecular and intermolecular correction energy
-            Timer intraTimer;
-            double bondEnergy, angleEnergy, torsionEnergy, improperEnergy;
-            auto intraEnergy = intraMolecularEnergy(procPool, cfg, dissolve.potentialMap(), bondEnergy, angleEnergy,
-                                                    torsionEnergy, improperEnergy);
-            intraTimer.stop();
-
-            Messenger::print("Time to do interatomic energy was {}, intramolecular energy was {} ({} comms).\n",
-                             interTimer.totalTimeString(), intraTimer.totalTimeString(), procPool.accumulatedTimeString());
-            Messenger::print("Total Energy (World) is {:15.9e} kJ/mol ({:15.9e} kJ/mol interatomic + {:15.9e} kJ/mol "
-                             "intramolecular).\n",
-                             interEnergy + intraEnergy, interEnergy, intraEnergy);
-            Messenger::print("Intramolecular contributions are - bonds = {:15.9e} kJ/mol, angles = {:15.9e} kJ/mol, "
-                             "torsions = {:15.9e} kJ/mol, impropers = {:15.9e} kJ/mol.\n",
-                             bondEnergy, angleEnergy, torsionEnergy, improperEnergy);
-
-            // Store current energies in the Configuration in case somebody else needs them
-            auto &interData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Inter", cfg->niceName()),
-                                                                              uniqueName(), GenericItem::InRestartFileFlag);
-            interData.addPoint(dissolve.iteration(), interEnergy);
-            auto &intraData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Intra", cfg->niceName()),
-                                                                              uniqueName(), GenericItem::InRestartFileFlag);
-            intraData.addPoint(dissolve.iteration(), intraEnergy);
-            auto &bondData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Bond", cfg->niceName()),
-                                                                             uniqueName(), GenericItem::InRestartFileFlag);
-            bondData.addPoint(dissolve.iteration(), bondEnergy);
-            auto &angleData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Angle", cfg->niceName()),
-                                                                              uniqueName(), GenericItem::InRestartFileFlag);
-            angleData.addPoint(dissolve.iteration(), angleEnergy);
-            auto &torsionData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Torsions", cfg->niceName()),
-                                                                                uniqueName(), GenericItem::InRestartFileFlag);
-            torsionData.addPoint(dissolve.iteration(), torsionEnergy);
-            auto &improperData = dissolve.processingModuleData().realise<Data1D>(fmt::format("{}//Impropers", cfg->niceName()),
-                                                                                 uniqueName(), GenericItem::InRestartFileFlag);
-            improperData.addPoint(dissolve.iteration(), improperEnergy);
-
-            // Append to arrays of total energies
-            auto &totalEnergyArray = dissolve.processingModuleData().realise<Data1D>(
-                fmt::format("{}//Total", cfg->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
-            totalEnergyArray.addPoint(dissolve.iteration(), interEnergy + intraEnergy);
-
-            // Determine stability of energy
-            // Check number of points already stored for the Configuration
-            auto grad = 0.0;
-            auto stable = false;
-            if (stabilityWindow_ > totalEnergyArray.nValues())
-                Messenger::print("Too few points to assess stability.\n");
-            else
-            {
-                auto yMean = 0.0;
-                grad = Regression::linear(totalEnergyArray, stabilityWindow_, yMean);
-                auto thresholdValue = fabs(stabilityThreshold_ * yMean);
-                stable = fabs(grad) < thresholdValue;
-
-                Messenger::print("Gradient of last {} points is {:e} kJ/mol/step (absolute threshold value is "
-                                 "{:e}, stable = {}).\n",
-                                 stabilityWindow_, grad, thresholdValue, DissolveSys::btoa(stable));
-            }
-
-            // Set energy data under the configuration's prefix
-            dissolve.processingModuleData().realise<double>("EnergyGradient", cfg->niceName(), GenericItem::InRestartFileFlag) =
-                grad;
-            dissolve.processingModuleData().realise<bool>("EnergyStable", cfg->niceName(), GenericItem::InRestartFileFlag) =
-                stable;
-
-            // If writing to a file, append it here
-            if (save_)
-            {
-                LineParser parser;
-                std::string filename = fmt::format("{}.energy.txt", cfg->niceName());
-
-                if (!DissolveSys::fileExists(filename))
-                {
-                    parser.openOutput(filename);
-                    parser.writeLineF("# Energies for Configuration '{}'.\n", cfg->name());
-                    parser.writeLine("# All values in kJ/mol.\n");
-                    parser.writeLine("# Iteration   Total         Inter         Bond          Angle        "
-                                     " Torsion      Improper    Gradient      S?\n");
-                }
-                else
-                    parser.appendOutput(filename);
-                parser.writeLineF("  {:10d}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {}\n",
-                                  dissolve.iteration(), interEnergy + intraEnergy, interEnergy, bondEnergy, angleEnergy,
-                                  torsionEnergy, improperEnergy, grad, stable);
-                parser.closeFiles();
-            }
+            delta = testReferenceIntra_.value() - intraEnergy;
+            Messenger::print("Reference intramolecular energy delta with production value is {:15.9e} kJ/mol "
+                             "and is {} (threshold is {:10.3e} kJ/mol)\n",
+                             delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+            if (!procPool.allTrue(fabs(delta) < testThreshold_))
+                return false;
         }
 
-        Messenger::print("\n");
+        // Compare production vs 'correct' values
+        auto interDelta = correctInterEnergy - interEnergy;
+        auto intraDelta = correctIntraEnergy - intraEnergy;
+        auto moleculeDelta = correctInterEnergy - molecularEnergy;
+        Messenger::print("Comparing 'correct' with production values...\n");
+        Messenger::print("Interatomic energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n", interDelta,
+                         fabs(interDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+        Messenger::print("Intramolecular energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
+                         intraDelta, fabs(intraDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+        Messenger::print("Intermolecular energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
+                         moleculeDelta, fabs(moleculeDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+
+        // All OK?
+        if (!procPool.allTrue((fabs(interDelta) < testThreshold_) && (fabs(intraDelta) < testThreshold_) &&
+                              (fabs(moleculeDelta) < testThreshold_)))
+            return false;
     }
+    else
+    {
+        /*
+         * Calculates the total energy of the entire system.
+         *
+         * This is a serial routine (subroutines called from within are parallel).
+         */
+
+        procPool.resetAccumulatedTime();
+
+        // Calculate intermolecular energy
+        Timer interTimer;
+        auto interEnergy = interAtomicEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
+        interTimer.stop();
+
+        // Calculate intramolecular and intermolecular correction energy
+        Timer intraTimer;
+        double bondEnergy, angleEnergy, torsionEnergy, improperEnergy;
+        auto intraEnergy = intraMolecularEnergy(procPool, targetConfiguration_, dissolve.potentialMap(), bondEnergy,
+                                                angleEnergy, torsionEnergy, improperEnergy);
+        intraTimer.stop();
+
+        Messenger::print("Time to do interatomic energy was {}, intramolecular energy was {} ({} comms).\n",
+                         interTimer.totalTimeString(), intraTimer.totalTimeString(), procPool.accumulatedTimeString());
+        Messenger::print("Total Energy (World) is {:15.9e} kJ/mol ({:15.9e} kJ/mol interatomic + {:15.9e} kJ/mol "
+                         "intramolecular).\n",
+                         interEnergy + intraEnergy, interEnergy, intraEnergy);
+        Messenger::print("Intramolecular contributions are - bonds = {:15.9e} kJ/mol, angles = {:15.9e} kJ/mol, "
+                         "torsions = {:15.9e} kJ/mol, impropers = {:15.9e} kJ/mol.\n",
+                         bondEnergy, angleEnergy, torsionEnergy, improperEnergy);
+
+        // Store current energies in the Configuration in case somebody else needs them
+        auto &interData = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Inter", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        interData.addPoint(dissolve.iteration(), interEnergy);
+        auto &intraData = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Intra", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        intraData.addPoint(dissolve.iteration(), intraEnergy);
+        auto &bondData = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Bond", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        bondData.addPoint(dissolve.iteration(), bondEnergy);
+        auto &angleData = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Angle", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        angleData.addPoint(dissolve.iteration(), angleEnergy);
+        auto &torsionData = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Torsions", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        torsionData.addPoint(dissolve.iteration(), torsionEnergy);
+        auto &improperData = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Impropers", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        improperData.addPoint(dissolve.iteration(), improperEnergy);
+
+        // Append to arrays of total energies
+        auto &totalEnergyArray = dissolve.processingModuleData().realise<Data1D>(
+            fmt::format("{}//Total", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        totalEnergyArray.addPoint(dissolve.iteration(), interEnergy + intraEnergy);
+
+        // Determine stability of energy
+        // Check number of points already stored for the Configuration
+        auto grad = 0.0;
+        auto stable = false;
+        if (stabilityWindow_ > totalEnergyArray.nValues())
+            Messenger::print("Too few points to assess stability.\n");
+        else
+        {
+            auto yMean = 0.0;
+            grad = Regression::linear(totalEnergyArray, stabilityWindow_, yMean);
+            auto thresholdValue = fabs(stabilityThreshold_ * yMean);
+            stable = fabs(grad) < thresholdValue;
+
+            Messenger::print("Gradient of last {} points is {:e} kJ/mol/step (absolute threshold value is "
+                             "{:e}, stable = {}).\n",
+                             stabilityWindow_, grad, thresholdValue, DissolveSys::btoa(stable));
+        }
+
+        // Set energy data under the configuration's prefix
+        dissolve.processingModuleData().realise<double>("EnergyGradient", targetConfiguration_->niceName(),
+                                                        GenericItem::InRestartFileFlag) = grad;
+        dissolve.processingModuleData().realise<bool>("EnergyStable", targetConfiguration_->niceName(),
+                                                      GenericItem::InRestartFileFlag) = stable;
+
+        // If writing to a file, append it here
+        if (save_)
+        {
+            LineParser parser;
+            std::string filename = fmt::format("{}.energy.txt", targetConfiguration_->niceName());
+
+            if (!DissolveSys::fileExists(filename))
+            {
+                parser.openOutput(filename);
+                parser.writeLineF("# Energies for Configuration '{}'.\n", targetConfiguration_->name());
+                parser.writeLine("# All values in kJ/mol.\n");
+                parser.writeLine("# Iteration   Total         Inter         Bond          Angle        "
+                                 " Torsion      Improper    Gradient      S?\n");
+            }
+            else
+                parser.appendOutput(filename);
+            parser.writeLineF("  {:10d}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {}\n",
+                              dissolve.iteration(), interEnergy + intraEnergy, interEnergy, bondEnergy, angleEnergy,
+                              torsionEnergy, improperEnergy, grad, stable);
+            parser.closeFiles();
+        }
+    }
+
+    Messenger::print("\n");
 
     return true;
 }

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Team Dissolve and contributors
 
-#include "classes/atomtype.h"
 #include "main/dissolve.h"
 #include "math/gaussfit.h"
 #include "math/poissonfit.h"

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -53,7 +53,7 @@ bool EPSRModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals
                 uniqueName_, module->uniqueName());
 
         // Check for number of targets, or different target if there's only 1
-        auto rdfConfigs = rdfModule->keywords().get<std::vector<Configuration *>>("Configuration");
+        auto rdfConfigs = rdfModule->keywords().get<std::vector<Configuration *>>("Configurations");
         if (rdfConfigs.size() != 1)
             return Messenger::error(
                 "[SETUP {}] RDF module '{}' targets multiple configurations, which is not permitted when using "

--- a/src/modules/export_coordinates/process.cpp
+++ b/src/modules/export_coordinates/process.cpp
@@ -19,7 +19,7 @@ bool ExportCoordinatesModule::process(Dissolve &dissolve, ProcessPool &procPool)
 
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());

--- a/src/modules/forces/forces.cpp
+++ b/src/modules/forces/forces.cpp
@@ -3,14 +3,14 @@
 
 #include "modules/forces/forces.h"
 #include "keywords/bool.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/fileandformat.h"
 
 ForcesModule::ForcesModule() : Module("Forces")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Test
     keywords_.add<BoolKeyword>(

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -24,7 +24,7 @@ class ForcesModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Test parallel force routines against basic serial versions and supplied reference values (if provided)
     bool test_{false};
     // Use analytic interatomic forces rather than (production) tabulated potentials for tests

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -24,7 +24,7 @@ class ForcesModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Test parallel force routines against basic serial versions and supplied reference values (if provided)
     bool test_{false};
     // Use analytic interatomic forces rather than (production) tabulated potentials for tests

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -38,76 +38,105 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+
+    // Retrieve control parameters
+    const auto saveData = exportedForces_.hasFilename();
+
+    // Calculate the total forces
+    if (test_)
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+        /*
+         * Calculate the total forces in the system using basic loops.
+         *
+         * This is a serial routine, with all processes independently calculating their own value.
+         */
 
-        // Retrieve control parameters
-        const auto saveData = exportedForces_.hasFilename();
+        Messenger::print("Calculating forces for Configuration '{}' in serial test mode...\n", targetConfiguration_->name());
+        if (testAnalytic_)
+            Messenger::print("Exact (analytic) forces will be calculated.\n");
+        Messenger::print("Test threshold for failure is {}%.\n", testThreshold_);
 
-        // Calculate the total forces
-        if (test_)
+        /*
+         * Calculation Begins
+         */
+
+        const auto &potentialMap = dissolve.potentialMap();
+        const auto cutoffSq = potentialMap.range() * potentialMap.range();
+
+        double magjisq, magji, magjk, dp, force, r;
+        Atom *i, *j, *k, *l;
+        Vec3<double> vecji, vecjk, veckl, forcei, forcek;
+        Vec3<double> xpj, xpk, temp;
+        double du_dphi;
+        std::shared_ptr<Molecule> molN, molM;
+        const auto *box = targetConfiguration_->box();
+        double scale;
+
+        // Allocate the force vectors
+        std::vector<Vec3<double>> fInter, fIntra, fRef, fInterCheck, fIntraCheck;
+        fInter.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+        fIntra.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+        fRef.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+        fInterCheck.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+        fIntraCheck.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+
+        // Calculate interatomic and intramlecular energy in a loop over defined Molecules
+        Timer timer;
+        for (auto n = 0; n < targetConfiguration_->nMolecules(); ++n)
         {
-            /*
-             * Calculate the total forces in the system using basic loops.
-             *
-             * This is a serial routine, with all processes independently calculating their own value.
-             */
+            molN = targetConfiguration_->molecule(n);
 
-            Messenger::print("Calculating forces for Configuration '{}' in serial test mode...\n", cfg->name());
-            if (testAnalytic_)
-                Messenger::print("Exact (analytic) forces will be calculated.\n");
-            Messenger::print("Test threshold for failure is {}%.\n", testThreshold_);
+            // Intramolecular forces (excluding bound terms) in molecule N
+            if (testInter_)
+                for (auto ii = 0; ii < molN->nAtoms() - 1; ++ii)
+                {
+                    i = molN->atom(ii);
 
-            /*
-             * Calculation Begins
-             */
+                    for (auto jj = ii + 1; jj < molN->nAtoms(); ++jj)
+                    {
+                        j = molN->atom(jj);
 
-            const auto &potentialMap = dissolve.potentialMap();
-            const auto cutoffSq = potentialMap.range() * potentialMap.range();
+                        // Get intramolecular scaling of atom pair
+                        scale = i->scaling(j);
+                        if (scale < 1.0e-3)
+                            continue;
 
-            double magjisq, magji, magjk, dp, force, r;
-            Atom *i, *j, *k, *l;
-            Vec3<double> vecji, vecjk, veckl, forcei, forcek;
-            Vec3<double> xpj, xpk, temp;
-            double du_dphi;
-            std::shared_ptr<Molecule> molN, molM;
-            const auto *box = cfg->box();
-            double scale;
+                        // Determine final forces
+                        vecji = box->minimumVector(i->r(), j->r());
+                        magjisq = vecji.magnitudeSq();
+                        if (magjisq > cutoffSq)
+                            continue;
+                        r = sqrt(magjisq);
+                        vecji /= r;
 
-            // Allocate the force vectors
-            std::vector<Vec3<double>> fInter, fIntra, fRef, fInterCheck, fIntraCheck;
-            fInter.resize(cfg->nAtoms(), Vec3<double>());
-            fIntra.resize(cfg->nAtoms(), Vec3<double>());
-            fRef.resize(cfg->nAtoms(), Vec3<double>());
-            fInterCheck.resize(cfg->nAtoms(), Vec3<double>());
-            fIntraCheck.resize(cfg->nAtoms(), Vec3<double>());
+                        if (testAnalytic_)
+                            vecji *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r) * scale;
+                        else
+                            vecji *= potentialMap.force(*molN->atom(ii), *molN->atom(jj), r) * scale;
+                        fInter[i->arrayIndex()] += vecji;
+                        fInter[j->arrayIndex()] -= vecji;
+                    }
+                }
 
-            // Calculate interatomic and intramlecular energy in a loop over defined Molecules
-            Timer timer;
-            for (auto n = 0; n < cfg->nMolecules(); ++n)
-            {
-                molN = cfg->molecule(n);
+            // Forces between molecule N and molecule M
+            if (testInter_)
+                for (auto m = n + 1; m < targetConfiguration_->nMolecules(); ++m)
+                {
+                    molM = targetConfiguration_->molecule(m);
 
-                // Intramolecular forces (excluding bound terms) in molecule N
-                if (testInter_)
-                    for (auto ii = 0; ii < molN->nAtoms() - 1; ++ii)
+                    // Double loop over atoms
+                    for (auto ii = 0; ii < molN->nAtoms(); ++ii)
                     {
                         i = molN->atom(ii);
 
-                        for (auto jj = ii + 1; jj < molN->nAtoms(); ++jj)
+                        for (auto jj = 0; jj < molM->nAtoms(); ++jj)
                         {
-                            j = molN->atom(jj);
-
-                            // Get intramolecular scaling of atom pair
-                            scale = i->scaling(j);
-                            if (scale < 1.0e-3)
-                                continue;
+                            j = molM->atom(jj);
 
                             // Determine final forces
                             vecji = box->minimumVector(i->r(), j->r());
@@ -118,408 +147,374 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
                             vecji /= r;
 
                             if (testAnalytic_)
-                                vecji *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r) * scale;
+                                vecji *= potentialMap.analyticForce(i, j, r);
                             else
-                                vecji *= potentialMap.force(*molN->atom(ii), *molN->atom(jj), r) * scale;
+                                vecji *= potentialMap.force(*i, *j, r);
+
                             fInter[i->arrayIndex()] += vecji;
                             fInter[j->arrayIndex()] -= vecji;
                         }
                     }
-
-                // Forces between molecule N and molecule M
-                if (testInter_)
-                    for (auto m = n + 1; m < cfg->nMolecules(); ++m)
-                    {
-                        molM = cfg->molecule(m);
-
-                        // Double loop over atoms
-                        for (auto ii = 0; ii < molN->nAtoms(); ++ii)
-                        {
-                            i = molN->atom(ii);
-
-                            for (auto jj = 0; jj < molM->nAtoms(); ++jj)
-                            {
-                                j = molM->atom(jj);
-
-                                // Determine final forces
-                                vecji = box->minimumVector(i->r(), j->r());
-                                magjisq = vecji.magnitudeSq();
-                                if (magjisq > cutoffSq)
-                                    continue;
-                                r = sqrt(magjisq);
-                                vecji /= r;
-
-                                if (testAnalytic_)
-                                    vecji *= potentialMap.analyticForce(i, j, r);
-                                else
-                                    vecji *= potentialMap.force(*i, *j, r);
-
-                                fInter[i->arrayIndex()] += vecji;
-                                fInter[j->arrayIndex()] -= vecji;
-                            }
-                        }
-                    }
-
-                if (testIntra_)
-                {
-                    // Bond forces
-                    for (const auto &bond : molN->species()->bonds())
-                    {
-                        // Grab pointers to atoms involved in bond
-                        i = molN->atom(bond.indexI());
-                        j = molN->atom(bond.indexJ());
-
-                        // Determine final forces
-                        vecji = box->minimumVector(i->r(), j->r());
-                        r = vecji.magAndNormalise();
-                        vecji *= bond.force(r);
-
-                        fIntra[i->arrayIndex()] -= vecji;
-                        fIntra[j->arrayIndex()] += vecji;
-                    }
-
-                    // Angle forces
-                    for (const auto &angle : molN->species()->angles())
-                    {
-                        // Grab pointers to atoms involved in angle
-                        i = molN->atom(angle.indexI());
-                        j = molN->atom(angle.indexJ());
-                        k = molN->atom(angle.indexK());
-
-                        // Get vectors 'j-i' and 'j-k'
-                        vecji = box->minimumVector(j->r(), i->r());
-                        vecjk = box->minimumVector(j->r(), k->r());
-                        magji = vecji.magAndNormalise();
-                        magjk = vecjk.magAndNormalise();
-
-                        // Determine Angle force vectors for atoms
-                        force = angle.force(Box::angleInDegrees(vecji, vecjk, dp));
-                        forcei = vecjk - vecji * dp;
-                        forcei *= force / magji;
-                        forcek = vecji - vecjk * dp;
-                        forcek *= force / magjk;
-
-                        // Store forces
-                        fIntra[i->arrayIndex()] += forcei;
-                        fIntra[j->arrayIndex()] -= forcei + forcek;
-                        fIntra[k->arrayIndex()] += forcek;
-                    }
-
-                    // Torsion forces
-                    for (const auto &torsion : molN->species()->torsions())
-                    {
-                        // Grab pointers to atoms involved in angle
-                        i = molN->atom(torsion.indexI());
-                        j = molN->atom(torsion.indexJ());
-                        k = molN->atom(torsion.indexK());
-                        l = molN->atom(torsion.indexL());
-
-                        // Calculate vectors, ensuring we account for minimum image
-                        vecji = box->minimumVector(i->r(), j->r());
-                        vecjk = box->minimumVector(k->r(), j->r());
-                        veckl = box->minimumVector(l->r(), k->r());
-
-                        // Calculate torsion force parameters
-                        auto tp = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
-                        du_dphi = torsion.force(tp.phi_ * DEGRAD);
-
-                        // Sum forces on Atoms
-                        fIntra[i->arrayIndex()].add(du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(0)),
-                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(1)),
-                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(2)));
-
-                        fIntra[j->arrayIndex()].add(
-                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(0) - tp.dxpj_dkj_.columnAsVec3(0)) -
-                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0))),
-                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(1) - tp.dxpj_dkj_.columnAsVec3(1)) -
-                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1))),
-                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(2) - tp.dxpj_dkj_.columnAsVec3(2)) -
-                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2))));
-
-                        fIntra[k->arrayIndex()].add(
-                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0) - tp.dxpk_dlk_.columnAsVec3(0)) +
-                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(0))),
-                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1) - tp.dxpk_dlk_.columnAsVec3(1)) +
-                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(1))),
-                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2) - tp.dxpk_dlk_.columnAsVec3(2)) +
-                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(2))));
-
-                        fIntra[l->arrayIndex()].add(du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(0)),
-                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(1)),
-                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(2)));
-                    }
-
-                    // Improper forces
-                    for (const auto &imp : molN->species()->impropers())
-                    {
-                        // Grab pointers to atoms involved in angle
-                        i = molN->atom(imp.indexI());
-                        j = molN->atom(imp.indexJ());
-                        k = molN->atom(imp.indexK());
-                        l = molN->atom(imp.indexL());
-
-                        // Calculate vectors, ensuring we account for minimum image
-                        vecji = box->minimumVector(i->r(), j->r());
-                        vecjk = box->minimumVector(k->r(), j->r());
-                        veckl = box->minimumVector(l->r(), k->r());
-
-                        // Calculate improper force parameters
-                        auto tp = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
-                        du_dphi = imp.force(tp.phi_ * DEGRAD);
-
-                        // Sum forces on Atoms
-                        fIntra[i->arrayIndex()].add(du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(0)),
-                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(1)),
-                                                    du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(2)));
-
-                        fIntra[j->arrayIndex()].add(
-                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(0) - tp.dxpj_dkj_.columnAsVec3(0)) -
-                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0))),
-                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(1) - tp.dxpj_dkj_.columnAsVec3(1)) -
-                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1))),
-                            du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(2) - tp.dxpj_dkj_.columnAsVec3(2)) -
-                                       tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2))));
-
-                        fIntra[k->arrayIndex()].add(
-                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0) - tp.dxpk_dlk_.columnAsVec3(0)) +
-                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(0))),
-                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1) - tp.dxpk_dlk_.columnAsVec3(1)) +
-                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(1))),
-                            du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2) - tp.dxpk_dlk_.columnAsVec3(2)) +
-                                       tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(2))));
-
-                        fIntra[l->arrayIndex()].add(du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(0)),
-                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(1)),
-                                                    du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(2)));
-                    }
                 }
-            }
-            timer.stop();
 
-            // Convert forces to 10J/mol
-            std::transform(fInter.begin(), fInter.end(), fInter.begin(), [](auto &f) { return f * 100.0; });
-            std::transform(fIntra.begin(), fIntra.end(), fIntra.begin(), [](auto &f) { return f * 100.0; });
-
-            Messenger::print("Time to do total (test) forces was {}.\n", timer.totalTimeString());
-
-            /*
-             * Test Calculation End
-             */
-
-            /*
-             * Production Calculation Begins
-             */
-
-            Messenger::print("Calculating total forces for Configuration '{}'...\n", cfg->name());
-
-            // Calculate interatomic forces
-            if (testInter_)
-            {
-                Timer interTimer;
-                interTimer.start();
-
-                interAtomicForces(procPool, cfg, dissolve.potentialMap(), fInterCheck);
-                if (!procPool.allSum(fInterCheck))
-                    return false;
-
-                interTimer.stop();
-                Messenger::print("Time to do interatomic forces was {}.\n", interTimer.totalTimeString());
-            }
-
-            // Calculate intramolecular forces
             if (testIntra_)
             {
-                Timer intraTimer;
-                intraTimer.start();
-
-                intraMolecularForces(procPool, cfg, dissolve.potentialMap(), fIntraCheck);
-                if (!procPool.allSum(fIntraCheck))
-                    return false;
-
-                intraTimer.stop();
-                Messenger::print("Time to do intramolecular forces was {}.\n", intraTimer.totalTimeString());
-            }
-
-            // Convert forces to 10J/mol
-            std::transform(fInterCheck.begin(), fInterCheck.end(), fInterCheck.begin(), [](auto &f) { return f * 100.0; });
-            std::transform(fIntraCheck.begin(), fIntraCheck.end(), fIntraCheck.begin(), [](auto &f) { return f * 100.0; });
-
-            /*
-             * Production Calculation Ends
-             */
-
-            // Test 'correct' forces against production forces
-            auto nFailed1 = 0;
-            bool failed;
-            Vec3<double> interRatio, intraRatio;
-            auto sumError = 0.0;
-
-            Messenger::print("Testing calculated 'correct' forces against calculated production forces - "
-                             "atoms with erroneous forces will be output...\n");
-
-            for (auto n = 0; n < cfg->nAtoms(); ++n)
-            {
-                interRatio = fInter[n] - fInterCheck[n];
-                intraRatio = fIntra[n] - fIntraCheck[n];
-                auto failed = false;
-
-                for (auto i = 0; i < 3; ++i)
+                // Bond forces
+                for (const auto &bond : molN->species()->bonds())
                 {
-                    if (fabs(fInter[n].get(i)) > 1.0e-6)
-                        interRatio[i] *= 100.0 / fInter[n].get(i);
-                    if (fabs(interRatio[i]) > testThreshold_)
-                        failed = true;
+                    // Grab pointers to atoms involved in bond
+                    i = molN->atom(bond.indexI());
+                    j = molN->atom(bond.indexJ());
 
-                    if (fabs(fIntra[n].get(i)) > 1.0e-6)
-                        intraRatio[i] *= 100.0 / fIntra[n].get(i);
-                    if (fabs(intraRatio[i]) > testThreshold_)
-                        failed = true;
+                    // Determine final forces
+                    vecji = box->minimumVector(i->r(), j->r());
+                    r = vecji.magAndNormalise();
+                    vecji *= bond.force(r);
+
+                    fIntra[i->arrayIndex()] -= vecji;
+                    fIntra[j->arrayIndex()] += vecji;
                 }
 
+                // Angle forces
+                for (const auto &angle : molN->species()->angles())
+                {
+                    // Grab pointers to atoms involved in angle
+                    i = molN->atom(angle.indexI());
+                    j = molN->atom(angle.indexJ());
+                    k = molN->atom(angle.indexK());
+
+                    // Get vectors 'j-i' and 'j-k'
+                    vecji = box->minimumVector(j->r(), i->r());
+                    vecjk = box->minimumVector(j->r(), k->r());
+                    magji = vecji.magAndNormalise();
+                    magjk = vecjk.magAndNormalise();
+
+                    // Determine Angle force vectors for atoms
+                    force = angle.force(Box::angleInDegrees(vecji, vecjk, dp));
+                    forcei = vecjk - vecji * dp;
+                    forcei *= force / magji;
+                    forcek = vecji - vecjk * dp;
+                    forcek *= force / magjk;
+
+                    // Store forces
+                    fIntra[i->arrayIndex()] += forcei;
+                    fIntra[j->arrayIndex()] -= forcei + forcek;
+                    fIntra[k->arrayIndex()] += forcek;
+                }
+
+                // Torsion forces
+                for (const auto &torsion : molN->species()->torsions())
+                {
+                    // Grab pointers to atoms involved in angle
+                    i = molN->atom(torsion.indexI());
+                    j = molN->atom(torsion.indexJ());
+                    k = molN->atom(torsion.indexK());
+                    l = molN->atom(torsion.indexL());
+
+                    // Calculate vectors, ensuring we account for minimum image
+                    vecji = box->minimumVector(i->r(), j->r());
+                    vecjk = box->minimumVector(k->r(), j->r());
+                    veckl = box->minimumVector(l->r(), k->r());
+
+                    // Calculate torsion force parameters
+                    auto tp = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
+                    du_dphi = torsion.force(tp.phi_ * DEGRAD);
+
+                    // Sum forces on Atoms
+                    fIntra[i->arrayIndex()].add(du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(0)),
+                                                du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(1)),
+                                                du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(2)));
+
+                    fIntra[j->arrayIndex()].add(
+                        du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(0) - tp.dxpj_dkj_.columnAsVec3(0)) -
+                                   tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0))),
+                        du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(1) - tp.dxpj_dkj_.columnAsVec3(1)) -
+                                   tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1))),
+                        du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(2) - tp.dxpj_dkj_.columnAsVec3(2)) -
+                                   tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2))));
+
+                    fIntra[k->arrayIndex()].add(
+                        du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0) - tp.dxpk_dlk_.columnAsVec3(0)) +
+                                   tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(0))),
+                        du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1) - tp.dxpk_dlk_.columnAsVec3(1)) +
+                                   tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(1))),
+                        du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2) - tp.dxpk_dlk_.columnAsVec3(2)) +
+                                   tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(2))));
+
+                    fIntra[l->arrayIndex()].add(du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(0)),
+                                                du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(1)),
+                                                du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(2)));
+                }
+
+                // Improper forces
+                for (const auto &imp : molN->species()->impropers())
+                {
+                    // Grab pointers to atoms involved in angle
+                    i = molN->atom(imp.indexI());
+                    j = molN->atom(imp.indexJ());
+                    k = molN->atom(imp.indexK());
+                    l = molN->atom(imp.indexL());
+
+                    // Calculate vectors, ensuring we account for minimum image
+                    vecji = box->minimumVector(i->r(), j->r());
+                    vecjk = box->minimumVector(k->r(), j->r());
+                    veckl = box->minimumVector(l->r(), k->r());
+
+                    // Calculate improper force parameters
+                    auto tp = ForceKernel::calculateTorsionParameters(vecji, vecjk, veckl);
+                    du_dphi = imp.force(tp.phi_ * DEGRAD);
+
+                    // Sum forces on Atoms
+                    fIntra[i->arrayIndex()].add(du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(0)),
+                                                du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(1)),
+                                                du_dphi * tp.dcos_dxpj_.dp(tp.dxpj_dij_.columnAsVec3(2)));
+
+                    fIntra[j->arrayIndex()].add(
+                        du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(0) - tp.dxpj_dkj_.columnAsVec3(0)) -
+                                   tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0))),
+                        du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(1) - tp.dxpj_dkj_.columnAsVec3(1)) -
+                                   tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1))),
+                        du_dphi * (tp.dcos_dxpj_.dp(-tp.dxpj_dij_.columnAsVec3(2) - tp.dxpj_dkj_.columnAsVec3(2)) -
+                                   tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2))));
+
+                    fIntra[k->arrayIndex()].add(
+                        du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(0) - tp.dxpk_dlk_.columnAsVec3(0)) +
+                                   tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(0))),
+                        du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(1) - tp.dxpk_dlk_.columnAsVec3(1)) +
+                                   tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(1))),
+                        du_dphi * (tp.dcos_dxpk_.dp(tp.dxpk_dkj_.columnAsVec3(2) - tp.dxpk_dlk_.columnAsVec3(2)) +
+                                   tp.dcos_dxpj_.dp(tp.dxpj_dkj_.columnAsVec3(2))));
+
+                    fIntra[l->arrayIndex()].add(du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(0)),
+                                                du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(1)),
+                                                du_dphi * tp.dcos_dxpk_.dp(tp.dxpk_dlk_.columnAsVec3(2)));
+                }
+            }
+        }
+        timer.stop();
+
+        // Convert forces to 10J/mol
+        std::transform(fInter.begin(), fInter.end(), fInter.begin(), [](auto &f) { return f * 100.0; });
+        std::transform(fIntra.begin(), fIntra.end(), fIntra.begin(), [](auto &f) { return f * 100.0; });
+
+        Messenger::print("Time to do total (test) forces was {}.\n", timer.totalTimeString());
+
+        /*
+         * Test Calculation End
+         */
+
+        /*
+         * Production Calculation Begins
+         */
+
+        Messenger::print("Calculating total forces for Configuration '{}'...\n", targetConfiguration_->name());
+
+        // Calculate interatomic forces
+        if (testInter_)
+        {
+            Timer interTimer;
+            interTimer.start();
+
+            interAtomicForces(procPool, targetConfiguration_, dissolve.potentialMap(), fInterCheck);
+            if (!procPool.allSum(fInterCheck))
+                return false;
+
+            interTimer.stop();
+            Messenger::print("Time to do interatomic forces was {}.\n", interTimer.totalTimeString());
+        }
+
+        // Calculate intramolecular forces
+        if (testIntra_)
+        {
+            Timer intraTimer;
+            intraTimer.start();
+
+            intraMolecularForces(procPool, targetConfiguration_, dissolve.potentialMap(), fIntraCheck);
+            if (!procPool.allSum(fIntraCheck))
+                return false;
+
+            intraTimer.stop();
+            Messenger::print("Time to do intramolecular forces was {}.\n", intraTimer.totalTimeString());
+        }
+
+        // Convert forces to 10J/mol
+        std::transform(fInterCheck.begin(), fInterCheck.end(), fInterCheck.begin(), [](auto &f) { return f * 100.0; });
+        std::transform(fIntraCheck.begin(), fIntraCheck.end(), fIntraCheck.begin(), [](auto &f) { return f * 100.0; });
+
+        /*
+         * Production Calculation Ends
+         */
+
+        // Test 'correct' forces against production forces
+        auto nFailed1 = 0;
+        bool failed;
+        Vec3<double> interRatio, intraRatio;
+        auto sumError = 0.0;
+
+        Messenger::print("Testing calculated 'correct' forces against calculated production forces - "
+                         "atoms with erroneous forces will be output...\n");
+
+        for (auto n = 0; n < targetConfiguration_->nAtoms(); ++n)
+        {
+            interRatio = fInter[n] - fInterCheck[n];
+            intraRatio = fIntra[n] - fIntraCheck[n];
+            auto failed = false;
+
+            for (auto i = 0; i < 3; ++i)
+            {
+                if (fabs(fInter[n].get(i)) > 1.0e-6)
+                    interRatio[i] *= 100.0 / fInter[n].get(i);
+                if (fabs(interRatio[i]) > testThreshold_)
+                    failed = true;
+
+                if (fabs(fIntra[n].get(i)) > 1.0e-6)
+                    intraRatio[i] *= 100.0 / fIntra[n].get(i);
+                if (fabs(intraRatio[i]) > testThreshold_)
+                    failed = true;
+            }
+
+            // Sum average errors
+            sumError += fabs(intraRatio.x) + fabs(intraRatio.y) + fabs(intraRatio.z) + fabs(interRatio.x) + fabs(interRatio.y) +
+                        fabs(interRatio.z);
+
+            if (failed)
+            {
+                Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
+                                 "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol (inter)\n",
+                                 n + 1, fInter[n].x - fInterCheck[n].x, interRatio.x, fInter[n].y - fInterCheck[n].y,
+                                 interRatio.y, fInter[n].z - fInterCheck[n].z, interRatio.z);
+                Messenger::print("                                   {:15.8e} ({:5.2f}%) {:15.8e} "
+                                 "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol (intra)\n",
+                                 fIntra[n].x - fIntraCheck[n].x, intraRatio.x, fIntra[n].y - fIntraCheck[n].y, intraRatio.y,
+                                 fIntra[n].z - fIntraCheck[n].z, intraRatio.z);
+                ++nFailed1;
+            }
+        }
+
+        Messenger::print("Number of atoms with failed force components = {} = {}\n", nFailed1, nFailed1 == 0 ? "OK" : "NOT OK");
+        Messenger::print("Average error in force components was {}%.\n", sumError / (targetConfiguration_->nAtoms() * 6));
+
+        // Test reference forces against production (if reference forces present)
+        auto nFailed2 = 0, nFailed3 = 0;
+        Vec3<double> totalRatio;
+        sumError = 0.0;
+        GenericList &processingData = dissolve.processingModuleData();
+        if (processingData.contains("ReferenceForces", uniqueName()))
+        {
+            // Grab reference force array and check size
+            const auto &fRef = processingData.value<std::vector<Vec3<double>>>("ReferenceForces", uniqueName());
+            if (fRef.size() != targetConfiguration_->nAtoms())
+                return Messenger::error("Number of force components in ReferenceForces is {}, but the "
+                                        "Configuration '{}' contains {} atoms.\n",
+                                        fRef.size(), targetConfiguration_->name(), targetConfiguration_->nAtoms());
+
+            Messenger::print("\nTesting reference forces against calculated 'correct' forces - "
+                             "atoms with erroneous forces will be output...\n");
+            sumError = 0.0;
+            for (auto n = 0; n < targetConfiguration_->nAtoms(); ++n)
+            {
+                totalRatio = fRef[n] - (fInter[n] + fIntra[n]);
+                if (fabs(fInter[n].x + fIntra[n].x) > 1.0e-6)
+                    totalRatio.x *= 100.0 / (fInter[n].x + fIntra[n].x);
+                if (fabs(fInter[n].y + fIntra[n].y) > 1.0e-6)
+                    totalRatio.y *= 100.0 / (fInter[n].y + fIntra[n].y);
+                if (fabs(fInter[n].z + fIntra[n].z) > 1.0e-6)
+                    totalRatio.z *= 100.0 / (fInter[n].z + fIntra[n].z);
+
+                if (std::isnan(totalRatio.x) || fabs(totalRatio.x) > testThreshold_)
+                    failed = true;
+                else if (std::isnan(totalRatio.y) || fabs(totalRatio.y) > testThreshold_)
+                    failed = true;
+                else if (std::isnan(totalRatio.z) || fabs(totalRatio.z) > testThreshold_)
+                    failed = true;
+                else
+                    failed = false;
+
                 // Sum average errors
-                sumError += fabs(intraRatio.x) + fabs(intraRatio.y) + fabs(intraRatio.z) + fabs(interRatio.x) +
-                            fabs(interRatio.y) + fabs(interRatio.z);
+                sumError += fabs(totalRatio.x) + fabs(totalRatio.y) + fabs(totalRatio.z);
 
                 if (failed)
                 {
                     Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
-                                     "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol (inter)\n",
-                                     n + 1, fInter[n].x - fInterCheck[n].x, interRatio.x, fInter[n].y - fInterCheck[n].y,
-                                     interRatio.y, fInter[n].z - fInterCheck[n].z, interRatio.z);
-                    Messenger::print("                                   {:15.8e} ({:5.2f}%) {:15.8e} "
-                                     "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol (intra)\n",
-                                     fIntra[n].x - fIntraCheck[n].x, intraRatio.x, fIntra[n].y - fIntraCheck[n].y, intraRatio.y,
-                                     fIntra[n].z - fIntraCheck[n].z, intraRatio.z);
-                    ++nFailed1;
+                                     "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol\n",
+                                     n + 1, fRef[n].x - (fInter[n].x + fIntra[n].x), totalRatio.x,
+                                     fRef[n].y - (fInter[n].y + fIntra[n].y), totalRatio.y,
+                                     fRef[n].z - (fInter[n].z + fIntra[n].z), totalRatio.z);
+                    ++nFailed2;
                 }
             }
+            Messenger::print("Number of atoms with failed force components = {} = {}\n", nFailed2,
+                             nFailed2 == 0 ? "OK" : "NOT OK");
+            Messenger::print("Average error in force components was {}%.\n", sumError / (targetConfiguration_->nAtoms() * 3));
 
-            Messenger::print("Number of atoms with failed force components = {} = {}\n", nFailed1,
-                             nFailed1 == 0 ? "OK" : "NOT OK");
-            Messenger::print("Average error in force components was {}%.\n", sumError / (cfg->nAtoms() * 6));
+            Messenger::print("\nTesting reference forces against calculated production forces - "
+                             "atoms with erroneous forces will be output...\n");
 
-            // Test reference forces against production (if reference forces present)
-            auto nFailed2 = 0, nFailed3 = 0;
-            Vec3<double> totalRatio;
             sumError = 0.0;
-            GenericList &processingData = dissolve.processingModuleData();
-            if (processingData.contains("ReferenceForces", uniqueName()))
+            for (auto n = 0; n < targetConfiguration_->nAtoms(); ++n)
             {
-                // Grab reference force array and check size
-                const auto &fRef = processingData.value<std::vector<Vec3<double>>>("ReferenceForces", uniqueName());
-                if (fRef.size() != cfg->nAtoms())
-                    return Messenger::error("Number of force components in ReferenceForces is {}, but the "
-                                            "Configuration '{}' contains {} atoms.\n",
-                                            fRef.size(), cfg->name(), cfg->nAtoms());
+                totalRatio = fRef[n] - (fInterCheck[n] + fIntraCheck[n]);
+                if (fabs(fInterCheck[n].x + fIntraCheck[n].x) > 1.0e-6)
+                    totalRatio.x *= 100.0 / (fInterCheck[n].x + fIntraCheck[n].x);
+                if (fabs(fInterCheck[n].y + fIntraCheck[n].y) > 1.0e-6)
+                    totalRatio.y *= 100.0 / (fInterCheck[n].y + fIntraCheck[n].y);
+                if (fabs(fInterCheck[n].z + fIntraCheck[n].z) > 1.0e-6)
+                    totalRatio.z *= 100.0 / (fInterCheck[n].z + fIntraCheck[n].z);
 
-                Messenger::print("\nTesting reference forces against calculated 'correct' forces - "
-                                 "atoms with erroneous forces will be output...\n");
-                sumError = 0.0;
-                for (auto n = 0; n < cfg->nAtoms(); ++n)
+                if (std::isnan(totalRatio.x) || fabs(totalRatio.x) > testThreshold_)
+                    failed = true;
+                else if (std::isnan(totalRatio.y) || fabs(totalRatio.y) > testThreshold_)
+                    failed = true;
+                else if (std::isnan(totalRatio.z) || fabs(totalRatio.z) > testThreshold_)
+                    failed = true;
+                else
+                    failed = false;
+
+                // Sum average errors
+                sumError += fabs(totalRatio.x) + fabs(totalRatio.y) + fabs(totalRatio.z);
+
+                if (failed)
                 {
-                    totalRatio = fRef[n] - (fInter[n] + fIntra[n]);
-                    if (fabs(fInter[n].x + fIntra[n].x) > 1.0e-6)
-                        totalRatio.x *= 100.0 / (fInter[n].x + fIntra[n].x);
-                    if (fabs(fInter[n].y + fIntra[n].y) > 1.0e-6)
-                        totalRatio.y *= 100.0 / (fInter[n].y + fIntra[n].y);
-                    if (fabs(fInter[n].z + fIntra[n].z) > 1.0e-6)
-                        totalRatio.z *= 100.0 / (fInter[n].z + fIntra[n].z);
-
-                    if (std::isnan(totalRatio.x) || fabs(totalRatio.x) > testThreshold_)
-                        failed = true;
-                    else if (std::isnan(totalRatio.y) || fabs(totalRatio.y) > testThreshold_)
-                        failed = true;
-                    else if (std::isnan(totalRatio.z) || fabs(totalRatio.z) > testThreshold_)
-                        failed = true;
-                    else
-                        failed = false;
-
-                    // Sum average errors
-                    sumError += fabs(totalRatio.x) + fabs(totalRatio.y) + fabs(totalRatio.z);
-
-                    if (failed)
-                    {
-                        Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
-                                         "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol\n",
-                                         n + 1, fRef[n].x - (fInter[n].x + fIntra[n].x), totalRatio.x,
-                                         fRef[n].y - (fInter[n].y + fIntra[n].y), totalRatio.y,
-                                         fRef[n].z - (fInter[n].z + fIntra[n].z), totalRatio.z);
-                        ++nFailed2;
-                    }
+                    Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
+                                     "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol\n",
+                                     n + 1, fRef[n].x - (fInterCheck[n].x + fIntraCheck[n].x), totalRatio.x,
+                                     fRef[n].y - (fInterCheck[n].y + fIntraCheck[n].y), totalRatio.y,
+                                     fRef[n].z - (fInterCheck[n].z + fIntraCheck[n].z), totalRatio.z);
+                    ++nFailed3;
                 }
-                Messenger::print("Number of atoms with failed force components = {} = {}\n", nFailed2,
-                                 nFailed2 == 0 ? "OK" : "NOT OK");
-                Messenger::print("Average error in force components was {}%.\n", sumError / (cfg->nAtoms() * 3));
-
-                Messenger::print("\nTesting reference forces against calculated production forces - "
-                                 "atoms with erroneous forces will be output...\n");
-
-                sumError = 0.0;
-                for (auto n = 0; n < cfg->nAtoms(); ++n)
-                {
-                    totalRatio = fRef[n] - (fInterCheck[n] + fIntraCheck[n]);
-                    if (fabs(fInterCheck[n].x + fIntraCheck[n].x) > 1.0e-6)
-                        totalRatio.x *= 100.0 / (fInterCheck[n].x + fIntraCheck[n].x);
-                    if (fabs(fInterCheck[n].y + fIntraCheck[n].y) > 1.0e-6)
-                        totalRatio.y *= 100.0 / (fInterCheck[n].y + fIntraCheck[n].y);
-                    if (fabs(fInterCheck[n].z + fIntraCheck[n].z) > 1.0e-6)
-                        totalRatio.z *= 100.0 / (fInterCheck[n].z + fIntraCheck[n].z);
-
-                    if (std::isnan(totalRatio.x) || fabs(totalRatio.x) > testThreshold_)
-                        failed = true;
-                    else if (std::isnan(totalRatio.y) || fabs(totalRatio.y) > testThreshold_)
-                        failed = true;
-                    else if (std::isnan(totalRatio.z) || fabs(totalRatio.z) > testThreshold_)
-                        failed = true;
-                    else
-                        failed = false;
-
-                    // Sum average errors
-                    sumError += fabs(totalRatio.x) + fabs(totalRatio.y) + fabs(totalRatio.z);
-
-                    if (failed)
-                    {
-                        Messenger::print("Check atom {:10d} - errors are {:15.8e} ({:5.2f}%) {:15.8e} "
-                                         "({:5.2f}%) {:15.8e} ({:5.2f}%) (x y z) 10J/mol\n",
-                                         n + 1, fRef[n].x - (fInterCheck[n].x + fIntraCheck[n].x), totalRatio.x,
-                                         fRef[n].y - (fInterCheck[n].y + fIntraCheck[n].y), totalRatio.y,
-                                         fRef[n].z - (fInterCheck[n].z + fIntraCheck[n].z), totalRatio.z);
-                        ++nFailed3;
-                    }
-                }
-                Messenger::print("Number of atoms with failed force components = {} = {}\n", nFailed3,
-                                 nFailed3 == 0 ? "OK" : "NOT OK");
-                Messenger::print("Average error in force components was {}%.\n", sumError / (cfg->nAtoms() * 6));
             }
-
-            if (!procPool.allTrue((nFailed1 + nFailed2 + nFailed3) == 0))
-                return false;
+            Messenger::print("Number of atoms with failed force components = {} = {}\n", nFailed3,
+                             nFailed3 == 0 ? "OK" : "NOT OK");
+            Messenger::print("Average error in force components was {}%.\n", sumError / (targetConfiguration_->nAtoms() * 6));
         }
-        else
-        {
-            /*
-             * Calculates the total forces in the system.
-             *
-             * This is a serial routine (subroutines called from within are parallel).
-             */
 
-            Messenger::print("Calculating total forces for Configuration '{}'...\n", cfg->name());
+        if (!procPool.allTrue((nFailed1 + nFailed2 + nFailed3) == 0))
+            return false;
+    }
+    else
+    {
+        /*
+         * Calculates the total forces in the system.
+         *
+         * This is a serial routine (subroutines called from within are parallel).
+         */
 
-            // Realise the force vector
-            auto &f = dissolve.processingModuleData().realise<std::vector<Vec3<double>>>(
-                fmt::format("{}//Forces", cfg->niceName()), uniqueName());
-            f.resize(cfg->nAtoms());
+        Messenger::print("Calculating total forces for Configuration '{}'...\n", targetConfiguration_->name());
 
-            // Calculate forces
-            totalForces(procPool, cfg, dissolve.potentialMap(), f);
+        // Realise the force vector
+        auto &f = dissolve.processingModuleData().realise<std::vector<Vec3<double>>>(
+            fmt::format("{}//Forces", targetConfiguration_->niceName()), uniqueName());
+        f.resize(targetConfiguration_->nAtoms());
 
-            // Convert forces to 10J/mol
-            std::transform(f.begin(), f.end(), f.begin(), [](auto val) { return val * 100.0; });
+        // Calculate forces
+        totalForces(procPool, targetConfiguration_, dissolve.potentialMap(), f);
 
-            // If writing to a file, append it here
-            if (saveData && !exportedForces_.exportData(f))
-                return Messenger::error("Failed to save forces.\n");
-        }
+        // Convert forces to 10J/mol
+        std::transform(f.begin(), f.end(), f.begin(), [](auto val) { return val * 100.0; });
+
+        // If writing to a file, append it here
+        if (saveData && !exportedForces_.exportData(f))
+            return Messenger::error("Failed to save forces.\n");
     }
 
     return true;

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -31,12 +31,6 @@ bool ForcesModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSigna
 // Run main processing
 bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * Calculate Forces for the target Configuration(s)
-     *
-     * This is a parallel routine, with processes operating in groups, unless in TEST mode.
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/geomopt/geomopt.cpp
+++ b/src/modules/geomopt/geomopt.cpp
@@ -2,15 +2,14 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "modules/geomopt/geomopt.h"
-#include "keywords/configurationvector.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/integer.h"
 
 GeometryOptimisationModule::GeometryOptimisationModule() : Module("GeometryOptimisation")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Method Control
     keywords_.add<IntegerKeyword>("Control", "MaxCycles", "Maximum number of minimisation cycles to perform", maxCycles_, 1);

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -24,7 +24,7 @@ class GeometryOptimisationModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Initial step size to employ
     double initialStepSize_{1.0e-5};
     // Maximum number of minimisation cycles to perform

--- a/src/modules/geomopt/geomopt.h
+++ b/src/modules/geomopt/geomopt.h
@@ -24,7 +24,7 @@ class GeometryOptimisationModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Initial step size to employ
     double initialStepSize_{1.0e-5};
     // Maximum number of minimisation cycles to perform

--- a/src/modules/geomopt/process.cpp
+++ b/src/modules/geomopt/process.cpp
@@ -17,22 +17,18 @@ bool GeometryOptimisationModule::process(Dissolve &dissolve, ProcessPool &procPo
     Messenger::print("\n");
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
-    {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
-        // Initialise working arrays for coordinates and forces
-        rRef_.resize(cfg->nAtoms(), Vec3<double>());
-        rTemp_.resize(cfg->nAtoms(), Vec3<double>());
-        f_.resize(cfg->nAtoms(), Vec3<double>());
+    // Initialise working arrays for coordinates and forces
+    rRef_.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+    rTemp_.resize(targetConfiguration_->nAtoms(), Vec3<double>());
+    f_.resize(targetConfiguration_->nAtoms(), Vec3<double>());
 
-        optimise<Configuration>(dissolve.potentialMap(), procPool, cfg);
-    }
+    optimise<Configuration>(dissolve.potentialMap(), procPool, targetConfiguration_);
 
     return true;
 }

--- a/src/modules/import_trajectory/process.cpp
+++ b/src/modules/import_trajectory/process.cpp
@@ -12,7 +12,7 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Set up process pool - must do this to ensure we are using all available processes
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());

--- a/src/modules/intrashake/intrashake.cpp
+++ b/src/modules/intrashake/intrashake.cpp
@@ -3,6 +3,7 @@
 
 #include "modules/intrashake/intrashake.h"
 #include "keywords/bool.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
@@ -10,8 +11,7 @@
 IntraShakeModule::IntraShakeModule() : Module("IntraShake")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
     keywords_.add<OptionalDoubleKeyword>(

--- a/src/modules/intrashake/intrashake.h
+++ b/src/modules/intrashake/intrashake.h
@@ -17,7 +17,7 @@ class IntraShakeModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Whether Bonds in the molecule should be shaken
     bool adjustBonds_{true};
     // Whether Angles in the molecule should be shaken

--- a/src/modules/intrashake/intrashake.h
+++ b/src/modules/intrashake/intrashake.h
@@ -17,7 +17,7 @@ class IntraShakeModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Whether Bonds in the molecule should be shaken
     bool adjustBonds_{true};
     // Whether Angles in the molecule should be shaken

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -16,12 +16,6 @@
 // Run main processing
 bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * Perform intramolecular shakes, modifying individual bound terms on molecules.
-     *
-     * This is a parallel routine, with processes operating as one pool
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -23,367 +23,356 @@ bool IntraShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+
+    // Retrieve control parameters
+    auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
+    const auto rRT = 1.0 / (.008314472 * targetConfiguration_->temperature());
+
+    // Print argument/parameter summary
+    Messenger::print("IntraShake: Cutoff distance is {}\n", rCut);
+    Messenger::print("IntraShake: Performing {} shake(s) per term\n", nShakesPerTerm_);
+    if (adjustBonds_)
+        Messenger::print("IntraShake: Distance step size for bond adjustments is {:.5f} Angstroms (allowed range "
+                         "is {} <= delta <= {}).\n",
+                         bondStepSize_, bondStepSizeMin_, bondStepSizeMax_);
+    if (adjustAngles_)
+        Messenger::print("IntraShake: Angle step size for angle adjustments is {:.5f} degrees (allowed range is {} "
+                         "<= delta <= {}).\n",
+                         angleStepSize_, angleStepSizeMin_, angleStepSizeMax_);
+    if (adjustTorsions_)
+        Messenger::print("IntraShake: Rotation step size for torsion adjustments is {:.5f} degrees (allowed range "
+                         "is {} <= delta <= {}).\n",
+                         torsionStepSize_, torsionStepSizeMin_, torsionStepSizeMax_);
+    Messenger::print("IntraShake: Target acceptance rate is {}.\n", targetAcceptanceRate_);
+    if (termEnergyOnly_)
+        Messenger::print("IntraShake: Only term energy will be considered (interatomic contributions with the "
+                         "system will be excluded).\n");
+    Messenger::print("\n");
+
+    ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();
+
+    // Create a Molecule distributor
+    RegionalDistributor distributor(targetConfiguration_->nMolecules(), targetConfiguration_->cells(), procPool, strategy);
+
+    // Create a local ChangeStore and EnergyKernel
+    ChangeStore changeStore(procPool);
+    EnergyKernel kernel(procPool, targetConfiguration_->box(), targetConfiguration_->cells(), dissolve.potentialMap(), rCut);
+
+    // Initialise the random number buffer
+    procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
+
+    // Ensure that the Species used in the present Configuration have attached atom lists
+    for (auto &spPop : targetConfiguration_->speciesPopulations())
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+        if (!spPop.first->attachedAtomListsGenerated())
+            return Messenger::error("Species '{}' has no attached atom lists, so module can't proceed.\n", spPop.first->name());
+    }
 
-        // Retrieve control parameters
-        auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
-        const auto rRT = 1.0 / (.008314472 * cfg->temperature());
+    int shake, nBondAttempts = 0, nAngleAttempts = 0, nTorsionAttempts = 0, nBondAccepted = 0, nAngleAccepted = 0,
+               nTorsionAccepted = 0;
+    int terminus;
+    bool accept;
+    double ppEnergy, newPPEnergy, intraEnergy, newIntraEnergy, delta, totalDelta = 0.0;
+    Vec3<double> vji, vjk, v;
+    Matrix3 transform;
+    const auto *box = targetConfiguration_->box();
+    Atom *i, *j, *k, *l;
 
-        // Print argument/parameter summary
-        Messenger::print("IntraShake: Cutoff distance is {}\n", rCut);
-        Messenger::print("IntraShake: Performing {} shake(s) per term\n", nShakesPerTerm_);
-        if (adjustBonds_)
-            Messenger::print("IntraShake: Distance step size for bond adjustments is {:.5f} Angstroms (allowed range "
-                             "is {} <= delta <= {}).\n",
-                             bondStepSize_, bondStepSizeMin_, bondStepSizeMax_);
-        if (adjustAngles_)
-            Messenger::print("IntraShake: Angle step size for angle adjustments is {:.5f} degrees (allowed range is {} "
-                             "<= delta <= {}).\n",
-                             angleStepSize_, angleStepSizeMin_, angleStepSizeMax_);
-        if (adjustTorsions_)
-            Messenger::print("IntraShake: Rotation step size for torsion adjustments is {:.5f} degrees (allowed range "
-                             "is {} <= delta <= {}).\n",
-                             torsionStepSize_, torsionStepSizeMin_, torsionStepSizeMax_);
-        Messenger::print("IntraShake: Target acceptance rate is {}.\n", targetAcceptanceRate_);
-        if (termEnergyOnly_)
-            Messenger::print("IntraShake: Only term energy will be considered (interatomic contributions with the "
-                             "system will be excluded).\n");
-        Messenger::print("\n");
+    Timer timer;
+    procPool.resetAccumulatedTime();
+    while (distributor.cycle())
+    {
+        // Get next set of Molecule targets from the distributor
+        std::vector<int> targetMolecules = distributor.assignedMolecules();
 
-        ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();
-
-        // Create a Molecule distributor
-        RegionalDistributor distributor(cfg->nMolecules(), cfg->cells(), procPool, strategy);
-
-        // Create a local ChangeStore and EnergyKernel
-        ChangeStore changeStore(procPool);
-        EnergyKernel kernel(procPool, cfg->box(), cfg->cells(), dissolve.potentialMap(), rCut);
-
-        // Initialise the random number buffer
-        procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
-
-        // Ensure that the Species used in the present Configuration have attached atom lists
-        for (auto &spPop : cfg->speciesPopulations())
+        // Switch parallel strategy if necessary
+        if (distributor.currentStrategy() != strategy)
         {
-            if (!spPop.first->attachedAtomListsGenerated())
-                return Messenger::error("Species '{}' has no attached atom lists, so module can't proceed.\n",
-                                        spPop.first->name());
+            // Set the new strategy
+            strategy = distributor.currentStrategy();
+
+            // Re-initialise the random buffer
+            procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
         }
 
-        int shake, nBondAttempts = 0, nAngleAttempts = 0, nTorsionAttempts = 0, nBondAccepted = 0, nAngleAccepted = 0,
-                   nTorsionAccepted = 0;
-        int terminus;
-        bool accept;
-        double ppEnergy, newPPEnergy, intraEnergy, newIntraEnergy, delta, totalDelta = 0.0;
-        Vec3<double> vji, vjk, v;
-        Matrix3 transform;
-        const auto *box = cfg->box();
-        Atom *i, *j, *k, *l;
-
-        Timer timer;
-        procPool.resetAccumulatedTime();
-        while (distributor.cycle())
+        // Loop over target Molecule
+        for (auto molId : targetMolecules)
         {
-            // Get next set of Molecule targets from the distributor
-            std::vector<int> targetMolecules = distributor.assignedMolecules();
+            /*
+             * Calculation Begins
+             */
 
-            // Switch parallel strategy if necessary
-            if (distributor.currentStrategy() != strategy)
-            {
-                // Set the new strategy
-                strategy = distributor.currentStrategy();
+            // Get Molecule index and pointer
+            std::shared_ptr<Molecule> mol = targetConfiguration_->molecule(molId);
+            const auto indexOffset = mol->atom(0)->arrayIndex();
 
-                // Re-initialise the random buffer
-                procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
-            }
+            // Set current atom targets in ChangeStore (whole molecule)
+            changeStore.add(mol);
 
-            // Loop over target Molecule
-            for (auto molId : targetMolecules)
-            {
-                /*
-                 * Calculation Begins
-                 */
+            // Calculate reference pairpotential energy for Molecule
+            ppEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
 
-                // Get Molecule index and pointer
-                std::shared_ptr<Molecule> mol = cfg->molecule(molId);
-                const auto indexOffset = mol->atom(0)->arrayIndex();
+            // Loop over defined bonds
+            if (adjustBonds_)
+                for (const auto &bond : mol->species()->bonds())
+                {
+                    // Get Atom pointers
+                    i = mol->atom(bond.indexI());
+                    j = mol->atom(bond.indexJ());
 
-                // Set current atom targets in ChangeStore (whole molecule)
-                changeStore.add(mol);
+                    // Store current energy of this intramolecular term, or the whole Molecule if it
+                    // is present in a cycle
+                    intraEnergy = bond.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(bond, *i, *j);
 
-                // Calculate reference pairpotential energy for Molecule
-                ppEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                    // Select random terminus
+                    terminus = procPool.random() > 0.5 ? 1 : 0;
 
-                // Loop over defined bonds
-                if (adjustBonds_)
-                    for (const auto &bond : mol->species()->bonds())
+                    // Loop over number of shakes per term
+                    for (shake = 0; shake < nShakesPerTerm_; ++shake)
                     {
-                        // Get Atom pointers
-                        i = mol->atom(bond.indexI());
-                        j = mol->atom(bond.indexJ());
+                        // Get translation vector, normalise, and apply random delta
+                        vji = box->minimumVector(i->r(), j->r());
+                        vji.normalise();
+                        vji *= procPool.randomPlusMinusOne() * bondStepSize_;
 
-                        // Store current energy of this intramolecular term, or the whole Molecule if it
-                        // is present in a cycle
-                        intraEnergy = bond.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(bond, *i, *j);
+                        // Adjust the Atoms attached to the selected terminus
+                        mol->translate(vji, bond.attachedAtoms(terminus));
 
-                        // Select random terminus
-                        terminus = procPool.random() > 0.5 ? 1 : 0;
+                        // Update Cell positions of the adjusted Atoms
+                        targetConfiguration_->updateCellLocation(bond.attachedAtoms(terminus), indexOffset);
 
-                        // Loop over number of shakes per term
-                        for (shake = 0; shake < nShakesPerTerm_; ++shake)
+                        // Calculate new energy
+                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                        newIntraEnergy = bond.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(bond, *i, *j);
+
+                        // Trial the transformed Molecule
+                        delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
+                        accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
+
+                        // Accept new (current) positions of the Molecule's Atoms?
+                        if (accept)
                         {
-                            // Get translation vector, normalise, and apply random delta
-                            vji = box->minimumVector(i->r(), j->r());
-                            vji.normalise();
-                            vji *= procPool.randomPlusMinusOne() * bondStepSize_;
-
-                            // Adjust the Atoms attached to the selected terminus
-                            mol->translate(vji, bond.attachedAtoms(terminus));
-
-                            // Update Cell positions of the adjusted Atoms
-                            cfg->updateCellLocation(bond.attachedAtoms(terminus), indexOffset);
-
-                            // Calculate new energy
-                            newPPEnergy =
-                                termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
-                            newIntraEnergy = bond.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(bond, *i, *j);
-
-                            // Trial the transformed Molecule
-                            delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                            accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
-
-                            // Accept new (current) positions of the Molecule's Atoms?
-                            if (accept)
-                            {
-                                changeStore.updateAll();
-                                ppEnergy = newPPEnergy;
-                                intraEnergy = newIntraEnergy;
-                                distributor.increase(totalDelta, delta);
-                                distributor.increment(nBondAccepted);
-                            }
-                            else
-                                changeStore.revertAll();
-
-                            distributor.increment(nBondAttempts);
+                            changeStore.updateAll();
+                            ppEnergy = newPPEnergy;
+                            intraEnergy = newIntraEnergy;
+                            distributor.increase(totalDelta, delta);
+                            distributor.increment(nBondAccepted);
                         }
+                        else
+                            changeStore.revertAll();
+
+                        distributor.increment(nBondAttempts);
                     }
+                }
 
-                // Loop over defined angles
-                if (adjustAngles_)
-                    for (const auto &angle : mol->species()->angles())
+            // Loop over defined angles
+            if (adjustAngles_)
+                for (const auto &angle : mol->species()->angles())
+                {
+                    // Get Atom pointers
+                    i = mol->atom(angle.indexI());
+                    j = mol->atom(angle.indexJ());
+                    k = mol->atom(angle.indexK());
+
+                    // Store current energy of this intramolecular term
+                    intraEnergy = angle.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(angle, *i, *j, *k);
+
+                    // Select random terminus
+                    terminus = procPool.random() > 0.5 ? 1 : 0;
+
+                    // Loop over number of shakes per term
+                    for (shake = 0; shake < nShakesPerTerm_; ++shake)
                     {
-                        // Get Atom pointers
-                        i = mol->atom(angle.indexI());
-                        j = mol->atom(angle.indexJ());
-                        k = mol->atom(angle.indexK());
+                        // Get bond vectors and calculate cross product to get rotation axis
+                        vji = box->minimumVector(j->r(), i->r());
+                        vjk = box->minimumVector(j->r(), k->r());
+                        v = vji * vjk;
 
-                        // Store current energy of this intramolecular term
-                        intraEnergy = angle.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(angle, *i, *j, *k);
+                        // Create suitable transformation matrix
+                        transform.createRotationAxis(v.x, v.y, v.z, procPool.randomPlusMinusOne() * angleStepSize_, true);
 
-                        // Select random terminus
-                        terminus = procPool.random() > 0.5 ? 1 : 0;
+                        // Adjust the Atoms attached to the selected terminus
+                        mol->transform(box, transform, angle.j()->r(), angle.attachedAtoms(terminus));
 
-                        // Loop over number of shakes per term
-                        for (shake = 0; shake < nShakesPerTerm_; ++shake)
+                        // Update Cell positions of the adjusted Atoms
+                        targetConfiguration_->updateCellLocation(angle.attachedAtoms(terminus), indexOffset);
+
+                        // Calculate new energy
+                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                        newIntraEnergy = angle.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(angle, *i, *j, *k);
+
+                        // Trial the transformed Molecule
+                        delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
+                        accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
+
+                        // Accept new (current) positions of the Molecule's Atoms?
+                        if (accept)
                         {
-                            // Get bond vectors and calculate cross product to get rotation axis
-                            vji = box->minimumVector(j->r(), i->r());
-                            vjk = box->minimumVector(j->r(), k->r());
-                            v = vji * vjk;
-
-                            // Create suitable transformation matrix
-                            transform.createRotationAxis(v.x, v.y, v.z, procPool.randomPlusMinusOne() * angleStepSize_, true);
-
-                            // Adjust the Atoms attached to the selected terminus
-                            mol->transform(box, transform, angle.j()->r(), angle.attachedAtoms(terminus));
-
-                            // Update Cell positions of the adjusted Atoms
-                            cfg->updateCellLocation(angle.attachedAtoms(terminus), indexOffset);
-
-                            // Calculate new energy
-                            newPPEnergy =
-                                termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
-                            newIntraEnergy =
-                                angle.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(angle, *i, *j, *k);
-
-                            // Trial the transformed Molecule
-                            delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                            accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
-
-                            // Accept new (current) positions of the Molecule's Atoms?
-                            if (accept)
-                            {
-                                changeStore.updateAll();
-                                ppEnergy = newPPEnergy;
-                                intraEnergy = newIntraEnergy;
-                                distributor.increase(totalDelta, delta);
-                                distributor.increment(nAngleAccepted);
-                            }
-                            else
-                                changeStore.revertAll();
-
-                            distributor.increment(nAngleAttempts);
+                            changeStore.updateAll();
+                            ppEnergy = newPPEnergy;
+                            intraEnergy = newIntraEnergy;
+                            distributor.increase(totalDelta, delta);
+                            distributor.increment(nAngleAccepted);
                         }
+                        else
+                            changeStore.revertAll();
+
+                        distributor.increment(nAngleAttempts);
                     }
+                }
 
-                // Loop over defined torsions
-                if (adjustTorsions_)
-                    for (const auto &torsion : mol->species()->torsions())
+            // Loop over defined torsions
+            if (adjustTorsions_)
+                for (const auto &torsion : mol->species()->torsions())
+                {
+                    // Get Atom pointers
+                    i = mol->atom(torsion.indexI());
+                    j = mol->atom(torsion.indexJ());
+                    k = mol->atom(torsion.indexK());
+                    l = mol->atom(torsion.indexL());
+
+                    // Store current energy of this intramolecular term
+                    intraEnergy =
+                        torsion.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(torsion, *i, *j, *k, *l);
+
+                    // Select random terminus
+                    terminus = procPool.random() > 0.5 ? 1 : 0;
+
+                    // Loop over number of shakes per term
+                    for (shake = 0; shake < nShakesPerTerm_; ++shake)
                     {
-                        // Get Atom pointers
-                        i = mol->atom(torsion.indexI());
-                        j = mol->atom(torsion.indexJ());
-                        k = mol->atom(torsion.indexK());
-                        l = mol->atom(torsion.indexL());
+                        // Get bond vectors j-k to get rotation axis
+                        vjk = box->minimumVector(j->r(), k->r());
 
-                        // Store current energy of this intramolecular term
-                        intraEnergy =
+                        // Create suitable transformation matrix
+                        transform.createRotationAxis(vjk.x, vjk.y, vjk.z, procPool.randomPlusMinusOne() * torsionStepSize_,
+                                                     true);
+
+                        // Adjust the Atoms attached to the selected terminus
+                        mol->transform(box, transform, terminus == 0 ? j->r() : k->r(), torsion.attachedAtoms(terminus));
+
+                        // Update Cell positions of the adjusted Atoms
+                        targetConfiguration_->updateCellLocation(torsion.attachedAtoms(terminus), indexOffset);
+
+                        // Calculate new energy
+                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                        newIntraEnergy =
                             torsion.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(torsion, *i, *j, *k, *l);
 
-                        // Select random terminus
-                        terminus = procPool.random() > 0.5 ? 1 : 0;
+                        // Trial the transformed Molecule
+                        delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
+                        accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
 
-                        // Loop over number of shakes per term
-                        for (shake = 0; shake < nShakesPerTerm_; ++shake)
+                        // Accept new (current) positions of the Molecule's Atoms?
+                        if (accept)
                         {
-                            // Get bond vectors j-k to get rotation axis
-                            vjk = box->minimumVector(j->r(), k->r());
-
-                            // Create suitable transformation matrix
-                            transform.createRotationAxis(vjk.x, vjk.y, vjk.z, procPool.randomPlusMinusOne() * torsionStepSize_,
-                                                         true);
-
-                            // Adjust the Atoms attached to the selected terminus
-                            mol->transform(box, transform, terminus == 0 ? j->r() : k->r(), torsion.attachedAtoms(terminus));
-
-                            // Update Cell positions of the adjusted Atoms
-                            cfg->updateCellLocation(torsion.attachedAtoms(terminus), indexOffset);
-
-                            // Calculate new energy
-                            newPPEnergy =
-                                termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
-                            newIntraEnergy =
-                                torsion.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(torsion, *i, *j, *k, *l);
-
-                            // Trial the transformed Molecule
-                            delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                            accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
-
-                            // Accept new (current) positions of the Molecule's Atoms?
-                            if (accept)
-                            {
-                                changeStore.updateAll();
-                                ppEnergy = newPPEnergy;
-                                intraEnergy = newIntraEnergy;
-                                distributor.increase(totalDelta, delta);
-                                distributor.increment(nTorsionAccepted);
-                            }
-                            else
-                                changeStore.revertAll();
-
-                            distributor.increment(nTorsionAttempts);
+                            changeStore.updateAll();
+                            ppEnergy = newPPEnergy;
+                            intraEnergy = newIntraEnergy;
+                            distributor.increase(totalDelta, delta);
+                            distributor.increment(nTorsionAccepted);
                         }
+                        else
+                            changeStore.revertAll();
+
+                        distributor.increment(nTorsionAttempts);
                     }
+                }
 
-                // Store modifications to Atom positions ready for broadcast
-                changeStore.storeAndReset();
+            // Store modifications to Atom positions ready for broadcast
+            changeStore.storeAndReset();
 
-                /*
-                 * Calculation End
-                 */
-            }
-
-            // Now all target Molecules have been processes, broadcast the changes made
-            changeStore.distributeAndApply(cfg);
-            changeStore.reset();
-        }
-        timer.stop();
-
-        // Collect statistics across all processe
-        if (!procPool.allSum(&totalDelta, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nBondAttempts, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nBondAccepted, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nAngleAttempts, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nAngleAccepted, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nTorsionAttempts, 1, strategy))
-            return false;
-        if (!procPool.allSum(&nTorsionAccepted, 1, strategy))
-            return false;
-
-        Messenger::print("IntraShake: Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
-        Messenger::print("IntraShake: Total number of attempted moves was {} ({} work, {} comms).\n",
-                         nBondAttempts + nAngleAttempts + nTorsionAttempts, timer.totalTimeString(),
-                         procPool.accumulatedTimeString());
-
-        // Calculate and report acceptance rates and adjust step sizes - if no moves were accepted, just decrease the
-        // current stepSize by a constant factor
-        if (adjustBonds_ && (nBondAttempts > 0))
-        {
-            double bondRate = double(nBondAccepted) / nBondAttempts;
-            Messenger::print("IntraShake: Overall bond shake acceptance rate was {:4.2f}% ({} of {} attempted moves).\n",
-                             100.0 * bondRate, nBondAccepted, nBondAttempts);
-
-            bondStepSize_ *= (nBondAccepted == 0) ? 0.8 : bondRate / targetAcceptanceRate_;
-            if (bondStepSize_ < bondStepSizeMin_)
-                bondStepSize_ = bondStepSizeMin_;
-            else if (bondStepSize_ > bondStepSizeMax_)
-                bondStepSize_ = bondStepSizeMax_;
-            keywords_.set("BondStepSize", bondStepSize_);
-
-            Messenger::print("IntraShake: Updated distance step size for bond adjustments is {:.5f} Angstroms.\n",
-                             bondStepSize_);
+            /*
+             * Calculation End
+             */
         }
 
-        if (adjustAngles_ && (nAngleAttempts > 0))
-        {
-            double angleRate = double(nAngleAccepted) / nAngleAttempts;
-            Messenger::print("IntraShake: Overall angle shake acceptance rate was {:4.2f}% ({} of {} attempted moves).\n",
-                             100.0 * angleRate, nAngleAccepted, nAngleAttempts);
-
-            angleStepSize_ *= (nAngleAccepted == 0) ? 0.8 : angleRate / targetAcceptanceRate_;
-            if (angleStepSize_ < angleStepSizeMin_)
-                angleStepSize_ = angleStepSizeMin_;
-            else if (angleStepSize_ > angleStepSizeMax_)
-                angleStepSize_ = angleStepSizeMax_;
-            keywords_.set("AngleStepSize", angleStepSize_);
-
-            Messenger::print("IntraShake: Updated rotation step size for angle adjustments is {:.5f} degrees.\n",
-                             angleStepSize_);
-        }
-
-        if (adjustTorsions_ && (nTorsionAttempts > 0))
-        {
-            double torsionRate = double(nTorsionAccepted) / nTorsionAttempts;
-            Messenger::print("IntraShake: Overall torsion shake acceptance rate was {:4.2f}% ({} of {} attempted moves).\n",
-                             100.0 * torsionRate, nTorsionAccepted, nTorsionAttempts);
-
-            torsionStepSize_ *= (nTorsionAccepted == 0) ? 0.8 : torsionRate / targetAcceptanceRate_;
-            if (torsionStepSize_ < torsionStepSizeMin_)
-                torsionStepSize_ = torsionStepSizeMin_;
-            else if (torsionStepSize_ > torsionStepSizeMax_)
-                torsionStepSize_ = torsionStepSizeMax_;
-            keywords_.set("TorsionStepSize", torsionStepSize_);
-
-            Messenger::print("IntraShake: Updated rotation step size for torsion adjustments is {:.5f} degrees.\n",
-                             torsionStepSize_);
-        }
-
-        // Increase contents version in Configuration
-        if ((nBondAccepted > 0) || (nAngleAccepted > 0) || (nTorsionAccepted > 0))
-            cfg->incrementContentsVersion();
+        // Now all target Molecules have been processes, broadcast the changes made
+        changeStore.distributeAndApply(targetConfiguration_);
+        changeStore.reset();
     }
+    timer.stop();
+
+    // Collect statistics across all processes
+    if (!procPool.allSum(&totalDelta, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nBondAttempts, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nBondAccepted, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nAngleAttempts, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nAngleAccepted, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nTorsionAttempts, 1, strategy))
+        return false;
+    if (!procPool.allSum(&nTorsionAccepted, 1, strategy))
+        return false;
+
+    Messenger::print("IntraShake: Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
+    Messenger::print("IntraShake: Total number of attempted moves was {} ({} work, {} comms).\n",
+                     nBondAttempts + nAngleAttempts + nTorsionAttempts, timer.totalTimeString(),
+                     procPool.accumulatedTimeString());
+
+    // Calculate and report acceptance rates and adjust step sizes - if no moves were accepted, just decrease the
+    // current stepSize by a constant factor
+    if (adjustBonds_ && (nBondAttempts > 0))
+    {
+        double bondRate = double(nBondAccepted) / nBondAttempts;
+        Messenger::print("IntraShake: Overall bond shake acceptance rate was {:4.2f}% ({} of {} attempted moves).\n",
+                         100.0 * bondRate, nBondAccepted, nBondAttempts);
+
+        bondStepSize_ *= (nBondAccepted == 0) ? 0.8 : bondRate / targetAcceptanceRate_;
+        if (bondStepSize_ < bondStepSizeMin_)
+            bondStepSize_ = bondStepSizeMin_;
+        else if (bondStepSize_ > bondStepSizeMax_)
+            bondStepSize_ = bondStepSizeMax_;
+        keywords_.set("BondStepSize", bondStepSize_);
+
+        Messenger::print("IntraShake: Updated distance step size for bond adjustments is {:.5f} Angstroms.\n", bondStepSize_);
+    }
+
+    if (adjustAngles_ && (nAngleAttempts > 0))
+    {
+        double angleRate = double(nAngleAccepted) / nAngleAttempts;
+        Messenger::print("IntraShake: Overall angle shake acceptance rate was {:4.2f}% ({} of {} attempted moves).\n",
+                         100.0 * angleRate, nAngleAccepted, nAngleAttempts);
+
+        angleStepSize_ *= (nAngleAccepted == 0) ? 0.8 : angleRate / targetAcceptanceRate_;
+        if (angleStepSize_ < angleStepSizeMin_)
+            angleStepSize_ = angleStepSizeMin_;
+        else if (angleStepSize_ > angleStepSizeMax_)
+            angleStepSize_ = angleStepSizeMax_;
+        keywords_.set("AngleStepSize", angleStepSize_);
+
+        Messenger::print("IntraShake: Updated rotation step size for angle adjustments is {:.5f} degrees.\n", angleStepSize_);
+    }
+
+    if (adjustTorsions_ && (nTorsionAttempts > 0))
+    {
+        double torsionRate = double(nTorsionAccepted) / nTorsionAttempts;
+        Messenger::print("IntraShake: Overall torsion shake acceptance rate was {:4.2f}% ({} of {} attempted moves).\n",
+                         100.0 * torsionRate, nTorsionAccepted, nTorsionAttempts);
+
+        torsionStepSize_ *= (nTorsionAccepted == 0) ? 0.8 : torsionRate / targetAcceptanceRate_;
+        if (torsionStepSize_ < torsionStepSizeMin_)
+            torsionStepSize_ = torsionStepSizeMin_;
+        else if (torsionStepSize_ > torsionStepSizeMax_)
+            torsionStepSize_ = torsionStepSizeMax_;
+        keywords_.set("TorsionStepSize", torsionStepSize_);
+
+        Messenger::print("IntraShake: Updated rotation step size for torsion adjustments is {:.5f} degrees.\n",
+                         torsionStepSize_);
+    }
+
+    // Increase contents version in Configuration
+    if ((nBondAccepted > 0) || (nAngleAccepted > 0) || (nTorsionAccepted > 0))
+        targetConfiguration_->incrementContentsVersion();
 
     return true;
 }

--- a/src/modules/md/md.cpp
+++ b/src/modules/md/md.cpp
@@ -3,6 +3,7 @@
 
 #include "modules/md/md.h"
 #include "keywords/bool.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
@@ -11,8 +12,7 @@
 MDModule::MDModule() : Module("MD")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
     keywords_.add<OptionalDoubleKeyword>(

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -20,7 +20,7 @@ class MDModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Control whether atomic forces are capped every step
     bool capForces_{false};
     // Set cap on allowable force (kJ/mol) per atom

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -20,7 +20,7 @@ class MDModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Control whether atomic forces are capped every step
     bool capForces_{false};
     // Set cap on allowable force (kJ/mol) per atom

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -24,8 +24,8 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Get control parameters
     const auto maxForce = capForcesAt_ * 100.0; // To convert from kJ/mol to 10 J/mol
@@ -64,290 +64,287 @@ bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
     }
     Messenger::print("\n");
 
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+
+    if (onlyWhenEnergyStable_)
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
-
-        if (onlyWhenEnergyStable_)
+        auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), targetConfiguration_);
+        if (stabilityResult == EnergyModule::NotAssessable)
+            return false;
+        else if (stabilityResult == EnergyModule::EnergyUnstable)
         {
-            auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), cfg);
-            if (stabilityResult == EnergyModule::NotAssessable)
-                return false;
-            else if (stabilityResult == EnergyModule::EnergyUnstable)
+            Messenger::print("Skipping MD for Configuration '{}'.\n", targetConfiguration_->niceName());
+            return true;
+        }
+    }
+
+    // Get temperature from Configuration
+    const auto temperature = targetConfiguration_->temperature();
+
+    // Create arrays
+    std::vector<double> mass(targetConfiguration_->nAtoms(), 0.0);
+    std::vector<Vec3<double>> forces(targetConfiguration_->nAtoms()), accelerations(targetConfiguration_->nAtoms());
+
+    // Variables
+    auto nCapped = 0;
+    auto &atoms = targetConfiguration_->atoms();
+    double tInstant, ke, tScale, peInter, peIntra;
+
+    // Determine target molecules from the restrictedSpecies vector (if any), and zero velocities for those atoms
+    std::vector<const Molecule *> targetMolecules;
+    std::vector<int> free(targetConfiguration_->nAtoms(), 0);
+    if (restrictToSpecies_.empty())
+        std::fill(free.begin(), free.end(), 1);
+    else
+        for (const auto &mol : targetConfiguration_->molecules())
+            if (std::find(restrictToSpecies_.begin(), restrictToSpecies_.end(), mol->species()) != restrictToSpecies_.end())
             {
-                Messenger::print("Skipping MD for Configuration '{}'.\n", cfg->niceName());
-                continue;
+                targetMolecules.push_back(mol.get());
+                for (const auto &i : mol->atoms())
+                    free[i->arrayIndex()] = 1;
             }
-        }
 
-        // Get temperature from Configuration
-        const auto temperature = cfg->temperature();
+    /*
+     * Calculation Begins
+     */
 
-        // Create arrays
-        std::vector<double> mass(cfg->nAtoms(), 0.0);
-        std::vector<Vec3<double>> forces(cfg->nAtoms()), accelerations(cfg->nAtoms());
+    // Initialise the random number buffer for all processes
+    procPool.initialiseRandomBuffer(ProcessPool::PoolProcessesCommunicator);
 
-        // Variables
-        auto nCapped = 0;
-        auto &atoms = cfg->atoms();
-        double tInstant, ke, tScale, peInter, peIntra;
-
-        // Determine target molecules from the restrictedSpecies vector (if any), and zero velocities for those atoms
-        std::vector<const Molecule *> targetMolecules;
-        std::vector<int> free(cfg->nAtoms(), 0);
-        if (restrictToSpecies_.empty())
-            std::fill(free.begin(), free.end(), 1);
-        else
-            for (const auto &mol : cfg->molecules())
-                if (std::find(restrictToSpecies_.begin(), restrictToSpecies_.end(), mol->species()) != restrictToSpecies_.end())
-                {
-                    targetMolecules.push_back(mol.get());
-                    for (const auto &i : mol->atoms())
-                        free[i->arrayIndex()] = 1;
-                }
-
-        /*
-         * Calculation Begins
-         */
-
-        // Initialise the random number buffer for all processes
-        procPool.initialiseRandomBuffer(ProcessPool::PoolProcessesCommunicator);
-
-        // Read in or assign random velocities
-        auto [velocities, status] = dissolve.processingModuleData().realiseIf<std::vector<Vec3<double>>>(
-            fmt::format("{}//Velocities", cfg->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
-        if (status == GenericItem::ItemStatus::Created || randomVelocities_)
-        {
-            Messenger::print("Random initial velocities will be assigned.\n");
-            velocities.resize(cfg->nAtoms(), Vec3<double>());
-            for (auto &&[v, iFree] : zip(velocities, free))
-            {
-                if (iFree)
-                    v.set(exp(procPool.random() - 0.5), exp(procPool.random() - 0.5), exp(procPool.random() - 0.5));
-                else
-                    v.zero();
-                v /= sqrt(TWOPI);
-            }
-        }
-        else
-            Messenger::print("Existing velocities will be used.\n");
-        Messenger::print("\n");
-
-        // Store atomic masses for future use
-        for (auto &&[i, m] : zip(atoms, mass))
-            m = AtomicMass::mass(i.speciesAtom()->Z());
-
-        // Calculate total velocity and mass over all atoms
-        Vec3<double> vCom;
-        auto massSum = 0.0;
-        for (auto &&[v, m, iFree] : zip(velocities, mass, free))
-        {
-            if (!iFree)
-                continue;
-            vCom += v * m;
-            massSum += m;
-        }
-
-        // Remove any velocity shift, and re-zero velocities on fixed atoms
-        vCom /= massSum;
-        std::transform(velocities.begin(), velocities.end(), velocities.begin(), [vCom](auto vel) { return vel - vCom; });
+    // Read in or assign random velocities
+    auto [velocities, status] = dissolve.processingModuleData().realiseIf<std::vector<Vec3<double>>>(
+        fmt::format("{}//Velocities", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+    if (status == GenericItem::ItemStatus::Created || randomVelocities_)
+    {
+        Messenger::print("Random initial velocities will be assigned.\n");
+        velocities.resize(targetConfiguration_->nAtoms(), Vec3<double>());
         for (auto &&[v, iFree] : zip(velocities, free))
-            if (!iFree)
+        {
+            if (iFree)
+                v.set(exp(procPool.random() - 0.5), exp(procPool.random() - 0.5), exp(procPool.random() - 0.5));
+            else
                 v.zero();
+            v /= sqrt(TWOPI);
+        }
+    }
+    else
+        Messenger::print("Existing velocities will be used.\n");
+    Messenger::print("\n");
 
-        // Calculate instantaneous temperature
-        // J = kg m2 s-2  -->   10 J = g Ang2 ps-2
-        // If ke is in units of [g mol-1 Angstroms2 ps-2] then must use kb in units of 10 J mol-1 K-1 (= 0.8314462)
-        const auto kb = 0.8314462;
+    // Store atomic masses for future use
+    for (auto &&[i, m] : zip(atoms, mass))
+        m = AtomicMass::mass(i.speciesAtom()->Z());
+
+    // Calculate total velocity and mass over all atoms
+    Vec3<double> vCom;
+    auto massSum = 0.0;
+    for (auto &&[v, m, iFree] : zip(velocities, mass, free))
+    {
+        if (!iFree)
+            continue;
+        vCom += v * m;
+        massSum += m;
+    }
+
+    // Remove any velocity shift, and re-zero velocities on fixed atoms
+    vCom /= massSum;
+    std::transform(velocities.begin(), velocities.end(), velocities.begin(), [vCom](auto vel) { return vel - vCom; });
+    for (auto &&[v, iFree] : zip(velocities, free))
+        if (!iFree)
+            v.zero();
+
+    // Calculate instantaneous temperature
+    // J = kg m2 s-2  -->   10 J = g Ang2 ps-2
+    // If ke is in units of [g mol-1 Angstroms2 ps-2] then must use kb in units of 10 J mol-1 K-1 (= 0.8314462)
+    const auto kb = 0.8314462;
+    ke = 0.0;
+    for (auto &&[m, v] : zip(mass, velocities))
+        ke += 0.5 * m * v.dp(v);
+    tInstant = ke * 2.0 / (3.0 * atoms.size() * kb);
+
+    // Rescale velocities for desired temperature
+    tScale = sqrt(temperature / tInstant);
+    std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto v) { return v * tScale; });
+
+    // Open trajectory file (if requested)
+    LineParser trajParser;
+    if (writeTraj)
+    {
+        std::string trajectoryFile = fmt::format("{}.md.xyz", targetConfiguration_->name());
+        if (procPool.isMaster())
+        {
+            if ((!trajParser.appendOutput(trajectoryFile)) || (!trajParser.isFileGoodForWriting()))
+            {
+                Messenger::error("Failed to open MD trajectory output file '{}'.\n", trajectoryFile);
+                procPool.decideFalse();
+                return false;
+            }
+            procPool.decideTrue();
+        }
+        else if (!procPool.decision())
+            return false;
+    }
+
+    // Write header
+    if (outputFrequency_ > 0)
+    {
+        Messenger::print("                                             Energies (kJ/mol)\n");
+        Messenger::print("  Step             T(K)         Kinetic      Inter        Intra        Total      "
+                         "deltaT(ps)\n");
+    }
+
+    // Start a timer and reset the ProcessPool's time accumulator
+    Timer timer;
+    timer.start();
+    procPool.resetAccumulatedTime();
+
+    // Variable timestep requires forces to be available immediately
+    if (variableTimestep_)
+    {
+        if (targetMolecules.empty())
+            ForcesModule::totalForces(procPool, targetConfiguration_, dissolve.potentialMap(), forces);
+        else
+            ForcesModule::totalForces(procPool, targetConfiguration_, targetMolecules, dissolve.potentialMap(), forces);
+
+        // Must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
+        std::transform(forces.begin(), forces.end(), forces.begin(), [](auto f) { return f * 100.0; });
+    }
+
+    // Ready to do MD propagation of system
+    for (auto step = 1; step <= nSteps_; ++step)
+    {
+        // Get timestep
+        auto dT = variableTimestep_ ? determineTimeStep(forces) : deltaT_;
+        auto deltaTSq = dT * dT;
+
+        // Velocity Verlet first stage (A)
+        // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
+        // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
+        // B:  a(t+dt) = F(t+dt)/m
+        // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
+        for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
+        {
+            // Propagate positions (by whole step)...
+            i.translateCoordinates(v * dT + a * 0.5 * deltaTSq);
+
+            // ...velocities (by half step)...
+            v += a * 0.5 * dT;
+        }
+
+        // Update Cell contents / Atom locations
+        targetConfiguration_->updateCellContents();
+
+        // Calculate forces - must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
+        if (targetMolecules.empty())
+            ForcesModule::totalForces(procPool, targetConfiguration_, dissolve.potentialMap(), forces);
+        else
+            ForcesModule::totalForces(procPool, targetConfiguration_, targetMolecules, dissolve.potentialMap(), forces);
+        std::transform(forces.begin(), forces.end(), forces.begin(), [](auto &f) { return f * 100.0; });
+
+        // Cap forces
+        if (capForces_)
+            nCapped = capForces(maxForce, forces);
+
+        // Velocity Verlet second stage (B) and velocity scaling
+        // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
+        // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
+        // B:  a(t+dt) = F(t+dt)/m
+        // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
         ke = 0.0;
-        for (auto &&[m, v] : zip(mass, velocities))
+        for (auto &&[f, v, a, m] : zip(forces, velocities, accelerations, mass))
+        {
+            // Determine new accelerations
+            a = f / m;
+
+            // ..and finally velocities again (by second half-step)
+            v += a * 0.5 * dT;
+
             ke += 0.5 * m * v.dp(v);
-        tInstant = ke * 2.0 / (3.0 * atoms.size() * kb);
+        }
 
         // Rescale velocities for desired temperature
+        tInstant = ke * 2.0 / (3.0 * targetConfiguration_->nAtoms() * kb);
         tScale = sqrt(temperature / tInstant);
-        std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto v) { return v * tScale; });
+        std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto &v) { return v * tScale; });
 
-        // Open trajectory file (if requested)
-        LineParser trajParser;
-        if (writeTraj)
+        // Convert ke from 10J/mol to kJ/mol
+        ke *= 0.01;
+
+        // Write step summary?
+        if ((step == 1) || (step % outputFrequency_ == 0))
         {
-            std::string trajectoryFile = fmt::format("{}.md.xyz", cfg->name());
+            // Include total energy term?
+            if ((energyFrequency_ > 0) && (step % energyFrequency_ == 0))
+            {
+                peInter = EnergyModule::interAtomicEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
+                peIntra = EnergyModule::intraMolecularEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
+                Messenger::print("  {:<10d}    {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}\n", step,
+                                 tInstant, ke, peInter, peIntra, ke + peIntra + peInter, dT);
+            }
+            else
+                Messenger::print("  {:<10d}    {:10.3e}   {:10.3e}                                          {:10.3e}\n", step,
+                                 tInstant, ke, dT);
+        }
+
+        // Save trajectory frame
+        if (writeTraj && (step % trajectoryFrequency_ == 0))
+        {
             if (procPool.isMaster())
             {
-                if ((!trajParser.appendOutput(trajectoryFile)) || (!trajParser.isFileGoodForWriting()))
+                // Write number of atoms
+                trajParser.writeLineF("{}\n", targetConfiguration_->nAtoms());
+
+                // Construct and write header
+                std::string header = fmt::format("Step {} of {}, T = {:10.3e}, ke = {:10.3e}", step, nSteps_, tInstant, ke);
+                if ((energyFrequency_ > 0) && (step % energyFrequency_ == 0))
+                    header += fmt::format(", inter = {:10.3e}, intra = {:10.3e}, tot = {:10.3e}", peInter, peIntra,
+                                          ke + peInter + peIntra);
+                if (!trajParser.writeLine(header))
                 {
-                    Messenger::error("Failed to open MD trajectory output file '{}'.\n", trajectoryFile);
                     procPool.decideFalse();
                     return false;
                 }
+
+                // Write Atoms
+                for (const auto &i : atoms)
+                {
+                    if (!trajParser.writeLineF("{:<3}   {:10.3f}  {:10.3f}  {:10.3f}\n", Elements::symbol(i.speciesAtom()->Z()),
+                                               i.r().x, i.r().y, i.r().z))
+                    {
+                        procPool.decideFalse();
+                        return false;
+                    }
+                }
+
                 procPool.decideTrue();
             }
             else if (!procPool.decision())
                 return false;
         }
-
-        // Write header
-        if (outputFrequency_ > 0)
-        {
-            Messenger::print("                                             Energies (kJ/mol)\n");
-            Messenger::print("  Step             T(K)         Kinetic      Inter        Intra        Total      "
-                             "deltaT(ps)\n");
-        }
-
-        // Start a timer and reset the ProcessPool's time accumulator
-        Timer timer;
-        timer.start();
-        procPool.resetAccumulatedTime();
-
-        // Variable timestep requires forces to be available immediately
-        if (variableTimestep_)
-        {
-            if (targetMolecules.empty())
-                ForcesModule::totalForces(procPool, cfg, dissolve.potentialMap(), forces);
-            else
-                ForcesModule::totalForces(procPool, cfg, targetMolecules, dissolve.potentialMap(), forces);
-
-            // Must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
-            std::transform(forces.begin(), forces.end(), forces.begin(), [](auto f) { return f * 100.0; });
-        }
-
-        // Ready to do MD propagation of system
-        for (auto step = 1; step <= nSteps_; ++step)
-        {
-            // Get timestep
-            auto dT = variableTimestep_ ? determineTimeStep(forces) : deltaT_;
-            auto deltaTSq = dT * dT;
-
-            // Velocity Verlet first stage (A)
-            // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
-            // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
-            // B:  a(t+dt) = F(t+dt)/m
-            // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
-            for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
-            {
-                // Propagate positions (by whole step)...
-                i.translateCoordinates(v * dT + a * 0.5 * deltaTSq);
-
-                // ...velocities (by half step)...
-                v += a * 0.5 * dT;
-            }
-
-            // Update Cell contents / Atom locations
-            cfg->updateCellContents();
-
-            // Calculate forces - must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
-            if (targetMolecules.empty())
-                ForcesModule::totalForces(procPool, cfg, dissolve.potentialMap(), forces);
-            else
-                ForcesModule::totalForces(procPool, cfg, targetMolecules, dissolve.potentialMap(), forces);
-            std::transform(forces.begin(), forces.end(), forces.begin(), [](auto &f) { return f * 100.0; });
-
-            // Cap forces
-            if (capForces_)
-                nCapped = capForces(maxForce, forces);
-
-            // Velocity Verlet second stage (B) and velocity scaling
-            // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
-            // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
-            // B:  a(t+dt) = F(t+dt)/m
-            // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
-            ke = 0.0;
-            for (auto &&[f, v, a, m] : zip(forces, velocities, accelerations, mass))
-            {
-                // Determine new accelerations
-                a = f / m;
-
-                // ..and finally velocities again (by second half-step)
-                v += a * 0.5 * dT;
-
-                ke += 0.5 * m * v.dp(v);
-            }
-
-            // Rescale velocities for desired temperature
-            tInstant = ke * 2.0 / (3.0 * cfg->nAtoms() * kb);
-            tScale = sqrt(temperature / tInstant);
-            std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto &v) { return v * tScale; });
-
-            // Convert ke from 10J/mol to kJ/mol
-            ke *= 0.01;
-
-            // Write step summary?
-            if ((step == 1) || (step % outputFrequency_ == 0))
-            {
-                // Include total energy term?
-                if ((energyFrequency_ > 0) && (step % energyFrequency_ == 0))
-                {
-                    peInter = EnergyModule::interAtomicEnergy(procPool, cfg, dissolve.potentialMap());
-                    peIntra = EnergyModule::intraMolecularEnergy(procPool, cfg, dissolve.potentialMap());
-                    Messenger::print("  {:<10d}    {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}\n", step,
-                                     tInstant, ke, peInter, peIntra, ke + peIntra + peInter, dT);
-                }
-                else
-                    Messenger::print("  {:<10d}    {:10.3e}   {:10.3e}                                          {:10.3e}\n",
-                                     step, tInstant, ke, dT);
-            }
-
-            // Save trajectory frame
-            if (writeTraj && (step % trajectoryFrequency_ == 0))
-            {
-                if (procPool.isMaster())
-                {
-                    // Write number of atoms
-                    trajParser.writeLineF("{}\n", cfg->nAtoms());
-
-                    // Construct and write header
-                    std::string header = fmt::format("Step {} of {}, T = {:10.3e}, ke = {:10.3e}", step, nSteps_, tInstant, ke);
-                    if ((energyFrequency_ > 0) && (step % energyFrequency_ == 0))
-                        header += fmt::format(", inter = {:10.3e}, intra = {:10.3e}, tot = {:10.3e}", peInter, peIntra,
-                                              ke + peInter + peIntra);
-                    if (!trajParser.writeLine(header))
-                    {
-                        procPool.decideFalse();
-                        return false;
-                    }
-
-                    // Write Atoms
-                    for (const auto &i : atoms)
-                    {
-                        if (!trajParser.writeLineF("{:<3}   {:10.3f}  {:10.3f}  {:10.3f}\n",
-                                                   Elements::symbol(i.speciesAtom()->Z()), i.r().x, i.r().y, i.r().z))
-                        {
-                            procPool.decideFalse();
-                            return false;
-                        }
-                    }
-
-                    procPool.decideTrue();
-                }
-                else if (!procPool.decision())
-                    return false;
-            }
-        }
-        timer.stop();
-
-        // Close trajectory file
-        if (writeTraj && procPool.isMaster())
-            trajParser.closeFiles();
-
-        if (capForces_)
-            Messenger::print("A total of {} forces were capped over the course of the dynamics ({:9.3e} per step).\n", nCapped,
-                             double(nCapped) / nSteps_);
-        Messenger::print("{} steps performed ({} work, {} comms)\n", nSteps_, timer.totalTimeString(),
-                         procPool.accumulatedTimeString());
-
-        // Variable timestep?
-        if (variableTimestep_)
-            keywords_.set("DeltaT", deltaT_);
-
-        // Increment configuration changeCount
-        cfg->incrementContentsVersion();
-
-        /*
-         * Calculation End
-         */
     }
+    timer.stop();
+
+    // Close trajectory file
+    if (writeTraj && procPool.isMaster())
+        trajParser.closeFiles();
+
+    if (capForces_)
+        Messenger::print("A total of {} forces were capped over the course of the dynamics ({:9.3e} per step).\n", nCapped,
+                         double(nCapped) / nSteps_);
+    Messenger::print("{} steps performed ({} work, {} comms)\n", nSteps_, timer.totalTimeString(),
+                     procPool.accumulatedTimeString());
+
+    // Variable timestep?
+    if (variableTimestep_)
+        keywords_.set("DeltaT", deltaT_);
+
+    // Increment configuration changeCount
+    targetConfiguration_->incrementContentsVersion();
+
+    /*
+     * Calculation End
+     */
 
     return true;
 }

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -17,12 +17,6 @@
 // Run main processing
 bool MDModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * Perform Molecular Dynamics on a given Configuration.
-     *
-     * This is a parallel routine, with processes operating in groups.
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/molshake/molshake.cpp
+++ b/src/modules/molshake/molshake.cpp
@@ -3,6 +3,7 @@
 
 #include "modules/molshake/molshake.h"
 #include "keywords/bool.h"
+#include "keywords/configuration.h"
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
@@ -11,8 +12,7 @@
 MolShakeModule::MolShakeModule() : Module("MolShake")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
-                                                    targetConfigurations_);
+    keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
     keywords_.add<OptionalDoubleKeyword>(

--- a/src/modules/molshake/molshake.h
+++ b/src/modules/molshake/molshake.h
@@ -17,7 +17,7 @@ class MolShakeModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
     // Interatomic cutoff distance to use for energy calculation
     std::optional<double> cutoffDistance_;
     // Number of shakes to attempt per molecule

--- a/src/modules/molshake/molshake.h
+++ b/src/modules/molshake/molshake.h
@@ -17,7 +17,7 @@ class MolShakeModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
     // Interatomic cutoff distance to use for energy calculation
     std::optional<double> cutoffDistance_;
     // Number of shakes to attempt per molecule

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -23,262 +23,257 @@ bool MolShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
+
+    // Retrieve control parameters from Configuration
+    auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
+    const auto rRT = 1.0 / (.008314472 * targetConfiguration_->temperature());
+
+    // Print argument/parameter summary
+    Messenger::print("MolShake: Cutoff distance is {}.\n", rCut);
+    Messenger::print("MolShake: Performing {} shake(s) per Molecule.\n", nShakesPerMolecule_);
+    Messenger::print("MolShake: Step size for translation adjustments is {:.5f} Angstroms (allowed range is {} <= "
+                     "delta <= {}).\n",
+                     translationStepSize_, translationStepSizeMin_, translationStepSizeMax_);
+    Messenger::print("MolShake: Step size for rotation adjustments is {:.5f} degrees (allowed range is {} <= delta <= {}).\n",
+                     rotationStepSize_, rotationStepSizeMin_, rotationStepSizeMax_);
+    if (!restrictToSpecies_.empty())
     {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+        std::string speciesNames;
+        for (auto *sp : restrictToSpecies_)
+            speciesNames += fmt::format("  {}", sp->name());
+        Messenger::print("MolShake: Calculation will be restricted to species:{}\n", speciesNames);
+    }
+    Messenger::print("\n");
 
-        // Retrieve control parameters from Configuration
-        auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
-        const auto rRT = 1.0 / (.008314472 * cfg->temperature());
+    ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();
 
-        // Print argument/parameter summary
-        Messenger::print("MolShake: Cutoff distance is {}.\n", rCut);
-        Messenger::print("MolShake: Performing {} shake(s) per Molecule.\n", nShakesPerMolecule_);
-        Messenger::print("MolShake: Step size for translation adjustments is {:.5f} Angstroms (allowed range is {} <= "
-                         "delta <= {}).\n",
-                         translationStepSize_, translationStepSizeMin_, translationStepSizeMax_);
-        Messenger::print(
-            "MolShake: Step size for rotation adjustments is {:.5f} degrees (allowed range is {} <= delta <= {}).\n",
-            rotationStepSize_, rotationStepSizeMin_, rotationStepSizeMax_);
-        if (!restrictToSpecies_.empty())
+    // Create a Molecule distributor
+    RegionalDistributor distributor(targetConfiguration_->nMolecules(), targetConfiguration_->cells(), procPool, strategy);
+
+    // Determine target molecules from the restrictedSpecies vector (if any) and give to the distributor
+    if (!restrictToSpecies_.empty())
+    {
+        std::vector<int> targetIndices;
+        auto id = 0;
+        for (const auto &mol : targetConfiguration_->molecules())
         {
-            std::string speciesNames;
-            for (auto *sp : restrictToSpecies_)
-                speciesNames += fmt::format("  {}", sp->name());
-            Messenger::print("MolShake: Calculation will be restricted to species:{}\n", speciesNames);
+            if (std::find(restrictToSpecies_.begin(), restrictToSpecies_.end(), mol->species()) != restrictToSpecies_.end())
+                targetIndices.push_back(id);
+            ++id;
         }
-        Messenger::print("\n");
+        distributor.setTargetMolecules(targetIndices);
+    }
 
-        ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();
+    // Create a local ChangeStore and a suitable EnergyKernel
+    ChangeStore changeStore(procPool);
+    EnergyKernel kernel(procPool, targetConfiguration_->box(), targetConfiguration_->cells(), dissolve.potentialMap(), rCut);
 
-        // Create a Molecule distributor
-        RegionalDistributor distributor(cfg->nMolecules(), cfg->cells(), procPool, strategy);
+    // Initialise the random number buffer
+    procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
 
-        // Determine target molecules from the restrictedSpecies vector (if any) and give to the distributor
-        if (!restrictToSpecies_.empty())
+    int shake, nRotationAttempts = 0, nTranslationAttempts = 0, nRotationsAccepted = 0, nTranslationsAccepted = 0,
+               nGeneralAttempts = 0;
+    bool accept;
+    double currentEnergy, newEnergy, delta, totalDelta = 0.0;
+    Matrix3 transform;
+    Vec3<double> rDelta;
+    const auto *box = targetConfiguration_->box();
+
+    /*
+     * In order to be able to adjust translation and rotational steps independently, we will perform 80% of moves
+     * including both a translation a rotation, 10% using only translations, and 10% using only rotations.
+     */
+
+    // Set initial random offset for our counter determining whether to perform R+T, R, or T.
+    auto count = procPool.random() * 10;
+    bool rotate, translate;
+
+    Timer timer;
+    procPool.resetAccumulatedTime();
+    while (distributor.cycle())
+    {
+        // Get next set of Molecule targets from the distributor
+        auto &targetIndices = distributor.assignedMolecules();
+
+        // Switch parallel strategy if necessary
+        if (distributor.currentStrategy() != strategy)
         {
-            std::vector<int> targetIndices;
-            auto id = 0;
-            for (const auto &mol : cfg->molecules())
-            {
-                if (std::find(restrictToSpecies_.begin(), restrictToSpecies_.end(), mol->species()) != restrictToSpecies_.end())
-                    targetIndices.push_back(id);
-                ++id;
-            }
-            distributor.setTargetMolecules(targetIndices);
+            // Set the new strategy
+            strategy = distributor.currentStrategy();
+
+            // Re-initialise the random buffer
+            procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
         }
 
-        // Create a local ChangeStore and a suitable EnergyKernel
-        ChangeStore changeStore(procPool);
-        EnergyKernel kernel(procPool, cfg->box(), cfg->cells(), dissolve.potentialMap(), rCut);
-
-        // Initialise the random number buffer
-        procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
-
-        int shake, nRotationAttempts = 0, nTranslationAttempts = 0, nRotationsAccepted = 0, nTranslationsAccepted = 0,
-                   nGeneralAttempts = 0;
-        bool accept;
-        double currentEnergy, newEnergy, delta, totalDelta = 0.0;
-        Matrix3 transform;
-        Vec3<double> rDelta;
-        const auto *box = cfg->box();
-
-        /*
-         * In order to be able to adjust translation and rotational steps independently, we will perform 80% of moves
-         * including both a translation a rotation, 10% using only translations, and 10% using only rotations.
-         */
-
-        // Set initial random offset for our counter determining whether to perform R+T, R, or T.
-        auto count = procPool.random() * 10;
-        bool rotate, translate;
-
-        Timer timer;
-        procPool.resetAccumulatedTime();
-        while (distributor.cycle())
+        // Loop over target Molecules
+        for (auto molId : targetIndices)
         {
-            // Get next set of Molecule targets from the distributor
-            auto &targetIndices = distributor.assignedMolecules();
+            /*
+             * Calculation Begins
+             */
 
-            // Switch parallel strategy if necessary
-            if (distributor.currentStrategy() != strategy)
+            // Get Molecule index and pointer
+            auto mol = targetConfiguration_->molecule(molId);
+
+            // Set current atom targets in ChangeStore (whole Molecule)
+            changeStore.add(mol);
+
+            // Calculate reference energy for Molecule, including intramolecular terms
+            currentEnergy = kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+
+            // Loop over number of shakes per atom
+            for (shake = 0; shake < nShakesPerMolecule_; ++shake)
             {
-                // Set the new strategy
-                strategy = distributor.currentStrategy();
-
-                // Re-initialise the random buffer
-                procPool.initialiseRandomBuffer(ProcessPool::subDivisionStrategy(strategy));
-            }
-
-            // Loop over target Molecules
-            for (auto molId : targetIndices)
-            {
-                /*
-                 * Calculation Begins
-                 */
-
-                // Get Molecule index and pointer
-                auto mol = cfg->molecule(molId);
-
-                // Set current atom targets in ChangeStore (whole Molecule)
-                changeStore.add(mol);
-
-                // Calculate reference energy for Molecule, including intramolecular terms
-                currentEnergy = kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
-
-                // Loop over number of shakes per atom
-                for (shake = 0; shake < nShakesPerMolecule_; ++shake)
+                // Determine what move(s) will we attempt
+                if (count == 0)
                 {
-                    // Determine what move(s) will we attempt
-                    if (count == 0)
-                    {
-                        rotate = true;
-                        translate = false;
-                    }
-                    else if (count == 1)
-                    {
-                        rotate = false;
-                        translate = true;
-                    }
-                    else
-                    {
-                        rotate = true;
-                        translate = true;
-                    }
-
-                    // Create a random translation vector and apply it to the Molecule's centre
-                    if (translate)
-                    {
-                        rDelta.set(procPool.randomPlusMinusOne() * translationStepSize_,
-                                   procPool.randomPlusMinusOne() * translationStepSize_,
-                                   procPool.randomPlusMinusOne() * translationStepSize_);
-                        mol->translate(rDelta);
-                    }
-
-                    // Create a random rotation matrix and apply it to the Molecule
-                    if (rotate)
-                    {
-                        transform.createRotationXY(procPool.randomPlusMinusOne() * rotationStepSize_,
-                                                   procPool.randomPlusMinusOne() * rotationStepSize_);
-                        mol->transform(box, transform);
-                    }
-
-                    // Update Cell positions of Atoms in the Molecule
-                    cfg->updateCellLocation(mol);
-
-                    // Calculate new energy
-                    newEnergy = kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
-
-                    // Trial the transformed atom position
-                    delta = newEnergy - currentEnergy;
-                    accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
-
-                    if (accept)
-                    {
-                        // Accept new (current) position of target Atoms
-                        changeStore.updateAll();
-                        currentEnergy = newEnergy;
-                    }
-                    else
-                        changeStore.revertAll();
-
-                    // Increase attempt counters
-                    // The strategy in force at any one time may vary, so use the distributor's helper
-                    // functions.
-                    if (distributor.collectStatistics())
-                    {
-                        if (accept)
-                            totalDelta += delta;
-                        if (rotate)
-                        {
-                            if (accept)
-                                ++nRotationsAccepted;
-                            ++nRotationAttempts;
-                        }
-                        if (translate)
-                        {
-                            if (accept)
-                                ++nTranslationsAccepted;
-                            ++nTranslationAttempts;
-                        }
-                        ++nGeneralAttempts;
-                    }
-
-                    // Increase and fold move type counter
-                    ++count;
-                    if (count > 9)
-                        count = 0;
+                    rotate = true;
+                    translate = false;
+                }
+                else if (count == 1)
+                {
+                    rotate = false;
+                    translate = true;
+                }
+                else
+                {
+                    rotate = true;
+                    translate = true;
                 }
 
-                // Store modifications to Atom positions ready for broadcast
-                changeStore.storeAndReset();
+                // Create a random translation vector and apply it to the Molecule's centre
+                if (translate)
+                {
+                    rDelta.set(procPool.randomPlusMinusOne() * translationStepSize_,
+                               procPool.randomPlusMinusOne() * translationStepSize_,
+                               procPool.randomPlusMinusOne() * translationStepSize_);
+                    mol->translate(rDelta);
+                }
 
-                /*
-                 * Calculation End
-                 */
+                // Create a random rotation matrix and apply it to the Molecule
+                if (rotate)
+                {
+                    transform.createRotationXY(procPool.randomPlusMinusOne() * rotationStepSize_,
+                                               procPool.randomPlusMinusOne() * rotationStepSize_);
+                    mol->transform(box, transform);
+                }
+
+                // Update Cell positions of Atoms in the Molecule
+                targetConfiguration_->updateCellLocation(mol);
+
+                // Calculate new energy
+                newEnergy = kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+
+                // Trial the transformed atom position
+                delta = newEnergy - currentEnergy;
+                accept = delta < 0 ? true : (procPool.random() < exp(-delta * rRT));
+
+                if (accept)
+                {
+                    // Accept new (current) position of target Atoms
+                    changeStore.updateAll();
+                    currentEnergy = newEnergy;
+                }
+                else
+                    changeStore.revertAll();
+
+                // Increase attempt counters
+                // The strategy in force at any one time may vary, so use the distributor's helper
+                // functions.
+                if (distributor.collectStatistics())
+                {
+                    if (accept)
+                        totalDelta += delta;
+                    if (rotate)
+                    {
+                        if (accept)
+                            ++nRotationsAccepted;
+                        ++nRotationAttempts;
+                    }
+                    if (translate)
+                    {
+                        if (accept)
+                            ++nTranslationsAccepted;
+                        ++nTranslationAttempts;
+                    }
+                    ++nGeneralAttempts;
+                }
+
+                // Increase and fold move type counter
+                ++count;
+                if (count > 9)
+                    count = 0;
             }
 
-            // Now all target Molecules have been processes, broadcast the changes made
-            changeStore.distributeAndApply(cfg);
-            changeStore.reset();
+            // Store modifications to Atom positions ready for broadcast
+            changeStore.storeAndReset();
+
+            /*
+             * Calculation End
+             */
         }
 
-        // Collect statistics across all processes
-        if (!procPool.allSum(&totalDelta, 1))
-            return false;
-        if (!procPool.allSum(&nGeneralAttempts, 1))
-            return false;
-        if (!procPool.allSum(&nTranslationAttempts, 1))
-            return false;
-        if (!procPool.allSum(&nTranslationsAccepted, 1))
-            return false;
-        if (!procPool.allSum(&nRotationAttempts, 1))
-            return false;
-        if (!procPool.allSum(&nRotationsAccepted, 1))
-            return false;
-
-        timer.stop();
-
-        Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
-
-        // Calculate and print acceptance rates
-        double transRate = double(nTranslationsAccepted) / nTranslationAttempts;
-        double rotRate = double(nRotationsAccepted) / nRotationAttempts;
-        Messenger::print("Total number of attempted moves was {} ({} work, {} comms)\n", nGeneralAttempts,
-                         timer.totalTimeString(), procPool.accumulatedTimeString());
-        Messenger::print("Overall translation acceptance rate was {:4.2f}% ({} of {} attempted moves)\n", 100.0 * transRate,
-                         nTranslationsAccepted, nTranslationAttempts);
-        Messenger::print("Overall rotation acceptance rate was {:4.2f}% ({} of {} attempted moves)\n", 100.0 * rotRate,
-                         nRotationsAccepted, nRotationAttempts);
-
-        // Update and set translation step size
-        translationStepSize_ *= (nTranslationsAccepted == 0) ? 0.8 : transRate / targetAcceptanceRate_;
-        if (translationStepSize_ < translationStepSizeMin_)
-            translationStepSize_ = translationStepSizeMin_;
-        else if (translationStepSize_ > translationStepSizeMax_)
-            translationStepSize_ = translationStepSizeMax_;
-        keywords_.set("TranslationStepSize", translationStepSize_);
-
-        Messenger::print("Updated step size for translations is {:.5f} Angstroms.\n", translationStepSize_);
-
-        // Update and set rotation step size
-        rotationStepSize_ *= (nRotationsAccepted == 0) ? 0.8 : rotRate / targetAcceptanceRate_;
-        if (rotationStepSize_ < rotationStepSizeMin_)
-            rotationStepSize_ = rotationStepSizeMin_;
-        else if (rotationStepSize_ > rotationStepSizeMax_)
-            rotationStepSize_ = rotationStepSizeMax_;
-        keywords_.set("RotationStepSize", rotationStepSize_);
-
-        Messenger::print("Updated step size for rotations is {:.5f} degrees.\n", rotationStepSize_);
-
-        // Increase contents version in Configuration
-        if ((nRotationsAccepted > 0) || (nTranslationsAccepted > 0))
-            cfg->incrementContentsVersion();
+        // Now all target Molecules have been processes, broadcast the changes made
+        changeStore.distributeAndApply(targetConfiguration_);
+        changeStore.reset();
     }
+
+    // Collect statistics across all processes
+    if (!procPool.allSum(&totalDelta, 1))
+        return false;
+    if (!procPool.allSum(&nGeneralAttempts, 1))
+        return false;
+    if (!procPool.allSum(&nTranslationAttempts, 1))
+        return false;
+    if (!procPool.allSum(&nTranslationsAccepted, 1))
+        return false;
+    if (!procPool.allSum(&nRotationAttempts, 1))
+        return false;
+    if (!procPool.allSum(&nRotationsAccepted, 1))
+        return false;
+
+    timer.stop();
+
+    Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
+
+    // Calculate and print acceptance rates
+    double transRate = double(nTranslationsAccepted) / nTranslationAttempts;
+    double rotRate = double(nRotationsAccepted) / nRotationAttempts;
+    Messenger::print("Total number of attempted moves was {} ({} work, {} comms)\n", nGeneralAttempts, timer.totalTimeString(),
+                     procPool.accumulatedTimeString());
+    Messenger::print("Overall translation acceptance rate was {:4.2f}% ({} of {} attempted moves)\n", 100.0 * transRate,
+                     nTranslationsAccepted, nTranslationAttempts);
+    Messenger::print("Overall rotation acceptance rate was {:4.2f}% ({} of {} attempted moves)\n", 100.0 * rotRate,
+                     nRotationsAccepted, nRotationAttempts);
+
+    // Update and set translation step size
+    translationStepSize_ *= (nTranslationsAccepted == 0) ? 0.8 : transRate / targetAcceptanceRate_;
+    if (translationStepSize_ < translationStepSizeMin_)
+        translationStepSize_ = translationStepSizeMin_;
+    else if (translationStepSize_ > translationStepSizeMax_)
+        translationStepSize_ = translationStepSizeMax_;
+    keywords_.set("TranslationStepSize", translationStepSize_);
+
+    Messenger::print("Updated step size for translations is {:.5f} Angstroms.\n", translationStepSize_);
+
+    // Update and set rotation step size
+    rotationStepSize_ *= (nRotationsAccepted == 0) ? 0.8 : rotRate / targetAcceptanceRate_;
+    if (rotationStepSize_ < rotationStepSizeMin_)
+        rotationStepSize_ = rotationStepSizeMin_;
+    else if (rotationStepSize_ > rotationStepSizeMax_)
+        rotationStepSize_ = rotationStepSizeMax_;
+    keywords_.set("RotationStepSize", rotationStepSize_);
+
+    Messenger::print("Updated step size for rotations is {:.5f} degrees.\n", rotationStepSize_);
+
+    // Increase contents version in Configuration
+    if ((nRotationsAccepted > 0) || (nTranslationsAccepted > 0))
+        targetConfiguration_->incrementContentsVersion();
 
     return true;
 }

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -16,12 +16,6 @@
 // Run main processing
 bool MolShakeModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * Perform a Molecule shake
-     *
-     * This is a parallel routine, with processes operating as groups.
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/neutronsq/neutronsq.h
+++ b/src/modules/neutronsq/neutronsq.h
@@ -83,6 +83,9 @@ class NeutronSQModule : public Module
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
+    // Set target data
+    void setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                    const std::map<std::string, std::vector<const Module *>> &moduleMap) override;
     // Run set-up stage
     bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 };

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -13,6 +13,15 @@
 #include "modules/rdf/rdf.h"
 #include "modules/sq/sq.h"
 
+// Set target data
+void NeutronSQModule::setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                                 const std::map<std::string, std::vector<const Module *>> &moduleMap)
+{
+    auto sqIt = moduleMap.find("SQ");
+    if (sqIt != moduleMap.end())
+        sourceSQ_ = dynamic_cast<const SQModule *>(sqIt->second.front());
+}
+
 // Run set-up stage
 bool NeutronSQModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {

--- a/src/modules/rdf/rdf.cpp
+++ b/src/modules/rdf/rdf.cpp
@@ -12,7 +12,7 @@
 RDFModule::RDFModule() : Module("RDF")
 {
     // Targets
-    keywords_.addTarget<ConfigurationVectorKeyword>("Configuration", "Set target configuration(s) for the module",
+    keywords_.addTarget<ConfigurationVectorKeyword>("Configurations", "Set target configuration(s) for the module",
                                                     targetConfigurations_);
 
     // Control

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -14,17 +14,13 @@ bool SkeletonModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
-    {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
-        // MODULE CODE
-    }
+    // MODULE CODE
 
     return false;
 }

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -8,11 +8,6 @@
 // Run main processing
 bool SkeletonModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * This is a XXX routine.
-     * XXX
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -17,7 +17,7 @@ class SkeletonModule : public Module
      */
     private:
     // Target configurations
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
 
     /*
      * Processing

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -17,7 +17,7 @@ class SkeletonModule : public Module
      */
     private:
     // Target configurations
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
 
     /*
      * Processing

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Team Dissolve and contributors
 
-#include "classes/box.h"
 #include "classes/configuration.h"
 #include "main/dissolve.h"
 #include "math/averaging.h"

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -11,6 +11,15 @@
 #include "modules/sq/sq.h"
 #include "templates/algorithms.h"
 
+// Set target data
+void SQModule::setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                          const std::map<std::string, std::vector<const Module *>> &moduleMap)
+{
+    auto sqIt = moduleMap.find("RDF");
+    if (sqIt != moduleMap.end())
+        sourceRDF_ = dynamic_cast<const RDFModule *>(sqIt->second.front());
+}
+
 // Run main processing
 bool SQModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -70,4 +70,9 @@ class SQModule : public Module
     private:
     // Run main processing
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
+
+    public:
+    // Set target data
+    void setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                    const std::map<std::string, std::vector<const Module *>> &moduleMap) override;
 };

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -14,17 +14,13 @@ bool TestModule::process(Dissolve &dissolve, ProcessPool &procPool)
      */
 
     // Check for zero Configuration targets
-    if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+    if (!targetConfiguration_)
+        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
-    // Loop over target Configurations
-    for (auto *cfg : targetConfigurations_)
-    {
-        // Set up process pool - must do this to ensure we are using all available processes
-        procPool.assignProcessesToGroups(cfg->processPool());
+    // Set up process pool - must do this to ensure we are using all available processes
+    procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
-        // MODULE CODE
-    }
+    // MODULE CODE
 
     return false;
 }

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -7,11 +7,6 @@
 // Run main processing
 bool TestModule::process(Dissolve &dissolve, ProcessPool &procPool)
 {
-    /*
-     * This is a XXX routine.
-     * XXX
-     */
-
     // Check for zero Configuration targets
     if (!targetConfiguration_)
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Team Dissolve and contributors
 
-#include "base/sysfunc.h"
 #include "main/dissolve.h"
 #include "modules/test/test.h"
 

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -17,7 +17,7 @@ class TestModule : public Module
      */
     private:
     // Target configuration
-    Configuration *targetConfiguration_;
+    Configuration *targetConfiguration_{nullptr};
 
     /*
      * Processing

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -17,7 +17,7 @@ class TestModule : public Module
      */
     private:
     // Target configuration
-    std::vector<Configuration *> targetConfigurations_;
+    Configuration *targetConfiguration_;
 
     /*
      * Processing

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -14,6 +14,15 @@
 #include "modules/xraysq/xraysq.h"
 #include "templates/algorithms.h"
 
+// Set target data
+void XRaySQModule::setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                              const std::map<std::string, std::vector<const Module *>> &moduleMap)
+{
+    auto sqIt = moduleMap.find("SQ");
+    if (sqIt != moduleMap.end())
+        sourceSQ_ = dynamic_cast<const SQModule *>(sqIt->second.front());
+}
+
 // Run set-up stage
 bool XRaySQModule::setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals)
 {

--- a/src/modules/xraysq/xraysq.h
+++ b/src/modules/xraysq/xraysq.h
@@ -85,6 +85,9 @@ class XRaySQModule : public Module
     bool process(Dissolve &dissolve, ProcessPool &procPool) override;
 
     public:
+    // Set target data
+    void setTargets(std::vector<std::unique_ptr<Configuration>> &configurations,
+                    const std::map<std::string, std::vector<const Module *>> &moduleMap) override;
     // Run set-up stage
     bool setUp(Dissolve &dissolve, ProcessPool &procPool, KeywordSignals actionSignals) override;
 };

--- a/tests/accumulate/accumulate.txt
+++ b/tests/accumulate/accumulate.txt
@@ -89,7 +89,7 @@ Layer  'Processing'
   # Calculate RDFs (no averaging)
   Module  RDF  'RDF01'
     Frequency  1
-    Configuration  'Bulk'
+    Configurations  'Bulk'
     Range  10.0
     BinWidth  0.01
     IntraBroadening  None
@@ -105,7 +105,7 @@ Layer  'Processing'
   # Calculate RDFs (with averaging)
   Module  RDF  'AveragedRDF'
     Frequency  1
-    Configuration  'Bulk'
+    Configurations  'Bulk'
     Range  10.0
     BinWidth  0.01
     IntraBroadening  None

--- a/tests/bragg/mgo.txt
+++ b/tests/bragg/mgo.txt
@@ -37,7 +37,7 @@ Layer  'Main Processing'
   Module  RDF  'RDFs'
     Frequency  1
     Method  Simple
-    Configuration  'Crystal'
+    Configurations  'Crystal'
 
   EndModule
 

--- a/tests/broadening/argon_dep0.1indep0.2.txt
+++ b/tests/broadening/argon_dep0.1indep0.2.txt
@@ -28,7 +28,7 @@ EndConfiguration
 Layer  'Processing'
 
 Module  RDF  'RDF01'
-  Configuration  'liquid'
+  Configurations  'liquid'
   Frequency  1
 EndModule
 

--- a/tests/broadening/argon_dep0.2indep0.1.txt
+++ b/tests/broadening/argon_dep0.2indep0.1.txt
@@ -28,7 +28,7 @@ EndConfiguration
 Layer  'Processing'
 
 Module  RDF  'RDF01'
-  Configuration  'liquid'
+  Configurations  'liquid'
   Frequency  1
 EndModule
 

--- a/tests/broadening/argon_qdep0.1.txt
+++ b/tests/broadening/argon_qdep0.1.txt
@@ -28,7 +28,7 @@ EndConfiguration
 Layer  'Processing'
 
 Module  RDF  'RDF01'
-  Configuration  'liquid'
+  Configurations  'liquid'
   Frequency  1
 EndModule
 

--- a/tests/broadening/argon_qdep0.2.txt
+++ b/tests/broadening/argon_qdep0.2.txt
@@ -28,7 +28,7 @@ EndConfiguration
 Layer  'Processing'
 
 Module  RDF  'RDF01'
-  Configuration  'liquid'
+  Configurations  'liquid'
   Frequency  1
 EndModule
 

--- a/tests/broadening/argon_qindep0.1.txt
+++ b/tests/broadening/argon_qindep0.1.txt
@@ -28,7 +28,7 @@ EndConfiguration
 Layer  'Processing'
 
 Module  RDF  'RDF01'
-  Configuration  'liquid'
+  Configurations  'liquid'
   Frequency  1
 EndModule
 

--- a/tests/broadening/argon_qindep0.2.txt
+++ b/tests/broadening/argon_qindep0.2.txt
@@ -28,7 +28,7 @@ EndConfiguration
 Layer  'Processing'
 
 Module  RDF  'RDF01'
-  Configuration  'liquid'
+  Configurations  'liquid'
   Frequency  1
 EndModule
 

--- a/tests/correlations/sq.txt
+++ b/tests/correlations/sq.txt
@@ -34,7 +34,7 @@ Layer  'Processing'
 
   # Calculate and test RDFs
   Module  RDF  'RDF01'
-    Configuration  'Bulk'
+    Configurations  'Bulk'
     Frequency  1
     BinWidth 0.03
     IntraBroadening  None

--- a/tests/epsr/benzene.txt
+++ b/tests/epsr/benzene.txt
@@ -129,7 +129,7 @@ Layer  'Processing'
 
 # Calculate RDFs
 Module  RDF  'RDFs'
-  Configuration  'Liquid'
+  Configurations  'Liquid'
   IntraBroadening  None
   BinWidth  0.03
   IntraBroadening  None

--- a/tests/epsr/pcof.txt
+++ b/tests/epsr/pcof.txt
@@ -129,7 +129,7 @@ Layer  'Processing'
 
 # Calculate RDFs
 Module  RDF  'RDFs'
-  Configuration  'Liquid'
+  Configurations  'Liquid'
   IntraBroadening  None
   BinWidth  0.03
   IntraBroadening  None

--- a/tests/epsr/water-neutron-xray.txt
+++ b/tests/epsr/water-neutron-xray.txt
@@ -102,7 +102,7 @@ Layer  'RDF / Neutron / XRay'
   Module  RDF  'RDFs'
     Frequency  1
 
-    Configuration  'Bulk'
+    Configurations  'Bulk'
     IntraBroadening  None
     #Save  On
   EndModule

--- a/tests/exchangeable/watermeth.txt
+++ b/tests/exchangeable/watermeth.txt
@@ -69,7 +69,7 @@ EndConfiguration
 Layer  'Correlations'
   # Calculate and test g(r)
   Module  RDF  RDFs
-    Configuration  'Mix'
+    Configurations  'Mix'
     #Save  On
     Frequency  1
     BinWidth 0.03

--- a/tests/rdfmethod/cells.txt
+++ b/tests/rdfmethod/cells.txt
@@ -25,7 +25,7 @@ Layer  'Processing'
 
   # Test 'Cells' method of RDF calculation
   Module  RDF
-    Configuration  'Box'
+    Configurations  'Box'
     Frequency  1
     InternalTest  On
     Method  Cells

--- a/tests/rdfmethod/simple.txt
+++ b/tests/rdfmethod/simple.txt
@@ -25,7 +25,7 @@ Layer  'Processing'
 
   # Test 'Simple' Method
   Module  RDF
-    Configuration  'Box'
+    Configurations  'Box'
     Frequency  1
     InternalTest  On
     Method  Simple

--- a/tests/restart/benzene.txt
+++ b/tests/restart/benzene.txt
@@ -200,7 +200,7 @@ Layer  'RDF / Neutron S(Q)'
   Module  RDF  'RDF01'
     Frequency  1
 
-    Configuration  'Bulk'
+    Configurations  'Bulk'
     IntraBroadening    Gaussian  1.800000e-01
   EndModule
 

--- a/tests/xray/water.txt
+++ b/tests/xray/water.txt
@@ -76,7 +76,7 @@ EndConfiguration
 Layer  'Processing'
 
   Module  RDF  'RDF01'
-    Configuration  'Bulk'
+    Configurations  'Bulk'
     Frequency  1
     BinWidth 0.03
     IntraBroadening  None


### PR DESCRIPTION
Here we make the GUI a little more user-friendly and automatically set relevant targets (e.g. `Configuration`s and specific module types) as soon as a new module is created in a layer.

This is achieved with a simple virtual function in the `Module` class which handles setting of `Configuration` targets by searching the `Keyword::targetsGroup_` vector for relevant keyword types (`ConfigurationKeyword` and `ConfigurationVectorKeyword`) and which is overridden in modules when specific module targets (e.g. `RDF`, `SQ`) are required. In those instances, target `Configuration`s are typically not required.

Some other changes are made to harmonise other aspects of target keywords, specifically forcing all modules taking `Configuration` targets to accept only one, the exception being `RDF` which is able to combine data from multiple `Configuration`s.

Closes #507.