### PR TITLE
Internal MD

### DIFF
--- a/benchmark/common/problems.h
+++ b/benchmark/common/problems.h
@@ -19,20 +19,26 @@ enum ProblemType
     atomic,
     smallMolecule,
     mediumMolecule,
+    frameworkMolecule,
 };
 
 enum Population
 {
+    single,
     small,
     medium,
-    large,
+    large
 };
 
 template <Population population> std::string getFileName(const std::string &systemName)
 {
     std::stringstream fileName;
     fileName << benchmark_path << systemName;
-    if constexpr (population == Population::small)
+    if constexpr (population == Population::single)
+    {
+        fileName << "single";
+    }
+    else if constexpr (population == Population::small)
     {
         fileName << "1k";
     }
@@ -61,6 +67,10 @@ template <ProblemType problem, Population population> std::string benchmarkFileP
     else if constexpr (problem == ProblemType::mediumMolecule)
     {
         return getFileName<population>("hexane");
+    }
+    else if constexpr (problem == ProblemType::frameworkMolecule)
+    {
+        return getFileName<population>("mof5-3x3x3");
     }
     else
         return {};

--- a/benchmark/forces/forces_benchmark.cpp
+++ b/benchmark/forces/forces_benchmark.cpp
@@ -82,7 +82,7 @@ static void BM_CalculateForces_TotalIntraMolecular(benchmark::State &state)
     auto &procPool = problemDef.dissolve_.worldPool();
     const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
     for (auto _ : state)
-        ForcesModule::intraMolecularForces(procPool, cfg, potentialMap, forces);
+        ForcesModule::internalMoleculeForces(procPool, cfg, potentialMap, true, forces);
 }
 
 template <ProblemType problem, Population population> static void BM_CalculateForces_TotalInterAtomic(benchmark::State &state)
@@ -96,7 +96,7 @@ template <ProblemType problem, Population population> static void BM_CalculateFo
     for (auto _ : state)
     {
         std::vector<Vec3<double>> forces(cfg->nAtoms());
-        ForcesModule::interAtomicForces(procPool, cfg, potentialMap, forces);
+        ForcesModule::pairPotentialForces(procPool, cfg, potentialMap, forces);
     }
 }
 

--- a/benchmark/forces/forces_benchmark.cpp
+++ b/benchmark/forces/forces_benchmark.cpp
@@ -85,6 +85,17 @@ static void BM_CalculateForces_TotalIntraMolecular(benchmark::State &state)
         ForcesModule::internalMoleculeForces(procPool, cfg, potentialMap, true, forces);
 }
 
+template <ProblemType problem, Population population> static void BM_CalculateForces_TotalSpecies(benchmark::State &state)
+{
+    Problem<problem, population> problemDef;
+    auto &sp = problemDef.dissolve_.species().front();
+    std::vector<Vec3<double>> forces(sp->nAtoms());
+    auto &procPool = problemDef.dissolve_.worldPool();
+    const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
+    for (auto _ : state)
+        ForcesModule::totalForces(procPool, sp.get(), potentialMap, forces);
+}
+
 template <ProblemType problem, Population population> static void BM_CalculateForces_TotalInterAtomic(benchmark::State &state)
 {
 
@@ -121,6 +132,7 @@ BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesBond, ProblemType::smallMolecule, P
 BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesAngle, ProblemType::smallMolecule, Population::small);
 BENCHMARK_TEMPLATE(BM_CalculateForces_TotalIntraMolecular, ProblemType::smallMolecule, Population::small)
     ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalSpecies, ProblemType::smallMolecule, Population::small);
 BENCHMARK_TEMPLATE(BM_CalculateForces_TotalInterAtomic, ProblemType::smallMolecule, Population::small)
     ->Iterations(5)
     ->Unit(benchmark::kMillisecond);
@@ -137,8 +149,12 @@ BENCHMARK_TEMPLATE(BM_CalculateForces_SpeciesTorsion, ProblemType::mediumMolecul
 BENCHMARK_TEMPLATE(BM_CalculateForces_TotalInterAtomic, ProblemType::mediumMolecule, Population::small)
     ->Iterations(5)
     ->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalSpecies, ProblemType::mediumMolecule, Population::small);
 BENCHMARK_TEMPLATE(BM_CalculateForces_TotalIntraMolecular, ProblemType::mediumMolecule, Population::small)
     ->Unit(benchmark::kMillisecond);
 BENCHMARK_TEMPLATE(BM_CalculateForces_TotalForces, ProblemType::mediumMolecule, Population::small)
     ->Iterations(5)
