### PR TITLE
Symmetrise angle

### DIFF
--- a/src/modules/calculate_angle/angle.h
+++ b/src/modules/calculate_angle/angle.h
@@ -7,9 +7,11 @@
 #include "procedure/procedure.h"
 
 // Forward Declarations
+class CalculateAngleProcedureNode;
 class Collect1DProcedureNode;
 class Collect2DProcedureNode;
 class Collect3DProcedureNode;
+class OperateExpressionProcedureNode;
 class Process1DProcedureNode;
 class Process2DProcedureNode;
 class Process3DProcedureNode;
@@ -41,6 +43,8 @@ class CalculateAngleModule : public Module
     Vec3<double> rangeBC_{0.0, 10.0, 0.05};
     // Range (min, max, binwidth) of angle axis
     Vec3<double> angleRange_{0.0, 180.0, 1.0};
+    // Whether the angular range should be considered symmetric about 90
+    bool symmetric_{false};
     // Analysis procedure to be run
     Procedure analyser_;
     // SelectNode for site A
@@ -49,6 +53,8 @@ class CalculateAngleModule : public Module
     std::shared_ptr<SelectProcedureNode> selectB_;
     // SelectNode for site C
     std::shared_ptr<SelectProcedureNode> selectC_;
+    // CalculateAngle node for A-B-C angle
+    std::shared_ptr<CalculateAngleProcedureNode> calculateAngle_;
     // Collect1DNode for A-B RDF
     std::shared_ptr<Collect1DProcedureNode> collectAB_;
     // Collect1DNode for B-C RDF
@@ -71,6 +77,8 @@ class CalculateAngleModule : public Module
     std::shared_ptr<Process2DProcedureNode> processDAngleAB_;
     // Process2DNode for A-(B-C) distance-angle data
     std::shared_ptr<Process2DProcedureNode> processDAngleBC_;
+    // Normalisation expressions for (A-B)-C and A-(B-C) maps
+    std::shared_ptr<OperateExpressionProcedureNode> dAngleABNormalisationExpression_, dAngleBCNormalisationExpression_;
     // Process3DNode for A-B vs B-C vs A-B-C distance-distance-angle data
     std::shared_ptr<Process3DProcedureNode> processDDA_;
 

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Team Dissolve and contributors
 
-#include "base/sysfunc.h"
+#include "expression/variable.h"
 #include "main/dissolve.h"
 #include "modules/calculate_angle/angle.h"
+#include "procedure/nodes/calculateangle.h"
 #include "procedure/nodes/collect1d.h"
 #include "procedure/nodes/collect2d.h"
 #include "procedure/nodes/collect3d.h"
+#include "procedure/nodes/operateexpression.h"
 #include "procedure/nodes/select.h"
 
 // Run main processing
