### PR TITLE
Manual Procedure Creation

### DIFF
--- a/src/keywords/nodevector.h
+++ b/src/keywords/nodevector.h
@@ -41,13 +41,11 @@ class NodeVectorKeywordBase : public NodeKeywordUnderlay, public KeywordBase
 template <class N> class NodeVectorKeyword : public NodeVectorKeywordBase
 {
     public:
-    NodeVectorKeyword(std::vector<std::shared_ptr<const N>> &data, ProcedureNode *parentNode, ProcedureNode::NodeType nodeType,
-                      bool onlyInScope)
+    NodeVectorKeyword(ConstNodeVector<N> &data, ProcedureNode *parentNode, ProcedureNode::NodeType nodeType, bool onlyInScope)
         : NodeVectorKeywordBase(parentNode, nodeType, onlyInScope), data_(data)
     {
     }
-    NodeVectorKeyword(std::vector<std::shared_ptr<const N>> &data, ProcedureNode *parentNode,
-                      ProcedureNode::NodeClass nodeClass, bool onlyInScope)
+    NodeVectorKeyword(ConstNodeVector<N> &data, ProcedureNode *parentNode, ProcedureNode::NodeClass nodeClass, bool onlyInScope)
         : NodeVectorKeywordBase(parentNode, nodeType, onlyInScope), data_(data)
     {
     }
@@ -58,12 +56,12 @@ template <class N> class NodeVectorKeyword : public NodeVectorKeywordBase
      */
     private:
     // Reference to vector of data
-    std::vector<std::shared_ptr<const N>> &data_;
+    ConstNodeVector<N> &data_;
 
     public:
     // Return reference to vector of data
-    std::vector<std::shared_ptr<const N>> &data() { return data_; }
-    const std::vector<std::shared_ptr<const N>> &data() const { return data_; }
+    ConstNodeVector<N> &data() { return data_; }
+    const ConstNodeVector<N> &data() const { return data_; }
     // Add node to vector
     bool addNode(ConstNodeRef node) override
     {

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -40,7 +40,7 @@ KeywordTypeMap::KeywordTypeMap()
                           NodeVectorKeyword<Collect1DProcedureNode>>();
     registerDirectMapping<std::shared_ptr<RegionProcedureNodeBase>, NodeKeyword<RegionProcedureNodeBase>>();
     registerDirectMapping<std::shared_ptr<SelectProcedureNode>, NodeKeyword<SelectProcedureNode>>();
-    registerDirectMapping<std::vector<std::shared_ptr<const SelectProcedureNode>>, NodeVectorKeyword<SelectProcedureNode>>();
+    registerDirectMapping<ConstNodeVector<SelectProcedureNode>, NodeVectorKeyword<SelectProcedureNode>>();
     registerDirectMapping<std::vector<Module *>, ModuleVectorKeyword>();
     registerDirectMapping<const Module *, ModuleKeywordBase>(
         [](ModuleKeywordBase *keyword, const Module *module) { return keyword->setData(module); },

--- a/src/modules/calculate_angle/angle.cpp
+++ b/src/modules/calculate_angle/angle.cpp
@@ -76,9 +76,9 @@ CalculateAngleModule::CalculateAngleModule() : Module("CalculateAngle"), analyse
         processAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
         auto rdfABNormalisation = processAB_->addNormalisationBranch();
         rdfABNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
         rdfABNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectB_}));
         rdfABNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
         // Process1D: 'RDF(BC)'
@@ -87,9 +87,9 @@ CalculateAngleModule::CalculateAngleModule() : Module("CalculateAngle"), analyse
         processBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
         auto rdfBCNormalisation = processBC_->addNormalisationBranch();
         rdfBCNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectA_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
         rdfBCNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectC_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectC_}));
         rdfBCNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
         // Process1D: 'ANGLE(ABC)'
@@ -108,9 +108,9 @@ CalculateAngleModule::CalculateAngleModule() : Module("CalculateAngle"), analyse
         auto dAngleABNormalisation = processDAngleAB_->addNormalisationBranch();
         dAngleABNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(y)/sin(yDelta)");
         dAngleABNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
         dAngleABNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectB_}));
         dAngleABNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
         // Process2D: 'DAngle A-(B-C)'
@@ -121,9 +121,9 @@ CalculateAngleModule::CalculateAngleModule() : Module("CalculateAngle"), analyse
         auto dAngleBCNormalisation = processDAngleBC_->addNormalisationBranch();
         dAngleBCNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(y)/sin(yDelta)");
         dAngleBCNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectA_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
         dAngleBCNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectC_}));
+            {}, ConstNodeVector<SelectProcedureNode>({selectC_}));
         dAngleBCNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
     }
     catch (...)

