### PR TITLE
Push to Harbor on release

### DIFF
--- a/.azure-pipelines/templates/create-release.yml
+++ b/.azure-pipelines/templates/create-release.yml
@@ -102,3 +102,20 @@ jobs:
         env:
           GITHUB_TOKEN: $(REPO_SECRET)
         displayName: 'Update Web Release Info'
+      - bash: |
+          VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
+          singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
+          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
+        env:
+            HARBOR_USER: $(HARBOR_USER)
+            HARBOR_SECRET: $(HARBOR_SECRET)
+        displayName: "Publish latest singularity image to Harbor registry."
+      - bash: |
+          VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
+          singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
+          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$VERSION
+        condition: eq('${{ parameters.continuous }}', false)
+        env:
+            HARBOR_USER: $(HARBOR_USER)
+            HARBOR_SECRET: $(HARBOR_SECRET)
+        displayName: "Publish versioned singularity image to Harbor registry."

--- a/.azure-pipelines/templates/create-release.yml
+++ b/.azure-pipelines/templates/create-release.yml
@@ -105,17 +105,18 @@ jobs:
       - bash: |
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
           singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
+          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous
+        condition: eq('${{ parameters.continuous }}', true)
         env:
             HARBOR_USER: $(HARBOR_USER)
             HARBOR_SECRET: $(HARBOR_SECRET)
-        displayName: "Publish latest singularity image to Harbor registry."
+        displayName: "Publish continuous singularity image to Harbor registry."
       - bash: |
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
           singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$VERSION
+          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
         condition: eq('${{ parameters.continuous }}', false)
         env:
             HARBOR_USER: $(HARBOR_USER)
             HARBOR_SECRET: $(HARBOR_SECRET)
-        displayName: "Publish versioned singularity image to Harbor registry."
+        displayName: "Publish latest singularity image to Harbor registry."


### PR DESCRIPTION
Obviously, I can't test this, so a look through would be appreciated to see if I missed anything.  The general idea is that both the continuous and release pipelines will update container tagged `latest`.  However, the release pipeline will also add a container tagged with the version number.

This will close #996.