### PR TITLE
Use nix to retrieve pre-compiled singularity for uploads

### DIFF
--- a/.azure-pipelines/templates/create-release.yml
+++ b/.azure-pipelines/templates/create-release.yml
@@ -103,27 +103,18 @@ jobs:
           GITHUB_TOKEN: $(REPO_SECRET)
         displayName: 'Update Web Release Info'
       - bash: |
-          sudo apt-get update && \
-          sudo apt-get install -y build-essential \
-          libseccomp-dev pkg-config squashfs-tools cryptsetup
-          export GOPATH=$(Agent.HomeDirectory)/go
-          go get -d github.com/sylabs/singularity
-          cd ${GOPATH}/src/github.com/sylabs/singularity && git fetch && git checkout v3.7.2
-          ./mconfig && make -C ./builddir && sudo make -C ./builddir install
-        displayName: "Compile Singularity"
-      - bash: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-          singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-gui-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous
+          nix run .#uploader ${HARBOR_USER} ${HARBOR_SECRET} $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-gui-$VERSION.sif  continuous
         condition: eq('${{ parameters.continuous }}', true)
         env:
             HARBOR_USER: $(HARBOR_USER)
             HARBOR_SECRET: $(HARBOR_SECRET)
         displayName: "Publish continuous singularity image to Harbor registry."
       - bash: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
           VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-          singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-          singularity push $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-gui-$VERSION.sif  oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
+          nix run .#uploader ${HARBOR_USER} ${HARBOR_SECRET} $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-gui-$VERSION.sif  latest
         condition: eq('${{ parameters.continuous }}', false)
         env:
             HARBOR_USER: $(HARBOR_USER)

--- a/flake.nix
+++ b/flake.nix
@@ -184,8 +184,8 @@
                 echo "Usage: nix run .#uploader HARBOR_USER HARBOR_SECRET IMAGE TAG" >&2
                 exit 1
               fi
-              ${pkgs.singularity}/bin/singularity remote login --username $1 --password 2 docker://harbor.stfc.ac.uk
-              ${pkgs.singularity}/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
+              ${outdated.legacyPackages.${system}.singularity}/bin/singularity remote login --username $1 --password 2 docker://harbor.stfc.ac.uk
+              ${outdated.legacyPackages.${system}.singularity}/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
             '');
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
               ++ pkgs.lib.optionals gui (gui_libs pkgs)
               ++ pkgs.lib.optionals checks (check_libs pkgs)
               ++ pkgs.lib.optional threading pkgs.tbb;
-            nativeBuildInputs = [pkgs.wrapGAppsHook];
+            nativeBuildInputs = [ pkgs.wrapGAppsHook ];
 
             TBB_DIR = "${pkgs.tbb}";
             CTEST_OUTPUT_ON_FAILURE = "ON";
@@ -174,6 +174,19 @@
           };
           dissolve-gui = flake-utils.lib.mkApp {
             drv = self.packages.${system}.dissolve-gui;
+          };
+          uploader = {
+            type="app";
+            program = toString (pkgs.writeScript "upload.sh" ''
+              #!/bin/sh
+              set -e
+              if [ "$#" -ne 4 ] ; then
+                echo "Usage: nix run .#uploader HARBOR_USER HARBOR_SECRET IMAGE TAG" >&2
+                exit 1
+              fi
+              ${pkgs.singularity}/bin/singularity remote login --username $1 --password 2 docker://harbor.stfc.ac.uk
+              ${pkgs.singularity}/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
+            '');
           };
         };
 


### PR DESCRIPTION
I woke up about two this morning, realizing that I'd been overthinking how to use the pre-compiled singularity packages on nix.  This should reuse the copy of singularity that we already download for building the image.