### PR TITLE
Copy Species From Existing

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -168,6 +168,7 @@ class DissolveWindow : public QMainWindow
     // Species
     void on_SpeciesCreateAtomicAction_triggered(bool checked);
     void on_SpeciesCreateDrawAction_triggered(bool checked);
+    void on_SpeciesCreateFromExistingAction_triggered(bool checked);
     void on_SpeciesImportFromDissolveAction_triggered(bool checked);
     void on_SpeciesImportFromXYZAction_triggered(bool checked);
     void on_SpeciesImportLigParGenAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -837,6 +837,7 @@
   <action name="SpeciesCreateFromExistingAction">
    <property name="text">
     <string>From &amp;Existing...</string>
+   </property>
   </action>
   <action name="LayerCreateCorrelationsRDFXRayAction">
    <property name="text">

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -202,6 +202,7 @@
      </property>
      <addaction name="SpeciesCreateAtomicAction"/>
      <addaction name="SpeciesCreateDrawAction"/>
+     <addaction name="SpeciesCreateFromExistingAction"/>
     </widget>
     <widget class="QMenu" name="SpeciesImportMenu">
      <property name="font">
@@ -752,7 +753,7 @@
   </action>
   <action name="SpeciesCreateDrawAction">
    <property name="text">
-    <string>Draw...</string>
+    <string>&amp;Draw...</string>
    </property>
   </action>
   <action name="WorkspaceRenameCurrentGizmoAction">
@@ -830,6 +831,11 @@
   <action name="SimulationCheckAction">
    <property name="text">
     <string>Prepare / Check</string>
+   </property>
+  </action>
+  <action name="SpeciesCreateFromExistingAction">
+   <property name="text">
+    <string>From &amp;Existing...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/models/speciesFilterProxy.cpp
+++ b/src/gui/models/speciesFilterProxy.cpp
@@ -4,10 +4,10 @@
 #include "gui/models/speciesFilterProxy.h"
 #include "classes/species.h"
 
-SpeciesFilterProxy::SpeciesFilterProxy(int flags) : filterFlags_(flags) {}
+SpeciesFilterProxy::SpeciesFilterProxy(const Flags<SpeciesFilterProxy::FilterFlags> &flags) : filterFlags_(flags) {}
 
 // Set filter flags
