### PR TITLE
Procedure Context

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -66,8 +66,7 @@ bool Configuration::generate(ProcessPool &procPool, double pairPotentialRange)
 
     // Generate the contents
     Messenger::print("\nExecuting generator procedure for Configuration '{}'...\n\n", niceName());
-    GenericList dummyList;
-    auto result = generator_.execute(procPool, this, "Generator", dummyList);
+    auto result = generator_.execute({procPool, this});
     if (!result)
         return Messenger::error("Failed to generate Configuration '{}'.\n", niceName());
     Messenger::print("\n");

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -16,7 +16,9 @@ bool AnalyseModule::process(Dissolve &dissolve, ProcessPool &procPool)
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
     // Execute the analysis
-    if (!analyser_.execute(procPool, targetConfiguration_, uniqueName(), dissolve.processingModuleData()))
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    if (!analyser_.execute(context))
         return Messenger::error("Analysis failed.\n");
 
     return true;

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -44,7 +44,9 @@ bool CalculateAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
     // Execute the analysis
-    if (!analyser_.execute(procPool, targetConfiguration_, uniqueName(), dissolve.processingModuleData()))
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    if (!analyser_.execute(context))
         return Messenger::error("CalculateAngle experienced problems with its analysis.\n");
 
     return true;

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -29,8 +29,10 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, ProcessPool &procPool
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
     // Execute the analysis
-    if (!analyser_.execute(procPool, targetConfiguration_, uniqueName(), dissolve.processingModuleData()))
-        return Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    if (!analyser_.execute(context))
+        return Messenger::error("CalculateAxisAngle experienced problems with its analysis.\n");
 
     return true;
 }

--- a/src/modules/calculate_cn/process.cpp
+++ b/src/modules/calculate_cn/process.cpp
@@ -23,8 +23,9 @@ bool CalculateCNModule::process(Dissolve &dissolve, ProcessPool &procPool)
     siteNormaliser_->keywords().set("Site", std::vector<std::shared_ptr<const SelectProcedureNode>>{sourceRDF_->selectANode()});
 
     // Execute the analysis on the Configuration targeted by the RDF module
-    auto *cfg = sourceRDF_->keywords().get<Configuration *>("Configuration");
-    if (!analyser_.execute(procPool, cfg, fmt::format("{}//Analyser", uniqueName()), dissolve.processingModuleData()))
+    ProcedureContext context(procPool, sourceRDF_->keywords().get<Configuration *>("Configuration"));
+    context.setDataListAndPrefix(dissolve.processingModuleData(), fmt::format("{}//Analyser", uniqueName()));
+    if (!analyser_.execute(context))
         return Messenger::error("CalculateCN experienced problems with its analysis.\n");
 
     // Test?

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -29,7 +29,9 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, ProcessPool &procPool)
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
     // Execute the analysis
-    if (!analyser_.execute(procPool, targetConfiguration_, uniqueName(), dissolve.processingModuleData()))
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    if (!analyser_.execute(context))
         return Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
 
     return true;

--- a/src/modules/calculate_rdf/process.cpp
+++ b/src/modules/calculate_rdf/process.cpp
@@ -26,7 +26,9 @@ bool CalculateRDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
     // Execute the analysis
-    if (!analyser_.execute(procPool, targetConfiguration_, uniqueName(), dissolve.processingModuleData()))
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    if (!analyser_.execute(context))
         return Messenger::error("CalculateRDF experienced problems with its analysis.\n");
 
     return true;

--- a/src/modules/calculate_sdf/process.cpp
+++ b/src/modules/calculate_sdf/process.cpp
@@ -29,7 +29,9 @@ bool CalculateSDFModule::process(Dissolve &dissolve, ProcessPool &procPool)
     procPool.assignProcessesToGroups(targetConfiguration_->processPool());
 
     // Execute the analysis
-    if (!analyser_.execute(procPool, targetConfiguration_, uniqueName(), dissolve.processingModuleData()))
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    if (!analyser_.execute(context))
         return Messenger::error("CalculateSDF experienced problems with its analysis.\n");
 
     // Save data?

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
   collect1d.cpp
   collect2d.cpp
   collect3d.cpp
+  context.cpp
   cylindricalregion.cpp
   dynamicsite.cpp
   fit1d.cpp
@@ -50,6 +51,7 @@ add_library(
   collect1d.h
   collect2d.h
   collect3d.h
+  context.h
   cylindricalregion.h
   dynamicsite.h
   fit1d.h

--- a/src/procedure/nodes/add.h
+++ b/src/procedure/nodes/add.h
@@ -76,7 +76,7 @@ class AddProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/box.cpp
+++ b/src/procedure/nodes/box.cpp
@@ -36,22 +36,23 @@ bool BoxProcedureNode::mustBeNamed() const { return false; }
  */
 
 // Prepare any necessary data, ready for execution
-bool BoxProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) { return true; }
+bool BoxProcedureNode::prepare(const ProcedureContext &procedureContext) { return true; }
 
-// Execute node, targetting the supplied Configuration
-bool BoxProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+// Execute node
+bool BoxProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     // Create a Box in the target Configuration with our lengths and angles
-    cfg->createBox({lengths_.x.asDouble(), lengths_.y.asDouble(), lengths_.z.asDouble()},
-                   {angles_.x.asDouble(), angles_.y.asDouble(), angles_.z.asDouble()}, nonPeriodic_);
+    procedureContext.configuration()->createBox({lengths_.x.asDouble(), lengths_.y.asDouble(), lengths_.z.asDouble()},
+                                                {angles_.x.asDouble(), angles_.y.asDouble(), angles_.z.asDouble()},
+                                                nonPeriodic_);
 
