### PR TITLE
Overcome Flat Geometries in Minimiser

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -123,6 +123,8 @@ class Species : public Serialisable
     int simplifyAtomTypes();
     // Return total charge of species from local/atomtype atomic charges
     double totalCharge(bool useAtomTypes) const;
+    // Apply random noise to atoms
+    void randomiseCoordinates(double maxDisplacement);
 
     /*
      * Intramolecular Data

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -310,3 +310,16 @@ double Species::totalCharge(bool useAtomTypes) const
         return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,
                                [](const auto acc, const auto &i) { return acc + i.charge(); });
 }
+
+// Apply random noise to atoms
+void Species::randomiseCoordinates(double maxDisplacement)
+{
+    Vec3<double> deltaR;
+
+    for (auto &i : atoms_)
+    {
+        deltaR.randomUnit();
+        deltaR *= maxDisplacement;
+        i.translateCoordinates(deltaR);
+    }
+}

--- a/src/gui/specieseditor_funcs.cpp
+++ b/src/gui/specieseditor_funcs.cpp
@@ -233,6 +233,10 @@ void SpeciesEditor::on_ToolsMinimiseButton_clicked(bool checked)
     if (!sp->checkSetUp())
         return;
 
+    // Apply a small randomisation to the Species so we can overcome edge cases in initial geometries (e.g. all atoms in one
+    // plane)
+    sp->randomiseCoordinates(0.0001);
+
     // Create a temporary potential map
     dissolve.regeneratePairPotentials();
     GeometryOptimisationModule optimiser;

--- a/src/gui/specieswidget_funcs.cpp
+++ b/src/gui/specieswidget_funcs.cpp
@@ -132,6 +132,10 @@ void SpeciesWidget::on_ToolsMinimiseButton_clicked(bool checked)
     if (!sp->checkSetUp())
         return;
 
+    // Apply a small randomisation to the Species so we can overcome edge cases in initial geometries (e.g. all atoms in one
+    // plane)
+    sp->randomiseCoordinates(0.0001);
+
     GeometryOptimisationModule optimiser;
     optimiser.optimiseSpecies(dissolve_->potentialMap(), dissolve_->worldPool(), sp);
 


### PR DESCRIPTION
Quick PR to allow the geometry optimise species to overcome the edge case where all atoms are in a single plane.  This is actually a relatively common case since most users draw molecules in the plane of the screen.

Closes #1056.