--- a/src/modules/calculate_angle/angle.cpp
+++ b/src/modules/calculate_angle/angle.cpp
@@ -25,282 +25,114 @@
 
 CalculateAngleModule::CalculateAngleModule() : Module("CalculateAngle"), analyser_(ProcedureNode::AnalysisContext)
 {
-    /*
-     * Assemble the following Procedure:
-     *
-     * Select  'B'
-     *   Site  ...
-     *   ForEach
-     *     Select  'A'
-     *       Site  ...
-     *       ForEach
-     *         Select  'C'
-     *           Site  ...
-     *           ForEach
-     *             Calculate  'rAB'
-     *               Distance  'A'  'B'
-     *             EndCalculate
-     *             Calculate  'rBC'
-     *               Distance  'B'  'C'
-     *             EndCalculate
-     *             Calculate  'aABC'
-     *               Angle  'A'  'B'  'C'
-     *             EndCalculate
-     *             Collect3D  'DDA'
-     *               QuantityX  'rAB'
-     *               QuantityY  'rBC'
-     *               QuantityZ  'aABC'
-     *               RangeX  0.0  10.0  0.05
-     *               RangeY  0.0  10.0  0.05
-     *               RangeZ  0.0  180.0  1.0
-     *               SubCollect
-     *                 Collect1D  'RDF(AB)'
-     *                   QuantityX  'rAB'
-     *                   RangeX  0.0  10.0  0.05
-     *                 EndCollect
-     *                 Collect1D  'RDF(BC)'
-     *                   QuantityX  'rBC'
-     *                   RangeX  0.0  10.0  0.05
-     *                 EndCollect
-     *                 Collect1D  'ANGLE(ABC)'
-     *                   QuantityX  'aABC'
-     *                   RangeX  0.0  180.0  1.0
-     *                 EndCollect
-     *                 Collect2D  'DAngle((A-B)-C)'
-     *                   QuantityX  'rAB'
-     *                   QuantityY  'aABC'
-     *                   RangeX  0.0  10.0  0.05
-     *                   RangeY  0.0  180.0  1.0
-     *                 EndCollect2D
-     *                 Collect2D  'DAngle(A-(B-C))'
-     *                   QuantityX  'rBC'
-     *                   QuantityY  'aABC'
-     *                   RangeX  0.0  10.0  0.05
-     *                   RangeY  0.0  180.0  1.0
-     *                 EndCollect2D
-     *               EndSubCollect
-     *             EndCollect3D
-     *           EndForEach  'C'
-     *         EndSelect  'C'
-     *       EndForEach  'B'
-     *     EndSelect  'B'
-     *   EndForEach  'A'
-     * EndSelect  'A'
-     * Process1D  'RDF(AB)'
-     *   Normalisation
-     *     OperateSitePopulationNormalise
-     *       Site  'B'  'C'
-     *     EndOperateSitePopulationNormalise
-     *     OperateNumberDensityNormalise
-     *       Site  'A'
-     *       Population  'Available'
-     *     EndOperateNumberDensityNormalise
-     *     OperateSphericalShellNormalise
-     *     EndOperateSphericalShellNormalise
-     *   EndNormalisation
-     *   LabelX  'r, Angstroms'
-     *   LabelValue  'g\\sub{AB}(r)'
-     * EndProcess1D
-     * Process1D  'RDF(BC)'
-     *   Normalisation
-     *     OperateSitePopulationNormalise
-     *       Site  'B'  'A'
-     *     EndOperateSitePopulationNormalise
-     *     OperateNumberDensityNormalise
-     *       Site  'C'
-     *       Population  'Available'
-     *     EndOperateNumberDensityNormalise
-     *     OperateSphericalShellNormalise
-     *     EndOperateSphericalShellNormalise
-     *   EndNormalisation
-     *   LabelX  'r, Angstroms'
-     *   LabelValue  'g\\sub{BC}(r)'
-     * EndProcess1D
-     * Process1D  'Angle(ABC)'
-     *   Normalisation
-     *     OperateExpression
-     *       Expression("value/sin(x)")
-     *     EndOperateExpression
-     *     OperateNormalise
-     *       Value  1.0
-     *     EndOperateNormalise
-     *   EndNormalisation
-     *   LabelValue  'g(r)'
-     *   LabelX  'theta, Degrees'
-     *   LabelValue  'Normalised Frequency'
-     * EndProcess1D
-     * Process2D  'DAngle (A-B)...C'
-     *   Normalisation
-     *     OperateEquationNormalise
-     *       Equation  value/sin(y)/sin(yDelta)
-     *     EndOperateEquationNormalise
-     *     OperateSitePopulationNormalise
-     *       Site  'B'  'A'
-     *     EndOperateSitePopulationNormalise
-     *     OperateNumberDensityNormalise
-     *       Site  'C'
-     *       Population  'Available'
-     *     EndOperateNumberDensityNormalise
-     *     OperateSphericalShellNormalise
-     *     EndOperateSphericalShellNormalise
-     *   EndNormalisation
-     *   LabelValue  'g(r)'
-     *   LabelX  'r, Angstroms'
-     *   LabelY  'theta, Degrees'
-     *   LabelValue  'Probability'
-     * EndProcess2D
-     * Process2D  'DAngle A...(B-C)'
-     *   Normalisation
-     *     OperateEquationNormalise
-     *       Equation  value/sin(y)/sin(yDelta)
-     *     EndOperateEquationNormalise
-     *     OperateSitePopulationNormalise
-     *       Site  'B'  'C'
-     *     EndOperateSitePopulationNormalise
-     *     OperateNumberDensityNormalise
-     *       Site  'A'
-     *       Population  'Available'
-     *     EndOperateNumberDensityNormalise
-     *     OperateSphericalShellNormalise
-     *     EndOperateSphericalShellNormalise
-     *   EndNormalisation
-     *   LabelValue  'g(r)'
-     *   LabelX  'r, Angstroms'
-     *   LabelY  'theta, Degrees'
-     *   LabelValue  'Probability'
-     * EndProcess2D
-     */
+    try
+    {
+        // Select: Site 'A'
+        selectA_ = analyser_.createRootNode<SelectProcedureNode>("A");
+        auto forEachA = selectA_->addForEachBranch(ProcedureNode::AnalysisContext);
 
-    // Select: Site 'A'
-    selectA_ = std::make_shared<SelectProcedureNode>();
-    selectA_->setName("A");
-    auto forEachA = selectA_->addForEachBranch(ProcedureNode::AnalysisContext);
-    analyser_.addRootSequenceNode(selectA_);
+        // -- Select: Site 'B'
+        selectB_ = forEachA->create<SelectProcedureNode>("B");
+        auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
 
-    // -- Select: Site 'B'
-    selectB_ = std::make_shared<SelectProcedureNode>();
-    selectB_->setName("B");
-    auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
-    forEachA->addNode(selectB_);
+        // -- -- Calculate: 'rAB'
+        auto calcAB = forEachB->create<CalculateDistanceProcedureNode>("rAB", selectA_, selectB_);
 
-    // -- -- Calculate: 'rAB'
-    auto calcAB = std::make_shared<CalculateDistanceProcedureNode>(selectA_, selectB_);
-    forEachB->addNode(calcAB);
+        // -- -- Collect1D:  'RDF(AB)'
+        collectAB_ = forEachB->create<Collect1DProcedureNode>({}, calcAB, rangeAB_.x, rangeAB_.y, rangeAB_.z);
 
-    // -- -- Collect1D:  'RDF(AB)'
-    collectAB_ = std::make_shared<Collect1DProcedureNode>(calcAB, rangeAB_.x, rangeAB_.y, rangeAB_.z);
-    forEachB->addNode(collectAB_);
+        // -- -- Select: Site 'C'
+        selectC_ = forEachB->create<SelectProcedureNode>("C");
+        auto forEachC = selectC_->addForEachBranch(ProcedureNode::AnalysisContext);
 
-    // -- -- Select: Site 'C'
-    selectC_ = std::make_shared<SelectProcedureNode>();
-    selectC_->setName("C");
-    auto forEachC = selectC_->addForEachBranch(ProcedureNode::AnalysisContext);
-    forEachB->addNode(selectC_);
+        // -- -- -- Calculate: 'rBC'
+        auto calcBC = forEachC->create<CalculateDistanceProcedureNode>({}, selectB_, selectC_);
 
-    // -- -- -- Calculate: 'rBC'
-    auto calcBC = std::make_shared<CalculateDistanceProcedureNode>(selectB_, selectC_);
-    forEachC->addNode(calcBC);
+        // -- -- -- Calculate: 'aABC'
+        auto calcABC = forEachC->create<CalculateAngleProcedureNode>({}, selectA_, selectB_, selectC_);
 
-    // -- -- -- Calculate: 'aABC'
-    auto calcABC = std::make_shared<CalculateAngleProcedureNode>(selectA_, selectB_, selectC_);
-    forEachC->addNode(calcABC);
+        // -- -- -- Collect1D:  'RDF(BC)'
+        collectBC_ = forEachC->create<Collect1DProcedureNode>({}, calcBC, rangeBC_.x, rangeBC_.y, rangeBC_.z);
 
-    // -- -- -- Collect1D:  'RDF(BC)'
-    collectBC_ = std::make_shared<Collect1DProcedureNode>(calcBC, rangeBC_.x, rangeBC_.y, rangeBC_.z);
-    forEachC->addNode(collectBC_);
+        // -- -- -- Collect1D:  'ANGLE(ABC)'
+        collectABC_ = forEachC->create<Collect1DProcedureNode>({}, calcABC, angleRange_.x, angleRange_.y, angleRange_.z);
 
-    // -- -- -- Collect1D:  'ANGLE(ABC)'
-    collectABC_ = std::make_shared<Collect1DProcedureNode>(calcABC, angleRange_.x, angleRange_.y, angleRange_.z);
-    forEachC->addNode(collectABC_);
+        // -- -- -- Collect2D:  'DAngle (A-B)-C'
+        collectDAngleAB_ = forEachC->create<Collect2DProcedureNode>({}, calcAB, calcABC, rangeAB_.x, rangeAB_.y, rangeAB_.z,
+                                                                    angleRange_.x, angleRange_.y, angleRange_.z);
 
-    // -- -- -- Collect2D:  'DAngle (A-B)-C'
-    collectDAngleAB_ = std::make_shared<Collect2DProcedureNode>(calcAB, calcABC, rangeAB_.x, rangeAB_.y, rangeAB_.z,
-                                                                angleRange_.x, angleRange_.y, angleRange_.z);
-    forEachC->addNode(collectDAngleAB_);
+        // -- -- -- Collect2D:  'DAngle A-(B-C)'
+        collectDAngleBC_ = forEachC->create<Collect2DProcedureNode>({}, calcBC, calcABC, rangeBC_.x, rangeBC_.y, rangeBC_.z,
+                                                                    angleRange_.x, angleRange_.y, angleRange_.z);
 
-    // -- -- -- Collect2D:  'DAngle A-(B-C)'
-    collectDAngleBC_ = std::make_shared<Collect2DProcedureNode>(calcBC, calcABC, rangeBC_.x, rangeBC_.y, rangeBC_.z,
-                                                                angleRange_.x, angleRange_.y, angleRange_.z);
-    forEachC->addNode(collectDAngleBC_);
+        // -- -- -- Collect3D:  'rAB vs rBC vs aABC'
+        collectDDA_ = forEachC->create<Collect3DProcedureNode>({}, calcAB, calcBC, calcABC, rangeAB_.x, rangeAB_.y, rangeAB_.z,
+                                                               rangeBC_.x, rangeBC_.y, rangeBC_.z, angleRange_.x, angleRange_.y,
+                                                               angleRange_.z);
 
-    // -- -- -- Collect3D:  'rAB vs rBC vs aABC'
-    collectDDA_ =
-        std::make_shared<Collect3DProcedureNode>(calcAB, calcBC, calcABC, rangeAB_.x, rangeAB_.y, rangeAB_.z, rangeBC_.x,
-                                                 rangeBC_.y, rangeBC_.z, angleRange_.x, angleRange_.y, angleRange_.z);
-    forEachC->addNode(collectDDA_);
+        // Process1D: 'RDF(AB)'
+        processAB_ = analyser_.createRootNode<Process1DProcedureNode>("RDF(AB)", collectAB_);
+        processAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
+        processAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+        auto rdfABNormalisation = processAB_->addNormalisationBranch();
+        rdfABNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
+        rdfABNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_}));
+        rdfABNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
-    // Process1D: 'RDF(AB)'
-    processAB_ = std::make_shared<Process1DProcedureNode>(collectAB_);
-    processAB_->setName("RDF(AB)");
-    processAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
-    processAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-    auto rdfABNormalisation = processAB_->addNormalisationBranch();
-    rdfABNormalisation->addNode(std::make_shared<OperateSitePopulationNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_})));
-    rdfABNormalisation->addNode(std::make_shared<OperateNumberDensityNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_}),
-        SelectProcedureNode::SelectionPopulation::Available));
-    rdfABNormalisation->addNode(std::make_shared<OperateSphericalShellNormaliseProcedureNode>());
-    analyser_.addRootSequenceNode(processAB_);
+        // Process1D: 'RDF(BC)'
+        processBC_ = analyser_.createRootNode<Process1DProcedureNode>("RDF(BC)", collectBC_);
+        processBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
+        processBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+        auto rdfBCNormalisation = processBC_->addNormalisationBranch();
+        rdfBCNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectA_}));
+        rdfBCNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectC_}));
+        rdfBCNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
-    // Process1D: 'RDF(BC)'
-    processBC_ = std::make_shared<Process1DProcedureNode>(collectBC_);
-    processBC_->setName("RDF(BC)");
-    processBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
-    processBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-    auto rdfBCNormalisation = processBC_->addNormalisationBranch();
-    rdfBCNormalisation->addNode(std::make_shared<OperateSitePopulationNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectA_})));
-    rdfBCNormalisation->addNode(std::make_shared<OperateNumberDensityNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectC_}),
-        SelectProcedureNode::SelectionPopulation::Available));
-    rdfBCNormalisation->addNode(std::make_shared<OperateSphericalShellNormaliseProcedureNode>());
-    analyser_.addRootSequenceNode(processBC_);
+        // Process1D: 'ANGLE(ABC)'
+        processAngle_ = analyser_.createRootNode<Process1DProcedureNode>("Angle(ABC)", collectABC_);
+        processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
+        processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
+        auto angleNormalisation = processAngle_->addNormalisationBranch();
+        angleNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+        angleNormalisation->create<OperateNormaliseProcedureNode>({}, 1.0);
 