-    Messenger::print("[Box] Volume is {} cubic Angstroms (reciprocal volume = {:e})\n", cfg->box()->volume(),
-                     cfg->box()->reciprocalVolume());
-    auto lengths = cfg->box()->axisLengths();
-    auto angles = cfg->box()->axisAngles();
+    auto *box = procedureContext.configuration()->box();
+    Messenger::print("[Box] Volume is {} cubic Angstroms (reciprocal volume = {:e})\n", box->volume(), box->reciprocalVolume());
+    auto lengths = box->axisLengths();
+    auto angles = box->axisAngles();
     Messenger::print(
         "[Box] Type is {}: A = {:10.4e} B = {:10.4e} C = {:10.4e}, alpha = {:10.4e} beta = {:10.4e} gamma = {:10.4e}\n",
-        Box::boxTypes().keyword(cfg->box()->type()), lengths.x, lengths.y, lengths.z, angles.x, angles.y, angles.z);
+        Box::boxTypes().keyword(box->type()), lengths.x, lengths.y, lengths.z, angles.x, angles.y, angles.z);
 
     return true;
 }

--- a/src/procedure/nodes/box.h
+++ b/src/procedure/nodes/box.h
@@ -39,7 +39,7 @@ class BoxProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/calculateangle.cpp
+++ b/src/procedure/nodes/calculateangle.cpp
@@ -36,17 +36,16 @@ int CalculateAngleProcedureNode::dimensionality() const { return 1; }
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool CalculateAngleProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                          GenericList &targetList)
+// Execute node
+bool CalculateAngleProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     assert(sites_[0] && sites_[0]->currentSite());
     assert(sites_[1] && sites_[1]->currentSite());
     assert(sites_[2] && sites_[2]->currentSite());
 
     // Determine the value of the observable
-    value_.x = cfg->box()->angleInDegrees(sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin(),
-                                          sites_[2]->currentSite()->origin());
+    value_.x = procedureContext.configuration()->box()->angleInDegrees(
+        sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin(), sites_[2]->currentSite()->origin());
 
     return true;
 }

--- a/src/procedure/nodes/calculateangle.h
+++ b/src/procedure/nodes/calculateangle.h
@@ -30,6 +30,6 @@ class CalculateAngleProcedureNode : public CalculateProcedureNodeBase
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/calculateaxisangle.cpp
+++ b/src/procedure/nodes/calculateaxisangle.cpp
@@ -53,18 +53,17 @@ int CalculateAxisAngleProcedureNode::dimensionality() const { return 1; }
  */
 
 // Prepare any necessary data, ready for execution
-bool CalculateAxisAngleProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool CalculateAxisAngleProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Call the base class function
-    if (!CalculateProcedureNodeBase::prepare(cfg, prefix, targetList))
+    if (!CalculateProcedureNodeBase::prepare(procedureContext))
         return false;
 
     return true;
 }
 
-// Execute node, targetting the supplied Configuration
-bool CalculateAxisAngleProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                              GenericList &targetList)
+// Execute node
+bool CalculateAxisAngleProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     assert(sites_[0] && sites_[0]->currentSite());
     assert(sites_[1] && sites_[1]->currentSite());

--- a/src/procedure/nodes/calculateaxisangle.h
+++ b/src/procedure/nodes/calculateaxisangle.h
@@ -44,7 +44,7 @@ class CalculateAxisAngleProcedureNode : public CalculateProcedureNodeBase
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/calculatebase.cpp
+++ b/src/procedure/nodes/calculatebase.cpp
@@ -40,7 +40,7 @@ Vec3<double> CalculateProcedureNodeBase::values() const { return value_; }
  */
 
 // Prepare any necessary data, ready for execution
-bool CalculateProcedureNodeBase::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool CalculateProcedureNodeBase::prepare(const ProcedureContext &procedureContext)
 {
     // Check that the sites have been properly defined
     for (auto n = 0; n < nSitesRequired(); ++n)

--- a/src/procedure/nodes/calculatebase.h
+++ b/src/procedure/nodes/calculatebase.h
@@ -51,5 +51,5 @@ class CalculateProcedureNodeBase : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/calculatedistance.cpp
+++ b/src/procedure/nodes/calculatedistance.cpp
@@ -33,16 +33,16 @@ int CalculateDistanceProcedureNode::dimensionality() const { return 1; }
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool CalculateDistanceProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                             GenericList &targetList)
+// Execute node
+bool CalculateDistanceProcedureNode::execute(const ProcedureContext &procedureContext)
 {
 
     assert(sites_[0] && sites_[0]->currentSite());
     assert(sites_[1] && sites_[1]->currentSite());
 
     // Determine the value of the observable
-    value_.x = cfg->box()->minimumDistance(sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin());
+    value_.x = procedureContext.configuration()->box()->minimumDistance(sites_[0]->currentSite()->origin(),
+                                                                        sites_[1]->currentSite()->origin());
 
     return true;
 }

--- a/src/procedure/nodes/calculatedistance.h
+++ b/src/procedure/nodes/calculatedistance.h
@@ -29,6 +29,6 @@ class CalculateDistanceProcedureNode : public CalculateProcedureNodeBase
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/calculatevector.cpp
+++ b/src/procedure/nodes/calculatevector.cpp
@@ -37,24 +37,24 @@ int CalculateVectorProcedureNode::dimensionality() const { return 3; }
  */
 
 // Prepare any necessary data, ready for execution