-void SpeciesFilterProxy::setFlags(int flags)
+void SpeciesFilterProxy::setFlags(const Flags<SpeciesFilterProxy::FilterFlags> &flags)
 {
     filterFlags_ = flags;
     invalidateFilter();
@@ -19,14 +19,14 @@ void SpeciesFilterProxy::setFlags(int flags)
 
 bool SpeciesFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
-    if (filterFlags_ == SpeciesFilterProxy::None)
+    if (!filterFlags_.anySet())
         return true;
 
     const auto *sp = sourceModel()->data(sourceModel()->index(row, 0, parent), Qt::UserRole).value<const Species *>();
 
-    if (filterFlags_ & SpeciesFilterProxy::HasPeriodicBox && sp->box()->type() == Box::BoxType::NonPeriodic)
+    if (filterFlags_.isSet(SpeciesFilterProxy::HasPeriodicBox) && sp->box()->type() == Box::BoxType::NonPeriodic)
         return false;
-    else if (filterFlags_ & SpeciesFilterProxy::NoPeriodicBox && sp->box()->type() != Box::BoxType::NonPeriodic)
+    else if (filterFlags_.isSet(SpeciesFilterProxy::NoPeriodicBox) && sp->box()->type() != Box::BoxType::NonPeriodic)
         return false;
 
     return true;

--- a/src/gui/models/speciesFilterProxy.h
+++ b/src/gui/models/speciesFilterProxy.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "templates/flags.h"
 #include <QSortFilterProxyModel>
 
 // Forward Declarations
@@ -13,20 +14,21 @@ class SpeciesFilterProxy : public QSortFilterProxyModel
     Q_OBJECT
 
     public:
-    SpeciesFilterProxy(int flags = SpeciesFilterProxy::None);
-
-    public:
     // Filter flags
     enum FilterFlags
     {
-        None = 0,
-        HasPeriodicBox = 1,
-        NoPeriodicBox = 2
+        HasPeriodicBox = 0,
+        NoPeriodicBox = 1
     };
+    SpeciesFilterProxy(const Flags<FilterFlags> &flags = {});
+
+    private:
     // Current filter flags
-    int filterFlags_;
+    Flags<FilterFlags> filterFlags_;
+
+    public:
     // Set filter flags
-    void setFlags(int flags);
+    void setFlags(const Flags<FilterFlags> &flags);
 
     /*
      * QSortFilterProxyModel overrides

--- a/src/gui/selectspeciesdialog.h
+++ b/src/gui/selectspeciesdialog.h
@@ -33,8 +33,8 @@ class SelectSpeciesDialog : public QDialog
 
     public:
     // Run the dialog, returning a single selected Species
-    const Species *selectSingleSpecies(int filterProxyFlags = SpeciesFilterProxy::None);
+    const Species *selectSingleSpecies(const Flags<SpeciesFilterProxy::FilterFlags> &flags = {});
     // Run the dialog, returning a list of selected Species
-    std::vector<const Species *> selectSpecies(int filterProxyFlags = SpeciesFilterProxy::None, int minSpecies = 1,
+    std::vector<const Species *> selectSpecies(const Flags<SpeciesFilterProxy::FilterFlags> &flags = {}, int minSpecies = 1,
                                                std::optional<int> maxSpecies = std::nullopt);
 };

--- a/src/gui/selectspeciesdialog_funcs.cpp
+++ b/src/gui/selectspeciesdialog_funcs.cpp
@@ -31,10 +31,10 @@ void SelectSpeciesDialog::on_SelectButton_clicked(bool checked) { accept(); }
 void SelectSpeciesDialog::on_CancelButton_clicked(bool checked) { reject(); }
 
 // Run the dialog, returning a single selected Species
-const Species *SelectSpeciesDialog::selectSingleSpecies(int filterProxyFlags)
+const Species *SelectSpeciesDialog::selectSingleSpecies(const Flags<SpeciesFilterProxy::FilterFlags> &flags)
 {
     ui_.SpeciesWidget->reset(1);
-    ui_.SpeciesWidget->setFilterProxyFlags(filterProxyFlags);
+    ui_.SpeciesWidget->setFilterProxyFlags(flags);
 
     show();
 
@@ -45,11 +45,11 @@ const Species *SelectSpeciesDialog::selectSingleSpecies(int filterProxyFlags)
 }
 
 // Run the dialog, returning a list of selected Species
-std::vector<const Species *> SelectSpeciesDialog::selectSpecies(int filterProxyFlags, int minSpecies,
-                                                                std::optional<int> maxSpecies)
+std::vector<const Species *> SelectSpeciesDialog::selectSpecies(const Flags<SpeciesFilterProxy::FilterFlags> &flags,
+                                                                int minSpecies, std::optional<int> maxSpecies)
 {
     ui_.SpeciesWidget->reset(minSpecies, maxSpecies);
-    ui_.SpeciesWidget->setFilterProxyFlags(filterProxyFlags);
+    ui_.SpeciesWidget->setFilterProxyFlags(flags);
 
     show();
 

--- a/src/gui/selectspecieswidget.h
+++ b/src/gui/selectspecieswidget.h
@@ -46,7 +46,7 @@ class SelectSpeciesWidget : public QWidget
 
     public:
     // Set flags for the filter proxy
-    void setFilterProxyFlags(int flags);
+    void setFilterProxyFlags(const Flags<SpeciesFilterProxy::FilterFlags> &flags);
     // Set target Species data
     void setSpecies(const std::vector<std::unique_ptr<Species>> &species);
     // Reset widget, applying specified min and max limits to selection

--- a/src/gui/selectspecieswidget_funcs.cpp
+++ b/src/gui/selectspecieswidget_funcs.cpp
@@ -27,7 +27,10 @@ SelectSpeciesWidget::SelectSpeciesWidget(QWidget *parent) : QWidget(parent)
  */
 
 // Set flags for the filter proxy
-void SelectSpeciesWidget::setFilterProxyFlags(int flags) { speciesFilterProxy_.setFlags(flags); }
+void SelectSpeciesWidget::setFilterProxyFlags(const Flags<SpeciesFilterProxy::FilterFlags> &flags)
+{
+    speciesFilterProxy_.setFlags(flags);
+}
 
 // Set target Species data
 void SelectSpeciesWidget::setSpecies(const std::vector<std::unique_ptr<Species>> &species) { speciesModel_.setData(species); }

--- a/unit/classes/flags.cpp
+++ b/unit/classes/flags.cpp
@@ -18,9 +18,8 @@ enum Crew
 
 TEST(FlagsTest, Basic)
 {
-    Flags<RedDwarf::Crew> blueMidget, starBug;
-
     // Add single signal
+    Flags<RedDwarf::Crew> blueMidget;
     blueMidget += RedDwarf::Crew::Lister;
     EXPECT_TRUE(blueMidget.isSet(RedDwarf::Crew::Lister));
     EXPECT_TRUE(blueMidget.isSetOrNone(RedDwarf::Crew::Lister));
@@ -29,6 +28,22 @@ TEST(FlagsTest, Basic)
     blueMidget = 0;
     EXPECT_FALSE(blueMidget.isSet(RedDwarf::Crew::Lister));
     EXPECT_TRUE(blueMidget.isSetOrNone(RedDwarf::Crew::Lister));
+
+    // Construct from single enum
+    Flags<RedDwarf::Crew> starBug1(RedDwarf::Crew::Rimmer);
+    EXPECT_FALSE(starBug1.isSet(RedDwarf::Crew::Cat));
+    EXPECT_FALSE(starBug1.isSet(RedDwarf::Crew::Holly));
+    EXPECT_FALSE(starBug1.isSet(RedDwarf::Crew::Kryten));
+    EXPECT_FALSE(starBug1.isSet(RedDwarf::Crew::Lister));
+    EXPECT_TRUE(starBug1.isSet(RedDwarf::Crew::Rimmer));
+
+    // Construct from integer
+    Flags<RedDwarf::Crew> starBug2(11);
+    EXPECT_TRUE(starBug2.isSet(RedDwarf::Crew::Cat));
+    EXPECT_TRUE(starBug2.isSet(RedDwarf::Crew::Holly));
+    EXPECT_FALSE(starBug2.isSet(RedDwarf::Crew::Kryten));
+    EXPECT_TRUE(starBug2.isSet(RedDwarf::Crew::Lister));
+    EXPECT_FALSE(starBug2.isSet(RedDwarf::Crew::Rimmer));
 }
 
 TEST(FlagsTest, Manipulation)


### PR DESCRIPTION
Nice quick PR to implement a bit of useful functionality.  The new option allows a Species to be created from an existing species in the simulation, raising an editor to make adjustments to the structure.

Closes #194.