### PR TITLE
GUI Data Updates

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -10,7 +10,7 @@ set(gui_MOC_HDRS
     graphgizmo.h
     integrator1dgizmo.h
     # Viewers
-    configurationwidget.h
+    configurationviewerwidget.h
     datawidget.h
     selectsymbol.h
     sitewidget.h
@@ -71,7 +71,7 @@ set(gui_UIS
     graphgizmo.ui
     integrator1dgizmo.ui
     # Viewers
-    configurationwidget.ui
+    configurationviewerwidget.ui
     datawidget.ui
     selectsymbol.ui
     sitewidget.ui
@@ -129,7 +129,7 @@ set(gui_SRCS
     configurationviewer_input.cpp
     configurationviewer_interaction.cpp
     configurationviewer_render.cpp
-    configurationwidget_funcs.cpp
+    configurationviewerwidget_funcs.cpp
     dataviewer_funcs.cpp
     dataviewer_input.cpp
     dataviewer_interaction.cpp

--- a/src/gui/configurationtab.ui
+++ b/src/gui/configurationtab.ui
@@ -697,7 +697,7 @@
     </widget>
    </item>
    <item>
-    <widget class="ConfigurationWidget" name="ViewerWidget" native="true">
+    <widget class="ConfigurationViewerWidget" name="ViewerWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>1</horstretch>
@@ -715,9 +715,9 @@
    <header>gui/widgets/exponentialspin.hui</header>
   </customwidget>
   <customwidget>
-   <class>ConfigurationWidget</class>
+   <class>ConfigurationViewerWidget</class>
    <extends>QWidget</extends>
-   <header>gui/configurationwidget.h</header>
+   <header>gui/configurationviewerwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/gui/configurationviewerwidget.h
+++ b/src/gui/configurationviewerwidget.h
@@ -3,24 +3,24 @@
 
 #pragma once
 
-#include "gui/ui_configurationwidget.h"
+#include "gui/ui_configurationviewerwidget.h"
 
 // Configuration Widget
-class ConfigurationWidget : public QWidget
+class ConfigurationViewerWidget : public QWidget
 {
     // All Qt declarations must include this macro
     Q_OBJECT
 
     public:
-    ConfigurationWidget(QWidget *parent = 0);
-    ~ConfigurationWidget();
+    ConfigurationViewerWidget(QWidget *parent = 0);
+    ~ConfigurationViewerWidget();
 
     /*
      * UI
      */
     private:
     // Main form declaration
-    Ui::ConfigurationWidget ui_;
+    Ui::ConfigurationViewerWidget ui_;
 
     private slots:
     // Notify that the style of displayed data in the underlying viewer has changed

--- a/src/gui/configurationviewerwidget.ui
+++ b/src/gui/configurationviewerwidget.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ConfigurationWidget</class>
- <widget class="QWidget" name="ConfigurationWidget">
+ <class>ConfigurationViewerWidget</class>
+ <widget class="QWidget" name="ConfigurationViewerWidget">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/gui/configurationviewerwidget_funcs.cpp
+++ b/src/gui/configurationviewerwidget_funcs.cpp
@@ -4,12 +4,12 @@
 #include "classes/configuration.h"
 #include "classes/coredata.h"
 #include "classes/empiricalformula.h"
-#include "gui/configurationwidget.h"
+#include "gui/configurationviewerwidget.h"
 #include "gui/widgets/elementselector.hui"
 #include "main/dissolve.h"
 #include <QButtonGroup>
 
-ConfigurationWidget::ConfigurationWidget(QWidget *parent) : QWidget(parent)
+ConfigurationViewerWidget::ConfigurationViewerWidget(QWidget *parent) : QWidget(parent)
 {
     // Set up our UI
     ui_.setupUi(this);
@@ -19,23 +19,23 @@ ConfigurationWidget::ConfigurationWidget(QWidget *parent) : QWidget(parent)
     connect(ui_.ConfigurationView, SIGNAL(styleModified()), this, SLOT(notifyStyleModified()));
 }
 
-ConfigurationWidget::~ConfigurationWidget() {}
+ConfigurationViewerWidget::~ConfigurationViewerWidget() {}
 
 /*
  * UI
  */
 
 // Notify that the style of displayed data in the underlying viewer has changed
-void ConfigurationWidget::notifyStyleModified() { emit(styleModified()); }
+void ConfigurationViewerWidget::notifyStyleModified() { emit(styleModified()); }
 
 // Notify that the displayed data in the underlying viewer has changed
-void ConfigurationWidget::notifyDataModified() { emit(dataModified()); }
+void ConfigurationViewerWidget::notifyDataModified() { emit(dataModified()); }
 
 // Post redisplay in the underlying view
-void ConfigurationWidget::postRedisplay() { ui_.ConfigurationView->postRedisplay(); }
+void ConfigurationViewerWidget::postRedisplay() { ui_.ConfigurationView->postRedisplay(); }
 
 // Update toolbar to reflect current viewer state
-void ConfigurationWidget::updateToolbar()
+void ConfigurationViewerWidget::updateToolbar()
 {
     // Set current interaction mode
     switch (configurationViewer()->interactionMode())
@@ -57,7 +57,7 @@ void ConfigurationWidget::updateToolbar()
  */
 
 // Set target Configuration, updating widget as necessary
-void ConfigurationWidget::setConfiguration(Configuration *cfg)
+void ConfigurationViewerWidget::setConfiguration(Configuration *cfg)
 {
     ui_.ConfigurationView->setConfiguration(cfg);
 
@@ -72,13 +72,13 @@ void ConfigurationWidget::setConfiguration(Configuration *cfg)
 }
 
 // Return contained ConfigurationViewer
-ConfigurationViewer *ConfigurationWidget::configurationViewer() { return ui_.ConfigurationView; }
+ConfigurationViewer *ConfigurationViewerWidget::configurationViewer() { return ui_.ConfigurationView; }
 
 /*
  * Toolbar
  */
 
-void ConfigurationWidget::on_ViewResetButton_clicked(bool checked)
+void ConfigurationViewerWidget::on_ViewResetButton_clicked(bool checked)
 {
     configurationViewer()->view().showAllData();
     configurationViewer()->view().resetViewMatrix();
@@ -86,7 +86,7 @@ void ConfigurationWidget::on_ViewResetButton_clicked(bool checked)
     configurationViewer()->postRedisplay();
 }
 
-void ConfigurationWidget::on_ViewSpheresButton_clicked(bool checked)
+void ConfigurationViewerWidget::on_ViewSpheresButton_clicked(bool checked)
 {
     configurationViewer()->setRenderableDrawStyle(checked ? RenderableConfiguration::SpheresStyle
                                                           : RenderableConfiguration::LinesStyle);
@@ -96,14 +96,14 @@ void ConfigurationWidget::on_ViewSpheresButton_clicked(bool checked)
     configurationViewer()->postRedisplay();
 }
 
-void ConfigurationWidget::on_ViewAxesVisibleButton_clicked(bool checked)
+void ConfigurationViewerWidget::on_ViewAxesVisibleButton_clicked(bool checked)
 {
     configurationViewer()->setAxesVisible(checked);
 
     configurationViewer()->postRedisplay();
 }
 
-void ConfigurationWidget::on_ViewCopyToClipboardButton_clicked(bool checked)
+void ConfigurationViewerWidget::on_ViewCopyToClipboardButton_clicked(bool checked)
 {
     configurationViewer()->copyViewToClipboard(checked);
 }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -6,6 +6,7 @@
 #include "classes/referencepoint.h"
 #include "gui/maintab.h"
 #include "gui/outputhandler.hui"
+#include "gui/signals.h"
 #include "gui/thread.hui"
 #include "gui/ui_gui.h"
 
@@ -52,14 +53,20 @@ class DissolveWindow : public QMainWindow
     // Prepare the simulation and run for a set count
     void setupIteration(int count);
 
-    public slots:
-    // Flag that data has been modified via the GUI
-    void setModified();
-
     public:
     // Return reference to Dissolve
     Dissolve &dissolve();
     const Dissolve &dissolve() const;
+
+    /*
+     * Data Mutation Signalling
+     */
+    public slots:
+    // Flag that data has been modified via the GUI
+    void setModified(Flags<DissolveSignals::DataMutations> dataMutationFlags = {});
+
+    signals:
+    void dataMutated(int);
 
     /*
      * StatusBar

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -97,18 +97,26 @@ void DissolveWindow::resizeEvent(QResizeEvent *event) {}
  * Dissolve Integration
  */
 
-// Flag that data has been modified via the GUI
-void DissolveWindow::setModified()
-{
-    modified_ = true;
-
-    updateWindowTitle();
-}
-
 // Return reference to Dissolve
 Dissolve &DissolveWindow::dissolve() { return dissolve_; }
 
 const Dissolve &DissolveWindow::dissolve() const { return dissolve_; }
+
+/*
+ * Data Mutation Signalling
+ */
+
+// Flag that data has been modified via the GUI
+void DissolveWindow::setModified(Flags<DissolveSignals::DataMutations> dataMutationFlags)
+{
+    modified_ = true;
+
+    // Signal if any data was modified
+    if (dataMutationFlags.anySet())
+        emit(dataMutated(dataMutationFlags));
+
+    updateWindowTitle();
+}
 
 /*
  * Statusbar

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -99,7 +99,7 @@ void DissolveWindow::closeTab(QWidget *page)
         auto *cfg = dynamic_cast<ConfigurationTab *>(tab)->configuration();
         ui_.MainTabs->removeByPage(page);
         dissolve_.removeConfiguration(cfg);
-        setModified();
+        setModified({DissolveSignals::ConfigurationsMutated});
     }
     else if (tab->type() == MainTab::TabType::Layer)
     {

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -99,22 +99,25 @@ void DissolveWindow::closeTab(QWidget *page)
         auto *cfg = dynamic_cast<ConfigurationTab *>(tab)->configuration();
         ui_.MainTabs->removeByPage(page);
         dissolve_.removeConfiguration(cfg);
+        setModified();
     }
     else if (tab->type() == MainTab::TabType::Layer)
     {
-        auto *layer = dynamic_cast<LayerTab *>(tab)->moduleLayer();
+        auto *layerTab = dynamic_cast<LayerTab *>(tab);
+        layerTab->removeModuleControlWidgets();
         ui_.MainTabs->removeByPage(page);
-        dissolve_.removeProcessingLayer(layer);
+        dissolve_.removeProcessingLayer(layerTab->moduleLayer());
+        setModified({DissolveSignals::ModulesMutated});
     }
     else if (tab->type() == MainTab::TabType::Species)
     {
         auto *sp = dynamic_cast<SpeciesTab *>(tab)->species();
         ui_.MainTabs->removeByPage(page);
         dissolve_.removeSpecies(sp);
+        setModified();
     }
     else
         return;
 
-    setModified();
     fullUpdate();
 }

--- a/src/gui/importcifdialog.ui
+++ b/src/gui/importcifdialog.ui
@@ -648,7 +648,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="ConfigurationWidget" name="StructureViewer" native="true">
+           <widget class="ConfigurationViewerWidget" name="StructureViewer" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>1</horstretch>
@@ -1318,7 +1318,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="ConfigurationWidget" name="SupercellViewer" native="true">
+           <widget class="ConfigurationViewerWidget" name="SupercellViewer" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>1</horstretch>
@@ -1578,7 +1578,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="ConfigurationWidget" name="PartitioningViewer" native="true">
+           <widget class="ConfigurationViewerWidget" name="PartitioningViewer" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>1</horstretch>
@@ -1601,9 +1601,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>ConfigurationWidget</class>
+   <class>ConfigurationViewerWidget</class>
    <extends>QWidget</extends>
-   <header>gui/configurationwidget.h</header>
+   <header>gui/configurationviewerwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/gui/keywordwidgets/CMakeLists.txt
+++ b/src/gui/keywordwidgets/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Meta-Objects
 set(keywordwidgets_MOC_HDRS
     atomtypevector.h
+    configuration.h
     configurationvector.h
     dialog.h
     dropdown.h
@@ -26,7 +27,6 @@ set(keywordwidgets_MOC_HDRS
     vec3integer.h
     vec3nodevalue.h
     bool.hui
-    configuration.hui
     double.hui
     dropwidget.hui
     enumoptions.hui
@@ -41,6 +41,7 @@ qt6_wrap_cpp(keywordwidgets_MOC_SRCS ${keywordwidgets_MOC_HDRS})
 # User Interface Files
 set(keywordwidgets_UIS
     atomtypevector.ui
+    configuration.ui
     configurationvector.ui
     dialog.ui
     dropdown.ui

--- a/src/gui/keywordwidgets/atomtypevector.h
+++ b/src/gui/keywordwidgets/atomtypevector.h
@@ -51,7 +51,7 @@ class AtomTypeVectorKeywordWidget : public KeywordDropDown, public KeywordWidget
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -45,7 +45,10 @@ void AtomTypeVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, c
  */
 
 // Update value displayed in widget
-void AtomTypeVectorKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void AtomTypeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void AtomTypeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/base.h
+++ b/src/gui/keywordwidgets/base.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include "gui/signals.h"
+#include "templates/flags.h"
+
 // Forward Declarations
 class CoreData;
 class GenericList;
@@ -29,5 +32,5 @@ class KeywordWidgetBase
 
     public:
     // Update value displayed in widget
-    virtual void updateValue() = 0;
+    virtual void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags = {}) = 0;
 };

--- a/src/gui/keywordwidgets/bool.hui
+++ b/src/gui/keywordwidgets/bool.hui
@@ -38,5 +38,5 @@ class BoolKeywordWidget : public QCheckBox, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/bool_funcs.cpp
+++ b/src/gui/keywordwidgets/bool_funcs.cpp
@@ -33,7 +33,7 @@ void BoolKeywordWidget::checkBoxClicked(bool checked)
  */
 
 // Update value displayed in widget
-void BoolKeywordWidget::updateValue()
+void BoolKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/configuration.h
+++ b/src/gui/keywordwidgets/configuration.h
@@ -4,13 +4,12 @@
 #pragma once
 
 #include "gui/keywordwidgets/base.h"
+#include "gui/keywordwidgets/ui_configuration.h"
+#include "gui/models/configurationModel.h"
 #include "keywords/configuration.h"
-#include <QComboBox>
+#include <QWidget>
 
-// Forward Declarations
-class Configuration;
-
-class ConfigurationKeywordWidget : public QComboBox, public KeywordWidgetBase
+class ConfigurationKeywordWidget : public QWidget, public KeywordWidgetBase
 {
     // All Qt declarations must include this macro
     Q_OBJECT
@@ -26,11 +25,17 @@ class ConfigurationKeywordWidget : public QComboBox, public KeywordWidgetBase
     ConfigurationKeyword *keyword_;
 
     /*
-     * Signals / Slots
+     * Widgets
      */
+    private:
+    // Main form declaration
+    Ui::ConfigurationWidget ui_;
+    // Model for combo box
+    ConfigurationModel configurationModel_;
+
     private slots:
-    // Combo box item changed
-    void comboIndexChanged(int index);
+    // Value changed
+    void on_ConfigurationCombo_currentIndexChanged(int index);
 
     signals:
     // Keyword data changed
@@ -39,6 +44,10 @@ class ConfigurationKeywordWidget : public QComboBox, public KeywordWidgetBase
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/configuration.hui
+++ b/src/gui/keywordwidgets/configuration.hui
@@ -41,5 +41,5 @@ class ConfigurationKeywordWidget : public QComboBox, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/configuration.ui
+++ b/src/gui/keywordwidgets/configuration.ui
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigurationWidget</class>
+ <widget class="QWidget" name="ConfigurationWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>207</width>
+    <height>29</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="font">
+   <font>
+    <pointsize>10</pointsize>
+   </font>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QComboBox" name="ConfigurationCombo">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../main.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/src/gui/keywordwidgets/configuration_funcs.cpp
+++ b/src/gui/keywordwidgets/configuration_funcs.cpp
@@ -1,34 +1,41 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Team Dissolve and contributors
 
-#include "classes/configuration.h"
 #include "classes/coredata.h"
-#include "gui/helpers/comboboxupdater.h"
 #include "gui/helpers/mousewheeladjustmentguard.h"
-#include "gui/keywordwidgets/configuration.hui"
+#include "gui/keywordwidgets/configuration.h"
 
 ConfigurationKeywordWidget::ConfigurationKeywordWidget(QWidget *parent, ConfigurationKeyword *keyword, const CoreData &coreData)
-    : QComboBox(parent), KeywordWidgetBase(coreData), keyword_(keyword)
+    : QWidget(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(comboIndexChanged(int)));
+    // Setup our UI
+    ui_.setupUi(this);
+
+    refreshing_ = false;
+
+    ui_.ConfigurationCombo->setModel(&configurationModel_);
+    resetModelData();
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)
-    installEventFilter(new MouseWheelWidgetAdjustmentGuard(this));
+    ui_.ConfigurationCombo->installEventFilter(new MouseWheelWidgetAdjustmentGuard(ui_.ConfigurationCombo));
 }
 
 /*
- * Signals / Slots
+ * Widgets
  */
 
-// Combo box item changed
-void ConfigurationKeywordWidget::comboIndexChanged(int index)
+// Value changed
+void ConfigurationKeywordWidget::on_ConfigurationCombo_currentIndexChanged(int index)
 {
     if (refreshing_)
         return;
 
-    Configuration *sp = (index == -1 ? nullptr : VariantPointer<Configuration>(itemData(index, Qt::UserRole)));
-    keyword_->data() = sp;
+    // Get data from the selected item
+    if (index == -1)
+        keyword_->data() = nullptr;
+    else
+        keyword_->data() = ui_.ConfigurationCombo->currentData(Qt::UserRole).value<Configuration *>();
 
     emit(keywordDataChanged(keyword_->editSignals()));
 }
@@ -37,13 +44,25 @@ void ConfigurationKeywordWidget::comboIndexChanged(int index)
  * Update
  */
 
-// Update value displayed in widget
-void ConfigurationKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+// Reset model data
+void ConfigurationKeywordWidget::resetModelData()
 {
     refreshing_ = true;
 
-    // Update the QComboBox against the global Configuration list
-    ComboBoxUpdater<Configuration> comboUpdater(this, coreData_.configurations(), keyword_->data());
+    configurationModel_.setData(coreData_.configurations());
+
+    // Set current index based on keyword data
+    auto it = std::find_if(coreData_.configurations().begin(), coreData_.configurations().end(),
+                           [&](const auto &cfg) { return cfg.get() == keyword_->data(); });
+    ui_.ConfigurationCombo->setCurrentIndex(it == coreData_.configurations().end() ? -1
+                                                                                   : it - coreData_.configurations().begin());
 
     refreshing_ = false;
+}
+
+// Update value displayed in widget
+void ConfigurationKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    if (mutationFlags.isSet(DissolveSignals::ConfigurationsMutated))
+        resetModelData();
 }

--- a/src/gui/keywordwidgets/configuration_funcs.cpp
+++ b/src/gui/keywordwidgets/configuration_funcs.cpp
@@ -10,10 +10,6 @@
 ConfigurationKeywordWidget::ConfigurationKeywordWidget(QWidget *parent, ConfigurationKeyword *keyword, const CoreData &coreData)
     : QComboBox(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
-    // Set current information
-    updateValue();
-
-    // Connect the
     connect(this, SIGNAL(currentIndexChanged(int)), this, SLOT(comboIndexChanged(int)));
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
@@ -42,7 +38,7 @@ void ConfigurationKeywordWidget::comboIndexChanged(int index)
  */
 
 // Update value displayed in widget
-void ConfigurationKeywordWidget::updateValue()
+void ConfigurationKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/configurationvector.h
+++ b/src/gui/keywordwidgets/configurationvector.h
@@ -49,7 +49,7 @@ class ConfigurationVectorKeywordWidget : public KeywordDropDown, public KeywordW
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/configurationvector_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationvector_funcs.cpp
@@ -44,7 +44,10 @@ void ConfigurationVectorKeywordWidget::modelDataChanged(const QModelIndex &topLe
  */
 
 // Update value displayed in widget
-void ConfigurationVectorKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void ConfigurationVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void ConfigurationVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/double.hui
+++ b/src/gui/keywordwidgets/double.hui
@@ -38,5 +38,5 @@ class DoubleKeywordWidget : public ExponentialSpin, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/double_funcs.cpp
+++ b/src/gui/keywordwidgets/double_funcs.cpp
@@ -43,7 +43,7 @@ void DoubleKeywordWidget::spinBoxValueChanged(double newValue)
  */
 
 // Update value displayed in widget
-void DoubleKeywordWidget::updateValue()
+void DoubleKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/enumoptions.hui
+++ b/src/gui/keywordwidgets/enumoptions.hui
@@ -38,5 +38,5 @@ class EnumOptionsKeywordWidget : public QComboBox, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/enumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/enumoptions_funcs.cpp
@@ -52,7 +52,7 @@ void EnumOptionsKeywordWidget::comboBoxIndexChanged(int index)
  */
 
 // Update value displayed in widget
-void EnumOptionsKeywordWidget::updateValue()
+void EnumOptionsKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/expressionvariablevector.h
+++ b/src/gui/keywordwidgets/expressionvariablevector.h
@@ -47,5 +47,5 @@ class ExpressionVariableVectorKeywordWidget : public QWidget, public KeywordWidg
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
+++ b/src/gui/keywordwidgets/expressionvariablevector_funcs.cpp
@@ -40,4 +40,4 @@ void ExpressionVariableVectorKeywordWidget::modelDataChanged(const QModelIndex &
 }
 
 // Update value displayed in widget
-void ExpressionVariableVectorKeywordWidget::updateValue() {}
+void ExpressionVariableVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}

--- a/src/gui/keywordwidgets/fileandformat.h
+++ b/src/gui/keywordwidgets/fileandformat.h
@@ -53,7 +53,7 @@ class FileAndFormatKeywordWidget : public QWidget, public KeywordWidgetBase
 
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData);
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/fileandformat_funcs.cpp
+++ b/src/gui/keywordwidgets/fileandformat_funcs.cpp
@@ -134,7 +134,10 @@ void FileAndFormatKeywordWidget::checkFileValidity()
 }
 
 // Update value displayed in widget
