### PR TITLE
Coordinate Sets for Species

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -13,15 +13,24 @@ dissolve_benchmark(forces)
 add_executable(benchmarks benchmarks.cpp ${benchmark_files})
 
 target_include_directories(benchmarks PRIVATE ${PROJECT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(
-  benchmarks
-  PRIVATE benchmark::benchmark
-  PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS}
-         # Module 'nogui' libs
-         ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
-  PRIVATE # External libs
-          antlr4-runtime ${EXTRA_LINK_LIBS} ${THREADING_LINK_LIBS}
-)
+
+if(CONAN)
+  target_link_libraries(
+    benchmarks
+    PRIVATE benchmark::benchmark
+    PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS} ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
+    PRIVATE ${EXTRA_LINK_LIBS} ${THREADING_LINK_LIBS}
+    INTERFACE CONAN_PKG::fmt CONAN_PKG::cli11 CONAN_PKG::antlr4-cppruntime
+  )
+else(CONAN)
+  target_link_libraries(
+    benchmarks
+    PRIVATE benchmark::benchmark
+    PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS} ${MODULENOGUI_LINK_LIBS} ${NO_WHOLE_ARCHIVE_FLAG}
+    PRIVATE antlr4-runtime ${EXTRA_LINK_LIBS} ${THREADING_LINK_LIBS}
+  )
+endif(CONAN)
+
 target_compile_options(benchmarks PRIVATE -O3)
 
 # Find all the input files

--- a/benchmark/forces/forces_benchmark.cpp
+++ b/benchmark/forces/forces_benchmark.cpp
@@ -53,7 +53,7 @@ template <ProblemType problem, Population population> static void BM_CalculateFo
     const auto &mol = problemDef.cfg_->molecules().front();
     const auto &angle = mol->species()->angles().back();
     for (auto _ : state)
-        forceKernel.forces(angle, angle.i()->r(),  angle.j()->r(),  angle.k()->r(), forces);
+        forceKernel.forces(angle, angle.i()->r(), angle.j()->r(), angle.k()->r(), forces);
 }
 template <ProblemType problem, Population population> static void BM_CalculateForces_SpeciesTorsion(benchmark::State &state)
 {

--- a/benchmark/forces/forces_benchmark.cpp
+++ b/benchmark/forces/forces_benchmark.cpp
@@ -41,9 +41,7 @@ template <ProblemType problem, Population population> static void BM_CalculateFo
     const auto &bond = mol->species()->bonds().back();
 
     for (auto _ : state)
-    {
-        forceKernel.forces(bond, forces);
-    }
+        forceKernel.forces(bond, bond.i()->r(), bond.j()->r(), forces);
 }
 
 template <ProblemType problem, Population population> static void BM_CalculateForces_SpeciesAngle(benchmark::State &state)
@@ -55,9 +53,7 @@ template <ProblemType problem, Population population> static void BM_CalculateFo
     const auto &mol = problemDef.cfg_->molecules().front();
     const auto &angle = mol->species()->angles().back();
     for (auto _ : state)
-    {
-        forceKernel.forces(angle, forces);
-    }
+        forceKernel.forces(angle, angle.i()->r(),  angle.j()->r(),  angle.k()->r(), forces);
 }
 template <ProblemType problem, Population population> static void BM_CalculateForces_SpeciesTorsion(benchmark::State &state)
 {
@@ -68,9 +64,7 @@ template <ProblemType problem, Population population> static void BM_CalculateFo
     const auto &mol = problemDef.cfg_->molecules().front();
     const auto &torsion = mol->species()->torsions().back();
     for (auto _ : state)
-    {
-        forceKernel.forces(torsion, forces);
-    }
+        forceKernel.forces(torsion, torsion.i()->r(), torsion.j()->r(), torsion.k()->r(), torsion.l()->r(), forces);
 }
 
 template <ProblemType problem, Population population>

--- a/examples/benzene/input.txt
+++ b/examples/benzene/input.txt
@@ -135,8 +135,11 @@ Configuration  'Bulk'
       Angles  9.000000e+01  9.000000e+01  9.000000e+01
       NonPeriodic  False
     EndBox
-    Add
+    CoordinateSets  'Benzene_Sets'
       Species  'Benzene'
+    EndCoordinateSets
+    Add
+      CoordinateSets  'Benzene_Sets'
       Population  '200'
       BoxAction  AddVolume
       Density  'rho'  g/cm3

--- a/examples/water/input.txt
+++ b/examples/water/input.txt
@@ -77,8 +77,11 @@ Configuration  'Bulk'
       Angles  9.000000e+01  9.000000e+01  9.000000e+01
       NonPeriodic  False
     EndBox
-    Add
+    CoordinateSets  'Water_Sets'
       Species  'Water'
+    EndCoordinateSets
+    Add
+      CoordinateSets  'Water_Sets'
       Population  '1000'
       Density  'rho'  atoms/A3
       Rotate  True

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -65,11 +65,11 @@ class Configuration
     // Return the current generator
     Procedure &generator();
     // Create the Configuration according to its generator Procedure
-    bool generate(const ProcessPool &procPool, double pairPotentialRange);
+    bool generate(const ProcedureContext &procedureContext);
     // Return import coordinates file / format
     CoordinateImportFileFormat &inputCoordinates();
     // Initialise (generate or load) the basic contents of the Configuration
-    bool initialiseContent(const ProcessPool &procPool, double pairPotentialRange, bool emptyCurrentContent = false);
+    bool initialiseContent(const ProcedureContext &procedureContext, bool emptyCurrentContent = false);
     // Set configuration temperature
     void setTemperature(double t);
     // Return configuration temperature

--- a/src/classes/forcekernel.cpp
+++ b/src/classes/forcekernel.cpp
@@ -423,9 +423,9 @@ void ForceKernel::forces(const Atom &onlyThis, const SpeciesBond &bond, const At
 }
 
 // Calculate SpeciesBond forces