-bool CalculateVectorProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool CalculateVectorProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Call the base class function
-    if (!CalculateProcedureNodeBase::prepare(cfg, prefix, targetList))
+    if (!CalculateProcedureNodeBase::prepare(procedureContext))
         return false;
 
     return true;
 }
 
-// Execute node, targetting the supplied Configuration
-bool CalculateVectorProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                           GenericList &targetList)
+// Execute node
+bool CalculateVectorProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     assert(sites_[0] && sites_[0]->currentSite());
     assert(sites_[1] && sites_[1]->currentSite());
 
     // Determine the value of the observable
-    value_ = cfg->box()->minimumVector(sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin());
+    value_ = procedureContext.configuration()->box()->minimumVector(sites_[0]->currentSite()->origin(),
+                                                                    sites_[1]->currentSite()->origin());
 
     // Rotate the vector into the local frame defined on the first site?
     if (rotateIntoFrame_)

--- a/src/procedure/nodes/calculatevector.h
+++ b/src/procedure/nodes/calculatevector.h
@@ -37,7 +37,7 @@ class CalculateVectorProcedureNode : public CalculateProcedureNodeBase
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/collect1d.h
+++ b/src/procedure/nodes/collect1d.h
@@ -65,9 +65,9 @@ class Collect1DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/collect2d.h
+++ b/src/procedure/nodes/collect2d.h
@@ -10,7 +10,6 @@
 class CalculateProcedureNodeBase;
 class SequenceProcedureNode;
 class LineParser;
-class NodeScopeStack;
 
 // Procedure Node - Collect2D
 class Collect2DProcedureNode : public ProcedureNode

--- a/src/procedure/nodes/collect2d.h
+++ b/src/procedure/nodes/collect2d.h
@@ -69,9 +69,9 @@ class Collect2DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/collect3d.h
+++ b/src/procedure/nodes/collect3d.h
@@ -10,7 +10,6 @@
 class CalculateProcedureNodeBase;
 class SequenceProcedureNode;
 class LineParser;
-class NodeScopeStack;
 
 // Procedure Node - Collect3D
 class Collect3DProcedureNode : public ProcedureNode