-void FileAndFormatKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void FileAndFormatKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void FileAndFormatKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/function1d.h
+++ b/src/gui/keywordwidgets/function1d.h
@@ -48,7 +48,7 @@ class Function1DKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/function1d_funcs.cpp
+++ b/src/gui/keywordwidgets/function1d_funcs.cpp
@@ -87,7 +87,10 @@ void Function1DKeywordWidget::parameterSpin_valueChanged(double value)
  */
 
 // Update value displayed in widget
-void Function1DKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void Function1DKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void Function1DKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/integer.hui
+++ b/src/gui/keywordwidgets/integer.hui
@@ -38,5 +38,5 @@ class IntegerKeywordWidget : public QSpinBox, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/integer_funcs.cpp
+++ b/src/gui/keywordwidgets/integer_funcs.cpp
@@ -42,7 +42,7 @@ void IntegerKeywordWidget::spinBoxValueChanged(int newValue)
  */
 
 // Update value displayed in widget
-void IntegerKeywordWidget::updateValue()
+void IntegerKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/isotopologueset.h
+++ b/src/gui/keywordwidgets/isotopologueset.h
@@ -54,7 +54,7 @@ class IsotopologueSetKeywordWidget : public KeywordDropDown, public KeywordWidge
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -114,7 +114,10 @@ void IsotopologueSetKeywordWidget::currentItemChanged()
  */
 
 // Update value displayed in widget
