### PR TITLE
Module layer context menu

### DIFF
--- a/src/base/sysfunc.cpp
+++ b/src/base/sysfunc.cpp
@@ -139,6 +139,16 @@ std::string_view DissolveSys::afterChar(const std::string_view s, std::string_vi
     return "";
 }
 
+// Get characters after first occurrence of the supplied string, or an empty string if it is not present
+std::string_view DissolveSys::afterString(const std::string_view s, std::string_view searchString)
+{
+    auto pos = s.find(searchString);
+    if ((pos == std::string::npos) || (pos == s.length() - searchString.length()))
+        return "";
+
+    return s.substr(pos + searchString.length());
+}
+
 // Get characters before last occurrence of designated character, or an empty string if the character does not exist
 std::string_view DissolveSys::beforeLastChar(const std::string_view s, char c)
 {

--- a/src/base/sysfunc.cpp
+++ b/src/base/sysfunc.cpp
@@ -143,7 +143,7 @@ std::string_view DissolveSys::afterChar(const std::string_view s, std::string_vi
 std::string_view DissolveSys::afterString(const std::string_view s, std::string_view searchString)
 {
     auto pos = s.find(searchString);
-    if ((pos == std::string::npos) || (pos == s.length() - searchString.length()))
+    if (pos == std::string::npos)
         return "";
 
     return s.substr(pos + searchString.length());

--- a/src/base/sysfunc.h
+++ b/src/base/sysfunc.h
@@ -41,6 +41,8 @@ class DissolveSys
     static std::string_view afterChar(const std::string_view s, char c);
     // Get characters after first occurrence of any of the supplied characters, or an empty string if none are present
     static std::string_view afterChar(const std::string_view s, std::string_view chars);
+    // Get characters after first occurrence of the supplied string, or an empty string if it is not present
+    static std::string_view afterString(const std::string_view s, std::string_view searchString);
     // Get characters before last occurrence of designated character, or an empty string if the character does not exist
     static std::string_view beforeLastChar(const std::string_view s, char c);
     // Get characters after last occurrence of designated character, or an empty string if the character does not exist

--- a/src/genericitems/list.cpp
+++ b/src/genericitems/list.cpp
@@ -51,8 +51,9 @@ void GenericList::remove(std::string_view name, std::string_view prefix)
 // Remove all items with specified prefix
 void GenericList::removeWithPrefix(std::string_view prefix)
 {
+    auto delimitedPrefix = fmt::format("{}//", prefix);
     for (auto it = items_.begin(); it != items_.end(); ++it)
-        if (DissolveSys::startsWith(it->first, prefix))
+        if (DissolveSys::startsWith(it->first, delimitedPrefix))
             items_.erase(it);
 }
 
@@ -70,6 +71,19 @@ void GenericList::rename(std::string_view oldName, std::string_view oldPrefix, s
     auto handle = items_.extract(oldVarName);
     handle.key() = newVarName;
     items_.insert(std::move(handle));
+}
+
+// Rename prefix of items
+void GenericList::renamePrefix(std::string_view oldPrefix, std::string_view newPrefix)
+{
+    auto delimitedPrefix = fmt::format("{}//", oldPrefix);
+    for (auto &[key, value] : items_)
+        if (DissolveSys::startsWith(key, delimitedPrefix))
+        {
+            auto handle = items_.extract(key);
+            handle.key() = fmt::format("{}//{}", newPrefix, DissolveSys::afterString(key, "//"));
+            items_.insert(std::move(handle));
+        }
 }
 
 // Prune all items with '@suffix'

--- a/src/genericitems/list.cpp
+++ b/src/genericitems/list.cpp
@@ -48,6 +48,14 @@ void GenericList::remove(std::string_view name, std::string_view prefix)
     items_.erase(it);
 }
 
+// Remove all items with specified prefix
+void GenericList::removeWithPrefix(std::string_view prefix)
+{
+    for (auto it = items_.begin(); it != items_.end(); ++it)
+        if (DissolveSys::startsWith(it->first, prefix))
+            items_.erase(it);
+}
+
 // Rename item
 void GenericList::rename(std::string_view oldName, std::string_view oldPrefix, std::string_view newName,
                          std::string_view newPrefix)

--- a/src/genericitems/list.h
+++ b/src/genericitems/list.h
@@ -40,6 +40,8 @@ class GenericList
     int version(std::string_view name, std::string_view prefix = "") const;
     // Remove named item
     void remove(std::string_view name, std::string_view prefix);
+    // Remove all items with specified prefix
+    void removeWithPrefix(std::string_view prefix);
     // Rename item
     void rename(std::string_view oldName, std::string_view oldPrefix, std::string_view newName, std::string_view newPrefix);
     // Prune all items with '@suffix'

--- a/src/genericitems/list.h
+++ b/src/genericitems/list.h
@@ -44,6 +44,8 @@ class GenericList
     void removeWithPrefix(std::string_view prefix);
     // Rename item
     void rename(std::string_view oldName, std::string_view oldPrefix, std::string_view newName, std::string_view newPrefix);
+    // Rename prefix of items
+    void renamePrefix(std::string_view oldPrefix, std::string_view newPrefix);
     // Prune all items with '@suffix'
     void pruneWithSuffix(std::string_view suffix);
 

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -67,6 +67,7 @@ class LayerTab : public QWidget, public MainTab
     void moduleNameChanged(const QModelIndex &);
     void layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);
     void updateModuleList();
+    void on_ModulesList_customContextMenuRequested(const QPoint &pos);
     void on_AvailableModulesTree_doubleClicked(const QModelIndex &index);
 
     /*

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -64,7 +64,7 @@ class LayerTab : public QWidget, public MainTab
     void on_EnabledButton_clicked(bool checked);
     void on_FrequencySpin_valueChanged(int value);
     void moduleSelectionChanged(const QItemSelection &current, const QItemSelection &previous);
-    void moduleNameChanged(const QModelIndex &);
+    void moduleNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
     void layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);
     void updateModuleList();
     void on_ModulesList_customContextMenuRequested(const QPoint &pos);

--- a/src/gui/layertab.ui
+++ b/src/gui/layertab.ui
@@ -176,6 +176,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="contextMenuPolicy">
+        <enum>Qt::CustomContextMenu</enum>
+       </property>
        <property name="dragEnabled">
         <bool>true</bool>
        </property>

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -228,6 +228,8 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
     disableModule->setEnabled(module->isEnabled());
     menu.addSeparator();
     auto *enableOnlyModule = menu.addAction("Enable &only this");
+    menu.addSeparator();
+    auto *clearData = menu.addAction("&Clear associated data");
 
     auto *action = menu.exec(ui_.ModulesList->mapToGlobal(pos));
     if (action == enableModule)
@@ -237,14 +239,16 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
     else if (action == enableOnlyModule)
         for (auto &m : moduleLayer_->modules())
             m->setEnabled(m.get() == module);
+    else if (action == clearData)
+        dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
 
     // Update required objects
     if (action == enableModule || action == disableModule || action == enableOnlyModule)
     {
         updateModuleList();
-        updateControls();
         dissolveWindow_->setModified();
     }
+    updateControls();
 }
 
 void LayerTab::on_AvailableModulesTree_doubleClicked(const QModelIndex &index)

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -233,6 +233,9 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
     auto *enableOnlyModule = menu.addAction("Enable &only this");
     menu.addSeparator();
     auto *clearData = menu.addAction("&Clear associated data");
+    menu.addSeparator();
+    auto *deleteModule = menu.addAction("&Delete");
+    deleteModule->setIcon(QIcon(":/general/icons/general_cross.svg"));
 
     auto *action = menu.exec(ui_.ModulesList->mapToGlobal(pos));
     if (action == enableModule)
@@ -244,9 +247,15 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
             m->setEnabled(m.get() == module);
     else if (action == clearData)
         dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
+    else if (action == deleteModule)
+    {
+        // Remove the module's data, then the module
+        dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
+        moduleLayerModel_.removeRows(index.row(), 1, QModelIndex());
+    }
 
     // Update required objects
-    if (action == enableModule || action == disableModule || action == enableOnlyModule)
+    if (action == enableModule || action == disableModule || action == enableOnlyModule || action == deleteModule)
     {
         updateModuleList();
         dissolveWindow_->setModified();

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -25,8 +25,8 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
             SLOT(moduleSelectionChanged(const QItemSelection &, const QItemSelection &)));
     connect(&moduleLayerModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
             SLOT(layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
-    connect(&moduleLayerModel_, SIGNAL(moduleNameChanged(const QModelIndex &)), this,
-            SLOT(moduleNameChanged(const QModelIndex &)));
+    connect(&moduleLayerModel_, SIGNAL(moduleNameChanged(const QModelIndex &, const QString &, const QString &)), this,
+            SLOT(moduleNameChanged(const QModelIndex &, const QString &, const QString &)));
 
     if (moduleLayer_->modules().size() >= 1)
     {
@@ -187,7 +187,7 @@ void LayerTab::layerDataChanged(const QModelIndex &, const QModelIndex &, const 
     dissolveWindow_->setModified();
 }
 
-void LayerTab::moduleNameChanged(const QModelIndex &index)
+void LayerTab::moduleNameChanged(const QModelIndex &index, const QString &oldName, const QString &newName)
 {
     auto *module = moduleLayerModel_.data(index, Qt::UserRole).value<Module *>();
     assert(module);
@@ -196,6 +196,9 @@ void LayerTab::moduleNameChanged(const QModelIndex &index)
     auto *mcw = getControlWidget(module);
     if (mcw)
         mcw->updateControls();
+
+    // Rename processing module data
+    dissolve_.processingModuleData().renamePrefix(oldName.toStdString(), newName.toStdString());
 }
 
 // Update the module list

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -258,7 +258,10 @@ bool ModuleLayerModel::removeRows(int row, int count, const QModelIndex &parent)
 
     beginRemoveRows(parent, row, row + count - 1);
     for (auto i = 0; i < count; ++i)
+    {
+        KeywordStore::objectNoLongerValid(moduleLayer_->modules()[row].get());
         moduleLayer_->modules().erase(moduleLayer_->modules().begin() + row);
+    }
     endRemoveRows();
 
     return true;

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -70,10 +70,19 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
 {
     if (role == Qt::EditRole)
     {
-        moduleLayer_->modules()[index.row()]->setUniqueName(value.toString().toStdString());
+        auto *module = rawData(index);
 
-        emit dataChanged(index, index);
-        emit(moduleNameChanged(index));
+        // Check for identical old/new names
+        if (value.toString() == QString::fromStdString(std::string(module->uniqueName())))
+            return false;
+
+        // Ensure uniqueness of new name
+        auto oldName = QString::fromStdString(std::string(module->uniqueName()));
+        auto newName = Module::uniqueName(value.toString().toStdString(), module);
+        module->setUniqueName(newName);
+
+        emit(dataChanged(index, index));
+        emit(moduleNameChanged(index, oldName, QString::fromStdString(newName)));
 
         return true;
     }

--- a/src/gui/models/moduleLayerModel.h
+++ b/src/gui/models/moduleLayerModel.h
@@ -58,5 +58,5 @@ class ModuleLayerModel : public QAbstractListModel
     QModelIndex appendNew(const QString &moduleType);
 
     signals:
-    void moduleNameChanged(const QModelIndex &);
+    void moduleNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
 };

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -5,6 +5,7 @@
 
 #include "base/lock.h"
 #include "gui/ui_modulecontrolwidget.h"
+#include "modules/widget.h"
 
 // Forward Declarations
 class ConfigurationVectorKeyword;
@@ -49,7 +50,7 @@ class ModuleControlWidget : public QWidget
      */
     public:
     // Update controls within widget
-    void updateControls();
+    void updateControls(Flags<ModuleWidget::UpdateFlags> updateFlags = {});
     // Disable sensitive controls
     void disableSensitiveControls();
     // Enable sensitive controls

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -82,7 +82,7 @@ void ModuleControlWidget::setModule(Module *module, Dissolve *dissolve)
     {
         ui_.ModuleControlsStack->addWidget(moduleWidget_);
         ui_.ModuleOutputButton->setEnabled(true);
-        moduleWidget_->updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+        moduleWidget_->updateControls(ModuleWidget::RecreateRenderablesFlag);
     }
 
     updateControls();
@@ -96,7 +96,7 @@ Module *ModuleControlWidget::module() const { return module_; }
  */
 
 // Update controls within widget
-void ModuleControlWidget::updateControls()
+void ModuleControlWidget::updateControls(Flags<ModuleWidget::UpdateFlags> updateFlags)
 {
     if ((!module_) || (!dissolve_))
         return;
@@ -123,7 +123,7 @@ void ModuleControlWidget::updateControls()
 
     // Update additional controls (if they exist)
     if (moduleWidget_)
-        moduleWidget_->updateControls(ModuleWidget::UpdateType::Normal);
+        moduleWidget_->updateControls(updateFlags);
 }
 
 // Disable sensitive controls
@@ -205,7 +205,5 @@ void ModuleControlWidget::moduleKeywordChanged(int signalMask)
 
     // Handle specific flags for the module widget
     if (moduleWidget_)
-        moduleWidget_->updateControls(keywordSignals.isSet(KeywordBase::RecreateRenderables)
-                                          ? ModuleWidget::UpdateType::RecreateRenderables
-                                          : ModuleWidget::UpdateType::Normal);
+        moduleWidget_->updateControls(Flags<ModuleWidget::UpdateFlags>(signalMask));
 }