--- a/src/procedure/nodes/collect3d.h
+++ b/src/procedure/nodes/collect3d.h
@@ -77,9 +77,9 @@ class Collect3DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "procedure/nodes/context.h"
+
+ProcedureContext::ProcedureContext(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+    : processPool_(procPool), configuration_(cfg), dataPrefix_(prefix), dataList_(targetList)
+{
+}
+
+// Return available process pool
+ProcessPool &ProcedureContext::processPool() const { return processPool_; };
+
+// Return target Configuration
+Configuration *ProcedureContext::configuration() const { return configuration_; }
+
+// Return prefix for generated data
+std::string_view ProcedureContext::dataPrefix() const { return dataPrefix_; }
+
+// Return target list for generated data
+GenericList &ProcedureContext::dataList() const { return dataList_; }

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -2,20 +2,38 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "procedure/nodes/context.h"
+#include <exception>
 
-ProcedureContext::ProcedureContext(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
-    : processPool_(procPool), configuration_(cfg), dataPrefix_(prefix), dataList_(targetList)
-{
-}
+ProcedureContext::ProcedureContext(ProcessPool &procPool, Configuration *cfg) : processPool_(procPool), configuration_(cfg) {}
 
 // Return available process pool
 ProcessPool &ProcedureContext::processPool() const { return processPool_; };
 
+// Set target Configuration
+void ProcedureContext::setConfiguration(Configuration *cfg) { configuration_ = cfg; }
+
 // Return target Configuration
-Configuration *ProcedureContext::configuration() const { return configuration_; }
+Configuration *ProcedureContext::configuration() const
+{
+    if (!configuration_)
+        throw(std::runtime_error("No configuration set in this procedure's context.\n"));
+    return configuration_;
+}
+
+// Set target data list and prefix
+void ProcedureContext::setDataListAndPrefix(GenericList &list, std::string_view prefix)
+{
+    dataList_ = list;
+    dataPrefix_ = prefix;
+}
 
 // Return prefix for generated data
 std::string_view ProcedureContext::dataPrefix() const { return dataPrefix_; }
 
 // Return target list for generated data
-GenericList &ProcedureContext::dataList() const { return dataList_; }
+GenericList &ProcedureContext::dataList() const
+{
+    if (!dataList_)
+        throw(std::runtime_error("No data list set in this procedure's context.\n"));
+    return dataList_->get();
+}

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "procedure/nodes/context.h"
-#include <exception>
+#include <stdexcept>
 
 ProcedureContext::ProcedureContext(ProcessPool &procPool, Configuration *cfg) : processPool_(procPool), configuration_(cfg) {}
 

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "templates/optionalref.h"
 #include <string_view>
 
 // Forward Declarations
@@ -14,7 +15,7 @@ class ProcessPool;
 class ProcedureContext
 {
     public:
-    ProcedureContext(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList);
+    ProcedureContext(ProcessPool &procPool, Configuration *cfg = nullptr);
 
     private:
     // Available process pool
@@ -24,13 +25,17 @@ class ProcedureContext
     // Prefix for generated data
     std::string_view dataPrefix_;
     // Target list for generated data
-    GenericList &dataList_;
+    OptionalReferenceWrapper<GenericList> dataList_;
 
     public:
     // Return available process pool
     ProcessPool &processPool() const;
+    // Set target Configuration
+    void setConfiguration(Configuration *cfg);
     // Return target Configuration
     Configuration *configuration() const;
+    // Set target data list and prefix
+    void setDataListAndPrefix(GenericList &list, std::string_view prefix);
     // Return prefix for generated data
     std::string_view dataPrefix() const;
     // Return target list for generated data

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include <string_view>
+
+// Forward Declarations
+class Configuration;
+class GenericList;
+class ProcessPool;
+
+// Node Operating Data
+class ProcedureContext
+{
+    public:
+    ProcedureContext(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList);
+
+    private:
+    // Available process pool
+    ProcessPool &processPool_;
+    // Target Configuration
+    Configuration *configuration_{nullptr};
+    // Prefix for generated data
+    std::string_view dataPrefix_;
+    // Target list for generated data
+    GenericList &dataList_;
+
+    public:
+    // Return available process pool
+    ProcessPool &processPool() const;
+    // Return target Configuration
+    Configuration *configuration() const;
+    // Return prefix for generated data
+    std::string_view dataPrefix() const;
+    // Return target list for generated data
+    GenericList &dataList() const;
+};

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "templates/optionalref.h"
-#include <string_view>
+#include <string>
 
 // Forward Declarations
 class Configuration;
@@ -23,7 +23,7 @@ class ProcedureContext
     // Target Configuration
     Configuration *configuration_{nullptr};
     // Prefix for generated data
-    std::string_view dataPrefix_;
+    std::string dataPrefix_;
     // Target list for generated data
     OptionalReferenceWrapper<GenericList> dataList_;
 

--- a/src/procedure/nodes/dynamicsite.cpp
+++ b/src/procedure/nodes/dynamicsite.cpp
@@ -70,9 +70,8 @@ const std::vector<Site> &DynamicSiteProcedureNode::generatedSites() const { retu
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool DynamicSiteProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                       GenericList &targetList)
+// Execute node
+bool DynamicSiteProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     // Clear our current list of sites
     generatedSites_.clear();
@@ -93,7 +92,7 @@ bool DynamicSiteProcedureNode::execute(ProcessPool &procPool, Configuration *cfg
     else
     {
         // Loop over Molecules in the target Configuration
-        for (const auto &molecule : cfg->molecules())
+        for (const auto &molecule : procedureContext.configuration()->molecules())
         {
             // Check Molecule exclusions
             if (std::find(excludedMolecules.begin(), excludedMolecules.end(), molecule) != excludedMolecules.end())

--- a/src/procedure/nodes/dynamicsite.h
+++ b/src/procedure/nodes/dynamicsite.h
@@ -14,7 +14,6 @@ class SelectProcedureNode;
 class AtomType;
 class LineParser;
 class Molecule;
-class NodeScopeStack;
 
 // Procedure Node - Dynamic Site
 class DynamicSiteProcedureNode : public ProcedureNode

--- a/src/procedure/nodes/dynamicsite.h
+++ b/src/procedure/nodes/dynamicsite.h
@@ -64,6 +64,6 @@ class DynamicSiteProcedureNode : public ProcedureNode
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/fit1d.cpp
+++ b/src/procedure/nodes/fit1d.cpp
@@ -84,10 +84,10 @@ void Fit1DProcedureNode::setSaveData(bool on) { saveData_ = on; }
  */
 
 // Prepare any necessary data, ready for execution
-bool Fit1DProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) { return true; }
+bool Fit1DProcedureNode::prepare(const ProcedureContext &procedureContext) { return true; }
 
 // Finalise any necessary data after execution
-bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool Fit1DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Copy reference data from the associated node
     std::shared_ptr<const Collect1DProcedureNode> collect1DNode;
@@ -162,7 +162,8 @@ bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std
     // Generate final fit data
     // Retrieve / realise the data from the supplied list
     auto &data =
-        targetList.realise<Data1D>(fmt::format("{}//{}", name(), cfg->niceName()), prefix, GenericItem::InRestartFileFlag);
+        procedureContext.dataList().realise<Data1D>(fmt::format("{}//{}", name(), procedureContext.configuration()->niceName()),
+                                                    procedureContext.dataPrefix(), GenericItem::InRestartFileFlag);
 
     data.setTag(name());
     data.clear();
@@ -180,29 +181,29 @@ bool Fit1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std
     // Save data?
     if (saveData_)
     {
-        if (procPool.isMaster())
+        if (procedureContext.processPool().isMaster())
         {
             LineParser parser;
-            if (!parser.openOutput(fmt::format("{}_{}.fit", name(), cfg->name())))
-                return procPool.decideFalse();
+            if (!parser.openOutput(fmt::format("{}_{}.fit", name(), procedureContext.configuration()->name())))
+                return procedureContext.processPool().decideFalse();
             if (!parser.writeLineF("# Fit Equation : {}\n", equation_.expressionString()))
-                return procPool.decideFalse();
+                return procedureContext.processPool().decideFalse();
             if (!parser.writeLineF("#  {:10}                (axis variable)\n", xVariable_->name()))
-                return procPool.decideFalse();
+                return procedureContext.processPool().decideFalse();
             for (const auto &var : fitTargets_)
                 if (!parser.writeLineF("#  {:10} = {:e} (fit)\n", var->name(), var->value().asDouble()))
-                    return procPool.decideFalse();
+                    return procedureContext.processPool().decideFalse();
             for (const auto &var : constants_)
                 if (!parser.writeLineF("#  {:10} = {:e} (constant)\n", var->name(), var->value().asDouble()))
-                    return procPool.decideFalse();
+                    return procedureContext.processPool().decideFalse();
 
             Data1DExportFileFormat exportFormat(name());
             if (exportFormat.exportData(data))
-                procPool.decideTrue();
+                procedureContext.processPool().decideTrue();
             else
-                return procPool.decideFalse();
+                return procedureContext.processPool().decideFalse();
         }
-        else if (!procPool.decision())
+        else if (!procedureContext.processPool().decision())
             return false;
     }
 

--- a/src/procedure/nodes/fit1d.h
+++ b/src/procedure/nodes/fit1d.h
@@ -13,7 +13,6 @@ class Collect1DProcedureNode;
 class SelectProcedureNode;
 class Data1D;
 class LineParser;
-class NodeScopeStack;
 
 // Procedure Node - Fit1D
 class Fit1DProcedureNode : public ProcedureNode

--- a/src/procedure/nodes/fit1d.h
+++ b/src/procedure/nodes/fit1d.h
@@ -85,9 +85,9 @@ class Fit1DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 
     /*
      * Read / Write

--- a/src/procedure/nodes/generalregion.cpp
+++ b/src/procedure/nodes/generalregion.cpp
@@ -28,7 +28,7 @@ bool GeneralRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Ve
  */
 
 // Prepare any necessary data, ready for execution
-bool GeneralRegionProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool GeneralRegionProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Retrieve keyword values
     toleranceSquared_ = tolerance_ * tolerance_;

--- a/src/procedure/nodes/generalregion.h
+++ b/src/procedure/nodes/generalregion.h
@@ -33,5 +33,5 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/integrate1d.cpp
+++ b/src/procedure/nodes/integrate1d.cpp
@@ -47,7 +47,7 @@ const SampledDouble &Integrate1DProcedureNode::integral(int index) const { retur
  */
 
 // Prepare any necessary data, ready for execution
-bool Integrate1DProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool Integrate1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     if (!sourceData_)
         return Messenger::error("No source Process1D node set in '{}'.\n", name());
@@ -56,8 +56,7 @@ bool Integrate1DProcedureNode::prepare(Configuration *cfg, std::string_view pref
 }
 
 // Finalise any necessary data after execution
-bool Integrate1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                        GenericList &targetList)
+bool Integrate1DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Calculate integrals
     integral_[0] += Integrator::trapezoid(sourceData_->processedData(), range_[0]);

--- a/src/procedure/nodes/integrate1d.h
+++ b/src/procedure/nodes/integrate1d.h
@@ -45,7 +45,7 @@ class Integrate1DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -256,19 +256,13 @@ OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>>
  */
 
 // Prepare any necessary data, ready for execution
-bool ProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) { return true; }
+bool ProcedureNode::prepare(const ProcedureContext &procedureContext) { return true; }
 
-// Execute node, targetting the supplied Configuration
-bool ProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
-{
-    return true;
-}
+// Execute node
+bool ProcedureNode::execute(const ProcedureContext &procedureContext) { return true; }
 
 // Finalise any necessary data after execution
-bool ProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
-{
-    return true;
-}
+bool ProcedureNode::finalise(const ProcedureContext &procedureContext) { return true; }
 
 /*
  * Read / Write

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -14,7 +14,6 @@ class CoreData;
 class ExpressionVariable;
 class GenericList;
 class LineParser;
-class NodeScopeStack;
 class Procedure;
 class ProcessPool;
 class SequenceProcedureNode;

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -6,6 +6,7 @@
 #include "base/enumoptions.h"
 #include "keywords/store.h"
 #include "procedure/nodes/aliases.h"
+#include "procedure/nodes/context.h"
 #include "templates/optionalref.h"
 
 // Forward Declarations
@@ -199,11 +200,11 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
      */
     public:
     // Prepare any necessary data, ready for execution
-    virtual bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList);
-    // Execute node, targetting the supplied Configuration
-    virtual bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList);
+    virtual bool prepare(const ProcedureContext &procedureContext);
+    // Execute node
+    virtual bool execute(const ProcedureContext &procedureContext);
     // Finalise any necessary data after execution
-    virtual bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList);
+    virtual bool finalise(const ProcedureContext &procedureContext);
 
     /*
      * Read / Write

--- a/src/procedure/nodes/operatebase.cpp
+++ b/src/procedure/nodes/operatebase.cpp
@@ -77,18 +77,17 @@ bool OperateProcedureNodeBase::operateData3D(ProcessPool &procPool, Configuratio
  */
 
 // Prepare any necessary data, ready for execution
-bool OperateProcedureNodeBase::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) { return true; }
+bool OperateProcedureNodeBase::prepare(const ProcedureContext &procedureContext) { return true; }
 