-    // Process1D: 'ANGLE(ABC)'
-    processAngle_ = std::make_shared<Process1DProcedureNode>(collectABC_);
-    processAngle_->setName("Angle(ABC)");
-    processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
-    processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
-    auto angleNormalisation = processAngle_->addNormalisationBranch();
-    angleNormalisation->addNode(std::make_shared<OperateExpressionProcedureNode>("value/sin(x)"));
-    angleNormalisation->addNode(std::make_shared<OperateNormaliseProcedureNode>(1.0));
-    analyser_.addRootSequenceNode(processAngle_);
+        // Process2D: 'DAngle (A-B)-C'
+        processDAngleAB_ = analyser_.createRootNode<Process2DProcedureNode>("DAngle((A-B)-C)", collectDAngleAB_);
+        processDAngleAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
+        processDAngleAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+        processDAngleAB_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
+        auto dAngleABNormalisation = processDAngleAB_->addNormalisationBranch();
+        dAngleABNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(y)/sin(yDelta)");
+        dAngleABNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
+        dAngleABNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_}));
+        dAngleABNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
-    // Process2D: 'DAngle (A-B)-C'
-    processDAngleAB_ = std::make_shared<Process2DProcedureNode>(collectDAngleAB_);
-    processDAngleAB_->setName("DAngle((A-B)-C)");
-    processDAngleAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
-    processDAngleAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-    processDAngleAB_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
-    auto dAngleABNormalisation = processDAngleAB_->addNormalisationBranch();
-    dAngleABNormalisation->addNode(std::make_shared<OperateExpressionProcedureNode>("value/sin(y)/sin(yDelta)"));
-    dAngleABNormalisation->addNode(std::make_shared<OperateSitePopulationNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectC_})));
-    dAngleABNormalisation->addNode(std::make_shared<OperateNumberDensityNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}),
-        SelectProcedureNode::SelectionPopulation::Available));
-    dAngleABNormalisation->addNode(std::make_shared<OperateSphericalShellNormaliseProcedureNode>());
-    analyser_.addRootSequenceNode(processDAngleAB_);
-
-    // Process2D: 'DAngle A-(B-C)'
-    processDAngleBC_ = std::make_shared<Process2DProcedureNode>(collectDAngleBC_);
-    processDAngleBC_->setName("DAngle(A-(B-C))");
-    processDAngleBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
-    processDAngleBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-    processDAngleBC_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
-    auto dAngleBCNormalisation = processDAngleBC_->addNormalisationBranch();
-    dAngleBCNormalisation->addNode(std::make_shared<OperateExpressionProcedureNode>("value/sin(y)/sin(yDelta)"));
-    dAngleBCNormalisation->addNode(std::make_shared<OperateSitePopulationNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectA_})));
-    dAngleBCNormalisation->addNode(std::make_shared<OperateNumberDensityNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectC_}),
-        SelectProcedureNode::SelectionPopulation::Available));
-    dAngleBCNormalisation->addNode(std::make_shared<OperateSphericalShellNormaliseProcedureNode>());
-    analyser_.addRootSequenceNode(processDAngleBC_);
+        // Process2D: 'DAngle A-(B-C)'
+        processDAngleBC_ = analyser_.createRootNode<Process2DProcedureNode>("DAngle(A-(B-C))", collectDAngleBC_);
+        processDAngleBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
+        processDAngleBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+        processDAngleBC_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
+        auto dAngleBCNormalisation = processDAngleBC_->addNormalisationBranch();
+        dAngleBCNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(y)/sin(yDelta)");
+        dAngleBCNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_, selectA_}));
+        dAngleBCNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectC_}));
+        dAngleBCNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
+    }
+    catch (...)
+    {
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+    }
 
     /*
-     * Keywords (including those exposed from the ProcedureNodes)
+     * Keywords
      */
 
     // Targets

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -32,17 +32,17 @@ bool CalculateAngleModule::process(Dissolve &dissolve, const ProcessPool &procPo
     collectDAngleBC_->keywords().set("RangeX", rangeBC_);
     collectDAngleBC_->keywords().set("RangeY", angleRange_);
     if (excludeSameMoleculeAB_)
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
     else
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
     if (excludeSameMoleculeBC_)
-        selectC_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectB_});
+        selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectB_});
     else
-        selectC_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{});
+        selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
     if (excludeSameSiteAC_)
-        selectC_->keywords().set("ExcludeSameSite", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectC_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectA_});
     else
-        selectC_->keywords().set("ExcludeSameSite", std::vector<std::shared_ptr<const SelectProcedureNode>>{});
+        selectC_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);