-void ForceKernel::forces(const SpeciesBond &bond, ForceVector &f) const
+void ForceKernel::forces(const SpeciesBond &bond, const Vec3<double> &ri, const Vec3<double> &rj, ForceVector &f) const
 {
-    auto vecji = box_->minimumVector(bond.i()->r(), bond.j()->r());
+    auto vecji = box_->minimumVector(ri, rj);
 
     // Get distance and normalise vector ready for force calculation
     const auto distance = vecji.magAndNormalise();
@@ -494,9 +494,10 @@ void ForceKernel::forces(const Atom &onlyThis, const SpeciesAngle &angle, const 
 }
 
 // Calculate SpeciesAngle forces
-void ForceKernel::forces(const SpeciesAngle &angle, ForceVector &f) const
+void ForceKernel::forces(const SpeciesAngle &angle, const Vec3<double> &ri, const Vec3<double> &rj, const Vec3<double> &rk,
+                         ForceVector &f) const
 {
-    auto angleParameters = calculateAngleParameters(angle.i()->r() - angle.j()->r(), angle.k()->r() - angle.j()->r());
+    auto angleParameters = calculateAngleParameters(ri - rj, rk - rj);
     const auto force = angle.force(angleParameters.theta_);
     angleParameters.dfi_dtheta_ *= force;
     angleParameters.dfk_dtheta_ *= force;
@@ -595,11 +596,12 @@ void ForceKernel::forces(const Atom &onlyThis, const SpeciesTorsion &torsion, co
 }
 
 // Calculate SpeciesTorsion forces
-void ForceKernel::forces(const SpeciesTorsion &torsion, ForceVector &f) const
+void ForceKernel::forces(const SpeciesTorsion &torsion, const Vec3<double> &ri, const Vec3<double> &rj, const Vec3<double> &rk,
+                         const Vec3<double> &rl, ForceVector &f) const
 {
-    auto vecji = box_->minimumVector(torsion.i()->r(), torsion.j()->r());
-    auto vecjk = box_->minimumVector(torsion.k()->r(), torsion.j()->r());
-    auto veckl = box_->minimumVector(torsion.l()->r(), torsion.k()->r());
+    auto vecji = box_->minimumVector(ri, rj);
+    auto vecjk = box_->minimumVector(rk, rj);
+    auto veckl = box_->minimumVector(rl, rk);
 
     auto torsionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = torsion.force(torsionParameters.phi_ * DEGRAD);
@@ -652,11 +654,12 @@ void ForceKernel::forces(const Atom &onlyThis, const SpeciesImproper &imp, const
 }
 
 // Calculate SpeciesImproper forces
-void ForceKernel::forces(const SpeciesImproper &imp, ForceVector &f) const
+void ForceKernel::forces(const SpeciesImproper &imp, const Vec3<double> &ri, const Vec3<double> &rj, const Vec3<double> &rk,
+                         const Vec3<double> &rl, ForceVector &f) const
 {
-    auto vecji = box_->minimumVector(imp.i()->r(), imp.j()->r());
-    auto vecjk = box_->minimumVector(imp.k()->r(), imp.j()->r());
-    auto veckl = box_->minimumVector(imp.l()->r(), imp.k()->r());
+    auto vecji = box_->minimumVector(ri, rj);
+    auto vecjk = box_->minimumVector(rk, rj);
+    auto veckl = box_->minimumVector(rl, rk);
 
     auto torsionParameters = calculateTorsionParameters(vecji, vecjk, veckl);
     const auto du_dphi = imp.force(torsionParameters.phi_ * DEGRAD);

--- a/src/classes/forcekernel.h
+++ b/src/classes/forcekernel.h
@@ -101,38 +101,37 @@ class ForceKernel
 
     public:
     // Bond terms
-    // Calculate SpeciesBond forces for given atoms
-    void forces(const SpeciesBond &bond, const Atom &i, const Atom &j, ForceVector &f) const;
     // Calculate SpeciesBond forces
-    void forces(const SpeciesBond &bond, ForceVector &f) const;
+    void forces(const SpeciesBond &bond, const Atom &i, const Atom &j, ForceVector &f) const;
+    void forces(const SpeciesBond &bond, const Vec3<double> &ri, const Vec3<double> &rj, ForceVector &f) const;
     // Calculate SpeciesBond forces for specified Atom only
     void forces(const Atom &onlyThis, const SpeciesBond &bond, const Atom &i, const Atom &j, ForceVector &f) const;
 
     // Angle terms
-    // Calculate SpeciesAngle forces for given atoms
-    void forces(const SpeciesAngle &angle, const Atom &i, const Atom &j, const Atom &k, ForceVector &f) const;
     // Calculate SpeciesAngle forces
-    void forces(const SpeciesAngle &angle, ForceVector &f) const;
+    void forces(const SpeciesAngle &angle, const Atom &i, const Atom &j, const Atom &k, ForceVector &f) const;
+    void forces(const SpeciesAngle &angle, const Vec3<double> &ri, const Vec3<double> &rj, const Vec3<double> &rk,
+                ForceVector &f) const;
     // Calculate SpeciesAngle forces for specified Atom only
     void forces(const Atom &onlyThis, const SpeciesAngle &angle, const Atom &i, const Atom &j, const Atom &k,
                 ForceVector &f) const;
 
     // Torsion terms
-    // Calculate SpeciesTorsion forces for given atoms
+    // Calculate SpeciesTorsion forces
     void forces(const SpeciesTorsion &torsion, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
                 ForceVector &f) const;
-    // Calculate SpeciesTorsion forces
-    void forces(const SpeciesTorsion &torsion, ForceVector &f) const;
+    void forces(const SpeciesTorsion &torsion, const Vec3<double> &ri, const Vec3<double> &rj, const Vec3<double> &rk,
+                const Vec3<double> &rl, ForceVector &f) const;
     // Calculate SpeciesTorsion forces for specified Atom only
     void forces(const Atom &onlyThis, const SpeciesTorsion &torsion, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
                 ForceVector &f) const;
 
     // Improper Terms
-    // Calculate SpeciesImproper forces for given atoms
+    // Calculate SpeciesImproper forces
     void forces(const SpeciesImproper &improper, const Atom &i, const Atom &j, const Atom &k, const Atom &l,
                 ForceVector &f) const;
-    // Calculate SpeciesImproper forces
-    void forces(const SpeciesImproper &improper, ForceVector &f) const;
+    void forces(const SpeciesImproper &torsion, const Vec3<double> &ri, const Vec3<double> &rj, const Vec3<double> &rk,
+                const Vec3<double> &rl, ForceVector &f) const;
     // Calculate SpeciesImproper forces for specified Atom only
     void forces(const Atom &onlyThis, const SpeciesImproper &improper, const Atom &i, const Atom &j, const Atom &k,
                 const Atom &l, ForceVector &f) const;

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -202,24 +202,3 @@ void Species::print() const
 
 // Return version
 int Species::version() const { return version_; }
-
-/*
- * Coordinate Sets
- */
-
-// Clear coordinate sets
-void Species::clearCoordinateSets() { coordinateSets_.clear(); }
-
-// Add new coordinate set
-std::vector<Vec3<double>> &Species::addCoordinateSet()
-{
-    auto &newSet = coordinateSets_.emplace_back(atoms_.size(), Vec3<double>());
-
-    return newSet;
-}
-
-// Return number of defined coordinate sets
-int Species::nCoordinateSets() const { return coordinateSets_.size(); }
-
-// Return coordinates sets
-const std::vector<std::vector<Vec3<double>>> &Species::coordinateSets() const { return coordinateSets_; }

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -322,25 +322,6 @@ class Species
     void centreAtOrigin();
 
     /*
-     * Coordinate Sets
-     */
-    private:
-    // Available coordinate sets representing conformers, symmetry copies etc.
-    std::vector<std::vector<Vec3<double>>> coordinateSets_;
-    // File / format of coordinate sets file, if provided
-    CoordinateImportFileFormat coordinateSetInputCoordinates_;
-
-    public:
-    // Clear coordinate sets
-    void clearCoordinateSets();
-    // Add new coordinate set
-    std::vector<Vec3<double>> &addCoordinateSet();
-    // Return number of defined coordinate sets
-    int nCoordinateSets() const;
-    // Return coordinates sets
-    const std::vector<std::vector<Vec3<double>>> &coordinateSets() const;
-
-    /*
      * File Input / Output
      */
     public:
@@ -356,25 +337,24 @@ class Species
     // Species Block Keyword Enum
     enum class SpeciesKeyword
     {
-        Angle,          /* 'Angle' - Defines an Angle joining three atoms */
-        Atom,           /* 'Atom' - Specifies an Atom in the Species */
-        Bond,           /* 'Bond' - Defines a Bond joining two atoms */
-        BondType,       /* 'BondType' - Sets the type of a specific bond */
-        BoxAngles,      /* 'BoxAngles' - Specify unit cell angles for the species */
-        BoxLengths,     /* 'BoxLengths' - Specify unit cell lengths for the species */
-        Charge,         /* 'Charge' - Specifies the atomic charge for an individual atom */
-        CoordinateSets, /* 'CoordinateSets' - File and format for any associated coordinate sets */
-        EndSpecies,     /* 'EndSpecies' - Signals the end of the current Species */
-        Forcefield,     /* 'Forcefield' - Sets the Forcefield from which to (re)generate or set terms */
-        Improper,       /* 'Improper' - Define an Improper interaction between four atoms */
-        Isotopologue,   /* 'Isotopologue' - Add an isotopologue to the Species */
-        NAngles,        /* 'NAngles' - Hint at the total number of angles in the Species */
-        NAtoms,         /* 'NAtoms' - Hint at the total number of atoms in the Species */
-        NBonds,         /* 'NBonds' - Hint at the total number of bonds in the Species */
-        NImpropers,     /* 'NImpropers' - Hint at the total number of impropers in the Species */
-        NTorsions,      /* 'NTorsions' - Hint at the total number of torsions in the Species */
-        Site,           /* 'Site' - Define an analysis site within the Species */
-        Torsion         /* 'Torsion' - Define a Torsion interaction between four atoms */
+        Angle,        /* 'Angle' - Defines an Angle joining three atoms */
+        Atom,         /* 'Atom' - Specifies an Atom in the Species */
+        Bond,         /* 'Bond' - Defines a Bond joining two atoms */
+        BondType,     /* 'BondType' - Sets the type of a specific bond */
+        BoxAngles,    /* 'BoxAngles' - Specify unit cell angles for the species */
+        BoxLengths,   /* 'BoxLengths' - Specify unit cell lengths for the species */
+        Charge,       /* 'Charge' - Specifies the atomic charge for an individual atom */
+        EndSpecies,   /* 'EndSpecies' - Signals the end of the current Species */
+        Forcefield,   /* 'Forcefield' - Sets the Forcefield from which to (re)generate or set terms */
+        Improper,     /* 'Improper' - Define an Improper interaction between four atoms */
+        Isotopologue, /* 'Isotopologue' - Add an isotopologue to the Species */
+        NAngles,      /* 'NAngles' - Hint at the total number of angles in the Species */
+        NAtoms,       /* 'NAtoms' - Hint at the total number of atoms in the Species */
+        NBonds,       /* 'NBonds' - Hint at the total number of bonds in the Species */
+        NImpropers,   /* 'NImpropers' - Hint at the total number of impropers in the Species */
+        NTorsions,    /* 'NTorsions' - Hint at the total number of torsions in the Species */
+        Site,         /* 'Site' - Define an analysis site within the Species */
+        Torsion       /* 'Torsion' - Define a Torsion interaction between four atoms */
     };
     // Return enum option info for SpeciesKeyword
     static EnumOptions<Species::SpeciesKeyword> keywords();

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -182,7 +182,7 @@ void ConfigurationTab::on_GeneratorRegenerateButton_clicked(bool checked)
 
     if (ret == QMessageBox::Yes)
     {
-        configuration_->initialiseContent(dissolve_.worldPool(), dissolve_.pairPotentialRange(), true);
+        configuration_->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()}, true);
         updateControls();
     }
 }

--- a/src/gui/keywordwidgets/nodevalueenumoptions.h
+++ b/src/gui/keywordwidgets/nodevalueenumoptions.h
@@ -44,6 +44,8 @@ class NodeValueEnumOptionsKeywordWidget : public QWidget, public KeywordWidgetBa
      * Update
      */
     public:
+    // Check validity of current value
+    void checkValueValidity();
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
 };