-// Execute node, targetting the supplied Configuration
-bool OperateProcedureNodeBase::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                       GenericList &targetList)
+// Execute node
+bool OperateProcedureNodeBase::execute(const ProcedureContext &procedureContext)
 {
     // Run the operation on any data target that exists
-    if (targetData1D_ && (!operateData1D(procPool, cfg)))
+    if (targetData1D_ && (!operateData1D(procedureContext.processPool(), procedureContext.configuration())))
         return false;
-    if (targetData2D_ && (!operateData2D(procPool, cfg)))
+    if (targetData2D_ && (!operateData2D(procedureContext.processPool(), procedureContext.configuration())))
         return false;
-    if (targetData3D_ && (!operateData3D(procPool, cfg)))
+    if (targetData3D_ && (!operateData3D(procedureContext.processPool(), procedureContext.configuration())))
         return false;
 
     return true;

--- a/src/procedure/nodes/operatebase.h
+++ b/src/procedure/nodes/operatebase.h
@@ -57,7 +57,7 @@ class OperateProcedureNodeBase : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/parameters.cpp
+++ b/src/procedure/nodes/parameters.cpp
@@ -55,11 +55,7 @@ OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>>
  */
 
 // Prepare any necessary data, ready for execution
-bool ParametersProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) { return true; }
+bool ParametersProcedureNode::prepare(const ProcedureContext &procedureContext) { return true; }
 
