### PR TITLE
HighDPI Scaling

### DIFF
--- a/src/dissolve-gui.cpp
+++ b/src/dissolve-gui.cpp
@@ -83,6 +83,9 @@ int main(int args, char **argv)
         }
     }
 
+    // Set device pixel ratio
+    BaseViewer::setDevicePixelRatio(dissolveWindow.devicePixelRatio());
+
     // Update the main window and exec the app
     dissolveWindow.fullUpdate();
 

--- a/src/gui/viewer.hui
+++ b/src/gui/viewer.hui
@@ -206,6 +206,8 @@ class BaseViewer : public QOpenGLWidget, protected QOpenGLFunctions
     QOffscreenSurface offscreenSurface_;
     // Current offscreen buffer
     QOpenGLFramebufferObject *offscreenBuffer_;
+    // Device pixel ratio
+    static double devicePixelRatio_;
 
     private:
     // Initialise context widget (when created by Qt)
@@ -250,6 +252,8 @@ class BaseViewer : public QOpenGLWidget, protected QOpenGLFunctions
     QPixmap generateImage(int imageWidth, int imageHeight);
     // Copy current view to clipboard as an image
     void copyViewToClipboard(bool checked);
+    // Set device pixel ratio
+    static void setDevicePixelRatio(double ratio);
 
     /*
      * Mouse / Keyboard Input

--- a/src/gui/viewer_render.cpp
+++ b/src/gui/viewer_render.cpp
@@ -12,6 +12,9 @@
 #include <QProgressDialog>
 #include <algorithm>
 
+// Device pixel ratio
+double BaseViewer::devicePixelRatio_{1.0};
+
 // Initialise context widget (when created by Qt)
 void BaseViewer::initializeGL()
 {
@@ -103,8 +106,8 @@ void BaseViewer::renderGL(int xOffset, int yOffset)
     view().recalculateView();
 
     // Set-up the GL viewport
-    glViewport(view_.viewportMatrix()[0] + xOffset, view_.viewportMatrix()[1] + yOffset, view_.viewportMatrix()[2],
-               view_.viewportMatrix()[3]);
+    glViewport(view_.viewportMatrix()[0] + xOffset, view_.viewportMatrix()[1] + yOffset,
+               view_.viewportMatrix()[2] * devicePixelRatio_, view_.viewportMatrix()[3] * devicePixelRatio_);
 
     // Apply our View's projection matrix
     glMatrixMode(GL_PROJECTION);
@@ -522,3 +525,6 @@ void BaseViewer::copyViewToClipboard(bool checked)
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setImage(pixmap.toImage());
 }
+
+// Set device pixel ratio
+void BaseViewer::setDevicePixelRatio(double ratio) { devicePixelRatio_ = ratio; }


### PR DESCRIPTION
Simple PR to account for device pixel ratio in our GL-based viewers, fixing "quarter-screen" rendering on, e.g. Retina displays. Untested in its current form, but an identical fix in a separate project yielded the correct results on OSX.

Closes #163.