--- a/src/modules/calculate_axisangle/axisangle.cpp
+++ b/src/modules/calculate_axisangle/axisangle.cpp
@@ -30,7 +30,7 @@ CalculateAxisAngleModule::CalculateAxisAngleModule() : Module("CalculateAxisAngl
 
         // -- Select: Site 'B'
         selectB_ = forEachA->create<SelectProcedureNode>("B", std::vector<const SpeciesSite *>{}, true);
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
         auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
 
         // -- -- Calculate: 'rAB'
@@ -61,10 +61,10 @@ CalculateAxisAngleModule::CalculateAxisAngleModule() : Module("CalculateAxisAngl
         processDistance_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
 
         auto rdfNormalisation = processDistance_->addNormalisationBranch();
-        rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
-        rdfNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>{selectB_});
+        rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>({},
+                                                                              ConstNodeVector<SelectProcedureNode>{selectA_});
+        rdfNormalisation->create<OperateNumberDensityNormaliseProcedureNode>({},
+                                                                             ConstNodeVector<SelectProcedureNode>{selectB_});
         rdfNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
         // Process1D: 'ANGLE(axis)'
@@ -83,9 +83,9 @@ CalculateAxisAngleModule::CalculateAxisAngleModule() : Module("CalculateAxisAngl
         auto dAngleNormalisation = processDAngle_->addNormalisationBranch();
         dAngleNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(y)/sin(yDelta)");
         dAngleNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
-        dAngleNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>{selectB_});
+            {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
+        dAngleNormalisation->create<OperateNumberDensityNormaliseProcedureNode>({},
+                                                                                ConstNodeVector<SelectProcedureNode>{selectB_});
         dAngleNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
     }
     catch (...)

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -23,9 +23,9 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, const ProcessPool &pr
     collectDAngle_->keywords().set("RangeX", distanceRange_);
     collectDAngle_->keywords().set("RangeY", angleRange_);
     if (excludeSameMolecule_)
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
     else
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);

--- a/src/modules/calculate_cn/cn.cpp
+++ b/src/modules/calculate_cn/cn.cpp
@@ -20,8 +20,8 @@ CalculateCNModule::CalculateCNModule() : Module("CalculateCN"), analyser_(Proced
         process1D_ = analyser_.createRootNode<Process1DProcedureNode>("HistogramNorm");
         process1D_->keywords().set("CurrentDataOnly", true);
         auto rdfNormalisation = process1D_->addNormalisationBranch();
-        siteNormaliser_ = rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>());
+        siteNormaliser_ =
+            rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>());
 
         // Sum1D
         sum1D_ = analyser_.createRootNode<Sum1DProcedureNode>("CN", process1D_);

--- a/src/modules/calculate_cn/process.cpp
+++ b/src/modules/calculate_cn/process.cpp
@@ -20,7 +20,7 @@ bool CalculateCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Set the target Collect1D and normalisation nodes in the Process1D
     process1D_->keywords().set("SourceData", sourceRDF_->collectDistanceNode());
-    siteNormaliser_->keywords().set("Site", std::vector<std::shared_ptr<const SelectProcedureNode>>{sourceRDF_->selectANode()});
+    siteNormaliser_->keywords().set("Site", ConstNodeVector<SelectProcedureNode>{sourceRDF_->selectANode()});
 
     // Execute the analysis on the Configuration targeted by the RDF module
     ProcedureContext context(procPool, sourceRDF_->keywords().get<Configuration *>("Configuration"));

--- a/src/modules/calculate_dangle/dangle.cpp
+++ b/src/modules/calculate_dangle/dangle.cpp
@@ -35,7 +35,7 @@ CalculateDAngleModule::CalculateDAngleModule() : Module("CalculateDAngle"), anal
 
         // -- -- Select: Site 'C'
         selectC_ = forEachB->create<SelectProcedureNode>("C");
-        selectC_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
         auto forEachC = selectC_->addForEachBranch(ProcedureNode::AnalysisContext);
 
         // -- -- -- Calculate: 'rBC'
@@ -62,9 +62,9 @@ CalculateDAngleModule::CalculateDAngleModule() : Module("CalculateDAngle"), anal
 
         auto rdfNormalisation = processDistance_->addNormalisationBranch();
         rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_, selectB_});
-        rdfNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>{selectC_});
+            {}, ConstNodeVector<SelectProcedureNode>{selectA_, selectB_});
+        rdfNormalisation->create<OperateNumberDensityNormaliseProcedureNode>({},
+                                                                             ConstNodeVector<SelectProcedureNode>{selectC_});
         rdfNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
 
         // Process1D: 'ANGLE(ABC)'

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -21,9 +21,9 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, const ProcessPool &procP
     collectDAngle_->keywords().set("RangeX", distanceRange_);
     collectDAngle_->keywords().set("RangeY", angleRange_);
     if (excludeSameMolecule_)
-        selectC_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
     else
-        selectC_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{});
+        selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);

--- a/src/modules/calculate_rdf/rdf.cpp
+++ b/src/modules/calculate_rdf/rdf.cpp
@@ -25,8 +25,8 @@ CalculateRDFModule::CalculateRDFModule() : Module("CalculateRDF"), analyser_(Pro
 
         // -- Select: Site 'B'
         selectB_ = forEachA->create<SelectProcedureNode>("B");
-        selectB_->keywords().set("ExcludeSameSite", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
         auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
 
         // -- -- Calculate: 'rAB'
@@ -41,10 +41,10 @@ CalculateRDFModule::CalculateRDFModule() : Module("CalculateRDF"), analyser_(Pro
         processDistance_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
 
         auto rdfNormalisation = processDistance_->addNormalisationBranch();
-        rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
-        rdfNormalisation->create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectB_}));
+        rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>({},
+                                                                              ConstNodeVector<SelectProcedureNode>({selectA_}));
+        rdfNormalisation->create<OperateNumberDensityNormaliseProcedureNode>({},
+                                                                             ConstNodeVector<SelectProcedureNode>({selectB_}));
         rdfNormalisation->create<OperateSphericalShellNormaliseProcedureNode>({});
     }
     catch (...)

--- a/src/modules/calculate_sdf/process.cpp
+++ b/src/modules/calculate_sdf/process.cpp
@@ -21,9 +21,9 @@ bool CalculateSDFModule::process(Dissolve &dissolve, const ProcessPool &procPool
     collectVector_->keywords().set("RangeY", rangeY_);
     collectVector_->keywords().set("RangeZ", rangeZ_);
     if (excludeSameMolecule_)
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
     else
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);

