### PR TITLE
Keep CellArrays consistent with pair potential range

### DIFF
--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -230,7 +230,8 @@ class Configuration
     public:
     // Write through specified LineParser
     bool serialise(LineParser &parser) const;
-    // Read through specified LineParser
-    bool read(LineParser &parser, const std::vector<std::unique_ptr<Species>> &availableSpecies, double pairPotentialRange);
+    // Read from specified LineParser
+    bool deserialise(LineParser &parser, const std::vector<std::unique_ptr<Species>> &availableSpecies,
+                     double pairPotentialRange);
     toml::basic_value<toml::discard_comments, std::map, std::vector> serialize();
 };

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -180,6 +180,8 @@ class Configuration
                            double pairPotentialRange);
     // Create Box definition from axes matrix, and initialise cell array
     void createBoxAndCells(const Matrix3 axes, double cellSize, double pairPotentialRange);
+    // Update cell array, and reassign atoms to cells
+    void updateCells(double cellSize, double pairPotentialRange);
     // Return Box
     const Box *box() const;
     // Scale Box lengths (and associated Cells) by specified factors

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -48,6 +48,13 @@ void Configuration::createBoxAndCells(const Matrix3 axes, double cellSize, doubl
     cells_.generate(box_.get(), cellSize, pairPotentialRange);
 }
 
+// Update cell array, and reassign atoms to cells
+void Configuration::updateCells(double cellSize, double pairPotentialRange)
+{
+    cells_.generate(box_.get(), cellSize, pairPotentialRange);
+    updateCellContents();
+}
+
 // Return Box
 const Box *Configuration::box() const { return box_.get(); }
 

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -62,9 +62,9 @@ bool Configuration::serialise(LineParser &parser) const
     return true;
 }
 
-// Read through specified LineParser
-bool Configuration::read(LineParser &parser, const std::vector<std::unique_ptr<Species>> &availableSpecies,
-                         double pairPotentialRange)
+// Read from specified LineParser
+bool Configuration::deserialise(LineParser &parser, const std::vector<std::unique_ptr<Species>> &availableSpecies,
+                                double pairPotentialRange)
 {
     // Clear current contents of Configuration
     empty();

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -496,7 +496,7 @@ bool Dissolve::loadRestart(std::string_view filename)
                 error = true;
                 break;
             }
-            else if (!cfg->read(parser, species(), pairPotentialRange_))
+            else if (!cfg->deserialise(parser, species(), pairPotentialRange_))
                 error = true;
         }
         else if (DissolveSys::sameString(parser.argsv(0), "Timing"))

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -522,7 +522,7 @@ bool Dissolve::loadRestart(std::string_view filename)
             error = true;
         }
 
-        // Error encounterd?
+        // Error encountered?
         if (error)
             break;
     }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -57,7 +57,7 @@ bool Dissolve::prepare()
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
 
-        // Accumulate the total species usage counts for the next check
+        // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);
     }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -65,7 +65,7 @@ bool Dissolve::prepare()
     {
         // Regenerate cell array if the pair potential range has changed
         if (newPairPotentialRange)
-            cfg->updateCells(7.0, newPairPotentialRange.value());
+            cfg->updateCells(7.0, *newPairPotentialRange.);
 
         // Check Box extent against pair potential range
         auto maxPPRange = cfg->box()->inscribedSphereRadius();

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -65,7 +65,7 @@ bool Dissolve::prepare()
     {
         // Regenerate cell array if the pair potential range has changed
         if (newPairPotentialRange)
-            cfg->updateCells(7.0, *newPairPotentialRange.);
+            cfg->updateCells(7.0, *newPairPotentialRange);
 
         // Check Box extent against pair potential range
         auto maxPPRange = cfg->box()->inscribedSphereRadius();


### PR DESCRIPTION
A straightforward PR to ensure that the `Configuration` `CellArray`s are updated if the user changes the pair potential range.

Closes #957.