+    ->Unit(benchmark::kMillisecond);
+
+BENCHMARK_TEMPLATE(BM_CalculateForces_TotalSpecies, ProblemType::frameworkMolecule, Population::single)
     ->Unit(benchmark::kMillisecond);

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -20,7 +20,7 @@ ForceKernel::ForceKernel(ProcessPool &procPool, const Box *box, const CellArray 
 }
 
 /*
- * Internal Force Calculation
+ * Force Calculation
  */
 
 // Calculate PairPotential forces between Atoms provided (no minimum image calculation)
@@ -55,23 +55,6 @@ void ForceKernel::forcesWithMim(const Atom &i, const Atom &j, ForceVector &f, do
 /*
  * PairPotential Terms
  */
-
-// Calculate forces between atoms
-void ForceKernel::forces(const Atom &i, const Atom &j, bool applyMim, bool excludeIgeJ, ForceVector &f) const
-{
-    // If Atoms are the same, we refuse to calculate
-    if (&i == &j)
-        return;
-
-    // Check indices of atoms if required
-    if (excludeIgeJ && (i.arrayIndex() >= j.arrayIndex()))
-        return;
-
-    if (applyMim)
-        forcesWithMim(i, j, f);
-    else
-        forcesWithoutMim(i, j, f);
-}
 
 // Calculate forces between atoms in supplied cells
 void ForceKernel::forces(const Cell *centralCell, const Cell *otherCell, bool applyMim, bool excludeIgeJ,

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -44,20 +44,13 @@ class ForceKernel
     double cutoffDistanceSquared_;
 
     /*
-     * Internal Force Calculation
+     * PairPotential Terms
      */
-    private:
+    public:
     // Calculate inter-particle forces between Atoms provided (no minimum image calculation)
     void forcesWithoutMim(const Atom &i, const Atom &j, ForceVector &f, double scale = 1.00) const;
     // Calculate inter-particle forces between Atoms provided (minimum image calculation)
     void forcesWithMim(const Atom &i, const Atom &j, ForceVector &f, double scale = 1.00) const;
-
-    /*
-     * PairPotential Terms
-     */
-    public:
-    // Calculate forces between atoms provided
-    void forces(const Atom &i, const Atom &j, bool applyMim, bool excludeIgeJ, ForceVector &f) const;
     // Calculate forces between two cells
     void forces(const Cell *cell, const Cell *otherCell, bool applyMim, bool excludeIgeJ,
                 ProcessPool::DivisionStrategy strategy, ForceVector &f) const;

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -55,18 +55,13 @@ class ForcesModule : public Module
      * Functions
      */
     public:
-    // Calculate interatomic forces within the specified Configuration
-    static void interAtomicForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                  std::vector<Vec3<double>> &f);
-    // Calculate interatomic forces within the specified Species
-    static void interAtomicForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
-                                  std::vector<Vec3<double>> &f);
-    // Calculate total intramolecular forces in Configuration
-    static void intraMolecularForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
-                                     std::vector<Vec3<double>> &f);
-    // Calculate total intramolecular forces in Species
-    static void intraMolecularForces(ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
-                                     std::vector<Vec3<double>> &f);
+    // Calculate internal molecule forces, optionally only over the supplied molecules
+    static void internalMoleculeForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+                                       bool includePairPotentialTerms, std::vector<Vec3<double>> &f,
+                                       OptionalReferenceWrapper<std::vector<const Molecule *>> targetMolecules = std::nullopt);
+    // Calculate pair potential forces within the specified Configuration
+    static void pairPotentialForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
+                                    std::vector<Vec3<double>> &f);
     // Calculate total forces within the specified Configuration
     static void totalForces(ProcessPool &procPool, Configuration *cfg, const PotentialMap &potentialMap,
                             std::vector<Vec3<double>> &f);

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -309,7 +309,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
             Timer interTimer;
             interTimer.start();
 
-            interAtomicForces(procPool, targetConfiguration_, dissolve.potentialMap(), fInterCheck);
+            pairPotentialForces(procPool, targetConfiguration_, dissolve.potentialMap(), fInterCheck);
             if (!procPool.allSum(fInterCheck))
                 return false;
 