--- a/src/modules/calculate_sdf/sdf.cpp
+++ b/src/modules/calculate_sdf/sdf.cpp
@@ -24,8 +24,8 @@ CalculateSDFModule::CalculateSDFModule() : Module("CalculateSDF"), analyser_(Pro
 
         // -- Select: Site 'B'
         selectB_ = forEachA->create<SelectProcedureNode>("B");
-        selectB_->keywords().set("ExcludeSameSite", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
-        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
         auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
 
         // -- -- Calculate: 'v(B->A)'
@@ -42,8 +42,8 @@ CalculateSDFModule::CalculateSDFModule() : Module("CalculateSDF"), analyser_(Pro
         processPosition_->keywords().set("LabelY", std::string("y, \\symbol{Angstrom}"));
         processPosition_->keywords().set("LabelZ", std::string("z, \\symbol{Angstrom}"));
         auto sdfNormalisation = processPosition_->addNormalisationBranch();
-        sdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
+        sdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>({},
+                                                                              ConstNodeVector<SelectProcedureNode>({selectA_}));
         sdfNormalisation->create<OperateGridNormaliseProcedureNode>({});
     }
     catch (...)

--- a/src/modules/calculate_sdf/sdf.cpp
+++ b/src/modules/calculate_sdf/sdf.cpp
@@ -16,86 +16,43 @@
 
 CalculateSDFModule::CalculateSDFModule() : Module("CalculateSDF"), analyser_(ProcedureNode::AnalysisContext)
 {
-    /*
-     * Assemble the following Procedure:
-     *
-     * Select  'A'
-     *   Site  ...
-     *   ForEach
-     *     Select  'B'
-     *       Site  ...
-     *       ExcludeSameSite  'A'
-     *       ExcludeSameMolecule  'A'
-     *       ForEach
-     *         CalculateVector  'vAB'
-     *           I  'A'
-     *           J  'B'
-     *           RotateIntoFrame  True
-     *         EndCalculate
-     *         Collect3D  RDF
-     *           QuantityX  'vAB'  1
-     *           QuantityY  'vAB'  2
-     *           QuantityZ  'vAB'  3
-     *           RangeX  -10.0  10.0  0.5
-     *           RangeY  -10.0  10.0  0.5
-     *           RangeZ  -10.0  10.0  0.5
-     *         EndCollect3D
-     *       EndForEach  'B'
-     *     EndSelect  'B'
-     *   EndForEach  'A'
-     * EndSelect  'A'
-     * Process3D  SDF
-     *   Normalisation
-     *     OperateSitePopulationNormalise
-     *       Site  'A'
-     *     EndOperateSitePopulationNormalise
-     *     OperateGridNormalise
-     *     EndOperateGridNormalise
-     *   EndNormalisation
-     *   LabelValue  'rho(x,y,z)'
-     *   LabelX  'x, Angstroms'
-     *   LabelY  'y, Angstroms'
-     *   LabelZ  'z, Angstroms'
-     * EndProcess3D
-     */
+    try
+    {
+        // Select: Site 'A'
+        selectA_ = analyser_.createRootNode<SelectProcedureNode>("A", std::vector<const SpeciesSite *>{}, true);
+        auto forEachA = selectA_->addForEachBranch(ProcedureNode::AnalysisContext);
 
-    // Select: Site 'A'
-    selectA_ = std::make_shared<SelectProcedureNode, std::vector<const SpeciesSite *>, bool>({}, true);
-    selectA_->setName("A");
-    auto forEachA = selectA_->addForEachBranch(ProcedureNode::AnalysisContext);
-    analyser_.addRootSequenceNode(selectA_);
+        // -- Select: Site 'B'
+        selectB_ = forEachA->create<SelectProcedureNode>("B");
+        selectB_->keywords().set("ExcludeSameSite", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
+        auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
 
-    // -- Select: Site 'B'
-    selectB_ = std::make_shared<SelectProcedureNode>();
-    selectB_->setName("B");
-    selectB_->keywords().set("ExcludeSameSite", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
-    selectB_->keywords().set("ExcludeSameMolecule", std::vector<std::shared_ptr<const SelectProcedureNode>>{selectA_});
-    auto forEachB = selectB_->addForEachBranch(ProcedureNode::AnalysisContext);
-    forEachA->addNode(selectB_);
+        // -- -- Calculate: 'v(B->A)'
+        auto calcVector = forEachB->create<CalculateVectorProcedureNode>({}, selectA_, selectB_, true);
 
-    // -- -- Calculate: 'v(B->A)'
-    auto calcVector = std::make_shared<CalculateVectorProcedureNode>(selectA_, selectB_, true);
-    forEachB->addNode(calcVector);
+        // -- -- Collect3D: 'SDF'
+        collectVector_ = forEachB->create<Collect3DProcedureNode>({}, calcVector, rangeX_.x, rangeX_.y, rangeX_.z, rangeY_.x,
+                                                                  rangeY_.y, rangeY_.z, rangeZ_.x, rangeZ_.y, rangeZ_.z);
 
-    // -- -- Collect3D: 'SDF'
-    collectVector_ = std::make_shared<Collect3DProcedureNode>(calcVector, -10.0, 10.0, 0.5, -10.0, 10.0, 0.5, -10.0, 10.0, 0.5);
-    forEachB->addNode(collectVector_);
-
-    // Process3D: @dataName
-    processPosition_ = std::make_shared<Process3DProcedureNode>(collectVector_);
-    processPosition_->setName("SDF");
-    processPosition_->keywords().set("LabelValue", std::string("\\symbol{rho}(x,y,z)"));
-    processPosition_->keywords().set("LabelX", std::string("x, \\symbol{Angstrom}"));
-    processPosition_->keywords().set("LabelY", std::string("y, \\symbol{Angstrom}"));
-    processPosition_->keywords().set("LabelZ", std::string("z, \\symbol{Angstrom}"));
-    auto sdfNormalisation = processPosition_->addNormalisationBranch();
-    sdfNormalisation->addNode(std::make_shared<OperateSitePopulationNormaliseProcedureNode>(
-        std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_})));
-    sdfNormalisation->addNode(std::make_shared<OperateGridNormaliseProcedureNode>());
-    analyser_.addRootSequenceNode(processPosition_);
+        // Process3D: @dataName
+        processPosition_ = analyser_.createRootNode<Process3DProcedureNode>("SDF", collectVector_);
+        processPosition_->keywords().set("LabelValue", std::string("\\symbol{rho}(x,y,z)"));
+        processPosition_->keywords().set("LabelX", std::string("x, \\symbol{Angstrom}"));
+        processPosition_->keywords().set("LabelY", std::string("y, \\symbol{Angstrom}"));
+        processPosition_->keywords().set("LabelZ", std::string("z, \\symbol{Angstrom}"));
+        auto sdfNormalisation = processPosition_->addNormalisationBranch();
+        sdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
+            {}, std::vector<std::shared_ptr<const SelectProcedureNode>>({selectA_}));
+        sdfNormalisation->create<OperateGridNormaliseProcedureNode>({});
+    }
+    catch (...)
+    {
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+    }
 
     /*
-     * Keywords (including those exposed from the ProcedureNodes)
+     * Keywords
      */
 
     // Targets

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   process2d.cpp
   process3d.cpp
   regionbase.cpp
+  registry.cpp
   remove.cpp
   select.cpp
   sequence.cpp
@@ -80,6 +81,7 @@ add_library(
   process2d.h
   process3d.h
   regionbase.h
+  registry.h
   remove.h
   transmute.h
   select.h

--- a/src/procedure/nodes/aliases.h
+++ b/src/procedure/nodes/aliases.h
@@ -4,7 +4,10 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 class ProcedureNode;
 using NodeRef = std::shared_ptr<ProcedureNode>;
 using ConstNodeRef = std::shared_ptr<const ProcedureNode>;
+
+template <class N> using ConstNodeVector = std::vector<std::shared_ptr<const N>>;

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -92,7 +92,7 @@ bool ProcedureNode::isContextRelevant(NodeContext context) { return false; }
 // Return whether a name for the node must be provided
 bool ProcedureNode::mustBeNamed() const { return true; }
 
-// Set node name (and nice name)
+// Set node name
 void ProcedureNode::setName(std::string_view name) { name_ = DissolveSys::niceName(name); }
 
 // Return node name

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -109,7 +109,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
     virtual bool isContextRelevant(NodeContext context);
     // Return whether a name for the node must be provided
     virtual bool mustBeNamed() const;
-    // Set node name (and nice name)
+    // Set node name
     void setName(std::string_view name);
     // Return node name
     std::string_view name() const;

--- a/src/procedure/nodes/operatenumberdensitynormalise.cpp
+++ b/src/procedure/nodes/operatenumberdensitynormalise.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/select.h"
 
 OperateNumberDensityNormaliseProcedureNode::OperateNumberDensityNormaliseProcedureNode(
-    std::vector<std::shared_ptr<const SelectProcedureNode>> nodes, SelectProcedureNode::SelectionPopulation populationTarget)
+    ConstNodeVector<SelectProcedureNode> nodes, SelectProcedureNode::SelectionPopulation populationTarget)
     : OperateProcedureNodeBase(ProcedureNode::NodeType::OperateNumberDensityNormalise),
       normalisationSites_(std::move(nodes)), targetPopulation_{populationTarget}
 {

--- a/src/procedure/nodes/operatenumberdensitynormalise.h
+++ b/src/procedure/nodes/operatenumberdensitynormalise.h
@@ -11,7 +11,7 @@ class OperateNumberDensityNormaliseProcedureNode : public OperateProcedureNodeBa
 {
     public:
     OperateNumberDensityNormaliseProcedureNode(
-        std::vector<std::shared_ptr<const SelectProcedureNode>> nodes = {},
+        ConstNodeVector<SelectProcedureNode> nodes = {},
         SelectProcedureNode::SelectionPopulation populationTarget = SelectProcedureNode::SelectionPopulation::Available);
     ~OperateNumberDensityNormaliseProcedureNode() override = default;
 
@@ -20,7 +20,7 @@ class OperateNumberDensityNormaliseProcedureNode : public OperateProcedureNodeBa
      */
     private:
     // Select nodes containing sites for normalisation
-    std::vector<std::shared_ptr<const SelectProcedureNode>> normalisationSites_;
+    ConstNodeVector<SelectProcedureNode> normalisationSites_;
     // Target population to normalise against
     SelectProcedureNode::SelectionPopulation targetPopulation_;
 

--- a/src/procedure/nodes/operatesitepopulationnormalise.cpp
+++ b/src/procedure/nodes/operatesitepopulationnormalise.cpp
@@ -10,7 +10,7 @@
 #include "procedure/nodes/select.h"
 
 OperateSitePopulationNormaliseProcedureNode::OperateSitePopulationNormaliseProcedureNode(
-    std::vector<std::shared_ptr<const SelectProcedureNode>> sites)
+    ConstNodeVector<SelectProcedureNode> sites)
     : OperateProcedureNodeBase(ProcedureNode::NodeType::OperateSitePopulationNormalise), normalisationSites_(std::move(sites))
 {
     // Create keywords - store the pointers to the superclasses for later use

--- a/src/procedure/nodes/operatesitepopulationnormalise.h
+++ b/src/procedure/nodes/operatesitepopulationnormalise.h
@@ -12,7 +12,7 @@ class SelectProcedureNode;
 class OperateSitePopulationNormaliseProcedureNode : public OperateProcedureNodeBase
 {
     public:
-    OperateSitePopulationNormaliseProcedureNode(std::vector<std::shared_ptr<const SelectProcedureNode>> sites = {});
+    OperateSitePopulationNormaliseProcedureNode(ConstNodeVector<SelectProcedureNode> sites = {});
     ~OperateSitePopulationNormaliseProcedureNode() override = default;
 
     /*
@@ -20,7 +20,7 @@ class OperateSitePopulationNormaliseProcedureNode : public OperateProcedureNodeB
      */
     private:
     // Select nodes containing sites for normalisation
-    std::vector<std::shared_ptr<const SelectProcedureNode>> normalisationSites_;
+    ConstNodeVector<SelectProcedureNode> normalisationSites_;
 
     /*
      * Data Target (implements virtuals in OperateProcedureNodeBase)

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "procedure/nodes/registry.h"
+#include "procedure/nodes/nodes.h"
+
+ProcedureNodeRegistry::ProcedureNodeRegistry()
+{
+    registerProducer<AddProcedureNode>(ProcedureNode::NodeType::Add, "Add molecules to a configuration", "Build");
+    registerProducer<BoxProcedureNode>(ProcedureNode::NodeType::Box, "Define containing box for a configuration", "Build");
+    registerProducer<CalculateAngleProcedureNode>(ProcedureNode::NodeType::CalculateAngle,
+                                                  "Calculate angle between three sites", "Calculate");
+    registerProducer<CalculateDistanceProcedureNode>(ProcedureNode::NodeType::CalculateDistance,
+                                                     "Calculate distance between two sites", "Calculate");
+    registerProducer<CalculateVectorProcedureNode>(ProcedureNode::NodeType::CalculateVector,
+                                                   "Calculate vector between two sites", "Calculate");
+    registerProducer<Collect1DProcedureNode>(ProcedureNode::NodeType::Collect1D, "Bin 1D quantity into a histogram", "Data");
+    registerProducer<Collect2DProcedureNode>(ProcedureNode::NodeType::Collect2D, "Bin 2D quantity into a histogram", "Data");
+    registerProducer<Collect3DProcedureNode>(ProcedureNode::NodeType::Collect3D, "Bin 3D quantity into a histogram", "Data");
+    registerProducer<CoordinateSetsProcedureNode>(ProcedureNode::NodeType::CoordinateSets,
+                                                  "Generate coordinate sets for a species", "Build");
+    registerProducer<CylindricalRegionProcedureNode>(ProcedureNode::NodeType::CylindricalRegion,
+                                                     "Define a cylindrical region in a configuration", "Regions");
+    registerProducer<Fit1DProcedureNode>(ProcedureNode::NodeType::Fit1D, "Fit a function to 1D data", "Fitting");
+    registerProducer<GeneralRegionProcedureNode>(ProcedureNode::NodeType::GeneralRegion,
+                                                 "Define a general region in a configuration", "Regions");
+    registerProducer<OperateDivideProcedureNode>(ProcedureNode::NodeType::OperateDivide, "Perform a division on data",
+                                                 "Operate");
+    registerProducer<OperateExpressionProcedureNode>(ProcedureNode::NodeType::OperateExpression, "Apply an expression to data",
+                                                     "Operate");
+    registerProducer<OperateMultiplyProcedureNode>(ProcedureNode::NodeType::OperateMultiply, "Perform a multiplication on data",
+                                                   "Operate");
+    registerProducer<OperateNormaliseProcedureNode>(ProcedureNode::NodeType::OperateNormalise, "Normalise data to a value",
+                                                    "Operate");
+    registerProducer<OperateNumberDensityNormaliseProcedureNode>(ProcedureNode::NodeType::OperateNumberDensityNormalise,
+                                                                 "Normalise data to a reference number density", "Operate");
+    registerProducer<OperateSitePopulationNormaliseProcedureNode>(ProcedureNode::NodeType::OperateSitePopulationNormalise,
+                                                                  "Normalise data to a reference site population", "Operate");
+    registerProducer<OperateSphericalShellNormaliseProcedureNode>(ProcedureNode::NodeType::OperateSphericalShellNormalise,
+                                                                  "Normalise data to spherical shell volumes", "Operate");
+    registerProducer<ParametersProcedureNode>(ProcedureNode::NodeType::Parameters, "Define parameters for use in expressions",
+                                              "General");
+    registerProducer<PickProcedureNode>(ProcedureNode::NodeType::Pick, "Pick all molecules of a given species", "Pick");
+    registerProducer<PickProximityProcedureNode>(ProcedureNode::NodeType::PickProximity,
+                                                 "Pick molecules based on proximity to others", "Pick");
+    registerProducer<PickRegionProcedureNode>(ProcedureNode::NodeType::PickRegion, "Pick molecules within a specific region",
+                                              "Pick");
+    registerProducer<Process1DProcedureNode>(ProcedureNode::NodeType::Process1D, "Process 1D histogram data", "Data");
+    registerProducer<Process2DProcedureNode>(ProcedureNode::NodeType::Process2D, "Process 2D histogram data", "Data");
+    registerProducer<Process3DProcedureNode>(ProcedureNode::NodeType::Process3D, "Process 3D histogram data", "Data");
+    registerProducer<RemoveProcedureNode>(ProcedureNode::NodeType::Remove, "Remove molecules from a configuration", "Build");
+    registerProducer<SelectProcedureNode>(ProcedureNode::NodeType::Select, "Select sites for consideration", "Calculate");
+    registerProducer<TransmuteProcedureNode>(ProcedureNode::NodeType::Transmute,
+                                             "Turn molecules from one species type into another", "Build");
+}
+
+/*
+ * Producers
+ */
+
+// Produce node of specified type
+std::shared_ptr<ProcedureNode> ProcedureNodeRegistry::produce(ProcedureNode::NodeType nodeType) const
+{
+    auto it = producers_.find(nodeType);
+    if (it == producers_.end())
+        throw(std::runtime_error(
+            fmt::format("A producer has not been registered for node type '{}', so a new instance cannot be created.\n",
+                        ProcedureNode::nodeTypes().keyword(nodeType))));
+
+    return (it->second.first)();
+}
+
+// Return categorised map of nodes
+const std::map<std::string, std::vector<ProcedureNodeRegistry::ProcedureNodeInfoData>> &
+ProcedureNodeRegistry::categories() const
+{
+    return categories_;
+}
+
+/*
+ * Instance
+ */
+
+// Return the producer instance
+const ProcedureNodeRegistry &ProcedureNodeRegistry::instance()
+{
+    static ProcedureNodeRegistry instance;
+
+    return instance;
+}
+
+/*
+ * ProcedureNode Management
+ */
+
+// Return category map
+const std::map<std::string, std::vector<ProcedureNodeRegistry::ProcedureNodeInfoData>> &ProcedureNodeRegistry::categoryMap()
+{
+    return instance().categories();
+}
+
+// Create a ProcedureNode instance for the named ProcedureNode type
+std::shared_ptr<ProcedureNode> ProcedureNodeRegistry::create(ProcedureNode::NodeType nodeType)
+{
+    return std::shared_ptr<ProcedureNode>(instance().produce(nodeType));
+}

--- a/src/procedure/nodes/registry.h
+++ b/src/procedure/nodes/registry.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/node.h"
+#include <map>
+
+// Forward Declarations
+class KeywordWidgetBase;
+class QWidget;
+
+// ProcedureNode Registry
+class ProcedureNodeRegistry
+{
+    private:
+    ProcedureNodeRegistry();
+
+    public:
+    ProcedureNodeRegistry(const ProcedureNodeRegistry &) = delete;
+    ProcedureNodeRegistry(ProcedureNodeRegistry &&) = delete;
+    ProcedureNodeRegistry &operator=(const ProcedureNodeRegistry &) = delete;
+    ProcedureNodeRegistry &operator=(ProcedureNodeRegistry &&) = delete;
+
+    /*
+     * Producers
+     */
+    private:
+    // Producer function type
+    using ProducerFunction = std::function<std::shared_ptr<ProcedureNode>()>;
+    // Typedefs
+    using ProcedureNodeRegistryData = std::pair<ProducerFunction, std::string>;
+    using ProcedureNodeInfoData = std::pair<ProcedureNode::NodeType, std::string>;
+    // Producers for all node types
+    std::map<ProcedureNode::NodeType, ProcedureNodeRegistryData> producers_;
+    // Categorised map of nodes
+    std::map<std::string, std::vector<ProcedureNodeRegistry::ProcedureNodeInfoData>> categories_;
+
+    private:
+    // Register producer for node
+    template <class N> void registerProducer(ProcedureNode::NodeType nodeType, std::string brief, std::string category = "")
+    {
+        // Check for duplicate node type
+        if (producers_.find(nodeType) != producers_.end())
+            throw(std::runtime_error(
+                fmt::format("A node producer for type '{}' already exists.\n", ProcedureNode::nodeTypes().keyword(nodeType))));
+
+        producers_.emplace(nodeType, ProcedureNodeRegistryData([]() { return std::make_shared<N>(); }, brief));
+
+        if (!category.empty())
+            categories_[category].emplace_back(ProcedureNodeInfoData(nodeType, brief));
+    }
+    // Produce node of specified type
+    std::shared_ptr<ProcedureNode> produce(ProcedureNode::NodeType nodeType) const;
+    // Return categorised map of nodes
+    const std::map<std::string, std::vector<ProcedureNodeRegistry::ProcedureNodeInfoData>> &categories() const;
+
+    /*
+     * Instance
+     */
+    private:
+    // Return the producer instance
+    static const ProcedureNodeRegistry &instance();
+
+    /*
+     * ProcedureNode Management
+     */
+    public:
+    // Return category map
+    static const std::map<std::string, std::vector<ProcedureNodeRegistry::ProcedureNodeInfoData>> &categoryMap();
+    // Create new node
+    static std::shared_ptr<ProcedureNode> create(ProcedureNode::NodeType nodeType);
+};

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -87,13 +87,13 @@ std::vector<ConstNodeRef> SelectProcedureNode::children() const { return {forEac
  */
 
 // Set other sites (nodes) which will exclude one of our sites if it has the same Molecule parent
-void SelectProcedureNode::setSameMoleculeExclusions(std::vector<std::shared_ptr<const SelectProcedureNode>> exclusions)
+void SelectProcedureNode::setSameMoleculeExclusions(ConstNodeVector<SelectProcedureNode> exclusions)
 {
     sameMoleculeExclusions_ = std::move(exclusions);
 }
 
 // Set other sites (nodes) which will exclude one of our sites if it is the same site
-void SelectProcedureNode::setSameSiteExclusions(std::vector<std::shared_ptr<const SelectProcedureNode>> exclusions)
+void SelectProcedureNode::setSameSiteExclusions(ConstNodeVector<SelectProcedureNode> exclusions)
 {
     sameSiteExclusions_ = std::move(exclusions);
 }

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -54,11 +54,11 @@ class SelectProcedureNode : public ProcedureNode
      */
     private:
     // Other sites (nodes) which will exclude one of our sites if it has the same Molecule parent
-    std::vector<std::shared_ptr<const SelectProcedureNode>> sameMoleculeExclusions_;
+    ConstNodeVector<SelectProcedureNode> sameMoleculeExclusions_;
     // Molecules currently excluded from selection
     std::vector<std::shared_ptr<const Molecule>> excludedMolecules_;
     // Other sites (nodes) which will exclude one of our sites if it is the same site
-    std::vector<std::shared_ptr<const SelectProcedureNode>> sameSiteExclusions_;
+    ConstNodeVector<SelectProcedureNode> sameSiteExclusions_;
     // Sites currently excluded from selection
     std::set<const Site *> excludedSites_;
     // Molecule (from site) in which the site must exist
@@ -70,9 +70,9 @@ class SelectProcedureNode : public ProcedureNode
 
     public:
     // Set other sites (nodes) which will exclude one of our sites if it has the same Molecule parent
-    void setSameMoleculeExclusions(std::vector<std::shared_ptr<const SelectProcedureNode>> exclusions);
+    void setSameMoleculeExclusions(ConstNodeVector<SelectProcedureNode> exclusions);
     // Set other sites (nodes) which will exclude one of our sites if it is the same site
-    void setSameSiteExclusions(std::vector<std::shared_ptr<const SelectProcedureNode>> exclusions);
+    void setSameSiteExclusions(ConstNodeVector<SelectProcedureNode> exclusions);
     // Return list of Molecules currently excluded from selection
     const std::vector<std::shared_ptr<const Molecule>> &excludedMolecules() const;
     // Return Molecule (from site) in which the site must exist

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -51,15 +51,15 @@ void SequenceProcedureNode::addNode(NodeRef nodeToAdd)
     assert(nodeToAdd);
 
     if (!nodeToAdd->isContextRelevant(context_))
-        Messenger::error("Node '{}' (type = '{}') is not relevant to the '{}' context.\n", nodeToAdd->name(),
-                         ProcedureNode::nodeTypes().keyword(nodeToAdd->type()),
-                         ProcedureNode::nodeContexts().keyword(context_));
+        throw(std::runtime_error(fmt::format("Node '{}' (type = '{}') is not relevant to the '{}' context.\n",
+                                             nodeToAdd->name(), ProcedureNode::nodeTypes().keyword(nodeToAdd->type()),
+                                             ProcedureNode::nodeContexts().keyword(context_))));
 
     // If the node hasn't been given a name, generate a unique one for it now based on its type
     if (nodeToAdd->name().empty())
     {
         auto n = 1;
-        while (node(fmt::format("{}{:02d}", ProcedureNode::nodeTypes().keyword(nodeToAdd->type()), n)))
+        while (nodeExists(fmt::format("{}{:02d}", ProcedureNode::nodeTypes().keyword(nodeToAdd->type()), n)))
             ++n;
         nodeToAdd->setName(fmt::format("{}{:02d}", ProcedureNode::nodeTypes().keyword(nodeToAdd->type()), n));
     }

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -61,6 +61,23 @@ class SequenceProcedureNode : public ProcedureNode
     void clear();
     // Add (own) node into sequence
     void addNode(NodeRef nodeToAdd);
+    // Create new node
+    template <class N, typename... Args> std::shared_ptr<N> create(std::string_view name, Args &&... args)
+    {
+        // Create the new node
+        auto node = std::make_shared<N>(args...);
+
+        // Set its name
+        node->setName(name);
+
+        // Set us as its scope
+        node->setScope(std::dynamic_pointer_cast<SequenceProcedureNode>(shared_from_this()));
+
+        // Add node to our sequence, checking context / naming
+        addNode(node);
+
+        return node;
+    }
     // Return sequential node list
     const std::vector<NodeRef> &sequence() const;
     // Return number of nodes in sequence

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -72,14 +72,13 @@ class SequenceProcedureNode : public ProcedureNode
         // Set its name
         node->setName(name);
 
-        // Set us as its scope
-        node->setScope(std::dynamic_pointer_cast<SequenceProcedureNode>(shared_from_this()));
-
         // Add node to our sequence, checking context / naming
         addNode(node);
 
         return node;
     }
+    // Create new node by enumerated type
+    std::shared_ptr<ProcedureNode> create(ProcedureNode::NodeType nodeType, std::string_view name);
     // Return sequential node list
     const std::vector<NodeRef> &sequence() const;
     // Return number of nodes in sequence

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -56,11 +56,13 @@ class SequenceProcedureNode : public ProcedureNode
         void next();
     };
 
+    private:
+    // Add (own) node into sequence
+    void addNode(NodeRef nodeToAdd);
+
     public:
     // Clear all data
     void clear();
-    // Add (own) node into sequence
-    void addNode(NodeRef nodeToAdd);
     // Create new node
     template <class N, typename... Args> std::shared_ptr<N> create(std::string_view name, Args &&... args)
     {

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -21,13 +21,6 @@ Procedure::~Procedure() = default;
 // Clear all data
 void Procedure::clear() { rootSequence_->clear(); }
 
-// Add (own) specified node to root sequence
-void Procedure::addRootSequenceNode(NodeRef node)
-{
-    rootSequence_->addNode(node);
-    node->setScope(std::dynamic_pointer_cast<SequenceProcedureNode>(rootSequence_->shared_from_this()));
-}
-
 // Return root sequence
 const SequenceProcedureNode &Procedure::rootSequence() const { return *rootSequence_; }
 

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -31,6 +31,11 @@ class Procedure
     void clear();
     // Add (own) specified node to root sequence
     void addRootSequenceNode(NodeRef node);
+    // Create new node
+    template <class N, typename... Args> std::shared_ptr<N> createRootNode(std::string_view name, Args &&... args)
+    {
+        return rootSequence_->create<N>(name, args...);
+    }
     // Return root sequence
     const SequenceProcedureNode &rootSequence() const;
     // Return the block termination keyword for the Procedure

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -29,8 +29,6 @@ class Procedure
     public:
     // Clear all data
     void clear();
-    // Add (own) specified node to root sequence
-    void addRootSequenceNode(NodeRef node);
     // Create new node
     template <class N, typename... Args> std::shared_ptr<N> createRootNode(std::string_view name, Args &&... args)
     {

--- a/tests/calculate_dangle/dangle.txt
+++ b/tests/calculate_dangle/dangle.txt
@@ -214,7 +214,7 @@ Module  Analyse  'DAngle(X-H...O)-Analyser'
       LabelX  'Angle, \\sym{degree}'
     EndProcess1D
 
-    Process2D  'DAngle(X-HO)'
+    Process2D  'RDF-Angle'
       SourceData  'DAngle(X-HO)'
       Normalisation
         OperateNormalise
@@ -257,7 +257,7 @@ EndModule
 
 Module DataTest
   Frequency  95
-  #Data2D  'DAngle(X-H...O)//Process2D//DAngle(A-BC)'  cartesian  '../_data/dlpoly/water267-analysis/water-267-298K.dahist1_02_1_01_02.surf'
+  #Data2D  'DAngle(X-H...O)//Process2D//RDF-Angle'  cartesian  '../_data/dlpoly/water267-analysis/water-267-298K.dahist1_02_1_01_02.surf'
 #    XRange  0.0  5.0  0.01
 #    YRange  0.0  180  1.0
   #EndData2D

--- a/unit/gui/expressionVariableVectorModel.cpp
+++ b/unit/gui/expressionVariableVectorModel.cpp
@@ -16,8 +16,7 @@ TEST(ExpressionVariableVectorModelTest, Basic)
 
     // Create a simple procedure with a parameters node
     Procedure procedure(ProcedureNode::AnalysisContext);
-    auto parameters = std::make_shared<ParametersProcedureNode>();
-    procedure.addRootSequenceNode(parameters);
+    auto parameters = procedure.createRootNode<ParametersProcedureNode>({});
     parameters->addParameter("Alpha", 1.2345);
     parameters->addParameter("Beta", 99);
     parameters->addParameter("Gamma", -10);

--- a/unit/gui/procedure.cpp
+++ b/unit/gui/procedure.cpp
@@ -20,24 +20,20 @@ TEST(ProcedureModelTest, Basic)
 
     // Create a simple procedure with a parameters node
     Procedure procedure(ProcedureNode::AnalysisContext);
-    auto selectA = std::make_shared<SelectProcedureNode>();
-    auto selectB = std::make_shared<SelectProcedureNode>();
-    selectA->setName("A");
-    selectB->setName("B");
-    auto calcAB = std::make_shared<CalculateDistanceProcedureNode>(selectA, selectB);
-    auto collect = std::make_shared<Collect1DProcedureNode>(calcAB);
-
+    auto selectA = procedure.createRootNode<SelectProcedureNode>("A");
+    auto selectB = procedure.createRootNode<SelectProcedureNode>("B");
+    auto calcAB = procedure.createRootNode<CalculateDistanceProcedureNode>({}, selectA, selectB);
+    auto collect = procedure.createRootNode<Collect1DProcedureNode>({}, calcAB);
     collect->addSubCollectBranch(ProcedureNode::AnalysisContext);
-    procedure.addRootSequenceNode(collect);
 
     ProcedureModel model(procedure);
 
     // Check out model root
     EXPECT_EQ(model.columnCount(QModelIndex()), 1);
-    EXPECT_EQ(model.rowCount(QModelIndex()), 1);
+    EXPECT_EQ(model.rowCount(QModelIndex()), 4);
 
-    // Checkout out first child
-    auto child = model.index(0, 0);
+    // Check out first child
+    auto child = model.index(3, 0);
     EXPECT_EQ(model.columnCount(child), 1);
     EXPECT_EQ(model.rowCount(child), 1);
     EXPECT_EQ(model.data(child, Qt::DisplayRole).toString().toStdString(), "Collect1D (Collect1D01)");


### PR DESCRIPTION
This PR implements templated node creation functions to allow more robust creation of manual procedures.

Major changes:
- Template `Procedure::createRootNode()` and `SequenceProcedureNode::create()`  replace `Procedure::addRootNode()` and SequenceProcedureNode::addNode()` respectively, with the former being removed completely and the latter being made `private` and called from the new templated function.
- `SequenceProcedureNode::create()` is now solely responsible for setting of the `scope_` of nodes and performing additional checks on validity.
- Long comments reflecting the structure of procedures in the `Calculate*` nodes have been removed, since the reduced verbosity of the procedure creation essentially reflects the same information.
- A `ProcedureNodeRegistry`, analogous to `ModuleRegistry`, has been added and handles creation of nodes from their enumerated type, as well as allowing nicer display of node types within models in the GUI in future.

Outcomes:
- Manual procedure creation is significantly cleaner.
- Procedure creation is more robust - duplicate node names are now not allowed within `Procedure`-scope since some nodes create processing data named after themselves.
- A bug introduced in #1031 meant that unique node names were only generated within local scope, rather than the required `Procedure`-scope. This was not possible to fix until proper scope-setting was remedied in the present PR.