--- a/src/modules/accumulate/gui/accumulatewidget.h
+++ b/src/modules/accumulate/gui/accumulatewidget.h
@@ -44,7 +44,7 @@ class AccumulateModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/accumulate/gui/accumulatewidget_funcs.cpp
+++ b/src/modules/accumulate/gui/accumulatewidget_funcs.cpp
@@ -74,7 +74,7 @@ void AccumulateModuleWidget::createPartialSetRenderables(std::string_view target
 }
 
 // Update controls within widget
-void AccumulateModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void AccumulateModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
@@ -86,7 +86,7 @@ void AccumulateModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
 
     // Need to recreate renderables if requested as the updateType, or if we previously had no target PartialSet and have just
     // located it
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || (!ui_.TotalButton->isChecked() && !targetPartials_))
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || (!ui_.TotalButton->isChecked() && !targetPartials_))
     {
         ui_.PlotWidget->clearRenderableData();
 
@@ -126,7 +126,7 @@ void AccumulateModuleWidget::on_TotalButton_clicked(bool checked)
     graph_->view().axes().setTitle(0, hasSQ ? "\\it{Q}, \\sym{angstrom}\\sup{-1}" : "\\it{r}, \\sym{angstrom}");
     graph_->view().axes().setTitle(1, hasSQ ? "F(Q)" : "G(r)");
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void AccumulateModuleWidget::on_PartialsButton_clicked(bool checked)
@@ -141,5 +141,5 @@ void AccumulateModuleWidget::on_PartialsButton_clicked(bool checked)
     graph_->view().axes().setTitle(0, hasSQ ? "\\it{Q}, \\sym{angstrom}\\sup{-1}" : "\\it{r}, \\sym{angstrom}");
     graph_->view().axes().setTitle(1, hasSQ ? "S(Q)" : "g(r)");
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }

--- a/src/modules/bragg/gui/braggwidget.h
+++ b/src/modules/bragg/gui/braggwidget.h
@@ -52,7 +52,7 @@ class BraggModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/bragg/gui/braggwidget_funcs.cpp
+++ b/src/modules/bragg/gui/braggwidget_funcs.cpp
@@ -39,7 +39,7 @@ BraggModuleWidget::BraggModuleWidget(QWidget *parent, BraggModule *module, Disso
  */
 
 // Update controls within widget
-void BraggModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
@@ -49,7 +49,7 @@ void BraggModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
             dissolve_.processingModuleData().valueIf<const AtomTypeMix>("SummedAtomTypes", module_->uniqueName());
 
     // Need to recreate renderables if requested as the updateType
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables)
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag))
     {
         ui_.PlotWidget->clearRenderableData();
 
@@ -128,7 +128,7 @@ void BraggModuleWidget::on_PartialsButton_clicked(bool checked)
 
     ui_.Stack->setCurrentIndex(0);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void BraggModuleWidget::on_TotalsButton_clicked(bool checked)
@@ -138,7 +138,7 @@ void BraggModuleWidget::on_TotalsButton_clicked(bool checked)
 
     ui_.Stack->setCurrentIndex(0);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void BraggModuleWidget::on_ReflectionsButton_clicked(bool checked)
@@ -148,7 +148,7 @@ void BraggModuleWidget::on_ReflectionsButton_clicked(bool checked)
 
     ui_.Stack->setCurrentIndex(1);
 
-    updateControls(ModuleWidget::UpdateType::Normal);
+    updateControls();
 }
 
 void BraggModuleWidget::on_HideSmallIntensitiesCheck_clicked(bool checked) { braggFilterProxy_.setEnabled(checked); }