-void IsotopologueSetKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void IsotopologueSetKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void IsotopologueSetKeywordWidget::updateWidgetValues(const CoreData &coreData) {}

--- a/src/gui/keywordwidgets/module.h
+++ b/src/gui/keywordwidgets/module.h
@@ -48,5 +48,5 @@ class ModuleKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/module.h
+++ b/src/gui/keywordwidgets/module.h
@@ -46,6 +46,10 @@ class ModuleKeywordWidget : public QWidget, public KeywordWidgetBase
     /*
      * Update
      */
+    private:
+    // Check / update allowed modules and displayed data
+    void updateAllowedModules();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/module_funcs.cpp
+++ b/src/gui/keywordwidgets/module_funcs.cpp
@@ -10,18 +10,14 @@ ModuleKeywordWidget::ModuleKeywordWidget(QWidget *parent, ModuleKeywordBase *key
     // Setup our UI
     ui_.setupUi(this);
 
-    refreshing_ = true;
-    allowedModules_ = Module::allOfType(keyword->moduleType());
-    moduleModel_.setData(allowedModules_);
+    refreshing_ = false;
+
     ui_.ModuleCombo->setModel(&moduleModel_);
-    auto it = std::find(allowedModules_.begin(), allowedModules_.end(), keyword->module());
-    ui_.ModuleCombo->setCurrentIndex(it == allowedModules_.end() ? -1 : it - allowedModules_.begin());
+    updateAllowedModules();
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)
     ui_.ModuleCombo->installEventFilter(new MouseWheelWidgetAdjustmentGuard(ui_.ModuleCombo));
