### PR TITLE
Update isotopologues when changing atom types in the GUI

### DIFF
--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -1,15 +1,12 @@
 #include "gui/models/speciesAtomModel.h"
 #include "classes/atomtype.h"
 
-SpeciesAtomModel::SpeciesAtomModel(std::vector<SpeciesAtom> &atoms, Species &species, Dissolve &dissolve)
-    : atoms_(atoms), dissolve_(dissolve), species_(species)
-{
-}
+SpeciesAtomModel::SpeciesAtomModel(Species &species, Dissolve &dissolve) : dissolve_(dissolve), species_(species) {}
 
 int SpeciesAtomModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);
-    return atoms_.size();
+    return species_.atoms().size();
 }
 
 int SpeciesAtomModel::columnCount(const QModelIndex &parent) const
@@ -23,7 +20,7 @@ QVariant SpeciesAtomModel::data(const QModelIndex &index, int role) const
     if (role == Qt::ToolTipRole)
         return headerData(index.column(), Qt::Horizontal, Qt::DisplayRole);
 
-    auto &item = *std::next(atoms_.begin(), index.row());
+    auto &item = species_.atom(index.row());
 
     if (role == Qt::UserRole)
         return QVariant::fromValue(&item);
@@ -85,7 +82,7 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
 {
     if (role != Qt::EditRole)
         return false;
-    SpeciesAtom &item = *std::next(atoms_.begin(), index.row());
+    SpeciesAtom &item = species_.atom(index.row());
     switch (index.column())
     {
         case 0:

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -1,7 +1,10 @@
 #include "gui/models/speciesAtomModel.h"
 #include "classes/atomtype.h"
 
-SpeciesAtomModel::SpeciesAtomModel(std::vector<SpeciesAtom> &atoms, Dissolve &dissolve) : atoms_(atoms), dissolve_(dissolve) {}
+SpeciesAtomModel::SpeciesAtomModel(std::vector<SpeciesAtom> &atoms, Species &species, Dissolve &dissolve)
+    : atoms_(atoms), dissolve_(dissolve), species_(species)
+{
+}
 
 int SpeciesAtomModel::rowCount(const QModelIndex &parent) const
 {
@@ -94,6 +97,7 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
                 if (!atomType)
                     return false;
                 item.setAtomType(atomType);
+                species_.updateIsotopologues();
                 emit atomTypeChanged();
             }
             break;

--- a/src/gui/models/speciesAtomModel.h
+++ b/src/gui/models/speciesAtomModel.h
@@ -14,13 +14,14 @@ class SpeciesAtomModel : public QAbstractTableModel
 
     private:
     std::vector<SpeciesAtom> &atoms_;
+    Species &species_;
     Dissolve &dissolve_;
 
     signals:
     void atomTypeChanged();
 
     public:
-    SpeciesAtomModel(std::vector<SpeciesAtom> &atoms, Dissolve &dissolve);
+    SpeciesAtomModel(std::vector<SpeciesAtom> &atoms, Species &species, Dissolve &dissolve);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 

--- a/src/gui/models/speciesAtomModel.h
+++ b/src/gui/models/speciesAtomModel.h
@@ -13,7 +13,6 @@ class SpeciesAtomModel : public QAbstractTableModel
     Q_OBJECT
 
     private:
-    std::vector<SpeciesAtom> &atoms_;
     Species &species_;
     Dissolve &dissolve_;
 
@@ -21,7 +20,7 @@ class SpeciesAtomModel : public QAbstractTableModel
     void atomTypeChanged();
 
     public:
-    SpeciesAtomModel(std::vector<SpeciesAtom> &atoms, Species &species, Dissolve &dissolve);
+    SpeciesAtomModel(Species &species, Dissolve &dissolve);
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -16,10 +16,10 @@
 
 SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                        Species *species)
-    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this),
-      atoms_(species->atoms(), *species, dissolve), angles_(species->angles(), dissolve.coreData()),
-      bonds_(species->bonds(), dissolve.coreData()), torsions_(species->torsions(), dissolve.coreData()),
-      impropers_(species->impropers(), dissolve.coreData()), isos_(*species), sites_(species->sites())
+    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this), atoms_(*species, dissolve),
+      angles_(species->angles(), dissolve.coreData()), bonds_(species->bonds(), dissolve.coreData()),
+      torsions_(species->torsions(), dissolve.coreData()), impropers_(species->impropers(), dissolve.coreData()),
+      isos_(*species), sites_(species->sites())
 {
     ui_.setupUi(this);
 

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -16,10 +16,10 @@
 
 SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title,
                        Species *species)
-    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this), atoms_(species->atoms(), dissolve),
-      angles_(species->angles(), dissolve.coreData()), bonds_(species->bonds(), dissolve.coreData()),
-      torsions_(species->torsions(), dissolve.coreData()), impropers_(species->impropers(), dissolve.coreData()),
-      isos_(*species), sites_(species->sites())
+    : MainTab(dissolveWindow, dissolve, parent, QString("Species: %1").arg(title), this),
+      atoms_(species->atoms(), *species, dissolve), angles_(species->angles(), dissolve.coreData()),
+      bonds_(species->bonds(), dissolve.coreData()), torsions_(species->torsions(), dissolve.coreData()),
+      impropers_(species->impropers(), dissolve.coreData()), isos_(*species), sites_(species->sites())
 {
     ui_.setupUi(this);
 

--- a/unit/gui/speciestab.cpp
+++ b/unit/gui/speciestab.cpp
@@ -37,7 +37,7 @@ TEST_F(SpeciesTabTest, Atoms)
     ASSERT_TRUE(dissolve.loadInput("inputs/benzene.txt"));
     auto &species = dissolve.species()[0];
 
-    SpeciesAtomModel atom(species->atoms(), dissolve);
+    SpeciesAtomModel atom(species->atoms(), *species, dissolve);
 
     // Test Atoms
     EXPECT_EQ(atom.columnCount(), 6);

--- a/unit/gui/speciestab.cpp
+++ b/unit/gui/speciestab.cpp
@@ -37,7 +37,7 @@ TEST_F(SpeciesTabTest, Atoms)
     ASSERT_TRUE(dissolve.loadInput("inputs/benzene.txt"));
     auto &species = dissolve.species()[0];
 
-    SpeciesAtomModel atom(species->atoms(), *species, dissolve);
+    SpeciesAtomModel atom(*species, dissolve);
 
     // Test Atoms
     EXPECT_EQ(atom.columnCount(), 6);


### PR DESCRIPTION
This only updates the isotopologues when the changes are in the GUI, but I believe that is the only place where this can occur.

Closes #956