--- a/src/modules/calculate_angle/gui/calculateanglewidget.h
+++ b/src/modules/calculate_angle/gui/calculateanglewidget.h
@@ -34,7 +34,7 @@ class CalculateAngleModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/calculate_angle/gui/calculateanglewidget_funcs.cpp
+++ b/src/modules/calculate_angle/gui/calculateanglewidget_funcs.cpp
@@ -76,7 +76,7 @@ CalculateAngleModuleWidget::CalculateAngleModuleWidget(QWidget *parent, Calculat
 
     setGraphDataTargets(module_);
 
-    updateControls(ModuleWidget::UpdateType::Normal);
+    updateControls();
 
     refreshing_ = false;
 }
@@ -86,7 +86,7 @@ CalculateAngleModuleWidget::CalculateAngleModuleWidget(QWidget *parent, Calculat
  */
 
 // Update controls within widget
-void CalculateAngleModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void CalculateAngleModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     ui_.RDFABPlotWidget->updateToolbar();
     ui_.RDFBCPlotWidget->updateToolbar();

--- a/src/modules/calculate_axisangle/gui/calculateaxisanglewidget.h
+++ b/src/modules/calculate_axisangle/gui/calculateaxisanglewidget.h
@@ -34,5 +34,5 @@ class CalculateAxisAngleModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 };

--- a/src/modules/calculate_axisangle/gui/calculateaxisanglewidget_funcs.cpp
+++ b/src/modules/calculate_axisangle/gui/calculateaxisanglewidget_funcs.cpp
@@ -59,9 +59,9 @@ CalculateAxisAngleModuleWidget::CalculateAxisAngleModuleWidget(QWidget *parent, 
  */
 
 // Update controls within widget
-void CalculateAxisAngleModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void CalculateAxisAngleModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables)
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag))
         rdfGraph_->clearRenderables();
 
     auto cfg = module_->keywords().get<Configuration *>("Configuration");

--- a/src/modules/calculate_cn/gui/calculatecnwidget.h
+++ b/src/modules/calculate_cn/gui/calculatecnwidget.h
@@ -38,7 +38,7 @@ class CalculateCNModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/calculate_cn/gui/calculatecnwidget_funcs.cpp
+++ b/src/modules/calculate_cn/gui/calculatecnwidget_funcs.cpp
@@ -33,7 +33,7 @@ CalculateCNModuleWidget::CalculateCNModuleWidget(QWidget *parent, CalculateCNMod
 }
 
 // Update controls within widget