-
-    refreshing_ = false;
 }
 
 /*
@@ -47,5 +43,25 @@ void ModuleKeywordWidget::on_ModuleCombo_currentIndexChanged(int index)
  * Update
  */
 
+// Check / update allowed modules and displayed data
+void ModuleKeywordWidget::updateAllowedModules()
+{
+    refreshing_ = true;
+
+    // Update allowed modules
+    allowedModules_ = Module::allOfType(keyword_->moduleType());
+    moduleModel_.setData(allowedModules_);
+
+    // Set current index based on keyword data
+    auto it = std::find(allowedModules_.begin(), allowedModules_.end(), keyword_->module());
+    ui_.ModuleCombo->setCurrentIndex(it == allowedModules_.end() ? -1 : it - allowedModules_.begin());
+
+    refreshing_ = false;
+}
+
 // Update value displayed in widget
-void ModuleKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}
+void ModuleKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    if (mutationFlags.isSet(DissolveSignals::ModulesMutated))
+        updateAllowedModules();
+}

--- a/src/gui/keywordwidgets/module_funcs.cpp
+++ b/src/gui/keywordwidgets/module_funcs.cpp
@@ -48,4 +48,4 @@ void ModuleKeywordWidget::on_ModuleCombo_currentIndexChanged(int index)
  */
 
 // Update value displayed in widget