-// Execute node, targetting the supplied Configuration
-bool ParametersProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                      GenericList &targetList)
-{
-    return true;
-}
+// Execute node
+bool ParametersProcedureNode::execute(const ProcedureContext &procedureContext) { return true; }

--- a/src/procedure/nodes/parameters.h
+++ b/src/procedure/nodes/parameters.h
@@ -46,7 +46,7 @@ class ParametersProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/pick.cpp
+++ b/src/procedure/nodes/pick.cpp
@@ -18,7 +18,7 @@ PickProcedureNode::PickProcedureNode(std::vector<const Species *> species)
  */
 
 // Prepare any necessary data, ready for execution
-bool PickProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool PickProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Check for at least one site being defined
     if (speciesToPick_.empty())
@@ -27,8 +27,8 @@ bool PickProcedureNode::prepare(Configuration *cfg, std::string_view prefix, Gen
     return true;
 }
 
-// Execute node, targetting the supplied Configuration
-bool PickProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+// Execute node
+bool PickProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     Messenger::print("[Pick] Molecules will be selected from {}.\n", moleculePoolName());
 
@@ -36,7 +36,7 @@ bool PickProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::
     pickedMolecules_.clear();
 
     // Loop over all molecules in supplied Configuration
-    for (const auto &mol : moleculePool(cfg))
+    for (const auto &mol : moleculePool(procedureContext.configuration()))
     {
         // Check Species type
         if (std::find(speciesToPick_.begin(), speciesToPick_.end(), mol->species()) == speciesToPick_.end())

--- a/src/procedure/nodes/pick.h
+++ b/src/procedure/nodes/pick.h
@@ -29,7 +29,7 @@ class PickProcedureNode : public PickProcedureNodeBase
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/pickbase.cpp
+++ b/src/procedure/nodes/pickbase.cpp
@@ -47,8 +47,7 @@ const std::vector<std::shared_ptr<Molecule>> &PickProcedureNodeBase::pickedMolec
  */
 
 // Finalise any necessary data after execution
-bool PickProcedureNodeBase::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                     GenericList &targetList)
+bool PickProcedureNodeBase::finalise(const ProcedureContext &procedureContext)
 {
     // Clear picked molecules
     pickedMolecules_.clear();

--- a/src/procedure/nodes/pickbase.h
+++ b/src/procedure/nodes/pickbase.h
@@ -49,5 +49,5 @@ class PickProcedureNodeBase : public ProcedureNode
      */
     protected:
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/pickproximity.cpp
+++ b/src/procedure/nodes/pickproximity.cpp
@@ -25,9 +25,8 @@ PickProximityProcedureNode::PickProximityProcedureNode() : PickProcedureNodeBase
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool PickProximityProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                         GenericList &targetList)
+// Execute node
+bool PickProximityProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     Messenger::print("[PickProximity] Molecules will be selected from {}.\n", moleculePoolName());
 