--- a/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
@@ -24,6 +24,10 @@ NodeValueEnumOptionsKeywordWidget::NodeValueEnumOptionsKeywordWidget(QWidget *pa
             ui_.OptionsCombo->setCurrentIndex(n);
     }
 
+    // Set expression text
+    ui_.ValueEdit->setText(QString::fromStdString(keyword_->value().asString()));
+    checkValueValidity();
+
     // Set event filtering on the combo so that we do not blindly accept mouse wheel events (problematic since we
     // will exist in a QScrollArea)
     ui_.OptionsCombo->installEventFilter(new MouseWheelWidgetAdjustmentGuard(ui_.OptionsCombo));
@@ -41,7 +45,7 @@ void NodeValueEnumOptionsKeywordWidget::on_ValueEdit_editingFinished()
         return;
 
     keyword_->setValue(qPrintable(ui_.ValueEdit->text()));
-    ui_.ValueValidIndicator->setOK(keyword_->value().isValid());
+    checkValueValidity();
 
     emit(keywordDataChanged(keyword_->editSignals()));
 }
@@ -52,7 +56,7 @@ void NodeValueEnumOptionsKeywordWidget::on_ValueEdit_returnPressed()
         return;
 
     keyword_->setValue(qPrintable(ui_.ValueEdit->text()));
-    ui_.ValueValidIndicator->setOK(keyword_->value().isValid());
+    checkValueValidity();
 
     emit(keywordDataChanged(keyword_->editSignals()));
 }
@@ -71,14 +75,18 @@ void NodeValueEnumOptionsKeywordWidget::on_OptionsCombo_currentIndexChanged(int 
  * Update
  */
 
+// Check validity of current value
+void NodeValueEnumOptionsKeywordWidget::checkValueValidity() { ui_.ValueValidIndicator->setOK(keyword_->value().isValid()); }
+
 // Update value displayed in widget
 void NodeValueEnumOptionsKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     refreshing_ = true;
 
     ui_.ValueEdit->setText(QString::fromStdString(keyword_->value().asString()));
-    ui_.ValueValidIndicator->setOK(keyword_->value().isValid());
     ui_.OptionsCombo->setCurrentIndex(keyword_->baseOptions().index());
+
+    checkValueValidity();
 
     refreshing_ = false;
 }

