### PR TITLE
Duplicate AtomTypes

### DIFF
--- a/src/gui/forcefieldtab.h
+++ b/src/gui/forcefieldtab.h
@@ -71,8 +71,10 @@ class ForcefieldTab : public QWidget, public MainTab
 
     private slots:
     // Atom Types
+    void on_AtomTypeDuplicateButton_clicked(bool checked);
     void on_AtomTypeAddButton_clicked(bool checked);
     void on_AtomTypeRemoveButton_clicked(bool checked);
+    void atomTypeSelectionChanged(const QItemSelection &current, const QItemSelection &previous);
     void atomTypeDataChanged(const QModelIndex &current, const QModelIndex &previous, const QVector<int> &);
     // Pair Potentials
     void on_PairPotentialRangeSpin_valueChanged(double value);

--- a/src/gui/forcefieldtab.h
+++ b/src/gui/forcefieldtab.h
@@ -28,8 +28,8 @@ class ForcefieldTab : public QWidget, public MainTab
     // Main form declaration
     Ui::ForcefieldTab ui_;
     // Models
-    AtomTypeModel atoms_;
-    PairPotentialModel pairs_;
+    AtomTypeModel atomTypesModel_;
+    PairPotentialModel pairPotentialModel_;
 
     /*
      * MainTab Reimplementations

--- a/src/gui/forcefieldtab.ui
+++ b/src/gui/forcefieldtab.ui
@@ -92,6 +92,35 @@
              <number>4</number>
             </property>
             <item>
+             <widget class="QToolButton" name="AtomTypeDuplicateButton">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Duplicate</string>
+              </property>
+              <property name="icon">
+               <iconset resource="main.qrc">
+                <normaloff>:/general/icons/general_copy.svg</normaloff>:/general/icons/general_copy.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>16</width>
+                <height>16</height>
+               </size>
+              </property>
+              <property name="toolButtonStyle">
+               <enum>Qt::ToolButtonTextBesideIcon</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
              <spacer name="horizontalSpacer_4">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>

--- a/src/gui/forcefieldtab.ui
+++ b/src/gui/forcefieldtab.ui
@@ -174,6 +174,12 @@
               <pointsize>10</pointsize>
              </font>
             </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::SingleSelection</enum>
+            </property>
+            <property name="selectionBehavior">
+             <enum>QAbstractItemView::SelectRows</enum>
+            </property>
             <attribute name="horizontalHeaderVisible">
              <bool>false</bool>
             </attribute>
@@ -767,7 +773,6 @@
              <property name="font">
               <font>
                <pointsize>10</pointsize>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -875,7 +880,6 @@
              <property name="font">
               <font>
                <pointsize>10</pointsize>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -983,7 +987,6 @@
              <property name="font">
               <font>
                <pointsize>10</pointsize>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -1091,7 +1094,6 @@
              <property name="font">
               <font>
                <pointsize>10</pointsize>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -240,7 +240,7 @@ void ForcefieldTab::on_AtomTypeAddButton_clicked(bool checked)
     if (!ok)
         return;
 
-    std::shared_ptr<AtomType> at = dissolve_.addAtomType(Z);
+    auto at = dissolve_.addAtomType(Z);
 
     Locker refreshLocker(refreshLock_);
 

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -18,7 +18,7 @@
 #include <QListWidgetItem>
 
 ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title)
-    : MainTab(dissolveWindow, dissolve, parent, title, this), pairs_(dissolve.pairPotentials())
+    : MainTab(dissolveWindow, dissolve, parent, title, this), pairPotentialModel_(dissolve.pairPotentials())
 {
     ui_.setupUi(this);
 
@@ -80,8 +80,8 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
     // Ensure fonts for table headers are set correctly and the headers themselves are visible
     ui_.AtomTypesTable->horizontalHeader()->setFont(font());
     ui_.AtomTypesTable->horizontalHeader()->setVisible(true);
-    ui_.AtomTypesTable->setModel(&atoms_);
-    connect(&atoms_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
+    ui_.AtomTypesTable->setModel(&atomTypesModel_);
+    connect(&atomTypesModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
             SLOT(atomTypeDataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)));
     connect(ui_.AtomTypesTable->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)),
             this, SLOT(atomTypeSelectionChanged(const QItemSelection &, const QItemSelection &)));
@@ -102,14 +102,14 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
     // Ensure fonts for table headers are set correctly and the headers themselves are visible
     ui_.PairPotentialsTable->horizontalHeader()->setFont(font());
     ui_.PairPotentialsTable->horizontalHeader()->setVisible(true);
-    ui_.PairPotentialsTable->setModel(&pairs_);
+    ui_.PairPotentialsTable->setModel(&pairPotentialModel_);
 
     DataViewer *viewer = ui_.PairPotentialsPlotWidget->dataViewer();
     viewer->view().axes().setTitle(0, "\\it{r}, \\sym{angstrom}");
     viewer->view().axes().setTitle(1, "U, kj/mol");
     viewer->view().axes().setRange(1, -100.0, 100.0);
 
-    connect(&pairs_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
+    connect(&pairPotentialModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
             SLOT(pairPotentialDataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)));
     connect(ui_.PairPotentialsTable->selectionModel(), SIGNAL(currentRowChanged(const QModelIndex &, const QModelIndex &)),
             this, SLOT(pairPotentialTableRowChanged(const QModelIndex &, const QModelIndex &)));
@@ -136,7 +136,7 @@ void ForcefieldTab::updatePairPotentials()
     Messenger::mute();
 
     dissolve_.generatePairPotentials();
-    pairs_.reset();
+    pairPotentialModel_.reset();
     ui_.PairPotentialsTable->resizeColumnsToContents();
 
     // Reinstate output
@@ -158,7 +158,7 @@ void ForcefieldTab::updateControls()
     ui_.MasterImpropersTable->resizeColumnsToContents();
 
     // AtomTypes Table
-    atoms_.setData(dissolve_.atomTypes());
+    atomTypesModel_.setData(dissolve_.atomTypes());
     ui_.AtomTypesTable->resizeColumnsToContents();
 
     // PairPotentials
@@ -208,7 +208,7 @@ void ForcefieldTab::on_AtomTypeDuplicateButton_clicked(bool checked)
         return;
 
     // Get selected atomtype
-    auto at = atoms_.rawData(index);
+    auto at = atomTypesModel_.rawData(index);
     if (!at)
         return;
 
@@ -222,7 +222,7 @@ void ForcefieldTab::on_AtomTypeDuplicateButton_clicked(bool checked)
 
     Locker refreshLocker(refreshLock_);
 
-    atoms_.setData(dissolve_.atomTypes());
+    atomTypesModel_.setData(dissolve_.atomTypes());
     ui_.AtomTypesTable->resizeColumnsToContents();
 
     // Re-set the current index
@@ -244,7 +244,7 @@ void ForcefieldTab::on_AtomTypeAddButton_clicked(bool checked)
 
     Locker refreshLocker(refreshLock_);
 
-    atoms_.setData(dissolve_.atomTypes());
+    atomTypesModel_.setData(dissolve_.atomTypes());
     ui_.AtomTypesTable->resizeColumnsToContents();
 
     dissolveWindow_->setModified();
@@ -375,7 +375,7 @@ void ForcefieldTab::pairPotentialTableRowChanged(const QModelIndex &current, con
 {
     ui_.PairPotentialsPlotWidget->clearRenderableData();
 
-    auto *pp = pairs_.data(current, Qt::UserRole).value<const PairPotential *>();
+    auto *pp = pairPotentialModel_.data(current, Qt::UserRole).value<const PairPotential *>();
     if (!pp)
         return;
 

--- a/src/gui/icons/general_copy.svg
+++ b/src/gui/icons/general_copy.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="100"
+   height="100"
+   id="svg2"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="general_copy.svg">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1136"
+     id="namedview22"
+     showgrid="false"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="-100.69507"
+     inkscape:cy="-73.014928"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs4" />
+  <g
+     id="g835"
+     transform="matrix(0.88324782,0,0,0.88324782,25.554826,20.507696)">
+    <path
+       style="opacity:1;fill:#ffffeb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00157;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.262883,13.556195 h 39.484471 l 16.625383,15.524716 0.707107,54.020166 c 0,2.310734 -1.860266,4.171 -4.171,4.171 H 23.262883 c -2.310734,0 -4.171,-1.860266 -4.171,-4.171 V 17.727195 c 0,-2.310734 1.860266,-4.171 4.171,-4.171 z"
+       id="rect1369"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccssssc" />
+    <g
+       id="g2180"
+       transform="matrix(1.1075798,0,0,1.1075798,-1.8597601,-0.2059301)" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 81.25,26.964284 q 1.25,1.25 2.142853,3.392863 0.892862,2.142853 0.892862,3.928569 v 51.428568 q 0,1.785716 -1.25,3.035716 Q 81.785715,90 80,90 H 20 q -1.785716,0 -3.035716,-1.25 -1.25,-1.25 -1.25,-3.035716 V 14.285716 q 0,-1.785716 1.25,-3.035716 Q 18.214284,10 20,10 h 40 q 1.785716,0 3.928568,0.892853 2.142863,0.892863 3.392863,2.142863 z M 61.428568,16.071431 V 32.857147 H 78.214284 Q 77.767857,31.562498 77.232142,31.026782 L 63.258924,17.053573 Q 62.723208,16.517858 61.428568,16.071431 Z M 78.571432,84.285716 V 38.571431 H 60 q -1.785716,0 -3.035716,-1.25 -1.25,-1.25 -1.25,-3.035715 V 15.714284 H 21.428568 v 68.571432 z"
+       id="path4422"
+       style="fill:#310049;fill-opacity:1;fill-rule:nonzero;stroke-width:0.888889" />
+  </g>
+  <g
+     id="g835-3"
+     transform="matrix(0.88324782,0,0,0.88324782,-13.879607,-8.8324782)">
+    <path
+       style="opacity:1;fill:#ffffeb;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00157;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.262883,13.556195 h 39.484471 l 16.625383,15.524716 0.707107,54.020166 c 0,2.310734 -1.860266,4.171 -4.171,4.171 H 23.262883 c -2.310734,0 -4.171,-1.860266 -4.171,-4.171 V 17.727195 c 0,-2.310734 1.860266,-4.171 4.171,-4.171 z"
+       id="rect1369-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccssssc" />
+    <g
+       id="g2180-7"
+       transform="matrix(1.1075798,0,0,1.1075798,-1.8597601,-0.2059301)" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 81.25,26.964284 q 1.25,1.25 2.142853,3.392863 0.892862,2.142853 0.892862,3.928569 v 51.428568 q 0,1.785716 -1.25,3.035716 Q 81.785715,90 80,90 H 20 q -1.785716,0 -3.035716,-1.25 -1.25,-1.25 -1.25,-3.035716 V 14.285716 q 0,-1.785716 1.25,-3.035716 Q 18.214284,10 20,10 h 40 q 1.785716,0 3.928568,0.892853 2.142863,0.892863 3.392863,2.142863 z M 61.428568,16.071431 V 32.857147 H 78.214284 Q 77.767857,31.562498 77.232142,31.026782 L 63.258924,17.053573 Q 62.723208,16.517858 61.428568,16.071431 Z M 78.571432,84.285716 V 38.571431 H 60 q -1.785716,0 -3.035716,-1.25 -1.25,-1.25 -1.25,-3.035715 V 15.714284 H 21.428568 v 68.571432 z"
+       id="path4422-5"
+       style="fill:#310049;fill-opacity:1;fill-rule:nonzero;stroke-width:0.888889" />
+  </g>
+</svg>

--- a/src/gui/main.qrc
+++ b/src/gui/main.qrc
@@ -166,6 +166,7 @@
     <file>icons/general_clock.svg</file>
     <file>icons/general_heartbeat.svg</file>
     <file>icons/general_local.svg</file>
+    <file>icons/general_copy.svg</file>
     <file>icons/general_movemodule.svg</file>
     <file>icons/general_restartfile.svg</file>
     <file>icons/general_font.svg</file>


### PR DESCRIPTION
Small PR to implement the ability to duplicate a selected `AtomType` in the table, copying its data but giving it a unique name.