@@ -52,10 +51,10 @@ bool PickProximityProcedureNode::execute(ProcessPool &procPool, Configuration *c
     else
         Messenger::print("[PickProximity] Allowed coordination count is N >= {}.\n", nMin);
 
-    const auto *box = cfg->box();
+    const auto *box = procedureContext.configuration()->box();
 
     // Loop over all target molecules
-    for (const auto &molI : moleculePool(cfg))
+    for (const auto &molI : moleculePool(procedureContext.configuration()))
     {
         auto count = 0;
 
@@ -63,7 +62,7 @@ bool PickProximityProcedureNode::execute(ProcessPool &procPool, Configuration *c
         auto iCog = molI->centreOfGeometry(box);
 
         // Loop over all molecules
-        for (const auto &molJ : cfg->molecules())
+        for (const auto &molJ : procedureContext.configuration()->molecules())
         {
             // Count surrounding species (if defined)
             if (std::find(speciesToPick_.begin(), speciesToPick_.end(), molJ->species()) != speciesToPick_.end())

--- a/src/procedure/nodes/pickproximity.h
+++ b/src/procedure/nodes/pickproximity.h
@@ -36,6 +36,6 @@ class PickProximityProcedureNode : public PickProcedureNodeBase
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/pickregion.cpp
+++ b/src/procedure/nodes/pickregion.cpp
@@ -19,9 +19,8 @@ PickRegionProcedureNode::PickRegionProcedureNode(std::shared_ptr<const RegionPro
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool PickRegionProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                      GenericList &targetList)
+// Execute node
+bool PickRegionProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     if (!region_)
         return Messenger::error("A region must be supplied to PickRegion.\n");
@@ -32,7 +31,7 @@ bool PickRegionProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
     pickedMolecules_.clear();
 
     // Get the updated region
-    auto region = region_->generateRegion(cfg);
+    auto region = region_->generateRegion(procedureContext.configuration());
     if (!region.isValid())
     {
         Messenger::warn("Region will not capture any molecules...\n");
@@ -40,8 +39,8 @@ bool PickRegionProcedureNode::execute(ProcessPool &procPool, Configuration *cfg,
     }
 
     // Loop over all molecules in supplied Configuration
-    for (const auto &mol : moleculePool(cfg))
-        if (region.validCoordinate(mol->centreOfGeometry(cfg->box())))
+    for (const auto &mol : moleculePool(procedureContext.configuration()))
+        if (region.validCoordinate(mol->centreOfGeometry(procedureContext.configuration()->box())))
             pickedMolecules_.push_back(mol);
 
     Messenger::print("[PickRegion] Total molecules picked = {}.\n", pickedMolecules_.size());

--- a/src/procedure/nodes/pickregion.h
+++ b/src/procedure/nodes/pickregion.h
@@ -26,6 +26,6 @@ class PickRegionProcedureNode : public PickProcedureNodeBase
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/process1d.h
+++ b/src/procedure/nodes/process1d.h
@@ -76,7 +76,7 @@ class Process1DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/process2d.h
+++ b/src/procedure/nodes/process2d.h
@@ -76,7 +76,7 @@ class Process2DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/process2d.h
+++ b/src/procedure/nodes/process2d.h
@@ -10,7 +10,6 @@
 class Collect2DProcedureNode;
 class Data2D;
 class LineParser;
-class NodeScopeStack;
 
 // Procedure Node - Process2D
 class Process2DProcedureNode : public ProcedureNode

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -104,23 +104,23 @@ std::vector<ConstNodeRef> Process3DProcedureNode::children() const { return {nor
  */
 
 // Prepare any necessary data, ready for execution
-bool Process3DProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool Process3DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     if (!sourceData_)
         return Messenger::error("No source Collect3D node set in '{}'.\n", name());
 
     if (normalisationBranch_)
-        normalisationBranch_->prepare(cfg, prefix, targetList);
+        normalisationBranch_->prepare(procedureContext);
 
     return true;
 }
 
 // Finalise any necessary data after execution
-bool Process3DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                      GenericList &targetList)
+bool Process3DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = targetList.realise<Data3D>(fmt::format("Process3D//{}", name()), prefix, GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.dataList().realise<Data3D>(fmt::format("Process3D//{}", name()),
+                                                             procedureContext.dataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 
@@ -141,24 +141,24 @@ bool Process3DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg,
             operateNode->setTarget(processedData_);
         }
 
-        if (!normalisationBranch_->execute(procPool, cfg, prefix, targetList))
+        if (!normalisationBranch_->execute(procedureContext))
             return false;
     }
 
     // Save data?
     if (exportFileAndFormat_.hasFilename())
     {
-        if (procPool.isMaster())
+        if (procedureContext.processPool().isMaster())
         {
             if (exportFileAndFormat_.exportData(data))
-                procPool.decideTrue();
+                procedureContext.processPool().decideTrue();
             else
             {
-                procPool.decideFalse();
+                procedureContext.processPool().decideFalse();
                 return false;
             }
         }
-        else if (!procPool.decision())
+        else if (!procedureContext.processPool().decision())
             return false;
     }
 

--- a/src/procedure/nodes/process3d.h
+++ b/src/procedure/nodes/process3d.h
@@ -81,7 +81,7 @@ class Process3DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/process3d.h
+++ b/src/procedure/nodes/process3d.h
@@ -11,7 +11,6 @@
 class Collect3DProcedureNode;
 class Data3D;
 class LineParser;
-class NodeScopeStack;
 
 // Procedure Node - Process3D
 class Process3DProcedureNode : public ProcedureNode

--- a/src/procedure/nodes/regionbase.cpp
+++ b/src/procedure/nodes/regionbase.cpp
@@ -46,10 +46,9 @@ const Region RegionProcedureNodeBase::generateRegion(const Configuration *cfg) c
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool RegionProcedureNodeBase::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                      GenericList &targetList)
+// Execute node
+bool RegionProcedureNodeBase::execute(const ProcedureContext &procedureContext)
 {
-    return region_.generate(cfg, voxelSize_,
+    return region_.generate(procedureContext.configuration(), voxelSize_,
                             [&](const Configuration *cfg, Vec3<double> r) { return isVoxelValid(cfg, r) != invert_; });
 }

--- a/src/procedure/nodes/regionbase.h
+++ b/src/procedure/nodes/regionbase.h
@@ -54,6 +54,6 @@ class RegionProcedureNodeBase : public ProcedureNode
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/remove.cpp
+++ b/src/procedure/nodes/remove.cpp
@@ -34,23 +34,24 @@ bool RemoveProcedureNode::mustBeNamed() const { return false; }
  * Execute
  */
 
-// Execute node, targetting the supplied Configuration
-bool RemoveProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+// Execute node
+bool RemoveProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     // Store current molecule population
-    auto nStartMolecules = cfg->nMolecules();
+    auto nStartMolecules = procedureContext.configuration()->nMolecules();
 
     // Remove molecules by Species type
     if (!speciesToRemove_.empty())
         for (auto *sp : speciesToRemove_)
-            cfg->removeMolecules(sp);
+            procedureContext.configuration()->removeMolecules(sp);
 
     // Remove molecules by selection
     if (selection_)
-        cfg->removeMolecules(selection_->pickedMolecules());
+        procedureContext.configuration()->removeMolecules(selection_->pickedMolecules());
 
-    Messenger::print("[Remove] Removed {} molecules from configuration '{}'.\n", nStartMolecules - cfg->nMolecules(),
-                     cfg->name());
+    Messenger::print("[Remove] Removed {} molecules from configuration '{}'.\n",
+                     nStartMolecules - procedureContext.configuration()->nMolecules(),
+                     procedureContext.configuration()->name());
 
     return true;
 }

--- a/src/procedure/nodes/remove.h
+++ b/src/procedure/nodes/remove.h
@@ -40,6 +40,6 @@ class RemoveProcedureNode : public ProcedureNode
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -125,9 +125,9 @@ class SelectProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -334,18 +334,18 @@ std::vector<std::shared_ptr<ExpressionVariable>> SequenceProcedureNode::paramete
  */
 
 // Prepare any necessary data, ready for execution
-bool SequenceProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool SequenceProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Loop over nodes in the list, preparing each in turn
     for (auto node : sequence_)
-        if (!node->prepare(cfg, prefix, targetList))
+        if (!node->prepare(procedureContext))
             return false;
 
     return true;
 }
 
-// Execute node, targetting the supplied Configuration
-bool SequenceProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+// Execute node
+bool SequenceProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     // If there are no nodes, just exit now
     if (sequence_.empty())
@@ -353,19 +353,18 @@ bool SequenceProcedureNode::execute(ProcessPool &procPool, Configuration *cfg, s
 
     // Loop over nodes in the list, executing each in turn
     for (auto node : sequence_)
-        if (!node->execute(procPool, cfg, prefix, targetList))
+        if (!node->execute(procedureContext))
             return false;
 
     return true;
 }
 
 // Finalise any necessary data after execution
-bool SequenceProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix,
-                                     GenericList &targetList)
+bool SequenceProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Loop over nodes in the list, finalising each in turn
     for (auto node : sequence_)
-        if (!node->finalise(procPool, cfg, prefix, targetList))
+        if (!node->finalise(procedureContext))
             return false;
 
     return true;

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -123,11 +123,11 @@ class SequenceProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 
     /*
      * Read / Write

--- a/src/procedure/nodes/sum1d.cpp
+++ b/src/procedure/nodes/sum1d.cpp
@@ -73,7 +73,7 @@ bool Sum1DProcedureNode::isRangeCEnabled() const { return rangeEnabled_[2]; }
  */
 
 // Prepare any necessary data, ready for execution
-bool Sum1DProcedureNode::prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool Sum1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     if (!sourceData_)
         return Messenger::error("No source Process1D node set in '{}'.\n", name());
@@ -82,7 +82,7 @@ bool Sum1DProcedureNode::prepare(Configuration *cfg, std::string_view prefix, Ge
 }
 
 // Finalise any necessary data after execution
-bool Sum1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList)
+bool Sum1DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Calculate integrals
     const std::vector<std::string> rangeNames = {"A", "B", "C"};
@@ -90,8 +90,9 @@ bool Sum1DProcedureNode::finalise(ProcessPool &procPool, Configuration *cfg, std
         if (rangeEnabled_[i])
         {
             if (!sum_[i].has_value())
-                sum_[i] = targetList.realise<SampledDouble>(fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), prefix,
-                                                            GenericItem::InRestartFileFlag);
+                sum_[i] = procedureContext.dataList().realise<SampledDouble>(
+                    fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), procedureContext.dataPrefix(),
+                    GenericItem::InRestartFileFlag);
             sum_[i]->get() += Integrator::sum(sourceData_->processedData(), range_[i]);
         }
 