-void ModuleKeywordWidget::updateValue() {}
+void ModuleKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -49,6 +49,10 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
     /*
      * Update
      */
+    private:
+    // Check / update allowed modules and displayed data
+    void updateAllowedModules();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -51,7 +51,7 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -17,10 +17,9 @@ ModuleVectorKeywordWidget::ModuleVectorKeywordWidget(QWidget *parent, ModuleVect
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
 
-    allowedModules_ = Module::allOfType(keyword->moduleTypes());
-    moduleModel_.setData(allowedModules_);
     moduleModel_.setCheckStateData(keyword_->data());
     ui_.ModuleList->setModel(&moduleModel_);
+    updateAllowedModules();
 
     // Connect signals / slots
     connect(&moduleModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
@@ -48,10 +47,26 @@ void ModuleVectorKeywordWidget::modelDataChanged(const QModelIndex &, const QMod
  * Update
  */
 
+// Check / update allowed modules and displayed data
+void ModuleVectorKeywordWidget::updateAllowedModules()
+{
+    refreshing_ = true;
+
+    // Update allowed modules
+    allowedModules_ = Module::allOfType(keyword_->moduleTypes());
+    moduleModel_.setData(allowedModules_);
+
+    refreshing_ = false;
+}
+
 // Update value displayed in widget
 void ModuleVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    if (mutationFlags.isSet(DissolveSignals::ModulesMutated))
+    {
+        updateAllowedModules();
+        updateSummaryText();
+    }
 }
 
 // Update widget values data based on keyword data

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -49,7 +49,10 @@ void ModuleVectorKeywordWidget::modelDataChanged(const QModelIndex &, const QMod
  */
 
 // Update value displayed in widget
-void ModuleVectorKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void ModuleVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void ModuleVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) {}

--- a/src/gui/keywordwidgets/node.h
+++ b/src/gui/keywordwidgets/node.h
@@ -47,5 +47,5 @@ class NodeKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/node_funcs.cpp
+++ b/src/gui/keywordwidgets/node_funcs.cpp
@@ -51,4 +51,4 @@ void NodeKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const QMode
  */
 
 // Update value displayed in widget
-void NodeKeywordWidget::updateValue() {}
+void NodeKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}

--- a/src/gui/keywordwidgets/nodeandinteger.h
+++ b/src/gui/keywordwidgets/nodeandinteger.h
@@ -48,5 +48,5 @@ class NodeAndIntegerKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
+++ b/src/gui/keywordwidgets/nodeandinteger_funcs.cpp
@@ -63,4 +63,4 @@ void NodeAndIntegerKeywordWidget::modelDataChanged(const QModelIndex &topLeft, c
  */
 
 // Update value displayed in widget
-void NodeAndIntegerKeywordWidget::updateValue() {}
+void NodeAndIntegerKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}

--- a/src/gui/keywordwidgets/nodevalue.h
+++ b/src/gui/keywordwidgets/nodevalue.h
@@ -48,5 +48,5 @@ class NodeValueKeywordWidget : public QWidget, public KeywordWidgetBase
 
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalue_funcs.cpp
@@ -52,7 +52,7 @@ void NodeValueKeywordWidget::on_ValueEdit_returnPressed()
 void NodeValueKeywordWidget::checkValueValidity() { ui_.ValueValidIndicator->setOK(keyword_->data().isValid()); }
 
 // Update value displayed in widget
-void NodeValueKeywordWidget::updateValue()
+void NodeValueKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/nodevalueenumoptions.h
+++ b/src/gui/keywordwidgets/nodevalueenumoptions.h
@@ -45,5 +45,5 @@ class NodeValueEnumOptionsKeywordWidget : public QWidget, public KeywordWidgetBa
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
@@ -28,9 +28,6 @@ NodeValueEnumOptionsKeywordWidget::NodeValueEnumOptionsKeywordWidget(QWidget *pa
     // will exist in a QScrollArea)
     ui_.OptionsCombo->installEventFilter(new MouseWheelWidgetAdjustmentGuard(ui_.OptionsCombo));
 
-    // Update values
-    updateValue();
-
     refreshing_ = false;
 }
 
@@ -75,7 +72,7 @@ void NodeValueEnumOptionsKeywordWidget::on_OptionsCombo_currentIndexChanged(int 
  */
 
 // Update value displayed in widget
-void NodeValueEnumOptionsKeywordWidget::updateValue()
+void NodeValueEnumOptionsKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/nodevector.h
+++ b/src/gui/keywordwidgets/nodevector.h
@@ -48,7 +48,7 @@ class NodeVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/nodevector_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevector_funcs.cpp
@@ -48,7 +48,10 @@ void NodeVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const
  */
 
 // Update value displayed in widget
-void NodeVectorKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void NodeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void NodeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/optionaldouble.hui
+++ b/src/gui/keywordwidgets/optionaldouble.hui
@@ -40,5 +40,5 @@ class OptionalDoubleKeywordWidget : public ExponentialSpin, public KeywordWidget
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/optionaldouble_funcs.cpp
+++ b/src/gui/keywordwidgets/optionaldouble_funcs.cpp
@@ -58,7 +58,7 @@ void OptionalDoubleKeywordWidget::spinBoxValueNullified()
  */
 
 // Update value displayed in widget
-void OptionalDoubleKeywordWidget::updateValue()
+void OptionalDoubleKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/optionalint.hui
+++ b/src/gui/keywordwidgets/optionalint.hui
@@ -40,5 +40,5 @@ class OptionalIntegerKeywordWidget : public ExponentialSpin, public KeywordWidge
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/optionalint_funcs.cpp
+++ b/src/gui/keywordwidgets/optionalint_funcs.cpp
@@ -59,7 +59,7 @@ void OptionalIntegerKeywordWidget::spinBoxValueNullified()
  */
 
 // Update value displayed in widget
-void OptionalIntegerKeywordWidget::updateValue()
+void OptionalIntegerKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/producers.cpp
+++ b/src/gui/keywordwidgets/producers.cpp
@@ -5,7 +5,7 @@
 #include "gui/keywordwidgets/atomtypevector.h"
 #include "gui/keywordwidgets/base.h"
 #include "gui/keywordwidgets/bool.hui"
-#include "gui/keywordwidgets/configuration.hui"
+#include "gui/keywordwidgets/configuration.h"
 #include "gui/keywordwidgets/configurationvector.h"
 #include "gui/keywordwidgets/double.hui"
 #include "gui/keywordwidgets/dropwidget.hui"

--- a/src/gui/keywordwidgets/range.h
+++ b/src/gui/keywordwidgets/range.h
@@ -43,5 +43,5 @@ class RangeKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/range_funcs.cpp
+++ b/src/gui/keywordwidgets/range_funcs.cpp
@@ -60,7 +60,7 @@ void RangeKeywordWidget::on_Spin2_valueChanged(double value)
  */
 
 // Update value displayed in widget
-void RangeKeywordWidget::updateValue()
+void RangeKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/species.h
+++ b/src/gui/keywordwidgets/species.h
@@ -46,5 +46,5 @@ class SpeciesKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/species_funcs.cpp
+++ b/src/gui/keywordwidgets/species_funcs.cpp
@@ -49,4 +49,4 @@ void SpeciesKeywordWidget::on_SpeciesCombo_currentIndexChanged(int index)
  */
 
 // Update value displayed in widget
-void SpeciesKeywordWidget::updateValue() {}
+void SpeciesKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}

--- a/src/gui/keywordwidgets/speciessite.h
+++ b/src/gui/keywordwidgets/speciessite.h
@@ -46,7 +46,7 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -51,7 +51,10 @@ void SpeciesSiteKeywordWidget::siteRadioButton_clicked(bool checked)
  */
 
 // Update value displayed in widget
-void SpeciesSiteKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void SpeciesSiteKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void SpeciesSiteKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/speciessitevector.h
+++ b/src/gui/keywordwidgets/speciessitevector.h
@@ -53,7 +53,7 @@ class SpeciesSiteVectorKeywordWidget : public KeywordDropDown, public KeywordWid
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -45,7 +45,10 @@ void SpeciesSiteVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft
  */
 
 // Update value displayed in widget
-void SpeciesSiteVectorKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void SpeciesSiteVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void SpeciesSiteVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/speciesvector.h
+++ b/src/gui/keywordwidgets/speciesvector.h
@@ -49,7 +49,7 @@ class SpeciesVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetB
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values

--- a/src/gui/keywordwidgets/speciesvector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesvector_funcs.cpp
@@ -42,7 +42,10 @@ void SpeciesVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, co
  */
 
 // Update value displayed in widget
-void SpeciesVectorKeywordWidget::updateValue() { updateWidgetValues(coreData_); }
+void SpeciesVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
+{
+    updateWidgetValues(coreData_);
+}
 
 // Update widget values data based on keyword data
 void SpeciesVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)

