### PR TITLE
Correct parameter name when there is an arbitrary number of params

### DIFF
--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -247,9 +247,9 @@ toml::basic_value<toml::discard_comments, std::map, std::vector> SpeciesImproper
     if (!values.empty())
     {
         toml::basic_value<toml::discard_comments, std::map, std::vector> parametersNode;
-        std::vector<std::string> parameters = TorsionFunctions::parameters(interactionForm());
-        for (auto &&[parameter, value] : zip(parameters, values))
-            parametersNode[parameter] = value;
+        int idx = 0;
+        for (auto &value : values)
+            parametersNode[TorsionFunctions::parameter(interactionForm(), idx++)] = value;
         improper["parameters"] = parametersNode;
     }
 

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -247,9 +247,9 @@ toml::basic_value<toml::discard_comments, std::map, std::vector> SpeciesImproper
     if (!values.empty())
     {
         toml::basic_value<toml::discard_comments, std::map, std::vector> parametersNode;
-        int idx = 0;
+        int index = 0;
         for (auto &value : values)
-            parametersNode[TorsionFunctions::parameter(interactionForm(), idx++)] = value;
+            parametersNode[TorsionFunctions::parameter(interactionForm(), index++)] = value;
         improper["parameters"] = parametersNode;
     }
 

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -616,9 +616,9 @@ toml::basic_value<toml::discard_comments, std::map, std::vector> SpeciesTorsion:
     if (!values.empty())
     {
         toml::basic_value<toml::discard_comments, std::map, std::vector> parametersNode;
-        std::vector<std::string> parameters = TorsionFunctions::parameters(interactionForm());
-        for (auto &&[parameter, value] : zip(parameters, values))
-            parametersNode[parameter] = value;
+        int idx = 0;
+        for (auto &value : values)
+            parametersNode[TorsionFunctions::parameter(interactionForm(), idx++)] = value;
         torsion["parameters"] = parametersNode;
     }
 

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -616,9 +616,9 @@ toml::basic_value<toml::discard_comments, std::map, std::vector> SpeciesTorsion:
     if (!values.empty())
     {
         toml::basic_value<toml::discard_comments, std::map, std::vector> parametersNode;
-        int idx = 0;
+        int index = 0;
         for (auto &value : values)
-            parametersNode[TorsionFunctions::parameter(interactionForm(), idx++)] = value;
+            parametersNode[TorsionFunctions::parameter(interactionForm(), index++)] = value;
         torsion["parameters"] = parametersNode;
     }
 


### PR DESCRIPTION
This handles the case where the Torsion has an arbitrary number of parameters.