### PR TITLE
Fix Benchmarks

### DIFF
--- a/src/base/processpool.cpp
+++ b/src/base/processpool.cpp
@@ -171,7 +171,7 @@ bool ProcessPool::setUp(std::string_view name, const std::vector<int> &worldRank
 {
     name_ = name;
 
-    Messenger::print("Setting up process pool '{}'...\n", name_);
+    Messenger::printVerbose("Setting up process pool '{}'...\n", name_);
 
     // Set rank list
     worldRanks_ = worldRanks;
@@ -182,7 +182,8 @@ bool ProcessPool::setUp(std::string_view name, const std::vector<int> &worldRank
         if (worldRank_ == worldRanks_[n])
         {
             poolRank_ = n;
-            Messenger::print("Process with world rank {} added to pool '{}' with local rank {}.\n", worldRanks_[n], name_, n);
+            Messenger::printVerbose("Process with world rank {} added to pool '{}' with local rank {}.\n", worldRanks_[n],
+                                    name_, n);
             break;
         }
     }
@@ -190,7 +191,8 @@ bool ProcessPool::setUp(std::string_view name, const std::vector<int> &worldRank
     // Set default maximum number of groups
     maxProcessGroups_ = worldRanks_.size();
 
-    Messenger::print("There are {} processes in pool '{}' (max groups = {}).\n", worldRanks_.size(), name_, maxProcessGroups_);
+    Messenger::printVerbose("There are {} processes in pool '{}' (max groups = {}).\n", worldRanks_.size(), name_,
+                            maxProcessGroups_);
 
 #ifdef PARALLEL
     // Create pool group and communicator


### PR DESCRIPTION
Quick PR to fix benchmarks in the continuous build, which have been failing for a while due to an issue introduced in #995. There, the setup of the MPI world pool was moved to the `Dissolve` class constructor, and which this occurred before any CLI arguments were passed. This meant that setting quiet output mode (as is the case in the benchmarks) had no effect on the world pool setup output, and which subsequently appeared in the `benchmark_results.json` file and broke it.