### PR TITLE
Bugfix 28/2/22 Add Layer Crash

### DIFF
--- a/.azure-pipelines/continuous.yml
+++ b/.azure-pipelines/continuous.yml
@@ -50,7 +50,7 @@ stages:
         displayName: 'Windows, Threads, CLI/GUI'
         timeoutInMinutes: 120
         pool:
-          vmImage: 'windows-latest' 
+          vmImage: 'windows-2019'
         steps:
           - checkout: self
             fetchDepth: 1

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -76,7 +76,7 @@ stages:
         displayName: "Windows, Threads, CLI/GUI"
         timeoutInMinutes: 120
         pool:
-          vmImage: "windows-latest"
+          vmImage: "windows-2019"
         steps:
           - checkout: self
             fetchDepth: 1

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -32,7 +32,7 @@ stages:
         displayName: 'Windows, Threads, CLI/GUI'
         timeoutInMinutes: 120
         pool:
-          vmImage: 'windows-latest'
+          vmImage: 'windows-2019'
         steps:
           - checkout: self
             fetchDepth: 1

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -158,11 +158,9 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF"));
     newLayer->setFrequency(5);
 
-    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
-
     // Add the RDF module
     auto *module = ModuleRegistry::create("RDF", newLayer);
-    module->keywords().set("Configuration", firstCfg);
+    module->keywords().set("Configurations", dissolve_.rawConfigurations());
 
     // Run set-up stages for modules
     newLayer->setUpAll(dissolve_, dissolve_.worldPool());
@@ -178,11 +176,9 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggere
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Unweighted S(Q)"));
     newLayer->setFrequency(5);
 
-    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
-
     // Add the RDF module
     auto *rdfModule = dynamic_cast<RDFModule *>(ModuleRegistry::create("RDF", newLayer));
-    rdfModule->keywords().set("Configuration", firstCfg);
+    rdfModule->keywords().set("Configurations", dissolve_.rawConfigurations());
 
     // Add a plain structure factor module
     auto *module = ModuleRegistry::create("SQ", newLayer);
@@ -202,11 +198,9 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool c
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Neutron S(Q)"));
     newLayer->setFrequency(5);
 
-    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
-
     // Add the RDF module
     auto *rdfModule = ModuleRegistry::create("RDF", newLayer);
-    rdfModule->keywords().set("Configuration", firstCfg);
+    rdfModule->keywords().set("Configurations", dissolve_.rawConfigurations());
 
     // Add a plain structure factor module
     auto *sqModule = dynamic_cast<SQModule *>(ModuleRegistry::create("SQ", newLayer));
@@ -230,11 +224,9 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bo
     newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Neutron S(Q) / X-Ray S(Q)"));
     newLayer->setFrequency(5);
 
-    auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
-
     // Add the RDF module
     auto *rdfModule = ModuleRegistry::create("RDF", newLayer);
-    rdfModule->keywords().set("Configuration", firstCfg);
+    rdfModule->keywords().set("Configurations", dissolve_.rawConfigurations());
 
     // Add a plain structure factor module
     auto *sqModule = ModuleRegistry::create("SQ", newLayer);

--- a/src/main/configurations.cpp
+++ b/src/main/configurations.cpp
@@ -44,8 +44,17 @@ void Dissolve::removeConfiguration(Configuration *cfg)
 // Return number of defined Configurations
 int Dissolve::nConfigurations() const { return coreData_.nConfigurations(); }
 
-// Return Configuration list
+// Return Configuration vector
 std::vector<std::unique_ptr<Configuration>> &Dissolve::configurations() { return coreData_.configurations(); }
+
+// Return raw Configuration vector
+std::vector<Configuration *> Dissolve::rawConfigurations() const
+{
+    std::vector<Configuration *> cfgs(coreData_.configurations().size());
+    std::transform(coreData_.configurations().begin(), coreData_.configurations().end(), cfgs.begin(),
+                   [](auto &cfg) { return cfg.get(); });
+    return cfgs;
+}
 
 const std::vector<std::unique_ptr<Configuration>> &Dissolve::configurations() const { return coreData_.configurations(); }
 

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -162,9 +162,11 @@ class Dissolve
     void removeConfiguration(Configuration *cfg);
     // Return number of defined Configurations
     int nConfigurations() const;
-    // Return Configuration list
+    // Return Configuration vector
     std::vector<std::unique_ptr<Configuration>> &configurations();
     const std::vector<std::unique_ptr<Configuration>> &configurations() const;
+    // Return raw Configuration vector
+    std::vector<Configuration *> rawConfigurations() const;
     // Find configuration by name
     Configuration *findConfiguration(std::string_view name) const;
     // Find configuration by 'nice' name


### PR DESCRIPTION
Bugfix PR to address crashes occurring when adding any correlation layer to a simulation, arising from the wrong keyword name being used (introduced in #955).