@@ -323,7 +323,7 @@ bool ForcesModule::process(Dissolve &dissolve, ProcessPool &procPool)
             Timer intraTimer;
             intraTimer.start();
 
-            intraMolecularForces(procPool, targetConfiguration_, dissolve.potentialMap(), fIntraCheck);
+            internalMoleculeForces(procPool, targetConfiguration_, dissolve.potentialMap(), false, fIntraCheck);
             if (!procPool.allSum(fIntraCheck))
                 return false;
 

--- a/src/modules/md/md.cpp
+++ b/src/modules/md/md.cpp
@@ -33,6 +33,10 @@ MDModule::MDModule() : Module("MD")
                                randomVelocities_);
     keywords_.add<SpeciesVectorKeyword>("Control", "RestrictToSpecies", "Restrict the calculation to the specified Species",
                                         restrictToSpecies_);
+    keywords_.add<BoolKeyword>(
+        "Control", "IntraOnly",
+        "Only forces arising from intramolecular terms (including pair potential contributions) will be calculated",
+        intramolecularForcesOnly_);
 
     // Output
     keywords_.add<IntegerKeyword>("Output", "EnergyFrequency",

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -31,6 +31,8 @@ class MDModule : public Module
     double deltaT_{1.0e-4};
     // Frequency at which to calculate total system energy (or 0 to inhibit)
     int energyFrequency_{10};
+    // Whether to restrict force calculation to intramolecular contributions only
+    bool intramolecularForcesOnly_{false};
     // Number of steps to perform
     int nSteps_{50};
     // Only run MD when target Configuration energies are stable

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -28,7 +28,7 @@ class MDModule : public Module
     // Interatomic cutoff distance to employ
     std::optional<double> cutoffDistance_;
     // Timestep (ps) to use in MD simulation
-    double deltaT_{1.0e-4};
+    double deltaT_{5.0e-4};
     // Frequency at which to calculate total system energy (or 0 to inhibit)
     int energyFrequency_{10};
     // Whether to restrict force calculation to intramolecular contributions only
@@ -46,7 +46,7 @@ class MDModule : public Module
     // Write frequency for trajectory file (or 0 to inhibit)
     int trajectoryFrequency_{0};
     // Whether a variable timestep should be used, determined from the maximal force vector
-    bool variableTimestep_{true};
+    bool variableTimestep_{false};
 
     /*
      * Functions

--- a/tests/md/benzene.txt
+++ b/tests/md/benzene.txt
@@ -162,6 +162,7 @@ Layer  'Evolve (Standard)'
     Configuration  'Bulk'
 
     OnlyWhenEnergyStable  False
+    VariableTimestep  True
     NSteps  10
   EndModule
 

--- a/web/content/docs/modules/evolution/md/_index.md
+++ b/web/content/docs/modules/evolution/md/_index.md
@@ -4,4 +4,60 @@ linkTitle: MD
 description: Run a short molecular dynamics simulation
 ---
 
-{{< todo-label >}}
+## Overview
+
+The `MD` module performs a molecular dynamics run on each supplied target configuration, and can be used to relax the intramolecular geometry of molecules and promote their "diversity".
+
+## Description
+
+### Basic Algorithm
+
+The `MD` module employs a standard two-stage velocity Verlet algorithm as follows. Initially, a set of random velocities $v^r$ is assigned to the atoms, with each vector component given a random value between {-0.5, 0.5}. These velocities are then adjusted so that no velocity shift in the system is present (i.e. the periodic box contents as a whole are not permitted to "drift") and scaled to represent the target temperature $T$:
+
+$$ v_i(0) = \left(v^r_i - \frac{\sum_i{v^r_i m_i}}{\sum_i{m_i}}\right) \sqrt{\frac{T}{ \frac{2}{3 N k_b}\sum_i{\frac{1}{2} m_i(v_i \cdot v_i)}}} $$
+
+where $m_i$ is the mass of the $i$th atom, $N$ is the number of atoms in the system, and $k_b$ is Boltzmann's constant.
+
+In the first stage of the velocity Verlet, at a given time $t$ the positions $r$ of all atoms are evolved by a full step according to the current timestep $\Delta t$:
+
+$$ r_i(t + \Delta t) = r_i(t) + v_i(t)\Delta t + \frac{1}{2}a_i(t)\Delta t^2 $$
+
+where $a_i$ is the acceleration of the $i$th atom (initially zero). The velocities are evolved by half a step as follows:
+
+$$ v_i\left(t + \frac{1}{2}\Delta t\right) = v_i(t) + \frac{1}{2}a_i(t)\Delta t $$
+
+At this point, the forces $f$ on the atoms are calculated and the new accelerations of the atoms determined...
+
+$$ a_i\left(t + \Delta t\right) = \frac{f_i(t)}{m_i} $$
+
+... and the velocities evolved by their remaining half-step using the new accelerations and re-scaled to give the desired temperature:
+
+$$ v_i\left(t + \Delta t\right) = v_i\left(t + \frac{1}{2}\Delta t\right) + \frac{1}{2} a_i(t + \Delta t) \Delta t $$
+
+$$ v_i\left(t + \Delta t, T\right) = v_i\left(t + \Delta t\right) \sqrt{\frac{T}{ \frac{2}{3 N k_b}\sum_i{\frac{1}{2} m_i\left(v_i\left(t + \Delta t, T\right) \cdot v_i\left(t + \Delta t, T\right)\right)}}} $$
+
+## Configuration
+
+### Target Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Configuration`|`Configuration ...`|--|Target configuration(s) on which to run the molecular dynamics. At least one must be provided.|
+
+### Control Keywords
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`CapForces`|`true|false`|`false`|Whether to cap forces acting on atoms to a predefined limit, preventing potential explosions when bad contacts are present in the system. The value at which to cap forces is set by the `CapForcesAt` keyword.|
+|`CapForcesAt`|`force`|`1.0e7`|Value (in 10 J/mol) at which to cap forces if `CapForces` is enabled.|
+|`CutoffDistance`|`r`|--|Interatomic cutoff distance $r$ to use for energy and force calculation. The default is to use the global pair potential cutoff defined in the simulation. If necessary, a short cutoff value can be set during early equilibration runs to significantly speed up calculation times at the expense of realism.|
+|`DeltaT`|`dt`|`1.0e-4`|Timestep to use in the simulation (if `VariableTimestep` is set to `false`).|
+|`IntraOnly`|`false`|`true`|Only calculate forces arising from internal molecule interactions (i.e. bonds, angles, torsion, impropers, and any allowed pair potential contributions) and ignore forces between molecules. This can be useful to force efficient exploration of intramolecular degrees of freedom at the expense of molecule-molecule interactions. If used, a subsequent relaxation with [`MolShake`]({{< ref "molshake" >}}) is highly recommended.|
+|`NSteps`|`n`|`50`|Number of shakes $n$ to attempt per atom|
+|`OnlyWhenEnergyStable`|`true|false`|`true`|Only run molecular dynamics on a configuration if the total energy of the configuration (as determined by an [`Energy`]({{< ref "energy" >}}) module is considered stable.|
+|`RandomVelocities`|`true|false`|`false`|Whether to always assign random velocities when starting the molecular dynamics simulation. If `false` then random velocities are only generated if no other velocities exist.|
+|`RestrictToSpecies`|`Species ...`|`--`|Restrict force calculation to only molecules of the specified species. Molecules of other species types remain at their current positions (always have zero force acting on them).|
+|`VariableTimestep`|`true|false`|`false`|Whether to utilise a variable timestep in the simulation.[1] This option can be a used to run molecular dynamics even when potentially bad atomic overlaps are present, since the timestep is determined based on the maximal force in the system. However, it can result in too-small timesteps for production runs once configurations have equilibrated, at which point a fixed timestep (specified with `DeltaT`) is recommended.|
+
+
+[1] "Variable timestep algorithm for molecular dynamics simulation of non-equilibrium processes", N. A. Marks and M. Robinson, _Nucl. Instrum. Meth. B_ **352**, 3 (2015), [10.1016/j.nimb.2014.11.094](https://doi.org/10.1016/j.nimb.2014.11.094)


### PR DESCRIPTION
This PR adds an option to calculate only intramolecular (internal) forces occurring between atoms in the same molecule, giving another option for efficient structure evolution as well as optimising the necessary code for application to isolated `Species` (useful in future features).

Along the way the force routines have been adjusted to provide better clarity on what they do, and documentation for the module has been added.