### PR TITLE
Manage master terms

### DIFF
--- a/src/base/sysfunc.h
+++ b/src/base/sysfunc.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <fmt/core.h>
 #include <string_view>
 #include <vector>
 
@@ -67,6 +69,24 @@ class DissolveSys
     static std::vector<double> splitStringToDoubles(std::string_view str, std::string_view delim = ", ");
     // Double any of the supplied characters in the string
     static std::string doubleChars(const std::string_view s, const std::string_view charsToDouble);
+    // Return unique name for object
+    template <class Range, class NameFunction>
+    static std::string uniqueName(std::string baseName, const Range &objects, NameFunction nameFunction)
+    {
+        // Check for empty base name
+        if (baseName.empty())
+            baseName = "UnnamedObject";
+        std::string uniqueName{baseName};
+
+        // Iterate until we find an unused name
+        auto suffix = 0;
+        while (std::find_if(objects.begin(), objects.end(), [nameFunction, &uniqueName](const auto &object) {
+                   return DissolveSys::sameString(nameFunction(object), uniqueName);
+               }) != objects.end())
+            uniqueName = fmt::format("{}{:02d}", baseName, ++suffix);
+
+        return uniqueName;
+    }
 
     /*
      * Files

--- a/src/base/sysfunc.h
+++ b/src/base/sysfunc.h
@@ -71,19 +71,18 @@ class DissolveSys
     static std::string doubleChars(const std::string_view s, const std::string_view charsToDouble);
     // Return unique name for object
     template <class Range, class NameFunction>
-    static std::string uniqueName(std::string baseName, const Range &objects, NameFunction nameFunction)
+    static std::string uniqueName(std::string_view baseName, const Range &objects, NameFunction nameFunction)
     {
-        // Check for empty base name
-        if (baseName.empty())
-            baseName = "UnnamedObject";
-        std::string uniqueName{baseName};
+        // Ensure our base string is valid and set the starting unique name
+        std::string base = baseName.empty() ? "UnnamedObject" : std::string(baseName);
+        std::string uniqueName{base};
 
         // Iterate until we find an unused name
         auto suffix = 0;
         while (std::find_if(objects.begin(), objects.end(), [nameFunction, &uniqueName](const auto &object) {
-                   return DissolveSys::sameString(nameFunction(object), uniqueName);
+                   return !nameFunction(object).empty() && DissolveSys::sameString(nameFunction(object), uniqueName);
                }) != objects.end())
-            uniqueName = fmt::format("{}{:02d}", baseName, ++suffix);
+            uniqueName = fmt::format("{}{:02d}", base, ++suffix);
 
         return uniqueName;
     }

--- a/src/classes/coredata.cpp
+++ b/src/classes/coredata.cpp
@@ -34,7 +34,8 @@ std::shared_ptr<AtomType> CoreData::addAtomType(Elements::Element Z)
     atomTypes_.push_back(newAtomType);
 
     // Create a suitable unique name
-    newAtomType->setName(uniqueAtomTypeName(Elements::symbol(Z)));
+    newAtomType->setName(DissolveSys::uniqueName(
+        Elements::symbol(Z), atomTypes_, [&](const auto &at) { return newAtomType == at ? std::string() : at->name(); }));
 
     // Set data
     newAtomType->setZ(Z);
@@ -62,19 +63,6 @@ const std::vector<std::shared_ptr<AtomType>> &CoreData::atomTypes() const { retu
 
 // Return nth AtomType in list
 std::shared_ptr<AtomType> CoreData::atomType(int n) { return atomTypes_[n]; }
-
-// Generate unique AtomType name with base name provided
-std::string CoreData::uniqueAtomTypeName(std::string_view base) const
-{
-    std::string uniqueName{base};
-
-    // Find an unused name starting with the baseName provided
-    auto suffix = 0;
-    while (findAtomType(uniqueName))
-        uniqueName = fmt::format("{}{}", base, ++suffix);
-
-    return uniqueName;
-}
 
 // Search for AtomType by name
 std::shared_ptr<AtomType> CoreData::findAtomType(std::string_view name) const
@@ -303,7 +291,8 @@ Species *CoreData::addSpecies()
     auto &newSpecies = species_.emplace_back(std::make_unique<Species>());
 
     // Create a suitable unique name
-    newSpecies->setName(uniqueSpeciesName("NewSpecies"));
+    newSpecies->setName(DissolveSys::uniqueName("NewSpecies", species_,
+                                                [&](const auto &sp) { return newSpecies == sp ? std::string() : sp->name(); }));
 
     return newSpecies.get();
 }
@@ -322,20 +311,6 @@ int CoreData::nSpecies() const { return species_.size(); }
 std::vector<std::unique_ptr<Species>> &CoreData::species() { return species_; }
 
 const std::vector<std::unique_ptr<Species>> &CoreData::species() const { return species_; }
-
-// Generate unique Species name with base name provided
-std::string CoreData::uniqueSpeciesName(std::string_view base) const
-{
-    std::string_view baseName = base.empty() ? "Unnamed" : base;
-    std::string uniqueName{baseName};
-
-    // Find an unused name starting with the baseName provided
-    auto suffix = 0;
-    while (findSpecies(uniqueName))
-        uniqueName = fmt::format("{}{}", baseName, ++suffix);
-
-    return uniqueName;
-}
 
 // Search for Species by name
 Species *CoreData::findSpecies(std::string_view name) const
@@ -362,7 +337,9 @@ Configuration *CoreData::addConfiguration()
     auto &newConfiguration = configurations_.emplace_back(std::make_unique<Configuration>());
 
     // Create a suitable unique name
-    newConfiguration->setName(uniqueConfigurationName("NewConfiguration"));
+    newConfiguration->setName(DissolveSys::uniqueName("NewConfiguration", configurations_, [&](const auto &cfg) {
+        return newConfiguration == cfg ? std::string() : cfg->name();
+    }));
 
     return newConfiguration.get();
 }
@@ -385,24 +362,6 @@ const std::vector<std::unique_ptr<Configuration>> &CoreData::configurations() co
 
 // Return nth Configuration in list
 Configuration *CoreData::configuration(int n) { return configurations_[n].get(); }
-
-// Generate unique Configuration name with base name provided
-std::string CoreData::uniqueConfigurationName(std::string_view base) const
-{
-    std::string baseName = base.empty() ? "Unnamed" : std::string(base);
-    std::string uniqueName = baseName;
-    auto suffix = 0;
-
-    // Find an unused name starting with the baseName provided
-    while (findConfiguration(uniqueName))
-    {
-        // Increase suffix value and regenerate uniqueName from baseName
-        ++suffix;
-        uniqueName = fmt::format("{}{}", baseName, suffix);
-    }
-
-    return uniqueName;
-}
 
 // Search for Configuration by name
 Configuration *CoreData::findConfiguration(std::string_view name) const

--- a/src/classes/coredata.h
+++ b/src/classes/coredata.h
@@ -46,8 +46,6 @@ class CoreData
     const std::vector<std::shared_ptr<AtomType>> &atomTypes() const;
     // Return nth AtomType in list
     std::shared_ptr<AtomType> atomType(int n);
-    // Generate unique AtomType name with base name provided
-    std::string uniqueAtomTypeName(std::string_view base) const;
     // Search for AtomType by name
     std::shared_ptr<AtomType> findAtomType(std::string_view name) const;
     // Bump AtomTypes version
@@ -133,8 +131,6 @@ class CoreData
     // Return core Species list
     std::vector<std::unique_ptr<Species>> &species();
     const std::vector<std::unique_ptr<Species>> &species() const;
-    // Generate unique Species name with base name provided
-    std::string uniqueSpeciesName(std::string_view baseName) const;
     // Search for Species by name
     Species *findSpecies(std::string_view name) const;
 
@@ -157,8 +153,6 @@ class CoreData
     const std::vector<std::unique_ptr<Configuration>> &configurations() const;
     // Return nth Configuration in list
     Configuration *configuration(int n);
-    // Generate unique Configuration name with base name provided
-    std::string uniqueConfigurationName(std::string_view base) const;
     // Search for Configuration by name
     Configuration *findConfiguration(std::string_view name) const;
 

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -225,6 +225,11 @@ class Species : public Serialisable
     void generateAttachedAtomLists();
     // Detach master term links for all interaction types, copying parameters to local SpeciesIntra
     void detachFromMasterTerms();
+    // Detach links to specified master term, copying parameters to local SpeciesIntra
+    void detachFromMasterTerm(MasterBond *master);
+    void detachFromMasterTerm(MasterAngle *master);
+    void detachFromMasterTerm(MasterTorsion *master);
+    void detachFromMasterTerm(MasterImproper *master);
     // Reduce intramolecular terms to master terms
     void reduceToMasterTerms(CoreData &coreData, bool selectionOnly = false);
 

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -291,10 +291,8 @@ class Species : public Serialisable
     const std::vector<std::unique_ptr<Isotopologue>> &isotopologues() const;
     // Return whether the specified Isotopologue exists
     bool hasIsotopologue(const Isotopologue *iso) const;
-    // Generate unique Isotopologue name with base name provided
-    std::string uniqueIsotopologueName(std::string_view baseName, const Isotopologue *exclude = nullptr);
     // Search for Isotopologue by name
-    const Isotopologue *findIsotopologue(std::string_view name, const Isotopologue *exclude = nullptr) const;
+    const Isotopologue *findIsotopologue(std::string_view name) const;
     // Return index of specified Isotopologue
     int indexOfIsotopologue(const Isotopologue *iso) const;
 

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -549,6 +549,35 @@ void Species::detachFromMasterTerms()
         improper.detachFromMasterTerm();
 }
 
+// Detach links to specified master term, copying parameters to local SpeciesIntra
+void Species::detachFromMasterTerm(MasterBond *master)
+{
+    for (auto &bond : bonds_)
+        if (bond.masterTerm() == master)
+            bond.detachFromMasterTerm();
+}
+
+void Species::detachFromMasterTerm(MasterAngle *master)
+{
+    for (auto &angle : angles_)
+        if (angle.masterTerm() == master)
+            angle.detachFromMasterTerm();
+}
+
+void Species::detachFromMasterTerm(MasterTorsion *master)
+{
+    for (auto &torsion : torsions_)
+        if (torsion.masterTerm() == master)
+            torsion.detachFromMasterTerm();
+}
+
+void Species::detachFromMasterTerm(MasterImproper *master)
+{
+    for (auto &improper : impropers_)
+        if (improper.masterTerm() == master)
+            improper.detachFromMasterTerm();
+}
+
 template <class Master, class Intra>
 void generateMasterTerm(Intra &term, std::string_view termName,
                         std::function<OptionalReferenceWrapper<Master>(std::string_view termName)> termGetter,

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -428,7 +428,8 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 }
                 break;
             case (Species::SpeciesKeyword::Isotopologue):
-                iso = addIsotopologue(uniqueIsotopologueName(parser.argsv(1)));
+                iso = addIsotopologue(
+                    DissolveSys::uniqueName(parser.argsv(1), isotopologues_, [](const auto &i) { return i->name(); }));
                 Messenger::printVerbose("Added Isotopologue '{}' to Species '{}'\n", iso->name(), name());
                 // Each parser argument is a string of the form ATOMTYPE=ISO
                 for (auto n = 2; n < parser.nArgs(); ++n)

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -213,7 +213,7 @@ void ForcefieldTab::on_AtomTypeDuplicateButton_clicked(bool checked)
         return;
 
     // Generate a unique name before we duplicate
-    auto newName = dissolve_.coreData().uniqueAtomTypeName(at->name());
+    auto newName = DissolveSys::uniqueName(at->name(), dissolve_.atomTypes(), [](const auto &at) { return at->name(); });
     auto newAt = dissolve_.addAtomType(at->Z());
     newAt->setName(newName);
     newAt->setCharge(at->charge());

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -409,11 +409,46 @@ void ForcefieldTab::masterImpropersDataChanged(const QModelIndex &, const QModel
     dissolveWindow_->setModified();
 }
 
-void ForcefieldTab::on_MasterTermAddBondButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
+void ForcefieldTab::on_MasterTermAddBondButton_clicked(bool checked)
+{
+    dissolve_.coreData().addMasterBond(
+        DissolveSys::uniqueName("NewTerm", dissolve_.coreData().masterBonds(), [](const auto &b) { return b->name(); }));
+    masterBondsTableModel_.setSourceData(dissolve_.coreData().masterBonds());
+    ui_.MasterBondsTable->resizeColumnsToContents();
+    dissolveWindow_->setModified();
+}
+
 void ForcefieldTab::on_MasterTermRemoveBondButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
-void ForcefieldTab::on_MasterTermAddAngleButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
+
+void ForcefieldTab::on_MasterTermAddAngleButton_clicked(bool checked)
+{
+    dissolve_.coreData().addMasterAngle(
+        DissolveSys::uniqueName("NewTerm", dissolve_.coreData().masterAngles(), [](const auto &a) { return a->name(); }));
+    masterAnglesTableModel_.setSourceData(dissolve_.coreData().masterAngles());
+    ui_.MasterAnglesTable->resizeColumnsToContents();
+    dissolveWindow_->setModified();
+}
+
 void ForcefieldTab::on_MasterTermRemoveAngleButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
-void ForcefieldTab::on_MasterTermAddTorsionButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
+
+void ForcefieldTab::on_MasterTermAddTorsionButton_clicked(bool checked)
+{
+    dissolve_.coreData().addMasterTorsion(
+        DissolveSys::uniqueName("NewTerm", dissolve_.coreData().masterTorsions(), [](const auto &t) { return t->name(); }));
+    masterTorsionsTableModel_.setSourceData(dissolve_.coreData().masterTorsions());
+    ui_.MasterTorsionsTable->resizeColumnsToContents();
+    dissolveWindow_->setModified();
+}
+
 void ForcefieldTab::on_MasterTermRemoveTorsionButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
-void ForcefieldTab::on_MasterTermAddImproperButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }
+
+void ForcefieldTab::on_MasterTermAddImproperButton_clicked(bool checked)
+{
+    dissolve_.coreData().addMasterImproper(
+        DissolveSys::uniqueName("NewTerm", dissolve_.coreData().masterImpropers(), [](const auto &i) { return i->name(); }));
+    masterImpropersTableModel_.setSourceData(dissolve_.coreData().masterImpropers());
+    ui_.MasterImpropersTable->resizeColumnsToContents();
+    dissolveWindow_->setModified();
+}
+
 void ForcefieldTab::on_MasterTermRemoveImproperButton_clicked(bool checked) { Messenger::error("NOT IMPLEMENTED YET.\n"); }

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -25,7 +25,8 @@ void DissolveWindow::on_LayerCreateEmptyAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (Basic Atomic)"));
+    newLayer->setName(DissolveSys::uniqueName("Evolve (Basic Atomic)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -49,7 +50,8 @@ void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checke
 void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (Atomic)"));
+    newLayer->setName(DissolveSys::uniqueName("Evolve (Atomic)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -78,7 +80,8 @@ void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (Standard)"));
+    newLayer->setName(DissolveSys::uniqueName("Evolve (Standard)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -107,7 +110,8 @@ void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Evolve (EPSR)"));
+    newLayer->setName(DissolveSys::uniqueName("Evolve (EPSR)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -135,7 +139,9 @@ void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateRefineEPSRAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Refine (EPSR)"));
+    newLayer->setName(DissolveSys::uniqueName("Refine (EPSR)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+
     newLayer->setFrequency(5);
 
     // Add the EPSR module
@@ -155,7 +161,9 @@ void DissolveWindow::on_LayerCreateRefineEPSRAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF"));
+    newLayer->setName(DissolveSys::uniqueName("RDF", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+
     newLayer->setFrequency(5);
 
     // Add the RDF module
@@ -172,7 +180,8 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Unweighted S(Q)"));
+    newLayer->setName(DissolveSys::uniqueName("RDF / Unweighted S(Q)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
 
     // Add the RDF module
@@ -192,7 +201,8 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggere
 void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Neutron S(Q)"));
+    newLayer->setName(DissolveSys::uniqueName("RDF / Neutron S(Q)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
 
     // Add the RDF module
@@ -215,7 +225,8 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool c
 void DissolveWindow::on_LayerCreateCorrelationsRDFXRayAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / X-ray S(Q)"));
+    newLayer->setName(DissolveSys::uniqueName("RDF / X-ray S(Q)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
 
     // Add the RDF module
@@ -238,7 +249,8 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFXRayAction_triggered(bool chec
 void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("RDF / Neutron S(Q) / X-ray S(Q)"));
+    newLayer->setName(DissolveSys::uniqueName("RDF / Neutron S(Q) / X-ray S(Q)", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
 
     // Add the RDF module
@@ -264,7 +276,8 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bo
 void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Analyse RDF/CN"));
+    newLayer->setName(DissolveSys::uniqueName("Analyse RDF/CN", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
@@ -287,7 +300,8 @@ void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
 void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.addProcessingLayer();
-    newLayer->setName(dissolve_.uniqueProcessingLayerName("Analyse AvgMol/SDF"));
+    newLayer->setName(DissolveSys::uniqueName("Analyse AvgMol/SDF", dissolve_.processingLayers(),
+                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -28,7 +28,9 @@ void DissolveWindow::on_SpeciesCreateAtomicAction_triggered(bool checked)
     // Create the new Species, and add a single atom at {0,0,0}
     auto *newSpecies = dissolve_.addSpecies();
     newSpecies->addAtom(Z, Vec3<double>());
-    newSpecies->setName(dissolve_.coreData().uniqueSpeciesName(Elements::symbol(Z)));
+    newSpecies->setName(DissolveSys::uniqueName(Elements::symbol(Z), dissolve().coreData().species(), [&](const auto &sp) {
+        return newSpecies == sp.get() ? std::string() : sp->name();
+    }));
 
     setModified();
     fullUpdate();

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -78,7 +78,9 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
 
         // Ensure uniqueness of new name
         auto oldName = QString::fromStdString(std::string(module->uniqueName()));
-        auto newName = Module::uniqueName(value.toString().toStdString(), module);
+        auto newName = DissolveSys::uniqueName(value.toString().toStdString(), Module::instances(), [&](const auto &inst) {
+            return inst == module ? std::string() : inst->uniqueName();
+        });
         module->setUniqueName(newName);
 
         emit(dataChanged(index, index));

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -200,8 +200,6 @@ class Dissolve : public Serialisable
     bool ownProcessingLayer(ModuleLayer *layer);
     // Return number of defined processing layers
     int nProcessingLayers() const;
-    // Generate unique processing layer name, with base name provided
-    std::string uniqueProcessingLayerName(std::string_view baseName) const;
     // Return list of processing layers
     std::vector<std::unique_ptr<ModuleLayer>> &processingLayers();
     // Run the set-up stages of all modules in all layers

--- a/src/main/layers.cpp
+++ b/src/main/layers.cpp
@@ -51,20 +51,6 @@ bool Dissolve::ownProcessingLayer(ModuleLayer *layer)
 // Return number of defined processing layers
 int Dissolve::nProcessingLayers() const { return processingLayers_.size(); }
 
-// Generate unique processing layer name with base name provided
-std::string Dissolve::uniqueProcessingLayerName(std::string_view base) const
-{
-    std::string_view baseName = base.empty() ? "Unnamed" : base;
-    std::string uniqueName{baseName};
-
-    // Find an unused name starting with the baseName provided
-    auto suffix = 0;
-    while (findProcessingLayer(uniqueName))
-        uniqueName = fmt::format("{}{}", baseName, ++suffix);
-
-    return uniqueName;
-}
-
 // Return list of processing layers
 std::vector<std::unique_ptr<ModuleLayer>> &Dissolve::processingLayers() { return processingLayers_; }
 

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -129,7 +129,9 @@ Species *Dissolve::copySpecies(const Species *species)
 {
     // Create our new Species
     Species *newSpecies = addSpecies();
-    newSpecies->setName(coreData_.uniqueSpeciesName(species->name()));
+    newSpecies->setName(DissolveSys::uniqueName(species->name(), coreData_.species(), [&](const auto &sp) {
+        return newSpecies == sp.get() ? std::string() : sp->name();
+    }));
 
     // Copy Box definition if one exists
     if (species->box()->type() != Box::BoxType::NonPeriodic)
@@ -172,11 +174,11 @@ Species *Dissolve::copySpecies(const Species *species)
     }
 
     // Duplicate impropers
-    for (auto &t : species->impropers())
+    for (const auto &improper : species->impropers())
     {
         // Create the improper in the new Species
-        auto &newImproper = newSpecies->addImproper(t.indexI(), t.indexJ(), t.indexK(), t.indexL());
-        copySpeciesImproper(t, newImproper);
+        auto &newImproper = newSpecies->addImproper(improper.indexI(), improper.indexJ(), improper.indexK(), improper.indexL());
+        copySpeciesImproper(improper, newImproper);
     }
 
     return newSpecies;

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -185,20 +185,3 @@ std::vector<Module *> Module::allOfType(std::vector<std::string> types)
                  [&types](const auto *m) { return std::find(types.begin(), types.end(), m->type()) != types.end(); });
     return modules;
 }
-
-// Generate unique Module name with base name provided
-std::string Module::uniqueName(std::string_view name, Module *exclude)
-{
-    std::string newName{name};
-
-    // Find an unused name starting with the baseName provided
-    auto suffix = 0;
-    while (std::find_if(instances_.begin(), instances_.end(), [newName, exclude](const auto *m) {
-               return (m != exclude) && DissolveSys::sameString(m->uniqueName(), newName);
-           }) != instances_.end())
-    {
-        newName = fmt::format("{}{:02d}", name, ++suffix);
-    }
-
-    return newName;
-}

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -135,6 +135,4 @@ class Module
 
         return results;
     }
-    // Generate unique name with base name provided
-    static std::string uniqueName(std::string_view name, Module *exclude = nullptr);
 };

--- a/src/modules/registry.cpp
+++ b/src/modules/registry.cpp
@@ -125,7 +125,9 @@ const std::map<std::string, std::vector<ModuleRegistry::ModuleInfoData>> &Module
 std::unique_ptr<Module> ModuleRegistry::create(std::string_view moduleType)
 {
     auto m = std::unique_ptr<Module>(instance().produce(std::string(moduleType)));
-    m->setUniqueName(Module::uniqueName(m->type(), m.get()));
+    m->setUniqueName(DissolveSys::uniqueName(m->type(), Module::instances(), [&](const auto &inst) {
+        return inst == m.get() ? std::string() : inst->uniqueName();
+    }));
     return m;
 }
 

--- a/unit/algorithms/sysFunc.cpp
+++ b/unit/algorithms/sysFunc.cpp
@@ -7,7 +7,11 @@
 
 namespace UnitTest
 {
-
+struct NameObject
+{
+    NameObject(std::string newName) : name(std::move(newName)){};
+    std::string name;
+};
 TEST(SysFunc, StringManipulation)
 {
     // String matching
@@ -105,6 +109,19 @@ TEST(SysFunc, StringManipulation)
     v = DissolveSys::splitString("   arma   dillo is in    pieces         ", " ");
     EXPECT_EQ(v.size(), 5);
     EXPECT_TRUE(expected == v);
+
+    // Unique Naming
+    std::vector<NameObject> names;
+    EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique");
+    names.emplace_back("IAmUnique");
+    EXPECT_FALSE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique");
+    EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique01");
+    auto &exc = names.emplace_back("IAmUnique01");
+    EXPECT_FALSE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique01");
+    EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique02");
+    EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [&](const auto &obj) {
+                    return &exc == &obj ? std::string() : obj.name;
+                }) == "IAmUnique01");
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
Here we add the ability to create new master terms from the GUI. Removal of master terms from the GUI (#1065) is left for a future PR due to time constraints.

We also remove a lot of duplicate/highly similar code related to searching for unique object names, and replace this with a templated function in `DissolveSys`.