--- a/src/procedure/nodes/sum1d.h
+++ b/src/procedure/nodes/sum1d.h
@@ -55,7 +55,7 @@ class Sum1DProcedureNode : public ProcedureNode
      */
     public:
     // Prepare any necessary data, ready for execution
-    bool prepare(Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool prepare(const ProcedureContext &procedureContext) override;
     // Finalise any necessary data after execution
-    bool finalise(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    bool finalise(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/transmute.h
+++ b/src/procedure/nodes/transmute.h
@@ -42,6 +42,6 @@ class TransmuteProcedureNode : public ProcedureNode
      * Execute
      */
     public:
-    // Execute node, targetting the supplied Configuration
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -77,15 +77,15 @@ bool Procedure::execute(ProcessPool &procPool, Configuration *cfg, std::string_v
     }
 
     // Prepare the nodes
-    if (!rootSequence_->prepare(cfg, prefix, targetList))
+    if (!rootSequence_->prepare({procPool, cfg, prefix, targetList}))
         return Messenger::error("Failed to prepare procedure for execution.\n");
 
     // Execute the root sequence
-    if (!rootSequence_->execute(procPool, cfg, prefix, targetList))
+    if (!rootSequence_->execute({procPool, cfg, prefix, targetList}))
         return Messenger::error("Failed to execute procedure.\n");
 
     // Finalise any nodes that need it
-    if (!rootSequence_->finalise(procPool, cfg, prefix, targetList))
+    if (!rootSequence_->finalise({procPool, cfg, prefix, targetList}))
         return Messenger::error("Failed to finalise procedure after execution.\n");
 
     return true;

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -50,8 +50,8 @@ class Procedure
     std::vector<std::pair<Configuration *, int>> configurationPoints_;
 
     public:
-    // Run procedure on specified Configuration, storing / retrieving generated data from supplied list
-    bool execute(ProcessPool &procPool, Configuration *cfg, std::string_view prefix, GenericList &targetList);
+    // Run procedure in the specified data context
+    bool execute(const ProcedureContext &context);
 
     /*
      * Read / Write


### PR DESCRIPTION
This PR introduces a straightforward data class, `ProcedureContext`, to contain references and pointers to lower-level data that the procedure is currently operating on. Previously, this information was passed to procedure node's `prepare`, `execute`, and `finalise` functions as individual data members. The new implementation simplifies this data passing with a const reference to a `ProcedureContext`, and permits new data to be added and passed much more easily.