@@ -21,6 +23,9 @@ bool CalculateAngleModule::process(Dissolve &dissolve, const ProcessPool &procPo
     selectB_->setInclusiveDistanceRange({rangeAB_.x, rangeAB_.y});
     selectC_->setDistanceReferenceSite(selectB_);
     selectC_->setInclusiveDistanceRange({rangeBC_.x, rangeBC_.y});
+    calculateAngle_->keywords().set("Symmetric", symmetric_);
+    dAngleABNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleBCNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
     collectDDA_->keywords().set("RangeX", rangeAB_);
     collectDDA_->keywords().set("RangeY", rangeBC_);
     collectDDA_->keywords().set("RangeZ", angleRange_);

--- a/src/modules/calculate_axisangle/axisangle.cpp
+++ b/src/modules/calculate_axisangle/axisangle.cpp
@@ -81,7 +81,8 @@ CalculateAxisAngleModule::CalculateAxisAngleModule() : Module("CalculateAxisAngl
         processDAngle_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
         processDAngle_->keywords().set("LabelValue", std::string("g(r)"));
         auto dAngleNormalisation = processDAngle_->addNormalisationBranch();
-        dAngleNormalisation->create<OperateExpressionProcedureNode>({}, "value/sin(y)/sin(yDelta)");
+        dAngleNormalisationExpression_ = dAngleNormalisation->create<OperateExpressionProcedureNode>(
+            {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
         dAngleNormalisation->create<OperateSitePopulationNormaliseProcedureNode>(
             {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
         dAngleNormalisation->create<OperateNumberDensityNormaliseProcedureNode>({},

--- a/src/modules/calculate_axisangle/axisangle.h
+++ b/src/modules/calculate_axisangle/axisangle.h
@@ -10,6 +10,7 @@
 class CalculateAxisAngleProcedureNode;
 class Collect1DProcedureNode;
 class Collect2DProcedureNode;
+class OperateExpressionProcedureNode;
 class Process1DProcedureNode;
 class Process2DProcedureNode;
 class SelectProcedureNode;
@@ -56,6 +57,8 @@ class CalculateAxisAngleModule : public Module
     std::shared_ptr<Process1DProcedureNode> processAngle_;
     // Process2DNode for distance-angle data
     std::shared_ptr<Process2DProcedureNode> processDAngle_;
+    // Normalisation expression for distance-angle map
+    std::shared_ptr<OperateExpressionProcedureNode> dAngleNormalisationExpression_;
 
     /*
      * Processing

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -7,6 +7,7 @@
 #include "procedure/nodes/calculateaxisangle.h"
 #include "procedure/nodes/collect1d.h"
 #include "procedure/nodes/collect2d.h"
+#include "procedure/nodes/operateexpression.h"
 #include "procedure/nodes/select.h"
 
 // Run main processing
@@ -18,6 +19,7 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, const ProcessPool &pr
 
     // Ensure any parameters in our nodes are set correctly
     calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
+    dAngleNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
     collectDistance_->keywords().set("RangeX", distanceRange_);
     collectAngle_->keywords().set("RangeX", angleRange_);
     collectDAngle_->keywords().set("RangeX", distanceRange_);

--- a/src/modules/calculate_dangle/dangle.h
+++ b/src/modules/calculate_dangle/dangle.h
@@ -7,8 +7,10 @@
 #include "procedure/procedure.h"
 
 // Forward Declarations
+class CalculateAngleProcedureNode;
 class Collect1DProcedureNode;
 class Collect2DProcedureNode;
+class OperateExpressionProcedureNode;
 class Process1DProcedureNode;
 class Process2DProcedureNode;
 class SelectProcedureNode;
@@ -33,6 +35,8 @@ class CalculateDAngleModule : public Module
     Vec3<double> distanceRange_{0.0, 10.0, 0.05};
     // Range (min, max, binwidth) of angle axis
     Vec3<double> angleRange_{0.0, 180.0, 1.0};
+    // Whether the angular range should be considered symmetric about 90
+    bool symmetric_{false};
     // Analysis procedure to be run
     Procedure analyser_;
     // SelectNode for site A
@@ -41,6 +45,8 @@ class CalculateDAngleModule : public Module
     std::shared_ptr<SelectProcedureNode> selectB_;
     // SelectNode for site C
     std::shared_ptr<SelectProcedureNode> selectC_;
+    // CalculateAngle node
+    std::shared_ptr<CalculateAngleProcedureNode> calculateAngle_;
     // Collect1DNode for B-C RDF
     std::shared_ptr<Collect1DProcedureNode> collectDistance_;
     // Collect1DNode for A-B-C angle histogram
@@ -53,6 +59,8 @@ class CalculateDAngleModule : public Module
     std::shared_ptr<Process1DProcedureNode> processAngle_;
     // Process2DNode for distance-angle data
     std::shared_ptr<Process2DProcedureNode> processDAngle_;
+    // Normalisation expression for distance-angle map
+    std::shared_ptr<OperateExpressionProcedureNode> dAngleNormalisationExpression_;
 
     /*
      * Processing

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -4,8 +4,10 @@
 #include "base/sysfunc.h"
 #include "main/dissolve.h"
 #include "modules/calculate_dangle/dangle.h"
+#include "procedure/nodes/calculateangle.h"
 #include "procedure/nodes/collect1d.h"
 #include "procedure/nodes/collect2d.h"
+#include "procedure/nodes/operateexpression.h"
 #include "procedure/nodes/select.h"
 
 // Run main processing
@@ -16,6 +18,8 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, const ProcessPool &procP
         return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
 
     // Ensure any parameters in our nodes are set correctly
+    calculateAngle_->keywords().set("Symmetric", symmetric_);
+    dAngleNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
     collectDistance_->keywords().set("RangeX", distanceRange_);
     collectAngle_->keywords().set("RangeX", angleRange_);
     collectDAngle_->keywords().set("RangeX", distanceRange_);

--- a/src/procedure/nodes/calculateangle.cpp
+++ b/src/procedure/nodes/calculateangle.cpp
@@ -2,11 +2,10 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "procedure/nodes/calculateangle.h"
-#include "base/lineparser.h"
-#include "base/sysfunc.h"
 #include "classes/box.h"
 #include "classes/configuration.h"
 #include "classes/species.h"
+#include "keywords/bool.h"
 #include "procedure/nodes/select.h"
 
 CalculateAngleProcedureNode::CalculateAngleProcedureNode(std::shared_ptr<SelectProcedureNode> site0,
@@ -20,6 +19,9 @@ CalculateAngleProcedureNode::CalculateAngleProcedureNode(std::shared_ptr<SelectP
                                                     this, ProcedureNode::NodeType::Select, true);
     keywords_.add<NodeKeyword<SelectProcedureNode>>("Control", "K", "Site that represents 'k' in the angle i-j-k", sites_[2],
                                                     this, ProcedureNode::NodeType::Select, true);
+    keywords_.add<BoolKeyword>("Control", "Symmetric",
+                               "Whether to consider angles as symmetric about 90, mapping all angles to the range 0 - 90",
+                               symmetric_);
 }
 
 /*
@@ -46,6 +48,9 @@ bool CalculateAngleProcedureNode::execute(const ProcedureContext &procedureConte
     // Determine the value of the observable
     value_.x = procedureContext.configuration()->box()->angleInDegrees(
         sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin(), sites_[2]->currentSite()->origin());
+
+    if (symmetric_ && value_.x > 90.0)
+        value_.x = 180.0 - value_.x;
 
     return true;
 }

--- a/src/procedure/nodes/calculateangle.h
+++ b/src/procedure/nodes/calculateangle.h
@@ -18,6 +18,13 @@ class CalculateAngleProcedureNode : public CalculateProcedureNodeBase
     ~CalculateAngleProcedureNode() override = default;
 
     /*
+     * Data
+     */
+    private:
+    // Whether the angle should be considered symmetric about 90 (i.e. 0 == 180)
+    bool symmetric_{false};
+
+    /*
      * Observable Target (implements virtuals in CalculateProcedureNodeBase)
      */
     public:

--- a/src/procedure/nodes/operateexpression.cpp
+++ b/src/procedure/nodes/operateexpression.cpp
@@ -33,6 +33,12 @@ OperateExpressionProcedureNode::OperateExpressionProcedureNode(std::string_view 
     keywords_.add<ExpressionKeyword>("Control", "Expression", "Expression to apply to values", expression_, variables_);
 }
 
+// Set the expression
+bool OperateExpressionProcedureNode::setExpression(std::string_view expressionText)
+{
+    return expression_.create(expressionText, variables_);
+}
+
 // Zero all variables
 void OperateExpressionProcedureNode::zeroVariables()
 {

--- a/src/procedure/nodes/operateexpression.h
+++ b/src/procedure/nodes/operateexpression.h
@@ -28,6 +28,10 @@ class OperateExpressionProcedureNode : public OperateProcedureNodeBase
     // Zero all variables
     void zeroVariables();
 
+    public:
+    // Set the expression
+    bool setExpression(std::string_view expressionText);
+
     /*
      * Data Target (implements virtuals in OperateProcedureNodeBase)
      */

--- a/src/procedure/nodes/parameters.cpp
+++ b/src/procedure/nodes/parameters.cpp
@@ -28,9 +28,9 @@ bool ParametersProcedureNode::mustBeNamed() const { return false; }
  */
 
 // Add new parameter
-void ParametersProcedureNode::addParameter(std::string_view name, ExpressionValue initialValue)
+std::shared_ptr<ExpressionVariable> ParametersProcedureNode::addParameter(std::string_view name, ExpressionValue initialValue)
 {
-    parameters_.push_back(std::make_shared<ExpressionVariable>(name, initialValue));
+    return parameters_.emplace_back(std::make_shared<ExpressionVariable>(name, initialValue));
 }
 
 // Return the named parameter (if it exists)

--- a/src/procedure/nodes/parameters.h
+++ b/src/procedure/nodes/parameters.h
@@ -34,7 +34,7 @@ class ParametersProcedureNode : public ProcedureNode
 
     public:
     // Add new parameter
-    void addParameter(std::string_view name, ExpressionValue initialValue);
+    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
     // Return the named parameter (if it exists)
     std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
                                                      std::shared_ptr<ExpressionVariable> excludeParameter) override;


### PR DESCRIPTION
This PR adds angle symmetrisation options to several calculation modules, and updates normalisation of distance-angle maps. This involves referencing a multiplication factor in the `OperateExpressionProcedureNode` and which would be best stored in a `ParametersNode`, but at present this is not possible to achieve (see #1063).