--- a/src/gui/keywordwidgets/species_funcs.cpp
+++ b/src/gui/keywordwidgets/species_funcs.cpp
@@ -39,7 +39,7 @@ void SpeciesKeywordWidget::on_SpeciesCombo_currentIndexChanged(int index)
     if (index == -1)
         keyword_->data() = nullptr;
     else
-        keyword_->data() = ui_.SpeciesCombo->currentData(Qt::UserRole).value<Species *>();
+        keyword_->data() = ui_.SpeciesCombo->currentData(Qt::UserRole).value<const Species *>();
 
     emit(keywordDataChanged(keyword_->editSignals()));
 }

--- a/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
+++ b/src/gui/keywordwidgets/vec3nodevalue_funcs.cpp
@@ -17,6 +17,15 @@ Vec3NodeValueKeywordWidget::Vec3NodeValueKeywordWidget(QWidget *parent, Vec3Node
     Vec3WidgetLabels::set(ui_.ValueBLabel, keyword_->labelType(), 1);
     Vec3WidgetLabels::set(ui_.ValueCLabel, keyword_->labelType(), 2);
 
+    // Set expression texts
+    ui_.ValueAEdit->setText(QString::fromStdString(keyword_->data().x.asString()));
+    ui_.ValueBEdit->setText(QString::fromStdString(keyword_->data().y.asString()));
+    ui_.ValueCEdit->setText(QString::fromStdString(keyword_->data().z.asString()));
+
+    ui_.ValueAValidIndicator->setOK(keyword_->data().x.isValid());
+    ui_.ValueBValidIndicator->setOK(keyword_->data().y.isValid());
+    ui_.ValueCValidIndicator->setOK(keyword_->data().z.isValid());
+
     refreshing_ = false;
 }
 

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -42,7 +42,7 @@ void DissolveWindow::on_ConfigurationCreateSimpleRandomMixAction_triggered(bool 
         generator.addRootSequenceNode(std::make_shared<AddProcedureNode>(sp, 100, NodeValue("rho", paramsNode->parameters())));
 
     // Run the generator
-    newConfiguration->generate(dissolve_.worldPool(), dissolve_.pairPotentialRange());
+    newConfiguration->generate({dissolve_.worldPool(), dissolve_.potentialMap()});
 
     setModified();
     fullUpdate();
@@ -87,7 +87,7 @@ void DissolveWindow::on_ConfigurationCreateRelativeRandomMixAction_triggered(boo
     }
 
     // Run the generator
-    newConfiguration->generate(dissolve_.worldPool(), dissolve_.pairPotentialRange());
+    newConfiguration->generate({dissolve_.worldPool(), dissolve_.potentialMap()});
 
     setModified();
     fullUpdate();
@@ -113,7 +113,7 @@ void DissolveWindow::on_ConfigurationCreateEmptyFrameworkAction_triggered(bool c
     generator.addRootSequenceNode(node);
 
     // Run the generator
-    newConfiguration->generate(dissolve_.worldPool(), dissolve_.pairPotentialRange());
+    newConfiguration->generate({dissolve_.worldPool(), dissolve_.potentialMap()});
 
     setModified();
     fullUpdate();
@@ -177,7 +177,7 @@ void DissolveWindow::on_ConfigurationCreateFrameworkAdsorbatesAction_triggered(b
     }
 
     // Run the generator
-    newConfiguration->generate(dissolve_.worldPool(), dissolve_.pairPotentialRange());
+    newConfiguration->generate({dissolve_.worldPool(), dissolve_.potentialMap()});
 
     setModified();
     fullUpdate();

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -8,6 +8,7 @@
 #include "main/dissolve.h"
 #include "procedure/nodes/add.h"
 #include "procedure/nodes/box.h"
+#include "procedure/nodes/coordinatesets.h"
 #include "procedure/nodes/generalregion.h"
 #include "procedure/nodes/parameters.h"
 #include <QFileDialog>
@@ -39,7 +40,13 @@ void DissolveWindow::on_ConfigurationCreateSimpleRandomMixAction_triggered(bool 
     generator.addRootSequenceNode(paramsNode);
     generator.addRootSequenceNode(std::make_shared<BoxProcedureNode>());
     for (const auto *sp : mixSpecies)
-        generator.addRootSequenceNode(std::make_shared<AddProcedureNode>(sp, 100, NodeValue("rho", paramsNode->parameters())));
+    {
+        auto coordSets = std::make_shared<CoordinateSetsProcedureNode>(sp);
+        coordSets->setName(fmt::format("{}_Sets", sp->name()));
+        generator.addRootSequenceNode(coordSets);
+        generator.addRootSequenceNode(
+            std::make_shared<AddProcedureNode>(coordSets.get(), 100, NodeValue("rho", paramsNode->parameters())));
+    }
 
     // Run the generator
     newConfiguration->generate({dissolve_.worldPool(), dissolve_.potentialMap()});
@@ -69,17 +76,22 @@ void DissolveWindow::on_ConfigurationCreateRelativeRandomMixAction_triggered(boo
     auto count = 0;
     for (auto *sp : mixSpecies)
     {
+        auto coordSets = std::make_shared<CoordinateSetsProcedureNode>(sp);
+        coordSets->setName(fmt::format("{}_Sets", sp->name()));
+        generator.addRootSequenceNode(coordSets);
+
         // Add a parameter for the ratio of this species to the first (or the population of the first)
         if (count == 0)
-            generator.addRootSequenceNode(std::make_shared<AddProcedureNode>(
-                sp, NodeValue("populationA", paramsNode->parameters()), NodeValue("rho", paramsNode->parameters())));
+            generator.addRootSequenceNode(std::make_shared<AddProcedureNode>(coordSets.get(),
+                                                                             NodeValue("populationA", paramsNode->parameters()),
+                                                                             NodeValue("rho", paramsNode->parameters())));
         else
         {
             auto parameterName = fmt::format("ratio{}", char(65 + count));
             paramsNode->addParameter(parameterName, 1);
 
             generator.addRootSequenceNode(std::make_shared<AddProcedureNode>(
-                sp, NodeValue(fmt::format("{}*populationA", parameterName), paramsNode->parameters()),
+                coordSets.get(), NodeValue(fmt::format("{}*populationA", parameterName), paramsNode->parameters()),
                 NodeValue("rho", paramsNode->parameters())));
         }
 
@@ -156,17 +168,22 @@ void DissolveWindow::on_ConfigurationCreateFrameworkAdsorbatesAction_triggered(b
     auto count = 0;
     for (auto *sp : adsorbates)
     {
+        auto coordSets = std::make_shared<CoordinateSetsProcedureNode>(sp);
+        coordSets->setName(fmt::format("{}_Sets", sp->name()));
+        generator.addRootSequenceNode(coordSets);
+
         // Add a parameter for the ratio of this species to the first (or the population of the first)
         std::shared_ptr<AddProcedureNode> addSpeciesNode = nullptr;
         if (count == 0)
-            addSpeciesNode = std::make_shared<AddProcedureNode>(sp, NodeValue("populationA", paramsNode->parameters()));
+            addSpeciesNode =
+                std::make_shared<AddProcedureNode>(coordSets.get(), NodeValue("populationA", paramsNode->parameters()));
         else
         {
             auto parameterName = fmt::format("ratio{}", char(65 + count));
             paramsNode->addParameter(parameterName, 1);
 
             addSpeciesNode = std::make_shared<AddProcedureNode>(
-                sp, NodeValue(fmt::format("{}*populationA", parameterName), paramsNode->parameters()));
+                coordSets.get(), NodeValue(fmt::format("{}*populationA", parameterName), paramsNode->parameters()));
         }
         addSpeciesNode->keywords().setEnumeration("BoxAction", AddProcedureNode::BoxActionStyle::None);
         addSpeciesNode->keywords().setEnumeration("Positioning", AddProcedureNode::PositioningType::Region);

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -34,15 +34,10 @@ bool SpeciesKeyword::deserialise(LineParser &parser, int startArg, const CoreDat
 // Serialise data to specified LineParser
 bool SpeciesKeyword::serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
-    if (data_)
-    {
-        if (!parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, data_->name()))
-            return false;
-    }
-    else if (!parser.writeLineF("{}{}  '?_?'\n", prefix, name()))
-        return false;
+    if (!data_)
+        return true;
 
-    return true;
+    return parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, data_->name());
 }
 
 /*

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -12,6 +12,7 @@
 #include "keywords/module.h"
 #include "keywords/modulevector.h"
 #include "keywords/nodevector.h"
+#include "keywords/species.h"
 #include "keywords/stdstring.h"
 #include "keywords/vec3double.h"
 #include "procedure/nodes/nodes.h"
@@ -46,6 +47,7 @@ KeywordTypeMap::KeywordTypeMap()
         [](ModuleKeywordBase *keyword) { return keyword->module(); });
     registerDirectMapping<Configuration *, ConfigurationKeyword>();
     registerDirectMapping<std::vector<Configuration *>, ConfigurationVectorKeyword>();
+    registerDirectMapping<const Species *, SpeciesKeyword>();
 
     // STL / Common Classes
     registerDirectMapping<std::string, StringKeyword>();

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -55,7 +55,7 @@ bool Dissolve::loadInput(LineParser &parser)
                 }
 
                 // Prepare the Configuration
-                if (!cfg->initialiseContent(worldPool(), pairPotentialRange_))
+                if (!cfg->initialiseContent({worldPool(), potentialMap()}))
                     error = true;
                 break;
             case (BlockKeywords::LayerBlockKeyword):

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -54,8 +54,12 @@ bool Dissolve::loadInput(LineParser &parser)
                     break;
                 }
 
+                // Need to update pair potentials in case they're needed in the generator
+                generatePairPotentials();
+                potentialMap_.initialise(coreData_.atomTypes(), pairPotentials_, pairPotentialRange_);
+
                 // Prepare the Configuration
-                if (!cfg->initialiseContent({worldPool(), potentialMap()}))
+                if (!cfg->initialiseContent({worldPool_, potentialMap_}))
                     error = true;
                 break;
             case (BlockKeywords::LayerBlockKeyword):

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -35,7 +35,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         {
             Timer timer;
             Messenger::mute();
-            targetConfiguration_->generate(procPool, dissolve.pairPotentialRange());
+            targetConfiguration_->generate({dissolve.worldPool(), dissolve.potentialMap()});
             Messenger::unMute();
             timing += timer.split();
         }

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -70,6 +70,9 @@ class ForcesModule : public Module
                             const std::vector<const Molecule *> &targetMolecules, const PotentialMap &potentialMap,
                             std::vector<Vec3<double>> &f, OptionalReferenceWrapper<Timer> commsTimer = {});
     // Calculate total forces within the specified Species
-    static void totalForces(const ProcessPool &procPool, Species *sp, const PotentialMap &potentialMap,
+    static void totalForces(const ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap,
                             std::vector<Vec3<double>> &f);
+    // Calculate total forces within the specified Species using the supplied reference coordinates
+    static void totalForces(const ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap,
+                            const std::vector<Vec3<double>> &r, std::vector<Vec3<double>> &f);
 };

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -37,7 +37,7 @@ double MDModule::determineTimeStep(const std::vector<Vec3<double>> &f)
 }
 
 // Evolve Species coordinates, returning new coordinates
-std::vector<Vec3<double>> MDModule::evolve(ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
+std::vector<Vec3<double>> MDModule::evolve(const ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
                                            double temperature, int nSteps, double deltaT,
                                            const std::vector<Vec3<double>> &rInit, std::vector<Vec3<double>> &velocities)
 {

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -2,6 +2,9 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "classes/configuration.h"
+#include "classes/species.h"
+#include "data/atomicmasses.h"
+#include "modules/forces/forces.h"
 #include "modules/md/md.h"
 
 // Cap forces in Configuration
@@ -31,4 +34,108 @@ double MDModule::determineTimeStep(const std::vector<Vec3<double>> &f)
     auto fMax = *std::max_element(f.begin(), f.end(), [](auto &left, auto &right) { return left.absMax() < right.absMax(); });
 
     return 1.0 / fMax.absMax();
+}
+
+// Evolve Species coordinates, returning new coordinates
+std::vector<Vec3<double>> MDModule::evolve(ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
+                                           double temperature, int nSteps, double deltaT,
+                                           const std::vector<Vec3<double>> &rInit, std::vector<Vec3<double>> &velocities)
+{
+    assert(sp);
+    assert(sp->nAtoms() == velocities.size());
+
+    // Create arrays
+    std::vector<double> mass(sp->nAtoms(), 0.0);
+    std::vector<Vec3<double>> forces(sp->nAtoms()), accelerations(sp->nAtoms());
+
+    // Variables
+    auto &atoms = sp->atoms();
+    double tInstant, ke, tScale;
+
+    // Units
+    // J = kg m2 s-2  -->   10 J = g Ang2 ps-2
+    // If ke is in units of [g mol-1 Angstroms2 ps-2] then must use kb in units of 10 J mol-1 K-1 (= 0.8314462)
+    const auto kb = 0.8314462;
+
+    // Store atomic masses for future use
+    for (auto &&[i, m] : zip(atoms, mass))
+        m = AtomicMass::mass(i.Z());
+
+    // Calculate total velocity and mass over all atoms
+    Vec3<double> vCom;
+    auto massSum = 0.0;
+    for (auto &&[v, m] : zip(velocities, mass))
+    {
+        vCom += v * m;
+        massSum += m;
+    }
+
+    // Remove any velocity shift
+    vCom /= massSum;
+    std::transform(velocities.begin(), velocities.end(), velocities.begin(), [vCom](auto vel) { return vel - vCom; });
+
+    // Calculate instantaneous temperature
+    ke = 0.0;
+    for (auto &&[m, v] : zip(mass, velocities))
+        ke += 0.5 * m * v.dp(v);
+    tInstant = ke * 2.0 / (3.0 * atoms.size() * kb);
+
+    // Rescale velocities for desired temperature
+    tScale = sqrt(temperature / tInstant);
+    std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto v) { return v * tScale; });
+
+    // Get timestep
+    auto deltaTSq = deltaT * deltaT;
+
+    // Copy coordinates ready for propagation
+    auto rNew = rInit;
+
+    // Ready to do MD propagation of the species
+    for (auto step = 1; step <= nSteps; ++step)
+    {
+        // Velocity Verlet first stage (A)
+        // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
+        // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
+        // B:  a(t+dt) = F(t+dt)/m
+        // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
+        for (auto &&[r, v, a] : zip(rNew, velocities, accelerations))
+        {
+            // Propagate positions (by whole step)...
+            r += v * deltaT + a * 0.5 * deltaTSq;
+
+            // ...velocities (by half step)...
+            v += a * 0.5 * deltaT;
+        }
+
+        // Zero force arrays
+        std::fill(forces.begin(), forces.end(), Vec3<double>());
+
+        // Calculate forces - must multiply by 100.0 to convert from kJ/mol to 10J/mol (our internal MD units)
+        ForcesModule::totalForces(procPool, sp, potentialMap, rNew, forces);
+        std::transform(forces.begin(), forces.end(), forces.begin(), [](auto &f) { return f * 100.0; });
+
+        // Velocity Verlet second stage (B) and velocity scaling
+        // A:  r(t+dt) = r(t) + v(t)*dt + 0.5*a(t)*dt**2
+        // A:  v(t+dt/2) = v(t) + 0.5*a(t)*dt
+        // B:  a(t+dt) = F(t+dt)/m
+        // B:  v(t+dt) = v(t+dt/2) + 0.5*a(t+dt)*dt
+        ke = 0.0;
+        for (auto &&[f, v, a, m] : zip(forces, velocities, accelerations, mass))
+        {
+            // Determine new accelerations
+            a = f / m;
+
+            // ..and finally velocities again (by second half-step)
+            v += a * 0.5 * deltaT;
+
+            ke += 0.5 * m * v.dp(v);
+        }
+
+        // Rescale velocities for desired temperature
+        tInstant = ke * 2.0 / (3.0 * sp->nAtoms() * kb);
+        tScale = sqrt(temperature / tInstant);
+        std::transform(velocities.begin(), velocities.end(), velocities.begin(), [tScale](auto &v) { return v * tScale; });
+    }
+
+    return rNew;
 }

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -60,7 +60,7 @@ class MDModule : public Module
 
     public:
     // Evolve Species coordinates, returning new coordinates
-    static std::vector<Vec3<double>> evolve(ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
+    static std::vector<Vec3<double>> evolve(const ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
                                             double temperature, int nSteps, double deltaT,
                                             const std::vector<Vec3<double>> &rInit, std::vector<Vec3<double>> &velocities);
 

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -6,6 +6,7 @@
 #include "module/module.h"
 
 // Forward Declarations
+class PotentialMap;
 class Species;
 
 // Molecular Dynamics Module
@@ -56,6 +57,12 @@ class MDModule : public Module
     int capForces(double maxForceSq, std::vector<Vec3<double>> &f);
     // Determine timestep based on maximal force component
     double determineTimeStep(const std::vector<Vec3<double>> &f);
+
+    public:
+    // Evolve Species coordinates, returning new coordinates
+    static std::vector<Vec3<double>> evolve(ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
+                                            double temperature, int nSteps, double deltaT,
+                                            const std::vector<Vec3<double>> &rInit, std::vector<Vec3<double>> &velocities);
 
     /*
      * Processing

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   collect2d.cpp
   collect3d.cpp
   context.cpp
+  coordinatesets.cpp
   cylindricalregion.cpp
   dynamicsite.cpp
   fit1d.cpp
@@ -52,6 +53,7 @@ add_library(
   collect2d.h
   collect3d.h
   context.h
+  coordinatesets.h
   cylindricalregion.h
   dynamicsite.h
   fit1d.h

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -2,9 +2,7 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "procedure/nodes/add.h"
-#include "base/lineparser.h"
 #include "base/randombuffer.h"
-#include "base/sysfunc.h"
 #include "classes/atomchangetoken.h"
 #include "classes/box.h"
 #include "classes/configuration.h"
@@ -21,6 +19,20 @@
 AddProcedureNode::AddProcedureNode(const Species *sp, const NodeValue &population, const NodeValue &density,
                                    Units::DensityUnits densityUnits)
     : ProcedureNode(ProcedureNode::NodeType::Add), density_{density, densityUnits}, population_(population), species_(sp)
+{
+    setUpKeywords();
+}
+
+AddProcedureNode::AddProcedureNode(const CoordinateSetsProcedureNode *sets, const NodeValue &population,
+                                   const NodeValue &density, Units::DensityUnits densityUnits)
+    : ProcedureNode(ProcedureNode::NodeType::Add), coordinateSets_(sets), density_{density, densityUnits},
+      population_(population)
+{
+    setUpKeywords();
+}
+
+// Set up keywords for node
+void AddProcedureNode::setUpKeywords()
 {
     // Set up keywords
     keywords_.add<SpeciesKeyword>("Control", "Species", "Target species to add", species_);

--- a/src/procedure/nodes/add.h
+++ b/src/procedure/nodes/add.h
@@ -8,6 +8,7 @@
 #include "procedure/nodevalue.h"
 
 // Forward Declarations
+class CoordinateSetsProcedureNode;
 class Species;
 class RegionProcedureNodeBase;
 
@@ -56,6 +57,8 @@ class AddProcedureNode : public ProcedureNode
     private:
     // Action to take on the Box geometry / volume on addition of the species
     AddProcedureNode::BoxActionStyle boxAction_{AddProcedureNode::BoxActionStyle::AddVolume};
+    // Coordinate set source for Species (if any)
+    std::shared_ptr<const CoordinateSetsProcedureNode> coordinateSets_{nullptr};
     // Target density when adding molecules
     std::pair<NodeValue, Units::DensityUnits> density_{1.0, Units::GramsPerCentimetreCubedUnits};
     // Population of molecules to add

--- a/src/procedure/nodes/add.h
+++ b/src/procedure/nodes/add.h
@@ -16,9 +16,15 @@ class RegionProcedureNodeBase;
 class AddProcedureNode : public ProcedureNode
 {
     public:
-    AddProcedureNode(const Species *sp = nullptr, const NodeValue &population = 0, const NodeValue &density = 0.1,
-                     Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
+    explicit AddProcedureNode(const Species *sp = nullptr, const NodeValue &population = 0, const NodeValue &density = 0.1,
+                              Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
+    explicit AddProcedureNode(const CoordinateSetsProcedureNode *sets, const NodeValue &population = 0,
+                              const NodeValue &density = 0.1, Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
     ~AddProcedureNode() override = default;
+
+    private:
+    // Set up keywords for node
+    void setUpKeywords();
 
     /*
      * Identity

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -4,8 +4,15 @@
 #include "procedure/nodes/context.h"
 #include <stdexcept>
 
+ProcedureContext::ProcedureContext(const ProcessPool &procPool) : processPool_(procPool) {}
+
 ProcedureContext::ProcedureContext(const ProcessPool &procPool, Configuration *cfg)
     : processPool_(procPool), configuration_(cfg)
+{
+}
+
+ProcedureContext::ProcedureContext(const ProcessPool &procPool, const PotentialMap &potentialMap)
+    : processPool_(procPool), potentialMap_(potentialMap)
 {
 }
 
@@ -39,4 +46,15 @@ GenericList &ProcedureContext::dataList() const
     if (!dataList_)
         throw(std::runtime_error("No data list set in this procedure's context.\n"));
     return dataList_->get();
+}
+
+// Set potential map
+void ProcedureContext::setPotentialMap(const PotentialMap &potentialMap) { potentialMap_ = potentialMap; }
+
+// Return potential map
+const PotentialMap &ProcedureContext::potentialMap() const
+{
+    if (!potentialMap_)
+        throw(std::runtime_error("No potential map was set in this procedure's context.\n"));
+    return potentialMap_->get();
 }

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -9,13 +9,16 @@
 // Forward Declarations
 class Configuration;
 class GenericList;
+class PotentialMap;
 class ProcessPool;
 
 // Node Operating Data
 class ProcedureContext
 {
     public:
-    ProcedureContext(const ProcessPool &procPool, Configuration *cfg = nullptr);
+    explicit ProcedureContext(const ProcessPool &procPool);
+    ProcedureContext(const ProcessPool &procPool, Configuration *cfg);
+    ProcedureContext(const ProcessPool &procPool, const PotentialMap &potentialMap);
 
     private:
     // Available process pool
@@ -26,6 +29,8 @@ class ProcedureContext
     std::string dataPrefix_;
     // Target list for generated data
     OptionalReferenceWrapper<GenericList> dataList_;
+    // Potential map
+    OptionalReferenceWrapper<const PotentialMap> potentialMap_;
 
     public:
     // Return available process pool
@@ -40,4 +45,8 @@ class ProcedureContext
     std::string_view dataPrefix() const;
     // Return target list for generated data
     GenericList &dataList() const;
+    // Set potential map
+    void setPotentialMap(const PotentialMap &potentialMap);
+    // Return potential map
+    const PotentialMap &potentialMap() const;
 };

--- a/src/procedure/nodes/coordinatesets.cpp
+++ b/src/procedure/nodes/coordinatesets.cpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "procedure/nodes/coordinatesets.h"
+#include "base/lineparser.h"
+#include "base/randombuffer.h"
+#include "base/sysfunc.h"
+#include "classes/atomchangetoken.h"
+#include "classes/configuration.h"
+#include "classes/species.h"
+#include "keywords/bool.h"
+#include "keywords/node.h"
+#include "keywords/nodevalue.h"
+#include "keywords/species.h"
+#include "modules/md/md.h"
+
+CoordinateSetsProcedureNode::CoordinateSetsProcedureNode(const Species *sp)
+    : ProcedureNode(ProcedureNode::NodeType::CoordinateSets), species_(sp)
+{
+    // Set up keywords
+    keywords_.add<SpeciesKeyword>("Control", "Species", "Target species", species_);
+    keywords_.add<NodeValueKeyword>("Control", "NSets", "Number of coordinate sets to generate", nSets_, this);
+    keywords_.add<NodeValueKeyword>("Control", "NSteps", "Number of steps to run (between storing coordinate sets)", nSteps_,
+                                    this);
+    keywords_.add<NodeValueKeyword>("Control", "DeltaT", "Timestep in ps", deltaT_, this);
+    keywords_.add<EnumOptionsKeyword<CoordinateSetsProcedureNode::CoordinateSetSource>>(
+        "Control", "Source", "Source of coordinate sets on addition of the species", source_, coordinateSetSources());
+    keywords_.add<BoolKeyword>("Control", "Force", "Force generation of coordinates, even if existing sets exist", force_);
+}
+
+/*
+ * Identity
+ */
+
+// Return whether specified context is relevant for this node type
+bool CoordinateSetsProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
+{
+    return (context == ProcedureNode::GenerationContext);
+}
+
+// Return whether a name for the node must be provided
+bool CoordinateSetsProcedureNode::mustBeNamed() const { return true; }
+
+/*
+ * Node Data
+ */
+
+// Return enum option info for SetCreationMethod
+EnumOptions<CoordinateSetsProcedureNode::CoordinateSetSource> CoordinateSetsProcedureNode::coordinateSetSources()
+{
+    return EnumOptions<CoordinateSetsProcedureNode::CoordinateSetSource>(
+        "SetCreationMethod", {{CoordinateSetsProcedureNode::CoordinateSetSource::File, "File"},
+                              {CoordinateSetsProcedureNode::CoordinateSetSource::MD, "MD"}});
+}
+
+// Add new coordinate set
+std::vector<Vec3<double>> &CoordinateSetsProcedureNode::addSet()
+{
+    assert(species_);
+    return sets_.emplace_back(species_->nAtoms(), Vec3<double>());
+}
+
+// Return number of available coordinates sets
+int CoordinateSetsProcedureNode::nSets() const { return sets_.size(); }
+
+// Return nth coordinate set
+const std::vector<Vec3<double>> &CoordinateSetsProcedureNode::set(int n) const { return sets_[n]; }
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool CoordinateSetsProcedureNode::prepare(const ProcedureContext &procedureContext)
+{
+    if (!species_)
+        return Messenger::error("No Species set in CoordinateSets node.\n");
+
+    // Clear existing sets?
+    if (force_)
+        sets_.clear();
+
+    // If a file source is selected, load its contents now
+    if (source_ == CoordinateSetSource::File && sets_.empty())
+    {
+        // Check import file format
+        if (!fileSource_.hasFilename())
+            return Messenger::error("A suitable coordinate file and format must be supplied.\n");
+
+        // Open the specified file
+        LineParser parser(&procedureContext.processPool());
+        if ((!parser.openInput(fileSource_.filename())) || (!parser.isFileGoodForReading()))
+            return Messenger::error("Couldn't open coordinate sets file '{}'.\n", fileSource_.filename());
+
+        // Read in as many coordinate sets as exists in the file
+        while (!parser.eofOrBlank())
+        {
+            auto &coordSet = addSet();
+            if (!fileSource_.importData(parser, coordSet))
+                return Messenger::error("Failed to read coordinate set {} from file.\n", sets_.size());
+        }
+
+        Messenger::print("{} coordinate sets read in for Species '{}'.\n", sets_.size(), name());
+    }
+
+    return true;
+}
+
+// Execute node
+bool CoordinateSetsProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    // Do we need to generate new sets?
+    if (!sets_.empty())
+        return true;
+
+    Messenger::print("[CoordinateSets] Target species is '{}'.\n", species_->name());
+
+    // For file-based import, this was done in prepare()
+    if (source_ == CoordinateSetSource::File)
+    {
+        Messenger::print("[CoordinateSets] File source specified, so nothing more to do.\n");
+        return true;
+    }
+
+    // Can't do MD on the Species if it has any missing core information
+    if (!species_->checkSetUp())
+        return Messenger::error("Can't generate coordinate sets via MD for species '{}' because it is not set up correctly.\n",
+                                species_->name());
+
+    // Initialise the random number buffer for all processes
+    RandomBuffer randomBuffer(procedureContext.processPool(),
+                              ProcessPool::subDivisionStrategy(procedureContext.processPool().bestStrategy()));
+
+    // Initialise random velocities
+    std::vector<Vec3<double>> velocities(species_->nAtoms());
+    std::generate(velocities.begin(), velocities.end(), [&]() {
+        return Vec3<double>(exp(randomBuffer.random() - 0.5), exp(randomBuffer.random() - 0.5),
+                            exp(randomBuffer.random() - 0.5)) /
+               sqrt(TWOPI);
+    });
+
+    // Grab current Species coordinates
+    std::vector<Vec3<double>> r(species_->nAtoms());
+    std::transform(species_->atoms().begin(), species_->atoms().end(), r.begin(), [](const auto &i) { return i.r(); });
+
+    Messenger::print("[CoordinateSets] Generating {} sets...\n", nSets_.asInteger());
+
+    for (auto n = 0; n < nSets_.asInteger(); ++n)
+    {
+        // Evolve our coordinates
+        r = MDModule::evolve(procedureContext.processPool(), procedureContext.potentialMap(), species_, temperature_.asDouble(),
+                             nSteps_.asInteger(), deltaT_.asDouble(), r, velocities);
+
+        // Store a new set
+        addSet() = r;
+    }
+
+    return true;
+}

--- a/src/procedure/nodes/coordinatesets.h
+++ b/src/procedure/nodes/coordinatesets.h
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "io/import/coordinates.h"
+#include "procedure/nodes/node.h"
+#include "procedure/nodevalue.h"
+#include <vector>
+
+// Forward Declarations
+class Species;
+
+// MD Node
+class CoordinateSetsProcedureNode : public ProcedureNode
+{
+    public:
+    CoordinateSetsProcedureNode(const Species *sp = nullptr);
+    ~CoordinateSetsProcedureNode() override = default;
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether specified context is relevant for this node type
+    bool isContextRelevant(ProcedureNode::NodeContext context) override;
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Node Data
+     */
+    public:
+    // Coordinate Set Source
+    enum class CoordinateSetSource
+    {
+        File, /* Import coordinates sets from file */
+        MD    /* Create coordinates via MD evolution of the parent species */
+    };
+    // Return enum option info for CoordinateSetSource
+    static EnumOptions<CoordinateSetSource> coordinateSetSources();
+
+    private:
+    // Target Species
+    const Species *species_{nullptr};
+    // Available coordinate sets
+    std::vector<std::vector<Vec3<double>>> sets_;
+    // Set Source
+    CoordinateSetSource source_{CoordinateSetSource::MD};
+    // Whether to force recreation of the coordinate sets
+    bool force_{false};
+    // File / format of coordinate sets file, if provided
+    CoordinateImportFileFormat fileSource_;
+    // Number of sets to generate
+    NodeValue nSets_{100};
+    // Number of MD steps to run between sets
+    NodeValue nSteps_{2000};
+    // Simulation temperature
+    NodeValue temperature_{300.0};
+    // Simulation timestep
+    NodeValue deltaT_{5.0e-4};
+
+    private:
+    // Add new coordinate set
+    std::vector<Vec3<double>> &addSet();
+
+    public:
+    // Return number of available coordinates sets
+    int nSets() const;
+    // Return nth coordinate set
+    const std::vector<Vec3<double>> &set(int n) const;
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+};

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -34,6 +34,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Collect1D, "Collect1D"},
                      {ProcedureNode::NodeType::Collect2D, "Collect2D"},
                      {ProcedureNode::NodeType::Collect3D, "Collect3D"},
+                     {ProcedureNode::NodeType::CoordinateSets, "CoordinateSets"},
                      {ProcedureNode::NodeType::CylindricalRegion, "CylindricalRegion"},
                      {ProcedureNode::NodeType::DynamicSite, "DynamicSite"},
                      {ProcedureNode::NodeType::Fit1D, "Fit1D"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -47,6 +47,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
         Collect1D,
         Collect2D,
         Collect3D,
+        CoordinateSets,
         CylindricalRegion,
         DynamicSite,
         Fit1D,

--- a/src/procedure/nodes/nodes.h
+++ b/src/procedure/nodes/nodes.h
@@ -15,6 +15,7 @@
 #include "procedure/nodes/collect1d.h"
 #include "procedure/nodes/collect2d.h"
 #include "procedure/nodes/collect3d.h"
+#include "procedure/nodes/coordinatesets.h"
 #include "procedure/nodes/cylindricalregion.h"
 #include "procedure/nodes/dynamicsite.h"
 #include "procedure/nodes/fit1d.h"

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -436,6 +436,9 @@ bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &core
             case (ProcedureNode::NodeType::Collect3D):
                 newNode = std::static_pointer_cast<ProcedureNode>(std::make_shared<Collect3DProcedureNode>());
                 break;
+            case (ProcedureNode::NodeType::CoordinateSets):
+                newNode = std::static_pointer_cast<ProcedureNode>(std::make_shared<CoordinateSetsProcedureNode>());
+                break;
             case (ProcedureNode::NodeType::CylindricalRegion):
                 newNode = std::static_pointer_cast<ProcedureNode>(std::make_shared<CylindricalRegionProcedureNode>());
                 break;


### PR DESCRIPTION
This PR implements the new `CoordinateSetsProcedureNode` which, when used in a generator context, performs MD on a given species in order to generate a set of "different" geometries.  When an `AddProcedureNode` is given this node instead of a target species, copies of the different geometries are used sequentially instead, resulting in a more diverse geometry in the starting configuration (which is a good thing).