--- a/src/gui/keywordwidgets/stdstring.hui
+++ b/src/gui/keywordwidgets/stdstring.hui
@@ -38,5 +38,5 @@ class StringKeywordWidget : public QLineEdit, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/stdstring_funcs.cpp
+++ b/src/gui/keywordwidgets/stdstring_funcs.cpp
@@ -32,7 +32,7 @@ void StringKeywordWidget::lineEditTextChanged(const QString &text)
  */
 
 // Update value displayed in widget
-void StringKeywordWidget::updateValue()
+void StringKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/vec3double.h
+++ b/src/gui/keywordwidgets/vec3double.h
@@ -44,5 +44,5 @@ class Vec3DoubleKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/vec3double_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3double_funcs.cpp
@@ -94,7 +94,7 @@ void Vec3DoubleKeywordWidget::on_Spin3_valueChanged(double value)
  */
 
 // Update value displayed in widget
-void Vec3DoubleKeywordWidget::updateValue()
+void Vec3DoubleKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/vec3integer.h
+++ b/src/gui/keywordwidgets/vec3integer.h
@@ -45,5 +45,5 @@ class Vec3IntegerKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/vec3integer_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3integer_funcs.cpp
@@ -87,7 +87,7 @@ void Vec3IntegerKeywordWidget::on_Spin3_valueChanged(int value)
  */
 
 // Update value displayed in widget
