### PR TITLE
Clear additional potentials

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -157,6 +157,7 @@ class DissolveWindow : public QMainWindow
     void on_SimulationSetRestartFileFrequencyAction_triggered(bool checked);
     void on_SimulationSaveRestartPointAction_triggered(bool checked);
     void on_SimulationDataManagerAction_triggered(bool checked);
+    void on_SimulationClearAdditionalPotentialsAction_triggered(bool checked);
     void on_SimulationClearModuleDataAction_triggered(bool checked);
     // Species
     void on_SpeciesCreateAtomicAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -166,6 +166,7 @@
     <addaction name="SimulationSetRestartFileFrequencyAction"/>
     <addaction name="SimulationSaveRestartPointAction"/>
     <addaction name="SimulationDataManagerAction"/>
+    <addaction name="SimulationClearAdditionalPotentialsAction"/>
     <addaction name="SimulationClearModuleDataAction"/>
    </widget>
    <widget class="QMenu" name="HelpMenu">
@@ -854,6 +855,11 @@
   <action name="FileLoadRestartFileAction">
    <property name="text">
     <string>Load &amp;Restart File...</string>
+   </property>
+  </action>
+  <action name="SimulationClearAdditionalPotentialsAction">
+   <property name="text">
+    <string>Clear Additional Potentials</string>
    </property>
   </action>
  </widget>

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -6,6 +6,7 @@
 #include "main/dissolve.h"
 #include <QFileDialog>
 #include <QInputDialog>
+#include <QMessageBox>
 
 void DissolveWindow::on_SimulationCheckAction_triggered(bool checked)
 {
@@ -64,6 +65,21 @@ void DissolveWindow::on_SimulationDataManagerAction_triggered(bool checked)
 {
     DataManagerDialog dataManagerDialog(this, dissolve_, referencePoints_, dissolve_.processingModuleData());
     dataManagerDialog.exec();
+}
+
+void DissolveWindow::on_SimulationClearAdditionalPotentialsAction_triggered(bool checked)
+{
+    if (QMessageBox::warning(this, "Clear Additional Potentials",
+                             "This will reset any generate additional (empirical) potentials, and reset the pair potentials to "
+                             "the reference parameters.\n\n"
+                             "This cannot be undone! Proceed?",
+                             QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No,
+                             QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
+    {
+        dissolve_.revertPairPotentials();
+
+        fullUpdate();
+    }
 }
 
 void DissolveWindow::on_SimulationClearModuleDataAction_triggered(bool checked) { clearModuleData(); }

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -151,6 +151,8 @@ class Dissolve
     bool regeneratePairPotentials();
     // Generate all necessary PairPotentials, adding missing terms where necessary
     bool generatePairPotentials(const std::shared_ptr<AtomType> &onlyInvolving = nullptr);
+    // Revert potentials to reference state, clearing additional potentials
+    void revertPairPotentials();
 
     /*
      * Configurations

--- a/src/main/pairpotentials.cpp
+++ b/src/main/pairpotentials.cpp
@@ -159,3 +159,17 @@ bool Dissolve::generatePairPotentials(const std::shared_ptr<AtomType> &onlyInvol
 
     return true;
 }
+
+// Revert potentials to reference state, clearing additional potentials
+void Dissolve::revertPairPotentials()
+{
+    for (auto &pp : pairPotentials_)
+    {
+        pp->resetUAdditional();
+
+        // Clear entry in processing module data if it exists
+        auto itemName = fmt::format("Potential_{}-{}_Additional", pp->atomTypeNameI(), pp->atomTypeNameJ());
+        if (processingModuleData_.contains(itemName, "Dissolve"))
+            processingModuleData_.remove(itemName, "Dissolve");
+    }
+}


### PR DESCRIPTION
Quick PR to add a menu item to clear all additional potentials from the simulation, reverting to the reference (input) forcefield.