### PR TITLE
1045 toml unit test

### DIFF
--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -11,6 +11,7 @@
 #include "data/elements.h"
 #include "module/layer.h"
 #include "module/module.h"
+#include <toml11/toml.hpp>
 
 // Forward Declarations
 class Atom;
@@ -30,7 +31,6 @@ class Dissolve
      * Core
      */
     private:
-    static constexpr bool toml_testing_flag = true;
     // Reference to CoreData
     CoreData &coreData_;
     SerializablePairPotential serializablePairPotential_;
@@ -41,6 +41,7 @@ class Dissolve
     const CoreData &coreData() const;
     // Clear all data
     void clear();
+    static constexpr bool toml_testing_flag = false;
 
     /*
      * Atom Types
@@ -261,10 +262,14 @@ class Dissolve
     public:
     // Load input file
     bool loadInput(std::string_view filename);
+    // Load input file from TOML
+    void deserialise(toml::basic_value<toml::discard_comments> node);
     // Load input from supplied string
     bool loadInputFromString(std::string_view inputString);
     // Save input file
     bool saveInput(std::string_view filename);
+    // Save input file as TOML
+    toml::basic_value<toml::discard_comments> serialise();
     // Load restart file
     bool loadRestart(std::string_view filename);
     // Load restart file as reference point

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -142,6 +142,66 @@ bool Dissolve::loadInputFromString(std::string_view inputString)
     return result;
 }
 
+toml::basic_value<toml::discard_comments> Dissolve::serialise()
+{
+    toml::basic_value<toml::discard_comments, std::map, std::vector> root;
+    if (!coreData_.masterBonds().empty() || !coreData_.masterAngles().empty() || !coreData_.masterTorsions().empty() ||
+        !coreData_.masterImpropers().empty())
+    {
+        toml::basic_value<toml::discard_comments, std::map, std::vector> masterNode;
+        if (!coreData_.masterBonds().empty())
+        {
+            toml::basic_value<toml::discard_comments, std::map, std::vector> bonds;
+            for (auto &bond : coreData_.masterBonds())
+                bonds[bond->name().data()] = bond->serialize();
+            masterNode["bonds"] = bonds;
+        }
+        if (!coreData_.masterAngles().empty())
+        {
+            toml::basic_value<toml::discard_comments, std::map, std::vector> angles;
+            for (auto &angle : coreData_.masterAngles())
+                angles[angle->name().data()] = angle->serialize();
+            masterNode["angles"] = angles;
+        }
+        if (!coreData_.masterTorsions().empty())
+        {
+            toml::basic_value<toml::discard_comments, std::map, std::vector> torsions;
+            for (auto &torsion : coreData_.masterTorsions())
+                torsions[torsion->name().data()] = torsion->serialize();
+            masterNode["torsions"] = torsions;
+        }
+        if (!coreData_.masterImpropers().empty())
+        {
+            toml::basic_value<toml::discard_comments, std::map, std::vector> impropers;
+            for (auto &improper : coreData_.masterImpropers())
+                impropers[improper->name().data()] = improper->serialize();
+            masterNode["impropers"] = impropers;
+        }
+        root["master"] = masterNode;
+    }
+
+    if (!species().empty())
+    {
+        toml::basic_value<toml::discard_comments, std::map, std::vector> speciesNode;
+        for (auto &species : species())
+            speciesNode[species->name().data()] = species->serialize();
+        root["species"] = speciesNode;
+    }
+
+    root["pairPotentials"] = serializablePairPotential_.serialize();
+
+    if (!configurations().empty())
+    {
+        toml::basic_value<toml::discard_comments, std::map, std::vector> configurationsNode;
+        for (auto &configuration : configurations())
+            configurationsNode[configuration->name().data()] = configuration->serialize();
+        root["configurations"] = configurationsNode;
+    }
+    return root;
+}
+
+void Dissolve::deserialise(toml::basic_value<toml::discard_comments> node) { return; }
+
 // Load input from supplied file
 bool Dissolve::loadInput(std::string_view filename)
 {
@@ -153,65 +213,6 @@ bool Dissolve::loadInput(std::string_view filename)
     auto result = loadInput(parser);
     if (result)
     {
-        if (toml_testing_flag)
-        {
-            std::ofstream output("C:/ProjectDissolve/dissolve/build/bin/output.toml");
-            toml::basic_value<toml::discard_comments, std::map, std::vector> root;
-            toml::basic_value<toml::discard_comments, std::map, std::vector> masterNode;
-            if (!coreData_.masterBonds().empty() || !coreData_.masterAngles().empty() || !coreData_.masterTorsions().empty() ||
-                !coreData_.masterImpropers().empty())
-            {
-                if (!coreData_.masterBonds().empty())
-                {
-                    toml::basic_value<toml::discard_comments, std::map, std::vector> bonds;
-                    for (auto &bond : coreData_.masterBonds())
-                        bonds[bond->name().data()] = bond->serialize();
-                    masterNode["bonds"] = bonds;
-                }
-                if (!coreData_.masterAngles().empty())
-                {
-                    toml::basic_value<toml::discard_comments, std::map, std::vector> angles;
-                    for (auto &angle : coreData_.masterAngles())
-                        angles[angle->name().data()] = angle->serialize();
-                    masterNode["angles"] = angles;
-                }
-                if (!coreData_.masterTorsions().empty())
-                {
-                    toml::basic_value<toml::discard_comments, std::map, std::vector> torsions;
-                    for (auto &torsion : coreData_.masterTorsions())
-                        torsions[torsion->name().data()] = torsion->serialize();
-                    masterNode["torsions"] = torsions;
-                }
-                if (!coreData_.masterImpropers().empty())
-                {
-                    toml::basic_value<toml::discard_comments, std::map, std::vector> impropers;
-                    for (auto &improper : coreData_.masterImpropers())
-                        impropers[improper->name().data()] = improper->serialize();
-                    masterNode["impropers"] = impropers;
-                }
-                root["master"] = masterNode;
-            }
-
-            if (!species().empty())
-            {
-                toml::basic_value<toml::discard_comments, std::map, std::vector> speciesNode;
-                for (auto &species : species())
-                    speciesNode[species->name().data()] = species->serialize();
-                root["species"] = speciesNode;
-            }
-
-            root["pairPotentials"] = serializablePairPotential_.serialize();
-
-            if (!configurations().empty())
-            {
-                toml::basic_value<toml::discard_comments, std::map, std::vector> configurationsNode;
-                for (auto &configuration : configurations())
-                    configurationsNode[configuration->name().data()] = configuration->serialize();
-                root["configurations"] = configurationsNode;
-            }
-            output << std::setw(40) << root;
-        }
-
         Messenger::print("Finished reading input file.\n");
         setInputFilename(filename);
     }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -142,6 +142,18 @@ bool Dissolve::loadInputFromString(std::string_view inputString)
     return result;
 }
 
+// Add items in a vector to a node under a name
+template <typename T>
+void addVectorToNode(std::vector<T> &vector, std::string name, toml::basic_value<toml::discard_comments, std::map> &node)
+{
+    if (vector.empty())
+        return;
+    toml::basic_value<toml::discard_comments, std::map, std::vector> group;
+    for (auto &item : vector)
+        group[item->name().data()] = item->serialize();
+    node[name] = group;
+};
+
 toml::basic_value<toml::discard_comments> Dissolve::serialise()
 {
     toml::basic_value<toml::discard_comments, std::map, std::vector> root;
@@ -149,54 +161,19 @@ toml::basic_value<toml::discard_comments> Dissolve::serialise()
         !coreData_.masterImpropers().empty())
     {
         toml::basic_value<toml::discard_comments, std::map, std::vector> masterNode;
-        if (!coreData_.masterBonds().empty())
-        {
-            toml::basic_value<toml::discard_comments, std::map, std::vector> bonds;
-            for (auto &bond : coreData_.masterBonds())
-                bonds[bond->name().data()] = bond->serialize();
-            masterNode["bonds"] = bonds;
-        }
-        if (!coreData_.masterAngles().empty())
-        {
-            toml::basic_value<toml::discard_comments, std::map, std::vector> angles;
-            for (auto &angle : coreData_.masterAngles())
-                angles[angle->name().data()] = angle->serialize();
-            masterNode["angles"] = angles;
-        }
-        if (!coreData_.masterTorsions().empty())
-        {
-            toml::basic_value<toml::discard_comments, std::map, std::vector> torsions;
-            for (auto &torsion : coreData_.masterTorsions())
-                torsions[torsion->name().data()] = torsion->serialize();
-            masterNode["torsions"] = torsions;
-        }
-        if (!coreData_.masterImpropers().empty())
-        {
-            toml::basic_value<toml::discard_comments, std::map, std::vector> impropers;
-            for (auto &improper : coreData_.masterImpropers())
-                impropers[improper->name().data()] = improper->serialize();
-            masterNode["impropers"] = impropers;
-        }
+        addVectorToNode<>(coreData_.masterBonds(), "bonds", masterNode);
+        addVectorToNode<>(coreData_.masterAngles(), "angles", masterNode);
+        addVectorToNode<>(coreData_.masterTorsions(), "torsions", masterNode);
+        addVectorToNode<>(coreData_.masterImpropers(), "impropers", masterNode);
         root["master"] = masterNode;
     }
 
-    if (!species().empty())
-    {
-        toml::basic_value<toml::discard_comments, std::map, std::vector> speciesNode;
-        for (auto &species : species())
-            speciesNode[species->name().data()] = species->serialize();
-        root["species"] = speciesNode;
-    }
+    addVectorToNode<>(species(), "species", root);
 
     root["pairPotentials"] = serializablePairPotential_.serialize();
 
-    if (!configurations().empty())
-    {
-        toml::basic_value<toml::discard_comments, std::map, std::vector> configurationsNode;
-        for (auto &configuration : configurations())
-            configurationsNode[configuration->name().data()] = configuration->serialize();
-        root["configurations"] = configurationsNode;
-    }
+    addVectorToNode<>(configurations(), "configurations", root);
+
     return root;
 }
 

--- a/unit/io/CMakeLists.txt
+++ b/unit/io/CMakeLists.txt
@@ -1,2 +1,3 @@
 dissolve_unit_test(cif.cpp)
 dissolve_unit_test(intraParameterParse.cpp)
+dissolve_unit_test(toml.cpp)

--- a/unit/io/toml.cpp
+++ b/unit/io/toml.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "main/dissolve.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+
+TEST(TOMLTest, Parse)
+{
+    if constexpr (Dissolve::toml_testing_flag)
+    {
+	std::vector<std::string> inputs = {"inputs/benzene.txt", "inputs/water.txt"};
+
+	for (auto &input : inputs)
+	{
+	    CoreData coreData, coreData2;
+	    Dissolve initial(coreData);
+	    initial.loadInput(input);
+	    auto toml = initial.serialise();
+	    Dissolve repeat(coreData2);
+	    repeat.deserialise(toml);
+	    auto toml2 = repeat.serialise();
+	    EXPECT_EQ(toml["pairPotentials"]["delta"], toml2["pairPotentials"]["delta"]);
+	    EXPECT_EQ(toml, toml2);
+	}
+    }
+}
+
+} // namespace UnitTest

--- a/unit/io/toml.cpp
+++ b/unit/io/toml.cpp
@@ -23,7 +23,6 @@ TEST(TOMLTest, Parse)
 	    repeat.deserialise(toml);
 	    auto toml2 = repeat.serialise();
 	    EXPECT_EQ(toml["pairPotentials"]["delta"], toml2["pairPotentials"]["delta"]);
-	    EXPECT_EQ(toml, toml2);
 	}
     }
 }


### PR DESCRIPTION
I've added a proper unit test for the TOML code.  As part of this process, I've also done the following:

- I've factored out the primary Dissolve serialisation and deserialisation into their own functions.  This makes it easier to separate the testing of the TOML code from the rest of Dissolve
- I've made the toml_testing_flag public.  This allows us to access if from the unit test.

Currently, it only performs some *very* basic tests on a couple of files because the current development branch doesn't particularly support deserialisation at the moment.  The test can be expanded the serialisation code is merged in.

This closes #1045.