-void Vec3IntegerKeywordWidget::updateValue()
+void Vec3IntegerKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/vec3nodevalue.h
+++ b/src/gui/keywordwidgets/vec3nodevalue.h
@@ -48,5 +48,5 @@ class Vec3NodeValueKeywordWidget : public QWidget, public KeywordWidgetBase
      */
     public:
     // Update value displayed in widget
-    void updateValue() override;
+    void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
@@ -12,8 +12,6 @@ Vec3NodeValueKeywordWidget::Vec3NodeValueKeywordWidget(QWidget *parent, Vec3Node
 
     refreshing_ = true;
 
-    updateValue();
-
     // Set appropriate labels
     Vec3WidgetLabels::set(ui_.ValueALabel, keyword_->labelType(), 0);
     Vec3WidgetLabels::set(ui_.ValueBLabel, keyword_->labelType(), 1);
@@ -97,7 +95,7 @@ void Vec3NodeValueKeywordWidget::on_ValueCEdit_returnPressed()
  */
 
 // Update value displayed in widget
-void Vec3NodeValueKeywordWidget::updateValue()
+void Vec3NodeValueKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 

--- a/src/gui/keywordwidgets/widget.hui
+++ b/src/gui/keywordwidgets/widget.hui
@@ -31,8 +31,10 @@ class KeywordsWidget : public QToolBox
     public:
     // Set up controls for specified keywords
     void setUp(const KeywordStore &keywords, const CoreData &coreData);
+
+    public slots:
     // Update controls within widget
-    void updateControls();
+    void updateControls(int dataMutationFlags = 0);
 
     /*
      * Signals / Slots

--- a/src/gui/keywordwidgets/widget_funcs.cpp
+++ b/src/gui/keywordwidgets/widget_funcs.cpp
@@ -3,6 +3,7 @@
 
 #include "gui/keywordwidgets/producers.h"
 #include "gui/keywordwidgets/widget.hui"
+#include "gui/signals.h"
 #include "main/dissolve.h"
 #include "module/module.h"
 #include <QFormLayout>
@@ -62,13 +63,15 @@ void KeywordsWidget::setUp(const KeywordStore &keywords, const CoreData &coreDat
 }
 
 // Update controls within widget
-void KeywordsWidget::updateControls()
+void KeywordsWidget::updateControls(int dataMutationFlags)
 {
     refreshing_ = true;
 
+    Flags<DissolveSignals::DataMutations> mutationFlags(dataMutationFlags);
+
     // Update all our keyword widgets
     for (auto *keywordWidget : keywordWidgets_)
-        keywordWidget->updateValue();
+        keywordWidget->updateValue(mutationFlags);
 
     refreshing_ = false;
 }

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -58,6 +58,8 @@ class LayerTab : public QWidget, public MainTab
     private:
     // Return ModuleControlWidget for the specified Module (if it exists)
     ModuleControlWidget *getControlWidget(const Module *module, bool setAsCurrent = false);
+    // Remove ModuleControlWidget for the specified Module (if it exists)
+    void removeControlWidget(const Module *module);
 
     private slots:
     void on_ShowAvailableModulesButton_clicked(bool checked);

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -72,6 +72,10 @@ class LayerTab : public QWidget, public MainTab
     void on_ModulesList_customContextMenuRequested(const QPoint &pos);
     void on_AvailableModulesTree_doubleClicked(const QModelIndex &index);
 
+    public:
+    // Remove all module control widgets
+    void removeModuleControlWidgets();
+
     /*
      * Update
      */

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -286,6 +286,18 @@ void LayerTab::on_AvailableModulesTree_doubleClicked(const QModelIndex &index)
     moduleLayerModel_.appendNew(modulePaletteModel_.data(index, Qt::DisplayRole).toString());
 }
 