-void CalculateCNModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void CalculateCNModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     // Update CN labels
     ui_.RegionAResultFrame->setText(
@@ -50,7 +50,7 @@ void CalculateCNModuleWidget::updateControls(ModuleWidget::UpdateType updateType
     ui_.RegionCResultFrame->setEnabled(rangeCOn);
 
     // Clear and recreate graph data targets?
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || !rdfData_)
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || !rdfData_)
     {
         rdfGraph_->clearRenderables();
 

--- a/src/modules/calculate_dangle/gui/calculatedanglewidget.h
+++ b/src/modules/calculate_dangle/gui/calculatedanglewidget.h
@@ -34,5 +34,5 @@ class CalculateDAngleModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 };

--- a/src/modules/calculate_dangle/gui/calculatedanglewidget_funcs.cpp
+++ b/src/modules/calculate_dangle/gui/calculatedanglewidget_funcs.cpp
@@ -58,9 +58,9 @@ CalculateDAngleModuleWidget::CalculateDAngleModuleWidget(QWidget *parent, Calcul
  */
 
 // Update controls within widget
-void CalculateDAngleModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void CalculateDAngleModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables)
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag))
         rdfGraph_->clearRenderables();
 
     // Calculated B...C RDF

--- a/src/modules/calculate_rdf/gui/calculaterdfwidget.h
+++ b/src/modules/calculate_rdf/gui/calculaterdfwidget.h
@@ -34,5 +34,5 @@ class CalculateRDFModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 };

--- a/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
+++ b/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
@@ -29,9 +29,9 @@ CalculateRDFModuleWidget::CalculateRDFModuleWidget(QWidget *parent, CalculateRDF
 }
 
 // Update controls within widget
-void CalculateRDFModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void CalculateRDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables)
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag))
         rdfGraph_->clearRenderables();
 
     if (rdfGraph_->renderables().empty())

--- a/src/modules/calculate_sdf/gui/calculatesdfwidget.h
+++ b/src/modules/calculate_sdf/gui/calculatesdfwidget.h
@@ -45,7 +45,7 @@ class CalculateSDFModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/calculate_sdf/gui/calculatesdfwidget_funcs.cpp
+++ b/src/modules/calculate_sdf/gui/calculatesdfwidget_funcs.cpp
@@ -54,7 +54,7 @@ CalculateSDFModuleWidget::CalculateSDFModuleWidget(QWidget *parent, CalculateSDF
  */
 
 // Update controls within widget
-void CalculateSDFModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void CalculateSDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
@@ -69,7 +69,7 @@ void CalculateSDFModuleWidget::updateControls(ModuleWidget::UpdateType updateTyp
         refMolecules.emplace_back(sp.get(), fmt::format("{} (Species)", sp->name()));
     ComboBoxUpdater<Species> refMoleculeUpdater(ui_.ReferenceMoleculeCombo, refMolecules, referenceMolecule_, 1, 0);
 
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || sdfGraph_->renderables().empty())
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || sdfGraph_->renderables().empty())
     {
         sdfGraph_->clearRenderables();
         sdfRenderable_ = nullptr;
@@ -162,5 +162,5 @@ void CalculateSDFModuleWidget::on_ReferenceMoleculeCombo_currentIndexChanged(int
         referenceMoleculeRenderable_ = nullptr;
     }
 
-    updateControls(ModuleWidget::UpdateType::Normal);
+    updateControls();
 }

--- a/src/modules/energy/gui/energywidget.h
+++ b/src/modules/energy/gui/energywidget.h
@@ -39,5 +39,5 @@ class EnergyModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 };

