### PR TITLE
Desensitize

### DIFF
--- a/src/gui/charts/chart.hui
+++ b/src/gui/charts/chart.hui
@@ -48,10 +48,10 @@ class ChartBase : public QWidget
     public:
     // Update controls within widget
     void updateControls();
-    // Disable sensitive controls within widget
-    void disableSensitiveControls();
-    // Enable sensitive controls within widget
-    void enableSensitiveControls();
+    // Prevent editing within widget
+    void preventEditing();
+    // Enable editing within widget
+    void enableEditing();
 
     /*
      * QWidget Reimplementations

--- a/src/gui/charts/chart.hui
+++ b/src/gui/charts/chart.hui
@@ -50,8 +50,8 @@ class ChartBase : public QWidget
     void updateControls();
     // Prevent editing within widget
     void preventEditing();
-    // Enable editing within widget
-    void enableEditing();
+    // Allow editing within widget
+    void allowEditing();
 
     /*
      * QWidget Reimplementations

--- a/src/gui/charts/chart_funcs.cpp
+++ b/src/gui/charts/chart_funcs.cpp
@@ -55,18 +55,18 @@ void ChartBase::updateControls()
     layOutWidgets();
 }
 
-// Disable sensitive controls within widget
-void ChartBase::disableSensitiveControls()
+// Prevent editing within widget
+void ChartBase::preventEditing()
 {
     for (ChartBlock *block : chartBlocks_)
-        block->disableSensitiveControls();
+        block->preventEditing();
 }
 
-// Enable sensitive controls within widget
-void ChartBase::enableSensitiveControls()
+// Enable editing within widget
+void ChartBase::enableEditing()
 {
     for (ChartBlock *block : chartBlocks_)
-        block->enableSensitiveControls();
+        block->enableEditing();
 }
 
 /*

--- a/src/gui/charts/chart_funcs.cpp
+++ b/src/gui/charts/chart_funcs.cpp
@@ -62,11 +62,11 @@ void ChartBase::preventEditing()
         block->preventEditing();
 }
 
-// Enable editing within widget
-void ChartBase::enableEditing()
+// Allow editing within widget
+void ChartBase::allowEditing()
 {
     for (ChartBlock *block : chartBlocks_)
-        block->enableEditing();
+        block->allowEditing();
 }
 
 /*

--- a/src/gui/charts/chartblock.h
+++ b/src/gui/charts/chartblock.h
@@ -54,8 +54,8 @@ class ChartBlock
     public:
     // Update controls within widget
     virtual void updateControls() = 0;
-    // Disable sensitive controls
-    virtual void disableSensitiveControls() = 0;
-    // Enable sensitive controls
-    virtual void enableSensitiveControls() = 0;
+    // Disable editing
+    virtual void preventEditing() = 0;
+    // Enable editing
+    virtual void enableEditing() = 0;
 };

--- a/src/gui/charts/chartblock.h
+++ b/src/gui/charts/chartblock.h
@@ -56,6 +56,6 @@ class ChartBlock
     virtual void updateControls() = 0;
     // Disable editing
     virtual void preventEditing() = 0;
-    // Enable editing
-    virtual void enableEditing() = 0;
+    // Allow editing
+    virtual void allowEditing() = 0;
 };

--- a/src/gui/charts/procedurenode.h
+++ b/src/gui/charts/procedurenode.h
@@ -100,10 +100,10 @@ class ProcedureChartNodeBlock : public QWidget, public ChartBlock
     public:
     // Update controls within widget
     void updateControls();
-    // Disable sensitive controls
-    void disableSensitiveControls();
-    // Enable sensitive controls
-    void enableSensitiveControls();
+    // Disable editing
+    void preventEditing();
+    // Enable editing
+    void enableEditing();
 
     /*
      * Signals / Slots

--- a/src/gui/charts/procedurenode.h
+++ b/src/gui/charts/procedurenode.h
@@ -102,8 +102,8 @@ class ProcedureChartNodeBlock : public QWidget, public ChartBlock
     void updateControls();
     // Disable editing
     void preventEditing();
-    // Enable editing
-    void enableEditing();
+    // Allow editing
+    void allowEditing();
 
     /*
      * Signals / Slots

--- a/src/gui/charts/procedurenode_funcs.cpp
+++ b/src/gui/charts/procedurenode_funcs.cpp
@@ -177,8 +177,8 @@ void ProcedureChartNodeBlock::preventEditing()
     ui_.RemoveButton->setEnabled(false);
 }
 
-// Enable editing
-void ProcedureChartNodeBlock::enableEditing()
+// Allow editing
+void ProcedureChartNodeBlock::allowEditing()
 {
     ui_.KeywordsControlWidget->setEnabled(true);
     ui_.RemoveButton->setEnabled(true);

--- a/src/gui/charts/procedurenode_funcs.cpp
+++ b/src/gui/charts/procedurenode_funcs.cpp
@@ -170,15 +170,15 @@ void ProcedureChartNodeBlock::updateControls()
     refreshing_ = false;
 }
 
-// Disable sensitive controls
-void ProcedureChartNodeBlock::disableSensitiveControls()
+// Disable editing
+void ProcedureChartNodeBlock::preventEditing()
 {
     ui_.KeywordsControlWidget->setEnabled(false);
     ui_.RemoveButton->setEnabled(false);
 }
 
-// Enable sensitive controls
-void ProcedureChartNodeBlock::enableSensitiveControls()
+// Enable editing
+void ProcedureChartNodeBlock::enableEditing()
 {
     ui_.KeywordsControlWidget->setEnabled(true);
     ui_.RemoveButton->setEnabled(true);

--- a/src/gui/configurationtab.h
+++ b/src/gui/configurationtab.h
@@ -73,8 +73,8 @@ class ConfigurationTab : public QWidget, public MainTab
     void updateControls() override;
     // Prevent editing within tab
     void preventEditing() override;
-    // Enable editing within tab
-    void enableEditing() override;
+    // Allow editing within tab
+    void allowEditing() override;
 
     /*
      * Signals / Slots

--- a/src/gui/configurationtab.h
+++ b/src/gui/configurationtab.h
@@ -71,10 +71,10 @@ class ConfigurationTab : public QWidget, public MainTab
     protected:
     // Update controls in tab
     void updateControls() override;
-    // Disable sensitive controls within tab
-    void disableSensitiveControls() override;
-    // Enable sensitive controls within tab
-    void enableSensitiveControls() override;
+    // Prevent editing within tab
+    void preventEditing() override;
+    // Enable editing within tab
+    void enableEditing() override;
 
     /*
      * Signals / Slots

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -149,16 +149,16 @@ void ConfigurationTab::updateControls()
     ui_.ViewerWidget->postRedisplay();
 }
 
-// Disable sensitive controls within tab
-void ConfigurationTab::disableSensitiveControls()
+// Prevent editing within tab
+void ConfigurationTab::preventEditing()
 {
     ui_.GeneratorGroup->setEnabled(false);
     ui_.TemperatureGroup->setEnabled(false);
     ui_.SizeFactorGroup->setEnabled(false);
 }
 
-// Enable sensitive controls within tab
-void ConfigurationTab::enableSensitiveControls()
+// Enable editing within tab
+void ConfigurationTab::enableEditing()
 {
     ui_.GeneratorGroup->setEnabled(true);
     ui_.TemperatureGroup->setEnabled(true);

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -157,8 +157,8 @@ void ConfigurationTab::preventEditing()
     ui_.SizeFactorGroup->setEnabled(false);
 }
 
-// Enable editing within tab
-void ConfigurationTab::enableEditing()
+// Allow editing within tab
+void ConfigurationTab::allowEditing()
 {
     ui_.GeneratorGroup->setEnabled(true);
     ui_.TemperatureGroup->setEnabled(true);

--- a/src/gui/forcefieldtab.h
+++ b/src/gui/forcefieldtab.h
@@ -59,8 +59,8 @@ class ForcefieldTab : public QWidget, public MainTab
     void updateControls() override;
     // Prevent editing within tab
     void preventEditing() override;
-    // Enable editing within tab
-    void enableEditing() override;
+    // Allow editing within tab
+    void allowEditing() override;
 
     /*
      * Signals / Slots

--- a/src/gui/forcefieldtab.h
+++ b/src/gui/forcefieldtab.h
@@ -57,10 +57,10 @@ class ForcefieldTab : public QWidget, public MainTab
     protected:
     // Update controls in tab
     void updateControls() override;
-    // Disable sensitive controls within tab
-    void disableSensitiveControls() override;
-    // Enable sensitive controls within tab
-    void enableSensitiveControls() override;
+    // Prevent editing within tab
+    void preventEditing() override;
+    // Enable editing within tab
+    void enableEditing() override;
 
     /*
      * Signals / Slots

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -182,8 +182,8 @@ void ForcefieldTab::updateControls()
 // Prevent editing within tab
 void ForcefieldTab::preventEditing() { setEnabled(false); }
 
-// Enable editing within tab
-void ForcefieldTab::enableEditing() { setEnabled(true); }
+// Allow editing within tab
+void ForcefieldTab::allowEditing() { setEnabled(true); }
 
 /*
  * Signals / Slots

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -179,11 +179,11 @@ void ForcefieldTab::updateControls()
     refreshLocker.unlock();
 }
 
-// Disable sensitive controls within tab
-void ForcefieldTab::disableSensitiveControls() { setEnabled(false); }
+// Prevent editing within tab
+void ForcefieldTab::preventEditing() { setEnabled(false); }
 
-// Enable sensitive controls within tab
-void ForcefieldTab::enableSensitiveControls() { setEnabled(true); }
+// Enable editing within tab
+void ForcefieldTab::enableEditing() { setEnabled(true); }
 
 /*
  * Signals / Slots

--- a/src/gui/gizmo.h
+++ b/src/gui/gizmo.h
@@ -75,8 +75,8 @@ class Gizmo
     virtual void updateControls() = 0;
     // Prevent editing within widget
     virtual void preventEditing() = 0;
-    // Enable editing within widget
-    virtual void enableEditing() = 0;
+    // Allow editing within widget
+    virtual void allowEditing() = 0;
 
     /*
      * Data Handling

--- a/src/gui/gizmo.h
+++ b/src/gui/gizmo.h
@@ -73,10 +73,10 @@ class Gizmo
     public:
     // Update controls within widget
     virtual void updateControls() = 0;
-    // Disable sensitive controls within widget
-    virtual void disableSensitiveControls() = 0;
-    // Enable sensitive controls within widget
-    virtual void enableSensitiveControls() = 0;
+    // Prevent editing within widget
+    virtual void preventEditing() = 0;
+    // Enable editing within widget
+    virtual void enableEditing() = 0;
 
     /*
      * Data Handling

--- a/src/gui/graphgizmo.h
+++ b/src/gui/graphgizmo.h
@@ -43,8 +43,8 @@ class GraphGizmo : public QWidget, public Gizmo
     void updateControls();
     // Prevent editing within widget
     void preventEditing();
-    // Enable editing within widget
-    void enableEditing();
+    // Allow editing within widget
+    void allowEditing();
 
     /*
      * Data Handling

--- a/src/gui/graphgizmo.h
+++ b/src/gui/graphgizmo.h
@@ -41,10 +41,10 @@ class GraphGizmo : public QWidget, public Gizmo
     public:
     // Update controls within widget
     void updateControls();
-    // Disable sensitive controls within widget
-    void disableSensitiveControls();
-    // Enable sensitive controls within widget
-    void enableSensitiveControls();
+    // Prevent editing within widget
+    void preventEditing();
+    // Enable editing within widget
+    void enableEditing();
 
     /*
      * Data Handling

--- a/src/gui/graphgizmo_funcs.cpp
+++ b/src/gui/graphgizmo_funcs.cpp
@@ -63,8 +63,8 @@ void GraphGizmo::updateControls()
 // Prevent editing within widget
 void GraphGizmo::preventEditing() {}
 
-// Enable editing within widget
-void GraphGizmo::enableEditing() {}
+// Allow editing within widget
+void GraphGizmo::allowEditing() {}
 
 /*
  * Data Handling

--- a/src/gui/graphgizmo_funcs.cpp
+++ b/src/gui/graphgizmo_funcs.cpp
@@ -60,11 +60,11 @@ void GraphGizmo::updateControls()
     refreshing_ = false;
 }
 
-// Disable sensitive controls within widget
-void GraphGizmo::disableSensitiveControls() {}
+// Prevent editing within widget
+void GraphGizmo::preventEditing() {}
 
-// Enable sensitive controls within widget
-void GraphGizmo::enableSensitiveControls() {}
+// Enable editing within widget
+void GraphGizmo::enableEditing() {}
 
 /*
  * Data Handling

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -240,10 +240,10 @@ class DissolveWindow : public QMainWindow
     const std::vector<MainTab *> allTabs() const;
 
     public slots:
-    // Disable sensitive controls
-    void disableSensitiveControls();
-    // Enable sensitive controls
-    void enableSensitiveControls();
+    // Disable editing
+    void preventEditing();
+    // Enable editing
+    void enableEditing();
     // All iterations requested are complete
     void iterationsComplete();
     // Specified tab (indicated by page widget) has been closed, and relevant data should be deleted accordingly

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -242,8 +242,8 @@ class DissolveWindow : public QMainWindow
     public slots:
     // Disable editing
     void preventEditing();
-    // Enable editing
-    void enableEditing();
+    // Allow editing
+    void allowEditing();
     // All iterations requested are complete
     void iterationsComplete();
     // Specified tab (indicated by page widget) has been closed, and relevant data should be deleted accordingly

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -24,8 +24,8 @@ void DissolveWindow::preventEditing()
     ui_.MainTabs->preventEditing();
 }
 
-// Enable editing
-void DissolveWindow::enableEditing()
+// Allow editing
+void DissolveWindow::allowEditing()
 {
     // Enable necessary simulation menu items
     ui_.SimulationRunAction->setEnabled(true);
@@ -40,14 +40,14 @@ void DissolveWindow::enableEditing()
     ui_.ConfigurationMenu->setEnabled(true);
     ui_.LayerMenu->setEnabled(true);
 
-    // Enable editing in all tabs
-    ui_.MainTabs->enableEditing();
+    // Allow editing in all tabs
+    ui_.MainTabs->allowEditing();
 }
 
 // All iterations requested are complete
 void DissolveWindow::iterationsComplete()
 {
-    enableEditing();
+    allowEditing();
     Renderable::setSourceDataAccessEnabled(true);
     dissolveIterating_ = false;
 

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -4,8 +4,8 @@
 #include "gui/gui.h"
 #include "main/dissolve.h"
 
-// Disable sensitive controls
-void DissolveWindow::disableSensitiveControls()
+// Disable editing
+void DissolveWindow::preventEditing()
 {
     // Disable necessary simulation menu items
     ui_.SimulationRunAction->setEnabled(false);
@@ -20,12 +20,12 @@ void DissolveWindow::disableSensitiveControls()
     ui_.ConfigurationMenu->setEnabled(false);
     ui_.LayerMenu->setEnabled(false);
 
-    // Disable sensitive controls in all tabs
-    ui_.MainTabs->disableSensitiveControls();
+    // Disable editing in all tabs
+    ui_.MainTabs->preventEditing();
 }
 
-// Enable sensitive controls
-void DissolveWindow::enableSensitiveControls()
+// Enable editing
+void DissolveWindow::enableEditing()
 {
     // Enable necessary simulation menu items
     ui_.SimulationRunAction->setEnabled(true);
@@ -40,14 +40,14 @@ void DissolveWindow::enableSensitiveControls()
     ui_.ConfigurationMenu->setEnabled(true);
     ui_.LayerMenu->setEnabled(true);
 
-    // Enable sensitive controls in all tabs
-    ui_.MainTabs->enableSensitiveControls();
+    // Enable editing in all tabs
+    ui_.MainTabs->enableEditing();
 }
 
 // All iterations requested are complete
 void DissolveWindow::iterationsComplete()
 {
-    enableSensitiveControls();
+    enableEditing();
     Renderable::setSourceDataAccessEnabled(true);
     dissolveIterating_ = false;
 

--- a/src/gui/integrator1dgizmo.h
+++ b/src/gui/integrator1dgizmo.h
@@ -42,10 +42,10 @@ class Integrator1DGizmo : public QWidget, public Gizmo
     public:
     // Update controls within widget
     void updateControls();
-    // Disable sensitive controls within widget
-    void disableSensitiveControls();
-    // Enable sensitive controls within widget
-    void enableSensitiveControls();
+    // Prevent editing within widget
+    void preventEditing();
+    // Enable editing within widget
+    void enableEditing();
 
     /*
      * Data

--- a/src/gui/integrator1dgizmo.h
+++ b/src/gui/integrator1dgizmo.h
@@ -44,8 +44,8 @@ class Integrator1DGizmo : public QWidget, public Gizmo
     void updateControls();
     // Prevent editing within widget
     void preventEditing();
-    // Enable editing within widget
-    void enableEditing();
+    // Allow editing within widget
+    void allowEditing();
 
     /*
      * Data

--- a/src/gui/integrator1dgizmo_funcs.cpp
+++ b/src/gui/integrator1dgizmo_funcs.cpp
@@ -64,11 +64,11 @@ void Integrator1DGizmo::updateControls()
     refreshing_ = false;
 }
 
-// Disable sensitive controls within widget
-void Integrator1DGizmo::disableSensitiveControls() {}
+// Prevent editing within widget
+void Integrator1DGizmo::preventEditing() {}
 
-// Enable sensitive controls within widget
-void Integrator1DGizmo::enableSensitiveControls() {}
+// Enable editing within widget
+void Integrator1DGizmo::enableEditing() {}
 
 /*
  * Data

--- a/src/gui/integrator1dgizmo_funcs.cpp
+++ b/src/gui/integrator1dgizmo_funcs.cpp
@@ -67,8 +67,8 @@ void Integrator1DGizmo::updateControls()
 // Prevent editing within widget
 void Integrator1DGizmo::preventEditing() {}
 
-// Enable editing within widget
-void Integrator1DGizmo::enableEditing() {}
+// Allow editing within widget
+void Integrator1DGizmo::allowEditing() {}
 
 /*
  * Data

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -84,6 +84,6 @@ class LayerTab : public QWidget, public MainTab
     void updateControls() override;
     // Prevent editing within tab
     void preventEditing() override;
-    // Enable editing within tab
-    void enableEditing() override;
+    // Allow editing within tab
+    void allowEditing() override;
 };

--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -82,8 +82,8 @@ class LayerTab : public QWidget, public MainTab
     protected:
     // Update controls in tab
     void updateControls() override;
-    // Disable sensitive controls within tab
-    void disableSensitiveControls() override;
-    // Enable sensitive controls within tab
-    void enableSensitiveControls() override;
+    // Prevent editing within tab
+    void preventEditing() override;
+    // Enable editing within tab
+    void enableEditing() override;
 };

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -192,6 +192,7 @@ void LayerTab::moduleSelectionChanged(const QItemSelection &current, const QItem
         connect(mcw, SIGNAL(statusChanged()), this, SLOT(updateModuleList()));
         ui_.ModuleControlsStack->setCurrentIndex(ui_.ModuleControlsStack->addWidget(mcw));
 
+        // If we're currently running, don;t allow editing in our new widget
         if (dissolveWindow_->dissolveIterating())
             mcw->preventEditing();
     }
@@ -240,6 +241,7 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
 
     QMenu menu;
     menu.setFont(font());
+    menu.setEnabled(!dissolveWindow_->dissolveIterating());
 
     // Construct the context menu
     auto *enableModule = menu.addAction("&Enable this");

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -336,8 +336,8 @@ void LayerTab::preventEditing()
     }
 }
 
-// Enable editing within tab
-void LayerTab::enableEditing()
+// Allow editing within tab
+void LayerTab::allowEditing()
 {
     ui_.EnabledButton->setEnabled(true);
     ui_.FrequencySpin->setEnabled(true);
@@ -348,6 +348,6 @@ void LayerTab::enableEditing()
     {
         auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw)
-            mcw->enableEditing();
+            mcw->allowEditing();
     }
 }

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -193,7 +193,7 @@ void LayerTab::moduleSelectionChanged(const QItemSelection &current, const QItem
         ui_.ModuleControlsStack->setCurrentIndex(ui_.ModuleControlsStack->addWidget(mcw));
 
         if (dissolveWindow_->dissolveIterating())
-            mcw->disableSensitiveControls();
+            mcw->preventEditing();
     }
     else
         mcw->updateControls();
@@ -318,8 +318,8 @@ void LayerTab::updateControls()
         mcw->updateControls();
 }
 
-// Disable sensitive controls within tab
-void LayerTab::disableSensitiveControls()
+// Prevent editing within tab
+void LayerTab::preventEditing()
 {
     ui_.EnabledButton->setEnabled(false);
     ui_.FrequencySpin->setEnabled(false);
@@ -330,12 +330,12 @@ void LayerTab::disableSensitiveControls()
     {
         auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw)
-            mcw->disableSensitiveControls();
+            mcw->preventEditing();
     }
 }
 
-// Enable sensitive controls within tab
-void LayerTab::enableSensitiveControls()
+// Enable editing within tab
+void LayerTab::enableEditing()
 {
     ui_.EnabledButton->setEnabled(true);
     ui_.FrequencySpin->setEnabled(true);
@@ -346,6 +346,6 @@ void LayerTab::enableSensitiveControls()
     {
         auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));
         if (mcw)
-            mcw->enableSensitiveControls();
+            mcw->enableEditing();
     }
 }

--- a/src/gui/maintab.h
+++ b/src/gui/maintab.h
@@ -86,8 +86,8 @@ class MainTab
     public:
     // Update controls in tab
     virtual void updateControls() = 0;
-    // Disable sensitive controls within the tab
-    virtual void disableSensitiveControls() = 0;
-    // Enable sensitive controls within the tab
-    virtual void enableSensitiveControls() = 0;
+    // Prevent editing within the tab
+    virtual void preventEditing() = 0;
+    // Enable editing within the tab
+    virtual void enableEditing() = 0;
 };

--- a/src/gui/maintab.h
+++ b/src/gui/maintab.h
@@ -88,6 +88,6 @@ class MainTab
     virtual void updateControls() = 0;
     // Prevent editing within the tab
     virtual void preventEditing() = 0;
-    // Enable editing within the tab
-    virtual void enableEditing() = 0;
+    // Allow editing within the tab
+    virtual void allowEditing() = 0;
 };

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -120,8 +120,8 @@ class MainTabsWidget : public QTabWidget
     void updateAllTabs();
     // Prevent editing in all tabs
     void preventEditing();
-    // Enable editing in all tabs
-    void enableEditing();
+    // Allow editing in all tabs
+    void allowEditing();
 
     /*
      * Tab Styling

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -118,10 +118,10 @@ class MainTabsWidget : public QTabWidget
     public:
     // Update all tabs
     void updateAllTabs();
-    // Disable sensitive controls in all tabs
-    void disableSensitiveControls();
-    // Enable sensitive controls in all tabs
-    void enableSensitiveControls();
+    // Prevent editing in all tabs
+    void preventEditing();
+    // Enable editing in all tabs
+    void enableEditing();
 
     /*
      * Tab Styling

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -452,11 +452,11 @@ void MainTabsWidget::preventEditing()
         button->setDisabled(true);
 }
 
-// Enable editing in all tabs
-void MainTabsWidget::enableEditing()
+// Allow editing in all tabs
+void MainTabsWidget::allowEditing()
 {
     for (auto tab : allTabs_)
-        tab->enableEditing();
+        tab->allowEditing();
 
     // Enable tab close buttons
     for (auto &[button, page] : closeButtons_)

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -441,22 +441,22 @@ void MainTabsWidget::updateAllTabs()
         tab->updateControls();
 }
 
-// Disable sensitive controls in all tabs
-void MainTabsWidget::disableSensitiveControls()
+// Prevent editing in all tabs
+void MainTabsWidget::preventEditing()
 {
     for (auto tab : allTabs_)
-        tab->disableSensitiveControls();
+        tab->preventEditing();
 
     // Disable tab close buttons
     for (auto &[button, page] : closeButtons_)
         button->setDisabled(true);
 }
 
-// Enable sensitive controls in all tabs
-void MainTabsWidget::enableSensitiveControls()
+// Enable editing in all tabs
+void MainTabsWidget::enableEditing()
 {
     for (auto tab : allTabs_)
-        tab->enableSensitiveControls();
+        tab->enableEditing();
 
     // Enable tab close buttons
     for (auto &[button, page] : closeButtons_)

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -28,7 +28,7 @@ void DissolveWindow::setupIteration(int count)
     }
 
     // Prepare the GUI
-    disableSensitiveControls();
+    preventEditing();
     Renderable::setSourceDataAccessEnabled(false);
     dissolveIterating_ = true;
 

--- a/src/gui/messagestab.h
+++ b/src/gui/messagestab.h
@@ -46,6 +46,6 @@ class MessagesTab : public QWidget, public MainTab
     void updateControls() override;
     // Prevent editing within tab
     void preventEditing() override;
-    // Enable editing within tab
-    void enableEditing() override;
+    // Allow editing within tab
+    void allowEditing() override;
 };

--- a/src/gui/messagestab.h
+++ b/src/gui/messagestab.h
@@ -44,8 +44,8 @@ class MessagesTab : public QWidget, public MainTab
     protected:
     // Update controls in tab
     void updateControls() override;
-    // Disable sensitive controls within tab
-    void disableSensitiveControls() override;
-    // Enable sensitive controls within tab
-    void enableSensitiveControls() override;
+    // Prevent editing within tab
+    void preventEditing() override;
+    // Enable editing within tab
+    void enableEditing() override;
 };

--- a/src/gui/messagestab_funcs.cpp
+++ b/src/gui/messagestab_funcs.cpp
@@ -59,8 +59,8 @@ MainTab::TabType MessagesTab::type() const { return MainTab::TabType::Messages; 
 // Update controls in tab
 void MessagesTab::updateControls() {}
 
-// Disable sensitive controls within tab
-void MessagesTab::disableSensitiveControls() {}
+// Prevent editing within tab
+void MessagesTab::preventEditing() {}
 
-// Enable sensitive controls within tab
-void MessagesTab::enableSensitiveControls() {}
+// Enable editing within tab
+void MessagesTab::enableEditing() {}

--- a/src/gui/messagestab_funcs.cpp
+++ b/src/gui/messagestab_funcs.cpp
@@ -62,5 +62,5 @@ void MessagesTab::updateControls() {}
 // Prevent editing within tab
 void MessagesTab::preventEditing() {}
 
-// Enable editing within tab
-void MessagesTab::enableEditing() {}
+// Allow editing within tab
+void MessagesTab::allowEditing() {}

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -51,8 +51,8 @@ class ModuleControlWidget : public QWidget
     void updateControls(Flags<ModuleWidget::UpdateFlags> updateFlags = {});
     // Disable editing
     void preventEditing();
-    // Enable editing
-    void enableEditing();
+    // Allow editing
+    void allowEditing();
 
     /*
      * UI

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -49,10 +49,10 @@ class ModuleControlWidget : public QWidget
     public:
     // Update controls within widget
     void updateControls(Flags<ModuleWidget::UpdateFlags> updateFlags = {});
-    // Disable sensitive controls
-    void disableSensitiveControls();
-    // Enable sensitive controls
-    void enableSensitiveControls();
+    // Disable editing
+    void preventEditing();
+    // Enable editing
+    void enableEditing();
 
     /*
      * UI

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -110,26 +110,26 @@ void ModuleControlWidget::updateControls(Flags<ModuleWidget::UpdateFlags> update
         moduleWidget_->updateControls(updateFlags);
 }
 
-// Disable sensitive controls
-void ModuleControlWidget::disableSensitiveControls()
+// Disable editing
+void ModuleControlWidget::preventEditing()
 {
     ui_.FrequencySpin->setEnabled(false);
     ui_.EnabledButton->setEnabled(false);
     ui_.TargetsGroup->setEnabled(false);
     ui_.ModuleKeywordsWidget->setEnabled(false);
     if (moduleWidget_)
-        moduleWidget_->disableSensitiveControls();
+        moduleWidget_->preventEditing();
 }
 
-// Enable sensitive controls
-void ModuleControlWidget::enableSensitiveControls()
+// Enable editing
+void ModuleControlWidget::enableEditing()
 {
     ui_.FrequencySpin->setEnabled(true);
     ui_.EnabledButton->setEnabled(true);
     ui_.TargetsGroup->setEnabled(true);
     ui_.ModuleKeywordsWidget->setEnabled(true);
     if (moduleWidget_)
-        moduleWidget_->enableSensitiveControls();
+        moduleWidget_->enableEditing();
 }
 
 /*

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -121,15 +121,15 @@ void ModuleControlWidget::preventEditing()
         moduleWidget_->preventEditing();
 }
 
-// Enable editing
-void ModuleControlWidget::enableEditing()
+// Allow editing
+void ModuleControlWidget::allowEditing()
 {
     ui_.FrequencySpin->setEnabled(true);
     ui_.EnabledButton->setEnabled(true);
     ui_.TargetsGroup->setEnabled(true);
     ui_.ModuleKeywordsWidget->setEnabled(true);
     if (moduleWidget_)
-        moduleWidget_->enableEditing();
+        moduleWidget_->allowEditing();
 }
 
 /*

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -51,8 +51,8 @@ class SpeciesTab : public QWidget, public MainTab
     void updateControls() override;
     // Prevent editing within tab
     void preventEditing() override;
-    // Enable editing within tab
-    void enableEditing() override;
+    // Allow editing within tab
+    void allowEditing() override;
 
     /*
      * MainTab Reimplementations

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -49,10 +49,10 @@ class SpeciesTab : public QWidget, public MainTab
     public slots:
     // Update controls in tab
     void updateControls() override;
-    // Disable sensitive controls within tab
-    void disableSensitiveControls() override;
-    // Enable sensitive controls within tab
-    void enableSensitiveControls() override;
+    // Prevent editing within tab
+    void preventEditing() override;
+    // Enable editing within tab
+    void enableEditing() override;
 
     /*
      * MainTab Reimplementations

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -138,11 +138,11 @@ void SpeciesTab::updateControls()
     speciesVersion_ = species_->version();
 }
 
-// Disable sensitive controls within tab
-void SpeciesTab::disableSensitiveControls() { setEnabled(false); }
+// Prevent editing within tab
+void SpeciesTab::preventEditing() { setEnabled(false); }
 
-// Enable sensitive controls within tab
-void SpeciesTab::enableSensitiveControls() { setEnabled(true); }
+// Enable editing within tab
+void SpeciesTab::enableEditing() { setEnabled(true); }
 
 /*
  * MainTab Reimplementations

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -141,8 +141,8 @@ void SpeciesTab::updateControls()
 // Prevent editing within tab
 void SpeciesTab::preventEditing() { setEnabled(false); }
 
-// Enable editing within tab
-void SpeciesTab::enableEditing() { setEnabled(true); }
+// Allow editing within tab
+void SpeciesTab::allowEditing() { setEnabled(true); }
 
 /*
  * MainTab Reimplementations

--- a/src/gui/workspacetab.h
+++ b/src/gui/workspacetab.h
@@ -40,10 +40,10 @@ class WorkspaceTab : public QWidget, public MainTab
     protected:
     // Update controls in tab
     void updateControls() override;
-    // Disable sensitive controls within tab
-    void disableSensitiveControls() override;
-    // Enable sensitive controls within tab
-    void enableSensitiveControls() override;
+    // Prevent editing within tab
+    void preventEditing() override;
+    // Enable editing within tab
+    void enableEditing() override;
 
     /*
      * Gizmo Management

--- a/src/gui/workspacetab.h
+++ b/src/gui/workspacetab.h
@@ -42,8 +42,8 @@ class WorkspaceTab : public QWidget, public MainTab
     void updateControls() override;
     // Prevent editing within tab
     void preventEditing() override;
-    // Enable editing within tab
-    void enableEditing() override;
+    // Allow editing within tab
+    void allowEditing() override;
 
     /*
      * Gizmo Management

--- a/src/gui/workspacetab_funcs.cpp
+++ b/src/gui/workspacetab_funcs.cpp
@@ -66,20 +66,20 @@ void WorkspaceTab::updateControls()
         gizmo->updateControls();
 }
 
-// Disable sensitive controls within tab
-void WorkspaceTab::disableSensitiveControls()
+// Prevent editing within tab
+void WorkspaceTab::preventEditing()
 {
-    // Disable sensitive controls in subwindows
+    // Prevent editing in subwindows
     for (auto &gizmo : gizmos_)
-        gizmo->disableSensitiveControls();
+        gizmo->preventEditing();
 }
 
-// Enable sensitive controls within tab
-void WorkspaceTab::enableSensitiveControls()
+// Enable editing within tab
+void WorkspaceTab::enableEditing()
 {
-    // Enable sensitive controls in subwindows
+    // Enable editing in subwindows
     for (auto &gizmo : gizmos_)
-        gizmo->enableSensitiveControls();
+        gizmo->enableEditing();
 }
 
 /*

--- a/src/gui/workspacetab_funcs.cpp
+++ b/src/gui/workspacetab_funcs.cpp
@@ -74,12 +74,12 @@ void WorkspaceTab::preventEditing()
         gizmo->preventEditing();
 }
 
-// Enable editing within tab
-void WorkspaceTab::enableEditing()
+// Allow editing within tab
+void WorkspaceTab::allowEditing()
 {
-    // Enable editing in subwindows
+    // Allow editing in subwindows
     for (auto &gizmo : gizmos_)
-        gizmo->enableEditing();
+        gizmo->allowEditing();
 }
 
 /*

--- a/src/modules/widget.cpp
+++ b/src/modules/widget.cpp
@@ -15,5 +15,5 @@ void ModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &update
 // Disable editing within widget
 void ModuleWidget::preventEditing() {}
 
-// Enable editing within widget
-void ModuleWidget::enableEditing() {}
+// Allow editing within widget
+void ModuleWidget::allowEditing() {}

--- a/src/modules/widget.cpp
+++ b/src/modules/widget.cpp
@@ -12,8 +12,8 @@ ModuleWidget::ModuleWidget(QWidget *parent, Dissolve &dissolve) : QWidget(parent
 // Update controls within widget
 void ModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &updateFlags) {}
 
-// Disable sensitive controls within widget
-void ModuleWidget::disableSensitiveControls() {}
+// Disable editing within widget
+void ModuleWidget::preventEditing() {}
 
-// Enable sensitive controls within widget
-void ModuleWidget::enableSensitiveControls() {}
+// Enable editing within widget
+void ModuleWidget::enableEditing() {}

--- a/src/modules/widget.h
+++ b/src/modules/widget.h
@@ -36,6 +36,6 @@ class ModuleWidget : public QWidget
     virtual void updateControls(const Flags<UpdateFlags> &updateFlags = {});
     // Disable editing within widget
     virtual void preventEditing();
-    // Enable editing within widget
-    virtual void enableEditing();
+    // Allow editing within widget
+    virtual void allowEditing();
 };

--- a/src/modules/widget.h
+++ b/src/modules/widget.h
@@ -34,8 +34,8 @@ class ModuleWidget : public QWidget
     };
     // Update controls within widget
     virtual void updateControls(const Flags<UpdateFlags> &updateFlags = {});
-    // Disable sensitive controls within widget
-    virtual void disableSensitiveControls();
-    // Enable sensitive controls within widget
-    virtual void enableSensitiveControls();
+    // Disable editing within widget
+    virtual void preventEditing();
+    // Enable editing within widget
+    virtual void enableEditing();
 };


### PR DESCRIPTION
This PR renames a bunch of functions throughout the GUI code relating to enabling/disabling widgets that edit data. For some unknown reason dating back to very early days of the project these had been termed "sensitive" controls, which I guess sort of makes sense, but isn't exactly descriptive.

Closes #1030.