+// Remove all module control widgets
+void LayerTab::removeModuleControlWidgets()
+{
+    for (auto n = 1; n < ui_.ModuleControlsStack->count(); ++n)
+    {
+        auto *w = ui_.ModuleControlsStack->widget(n);
+        ui_.ModuleControlsStack->removeWidget(w);
+        w->setParent(nullptr);
+        w->deleteLater();
+    }
+}
+
 /*
  * Update
  */

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -183,7 +183,7 @@ void LayerTab::moduleSelectionChanged(const QItemSelection &current, const QItem
 
 void LayerTab::layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)
 {
-    dissolveWindow_->setModified();
+    dissolveWindow_->setModified({DissolveSignals::ModulesMutated});
 }
 
 void LayerTab::moduleNameChanged(const QModelIndex &index, const QString &oldName, const QString &newName)
@@ -257,7 +257,7 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
     if (action == enableModule || action == disableModule || action == enableOnlyModule || action == deleteModule)
     {
         updateModuleList();
-        dissolveWindow_->setModified();
+        dissolveWindow_->setModified({DissolveSignals::ModulesMutated});
     }
     updateControls();
 }

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -109,6 +109,24 @@ ModuleControlWidget *LayerTab::getControlWidget(const Module *module, bool setAs
     return nullptr;
 }
 
+// Remove ModuleControlWidget for the specified Module (if it exists)
+void LayerTab::removeControlWidget(const Module *module)
+{
+    for (auto n = 1; n < ui_.ModuleControlsStack->count(); ++n)
+    {
+        auto *w = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
+        if (w && (w->module() == module))
+        {
+            if (ui_.ModuleControlsStack->currentIndex() == n)
+                ui_.ModuleControlsStack->setCurrentIndex((n + 1) < ui_.ModuleControlsStack->count() ? n + 1 : n - 1);
+            ui_.ModuleControlsStack->removeWidget(w);
+            w->setParent(nullptr);
+            w->deleteLater();
+            return;
+        }
+    }
+}
+
 void LayerTab::on_ShowAvailableModulesButton_clicked(bool checked)
 {
     // Toggle the visibility of the available modules tree
@@ -248,8 +266,9 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
         dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
     else if (action == deleteModule)
     {
-        // Remove the module's data, then the module
+        // Remove the module's data, the module control widget, then the module itself
         dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
+        removeControlWidget(module);
         moduleLayerModel_.removeRows(index.row(), 1, QModelIndex());
     }
 

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -169,8 +169,7 @@ void LayerTab::moduleSelectionChanged(const QItemSelection &current, const QItem
     if (!mcw)
     {
         // Create a new widget to display this Module
-        mcw = new ModuleControlWidget;
-        mcw->setModule(module, &dissolveWindow_->dissolve());
+        mcw = new ModuleControlWidget(dissolveWindow_, module);
         connect(mcw, SIGNAL(dataModified()), dissolveWindow_, SLOT(setModified()));
         connect(mcw, SIGNAL(statusChanged()), this, SLOT(updateModuleList()));
         ui_.ModuleControlsStack->setCurrentIndex(ui_.ModuleControlsStack->addWidget(mcw));

--- a/src/gui/models/moduleModel.cpp
+++ b/src/gui/models/moduleModel.cpp
@@ -3,7 +3,7 @@
 
 #include "gui/models/moduleModel.h"
 
-// Set source Species data
+// Set source Module data
 void ModuleModel::setData(const std::vector<Module *> &modules)
 {
     beginResetModel();

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -23,7 +23,7 @@ class ModuleControlWidget : public QWidget
     Q_OBJECT
 
     public:
-    ModuleControlWidget(QWidget *parent = nullptr);
+    ModuleControlWidget(DissolveWindow *dissolveWindow, Module *module);
     ~ModuleControlWidget() = default;
 
     private:
@@ -34,14 +34,12 @@ class ModuleControlWidget : public QWidget
      * Module Target
      */
     private:
-    // Pointer to Dissolve
-    Dissolve *dissolve_;
+    // Reference to Dissolve
+    Dissolve &dissolve_;
     // Associated Module
     Module *module_;
 
     public:
-    // Set target Module to display
-    void setModule(Module *module, Dissolve *dissolve);
     // Return target Module for the widget
     Module *module() const;
 

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -70,7 +70,12 @@ class ModuleControlWidget : public QWidget
     void on_ModuleOutputButton_clicked(bool checked);
     void on_EnabledButton_clicked(bool checked);
     void on_FrequencySpin_valueChanged(int value);
-    void moduleKeywordChanged(int signalMask);
+
+    public slots:
+    // Local keyword data changed
+    void localKeywordChanged(int signalMask);
+    // Global data mutated
+    void globalDataMutated(int mutationFlags);
 
     signals:
     // Notify that the Module's data has been modified in some way

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -195,6 +195,10 @@ void ModuleControlWidget::localKeywordChanged(int signalMask)
 // Global data mutated
 void ModuleControlWidget::globalDataMutated(int mutationFlags)
 {
+    // If we have no valid parent, don't try to update keyword data
+    if (!parent())
+        return;
+
     Flags<DissolveSignals::DataMutations> dataMutations(mutationFlags);
     if (!dataMutations.anySet())
         return;

--- a/src/gui/signals.h
+++ b/src/gui/signals.h
@@ -8,6 +8,7 @@ namespace DissolveSignals
 // Data Mutation Flags
 enum DataMutations
 {
+    ConfigurationsMutated,
     ModulesMutated
 };
 }; // namespace DissolveSignals

--- a/src/gui/signals.h
+++ b/src/gui/signals.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+namespace DissolveSignals
+{
+// Data Mutation Flags
+enum DataMutations
+{
+    ModulesMutated
+};
+}; // namespace DissolveSignals


### PR DESCRIPTION
This PR implements a basic framework for signalling between components in order to notify that underlying core data (e.g. `Module`s, `Configuration`s) has been mutated (e.g. renamed, deleted, created).  This allows dependent widgets, in particular keyword widgets, to react to those changes and avoid invalid pointer referencing etc.