--- a/src/modules/energy/gui/energywidget_funcs.cpp
+++ b/src/modules/energy/gui/energywidget_funcs.cpp
@@ -44,7 +44,7 @@ EnergyModuleWidget::EnergyModuleWidget(QWidget *parent, EnergyModule *module, Di
  */
 
 // Update controls within widget
-void EnergyModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     const auto *cfg = module_->keywords().get<Configuration *>("Configuration");
 
@@ -55,7 +55,7 @@ void EnergyModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
     // Create / update renderables?
     if (!cfg)
         energyGraph_->clearRenderables();
-    else if (updateType == ModuleWidget::UpdateType::RecreateRenderables || energyGraph_->renderables().empty())
+    else if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || energyGraph_->renderables().empty())
     {
         // Clear any existing renderables
         energyGraph_->clearRenderables();

--- a/src/modules/epsr/gui/epsrwidget.h
+++ b/src/modules/epsr/gui/epsrwidget.h
@@ -38,7 +38,7 @@ class EPSRModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/epsr/gui/epsrwidget_funcs.cpp
+++ b/src/modules/epsr/gui/epsrwidget_funcs.cpp
@@ -60,11 +60,11 @@ EPSRModuleWidget::EPSRModuleWidget(QWidget *parent, EPSRModule *module, Dissolve
  */
 
 // Update controls within widget
-void EPSRModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || ui_.PlotWidget->dataViewer()->renderables().empty())
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || ui_.PlotWidget->dataViewer()->renderables().empty())
     {
         ui_.PlotWidget->clearRenderableData();
 
@@ -245,7 +245,7 @@ void EPSRModuleWidget::on_TotalFQButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Decimal));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_DeltaFQButton_clicked(bool checked)
@@ -260,7 +260,7 @@ void EPSRModuleWidget::on_DeltaFQButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Decimal));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_EstimatedSQButton_clicked(bool checked)
@@ -275,7 +275,7 @@ void EPSRModuleWidget::on_EstimatedSQButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Decimal));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_EstimatedGRButton_clicked(bool checked)
@@ -290,7 +290,7 @@ void EPSRModuleWidget::on_EstimatedGRButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Decimal));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_TotalGRButton_clicked(bool checked)
@@ -305,7 +305,7 @@ void EPSRModuleWidget::on_TotalGRButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Decimal));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_PotentialsButton_clicked(bool checked)
@@ -320,7 +320,7 @@ void EPSRModuleWidget::on_PotentialsButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Decimal));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_RFactorButton_clicked(bool checked)
@@ -335,7 +335,7 @@ void EPSRModuleWidget::on_RFactorButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Integer));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Scientific));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void EPSRModuleWidget::on_EReqButton_clicked(bool checked)
@@ -350,5 +350,5 @@ void EPSRModuleWidget::on_EReqButton_clicked(bool checked)
     graph_->view().axes().setNumberFormat(0, NumberFormat(NumberFormat::FormatType::Integer));
     graph_->view().axes().setNumberFormat(1, NumberFormat(NumberFormat::FormatType::Decimal));
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }

--- a/src/modules/neutronsq/gui/neutronsqwidget.h
+++ b/src/modules/neutronsq/gui/neutronsqwidget.h
@@ -43,7 +43,7 @@ class NeutronSQModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/neutronsq/gui/neutronsqwidget_funcs.cpp
+++ b/src/modules/neutronsq/gui/neutronsqwidget_funcs.cpp
@@ -85,13 +85,13 @@ void NeutronSQModuleWidget::createPartialSetRenderables(std::string_view targetP
 }
 
 // Update controls within widget
-void NeutronSQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void NeutronSQModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
     // Need to recreate renderables if requested as the updateType, or if we previously had no target PartialSet and have just
     // located it
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables ||
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) ||
         (!ui_.TotalFQButton->isChecked() && !ui_.TotalGRButton->isChecked() && !targetPartials_))
     {
         ui_.PlotWidget->clearRenderableData();
@@ -169,7 +169,7 @@ void NeutronSQModuleWidget::on_TotalFQButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "F(Q)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void NeutronSQModuleWidget::on_PartialSQButton_clicked(bool checked)
@@ -181,7 +181,7 @@ void NeutronSQModuleWidget::on_PartialSQButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "S(Q)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void NeutronSQModuleWidget::on_TotalGRButton_clicked(bool checked)
@@ -193,7 +193,7 @@ void NeutronSQModuleWidget::on_TotalGRButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "G(r)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void NeutronSQModuleWidget::on_PartialGRButton_clicked(bool checked)
@@ -205,16 +205,13 @@ void NeutronSQModuleWidget::on_PartialGRButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "g(r)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
-void NeutronSQModuleWidget::on_FilterEdit_textChanged(QString text)
-{
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
-}
+void NeutronSQModuleWidget::on_FilterEdit_textChanged(QString text) { updateControls(ModuleWidget::RecreateRenderablesFlag); }
 
 void NeutronSQModuleWidget::on_ClearFilterButton_clicked(bool checked)
 {
     ui_.FilterEdit->setText("");
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }

--- a/src/modules/rdf/gui/rdfwidget.h
+++ b/src/modules/rdf/gui/rdfwidget.h
@@ -46,7 +46,7 @@ class RDFModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/rdf/gui/rdfwidget_funcs.cpp
+++ b/src/modules/rdf/gui/rdfwidget_funcs.cpp
@@ -90,7 +90,7 @@ void RDFModuleWidget::createPartialSetRenderables(std::string_view targetPrefix)
 }
 
 // Update controls within widget
-void RDFModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void RDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
@@ -102,7 +102,7 @@ void RDFModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
 
     // Need to recreate renderables if requested as the updateType, or if we previously had no target PartialSet and have just
     // located it
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || (!ui_.TotalsButton->isChecked() && !targetPartials_))
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || (!ui_.TotalsButton->isChecked() && !targetPartials_))
     {
         ui_.RDFPlotWidget->clearRenderableData();
 
@@ -147,7 +147,7 @@ void RDFModuleWidget::on_SummedPartialsButton_clicked(bool checked)
     rdfGraph_->view().axes().setTitle(1, "g(r)");
     rdfGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void RDFModuleWidget::on_TotalsButton_clicked(bool checked)
@@ -160,7 +160,7 @@ void RDFModuleWidget::on_TotalsButton_clicked(bool checked)
     rdfGraph_->view().axes().setTitle(1, "G(r)");
     rdfGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::OneVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void RDFModuleWidget::on_ConfigurationPartialsButton_clicked(bool checked)
@@ -173,7 +173,7 @@ void RDFModuleWidget::on_ConfigurationPartialsButton_clicked(bool checked)
     rdfGraph_->view().axes().setTitle(1, "g(r)");
     rdfGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void RDFModuleWidget::on_ConfigurationTargetCombo_currentIndexChanged(int index)
@@ -181,13 +181,13 @@ void RDFModuleWidget::on_ConfigurationTargetCombo_currentIndexChanged(int index)
     if (refreshing_)
         return;
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
-void RDFModuleWidget::on_FilterEdit_textChanged(QString text) { updateControls(ModuleWidget::UpdateType::RecreateRenderables); }
+void RDFModuleWidget::on_FilterEdit_textChanged(QString text) { updateControls(ModuleWidget::RecreateRenderablesFlag); }
 
 void RDFModuleWidget::on_ClearFilterButton_clicked(bool checked)
 {
     ui_.FilterEdit->setText("");
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }

--- a/src/modules/sq/gui/sqwidget.h
+++ b/src/modules/sq/gui/sqwidget.h
@@ -44,7 +44,7 @@ class SQModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/sq/gui/sqwidget_funcs.cpp
+++ b/src/modules/sq/gui/sqwidget_funcs.cpp
@@ -85,13 +85,13 @@ void SQModuleWidget::createPartialSetRenderables(std::string_view targetPrefix)
 }
 
 // Update controls within widget
-void SQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void SQModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
     // Need to recreate renderables if requested as the updateType, or if we previously had no target PartialSet and have just
     // located it
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables || (!ui_.TotalButton->isChecked() && !targetPartials_))
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) || (!ui_.TotalButton->isChecked() && !targetPartials_))
     {
         ui_.SQPlotWidget->clearRenderableData();
 
@@ -126,7 +126,7 @@ void SQModuleWidget::on_TotalButton_clicked(bool checked)
     sqGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
     sqGraph_->view().axes().setTitle(1, "F(Q)");
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void SQModuleWidget::on_PartialsButton_clicked(bool checked)
@@ -137,13 +137,13 @@ void SQModuleWidget::on_PartialsButton_clicked(bool checked)
     sqGraph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
     sqGraph_->view().axes().setTitle(1, "S(Q)");
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
-void SQModuleWidget::on_FilterEdit_textChanged(QString text) { updateControls(ModuleWidget::UpdateType::RecreateRenderables); }
+void SQModuleWidget::on_FilterEdit_textChanged(QString text) { updateControls(ModuleWidget::RecreateRenderablesFlag); }
 
 void SQModuleWidget::on_ClearFilterButton_clicked(bool checked)
 {
     ui_.FilterEdit->setText("");
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }

--- a/src/modules/widget.cpp
+++ b/src/modules/widget.cpp
@@ -10,7 +10,7 @@ ModuleWidget::ModuleWidget(QWidget *parent, Dissolve &dissolve) : QWidget(parent
  */
 
 // Update controls within widget
-void ModuleWidget::updateControls(UpdateType updateType) {}
+void ModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags) {}
 
 // Disable sensitive controls within widget
 void ModuleWidget::disableSensitiveControls() {}

--- a/src/modules/widget.h
+++ b/src/modules/widget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "templates/flags.h"
 #include <QWidget>
 
 // Forward Declarations
@@ -26,14 +27,13 @@ class ModuleWidget : public QWidget
     bool refreshing_;
 
     public:
-    // Update Types
-    enum class UpdateType
+    // Update Flags
+    enum UpdateFlags
     {
-        Normal,             /* Standard update - refresh / update existing content etc. */
-        RecreateRenderables /* Update as normal, but any existing renderables must be cleared and regenerated */
+        RecreateRenderablesFlag /* Update as normal, but any existing renderables must be cleared and regenerated */
     };
     // Update controls within widget
-    virtual void updateControls(UpdateType updateType);
+    virtual void updateControls(const Flags<UpdateFlags> &updateFlags = {});
     // Disable sensitive controls within widget
     virtual void disableSensitiveControls();
     // Enable sensitive controls within widget

--- a/src/modules/xraysq/gui/xraysqwidget.h
+++ b/src/modules/xraysq/gui/xraysqwidget.h
@@ -43,7 +43,7 @@ class XRaySQModuleWidget : public ModuleWidget
 
     public:
     // Update controls within widget
-    void updateControls(ModuleWidget::UpdateType updateType) override;
+    void updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags = {}) override;
 
     /*
      * Widgets / Functions

--- a/src/modules/xraysq/gui/xraysqwidget_funcs.cpp
+++ b/src/modules/xraysq/gui/xraysqwidget_funcs.cpp
@@ -83,13 +83,13 @@ void XRaySQModuleWidget::createPartialSetRenderables(std::string_view targetPref
 }
 
 // Update controls within widget
-void XRaySQModuleWidget::updateControls(ModuleWidget::UpdateType updateType)
+void XRaySQModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags)
 {
     refreshing_ = true;
 
     // Need to recreate renderables if requested as the updateType, or if we previously had no target PartialSet and have just
     // located it
-    if (updateType == ModuleWidget::UpdateType::RecreateRenderables ||
+    if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag) ||
         (!ui_.TotalFQButton->isChecked() && !ui_.TotalGRButton->isChecked() && !targetPartials_))
     {
         ui_.PlotWidget->clearRenderableData();
@@ -167,7 +167,7 @@ void XRaySQModuleWidget::on_TotalFQButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "F(Q)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void XRaySQModuleWidget::on_PartialSQButton_clicked(bool checked)
@@ -179,7 +179,7 @@ void XRaySQModuleWidget::on_PartialSQButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "S(Q)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void XRaySQModuleWidget::on_TotalGRButton_clicked(bool checked)
@@ -191,7 +191,7 @@ void XRaySQModuleWidget::on_TotalGRButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "G(r)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::NoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
 void XRaySQModuleWidget::on_PartialGRButton_clicked(bool checked)
@@ -203,16 +203,13 @@ void XRaySQModuleWidget::on_PartialGRButton_clicked(bool checked)
     graph_->view().axes().setTitle(1, "g(r)");
     graph_->groupManager().setVerticalShiftAmount(RenderableGroupManager::TwoVerticalShift);
 
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }
 
-void XRaySQModuleWidget::on_FilterEdit_textChanged(QString text)
-{
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
-}
+void XRaySQModuleWidget::on_FilterEdit_textChanged(QString text) { updateControls(ModuleWidget::RecreateRenderablesFlag); }
 
 void XRaySQModuleWidget::on_ClearFilterButton_clicked(bool checked)
 {
     ui_.FilterEdit->setText("");
-    updateControls(ModuleWidget::UpdateType::RecreateRenderables);
+    updateControls(ModuleWidget::RecreateRenderablesFlag);
 }

--- a/unit/algorithms/sysFunc.cpp
+++ b/unit/algorithms/sysFunc.cpp
@@ -29,11 +29,12 @@ TEST(SysFunc, StringManipulation)
     EXPECT_FALSE(DissolveSys::sameWildString("abc*efg", "ABCDEFGH"));
     EXPECT_TRUE(DissolveSys::sameWildString("abc*efg?", "ABCDEFGH"));
 
-    // Before / after char
+    // Before / after chars and strings
     EXPECT_TRUE(DissolveSys::beforeChar("Something=This", '=') == "Something");
     EXPECT_TRUE(DissolveSys::afterChar("Something=This", '=') == "This");
     EXPECT_TRUE(DissolveSys::beforeChar("Something=This=That=Other", '=') == "Something");
     EXPECT_TRUE(DissolveSys::afterChar("Something=This=That=Other", '=') == "This=That=Other");
+    EXPECT_TRUE(DissolveSys::afterString("Something=This=That=Other", "This=") == "That=Other");
     EXPECT_TRUE(DissolveSys::beforeLastChar("Something=This=That=Other", '=') == "Something=This=That");
     EXPECT_TRUE(DissolveSys::afterLastChar("Something=This=That=Other", '=') == "Other");
     EXPECT_TRUE(DissolveSys::beforeChar("Just a string", '=').empty());

--- a/unit/algorithms/sysFunc.cpp
+++ b/unit/algorithms/sysFunc.cpp
@@ -41,6 +41,8 @@ TEST(SysFunc, StringManipulation)
     EXPECT_TRUE(DissolveSys::afterChar("Just a string", '=').empty());
     EXPECT_TRUE(DissolveSys::beforeLastChar("Just a string", '=').empty());
     EXPECT_TRUE(DissolveSys::afterLastChar("Just a string", '=').empty());
+    EXPECT_TRUE(DissolveSys::afterString("Just a string", "I'm not here").empty());
+    EXPECT_TRUE(DissolveSys::afterString("Just a string", "string").empty());
 
     // Starts / ends with
     EXPECT_TRUE(DissolveSys::startsWith("I am a little man", "I am"));


### PR DESCRIPTION
This PR adds a context menu to the module layer list offering the following functionality:

- Enable / disable this or "other" modules in the list.
- Clear any processing data associated to the clicked module (closes #149).
- Renames associated data on module rename (closes #113).
- Enables deletion of individual modules from a layer.

This PR also introduces a crash when deleting modules, related to inconsistent updating of dependent controls elsewhere in the GUI.  This is resolved in PR #990.