### PR TITLE
Legacy Restart Data Deserialisation

### DIFF
--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -552,10 +552,19 @@ bool PartialSet::deserialise(LineParser &parser, const CoreData &coreData)
     // Read totals
     if (!total_.deserialise(parser))
         return false;
-    if (!boundTotal_.deserialise(parser))
-        return false;
-    if (!unboundTotal_.deserialise(parser))
-        return false;
+    if (GenericList::baseDataVersion() == GenericList::DeserialisableDataVersion::Version089)
+    {
+        // Writing of bound & unbound totals introduced in 0.9.0
+        boundTotal_.initialise(total_);
+        unboundTotal_.initialise(total_);
+    }
+    else
+    {
+        if (!boundTotal_.deserialise(parser))
+            return false;
+        if (!unboundTotal_.deserialise(parser))
+            return false;
+    }
 
     // Read empty bound flags
     if (!GenericItemDeserialiser::deserialise<Array2D<char>>(emptyBoundPartials_, parser))

--- a/src/genericitems/CMakeLists.txt
+++ b/src/genericitems/CMakeLists.txt
@@ -1,11 +1,13 @@
 add_library(
   genericitems
   deserialisers.cpp
+  legacy.cpp
   list.cpp
   producers.cpp
   searchers.cpp
   serialisers.cpp
   deserialisers.h
+  legacy.h
   list.h
   producers.h
   serialisers.h

--- a/src/genericitems/deserialisers.cpp
+++ b/src/genericitems/deserialisers.cpp
@@ -3,11 +3,13 @@
 
 #include "genericitems/deserialisers.h"
 #include "base/lineparser.h"
+#include "classes/atomtypedata.h"
 #include "classes/braggreflection.h"
 #include "classes/neutronweights.h"
 #include "classes/partialset.h"
 #include "classes/partialsetaccumulator.h"
 #include "classes/xrayweights.h"
+#include "genericitems/legacy.h"
 #include "math/data1d.h"
 #include "math/data2d.h"
 #include "math/data3d.h"
@@ -162,6 +164,9 @@ GenericItemDeserialiser::GenericItemDeserialiser()
 
     // Containers of Custom Classes
     registerDeserialiser<std::vector<BraggReflection>>(vectorDeserialise<BraggReflection>);
+
+    // Legacy Classes
+    registerLegacyDeserialiser<LegacyAtomTypeListItem>(simpleDeserialiseCore<LegacyAtomTypeListItem>);
 }
 
 /*
@@ -174,6 +179,8 @@ bool GenericItemDeserialiser::deserialiseObject(std::any &a, LineParser &parser,
     // Find a suitable deserialiser and call it
     auto it = deserialisers_.find(a.type());
     if (it == deserialisers_.end())
+        it = legacyDeserialisers_.find(a.type());
+    if (it == legacyDeserialisers_.end())
         throw(std::runtime_error(fmt::format(
             "Item of type '{}' cannot be deserialised as no suitable deserialiser has been registered.\n", a.type().name())));
 
@@ -197,3 +204,6 @@ bool GenericItemDeserialiser::deserialise(std::any &a, LineParser &parser, const
 {
     return instance().deserialiseObject(a, parser, coreData);
 }
+
+// Return whether supplied object is a legacy object
+bool GenericItemDeserialiser::isLegacyObject(std::any &object) { return instance().hasLegacyDeserialiser(object); }

--- a/src/genericitems/deserialisers.h
+++ b/src/genericitems/deserialisers.h
@@ -30,7 +30,7 @@ class GenericItemDeserialiser
     // Deserialisation function type
     using DeserialiseFunction = std::function<bool(std::any &a, LineParser &parser, const CoreData &coreData)>;
     // Deserialisers for all data types
-    std::unordered_map<std::type_index, DeserialiseFunction> deserialisers_;
+    std::unordered_map<std::type_index, DeserialiseFunction> deserialisers_, legacyDeserialisers_;
 
     private:
     template <class T> static bool simpleDeserialise(std::any &a, LineParser &parser, const CoreData &coreData)
@@ -55,6 +55,11 @@ class GenericItemDeserialiser
     }
     // Register deserialiser for specific class
     template <class T> void registerDeserialiser(DeserialiseFunction func) { deserialisers_[typeid(T)] = std::move(func); }
+    // Register legacy deserialiser for specific class
+    template <class T> void registerLegacyDeserialiser(DeserialiseFunction func)
+    {
+        legacyDeserialisers_[typeid(T)] = std::move(func);
+    }
     // Deserialise object of specified type
     bool deserialiseObject(std::any &a, LineParser &parser, const CoreData &coreData) const;
     // Deserialise templated object
@@ -73,6 +78,11 @@ class GenericItemDeserialiser
         object = std::move(std::any_cast<T>(a));
 
         return true;
+    }
+    // Return whether the supplied object has a legacy deserialiser
+    bool hasLegacyDeserialiser(std::any &object) const
+    {
+        return legacyDeserialisers_.find(object.type()) != legacyDeserialisers_.end();
     }
 
     /*
@@ -98,4 +108,6 @@ class GenericItemDeserialiser
     }
     // Deserialise supplied object
     static bool deserialise(std::any &a, LineParser &parser, const CoreData &coreData);
+    // Return whether supplied object is a legacy object
+    static bool isLegacyObject(std::any &object);
 };

--- a/src/genericitems/legacy.cpp
+++ b/src/genericitems/legacy.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "genericitems/legacy.h"
+
+// AtomTypeList (removed in 0.9.0)
+bool LegacyAtomTypeListItem::deserialise(LineParser &parser, const CoreData &coreData)
+{
+    // First line is contains the number of items we must discard
+    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+        return false;
+    return parser.skipLines(parser.argi(0)) == LineParser::Success;
+}

--- a/src/genericitems/legacy.h
+++ b/src/genericitems/legacy.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/lineparser.h"
+
+// Forward Declarations
+class CoreData;
+
+// Legacy Dummy Classes
+// Enable production and deserialisation in order to support legacy file read
+
+// AtomTypeList (removed in 0.9.0)
+class LegacyAtomTypeListItem
+{
+    public:
+    // Discard data from specified LineParser
+    bool deserialise(LineParser &parser, const CoreData &coreData);
+};

--- a/src/genericitems/list.cpp
+++ b/src/genericitems/list.cpp
@@ -126,10 +126,10 @@ bool GenericList::serialiseAll(LineParser &parser, std::string_view headerPrefix
 
 // Deserialise an object from the LineParser into our map
 bool GenericList::deserialise(LineParser &parser, CoreData &coreData, const std::string &name, const std::string &itemClass,
-                              int version, int flags)
+                              int dataVersion, int flags)
 {
     // Create the item
-    items_[std::string(name)] = GenericItem::Type(GenericItemProducer::create(itemClass), itemClass, version, flags);
+    items_[std::string(name)] = GenericItem::Type(GenericItemProducer::create(itemClass), itemClass, dataVersion, flags);
     auto &data = std::get<GenericItem::AnyObject>(items_[std::string(name)]);
 
     // Find its deserialiser and call it

--- a/src/genericitems/list.cpp
+++ b/src/genericitems/list.cpp
@@ -169,5 +169,14 @@ bool GenericList::deserialise(LineParser &parser, CoreData &coreData, const std:
     if (!GenericItemDeserialiser::deserialise(data, parser, coreData))
         return Messenger::error(fmt::format("Deserialisation of item '{}' failed.\n", name));
 
+    // Check for legacy objects - we don't re-serialise them
+    if (GenericItemDeserialiser::isLegacyObject(data))
+    {
+        Messenger::warn("Legacy data '{}' will not be captured in written restart files.\n", itemClass);
+        auto &itemFlags = std::get<GenericItem::Flags>(items_[std::string(name)]);
+        if (itemFlags & GenericItem::InRestartFileFlag)
+            itemFlags -= GenericItem::InRestartFileFlag;
+    }
+
     return true;
 }

--- a/src/genericitems/list.cpp
+++ b/src/genericitems/list.cpp
@@ -134,7 +134,7 @@ bool GenericList::deserialise(LineParser &parser, CoreData &coreData, const std:
 
     // Find its deserialiser and call it
     if (!GenericItemDeserialiser::deserialise(data, parser, coreData))
-        return Messenger::error(fmt::format("Deerialisation of item '{}' failed.\n", name));
+        return Messenger::error(fmt::format("Deserialisation of item '{}' failed.\n", name));
 
     return true;
 }

--- a/src/genericitems/list.h
+++ b/src/genericitems/list.h
@@ -180,7 +180,7 @@ class GenericList
     bool serialiseAll(LineParser &parser, std::string_view headerPrefix) const;
     // Deserialise an object from the LineParser into our map
     bool deserialise(LineParser &parser, CoreData &coreData, const std::string &name, const std::string &itemClass,
-                     int version = 0, int flags = 0);
+                     int dataVersion = 0, int flags = 0);
 
     /*
      * Searchers

--- a/src/genericitems/list.h
+++ b/src/genericitems/list.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/enumoptions.h"
 #include "base/lineparser.h"
 #include "base/sysfunc.h"
 #include "genericitems/item.h"
@@ -176,6 +177,24 @@ class GenericList
      * Serialisation
      */
     public:
+    // Data Versions
+    enum class DeserialisableDataVersion
+    {
+        Version089,
+        Current
+    };
+    // Return EnumOptions for DataVersion
+    static EnumOptions<DeserialisableDataVersion> deserialisableDataVersions();
+
+    private:
+    // Current data version being deserialised
+    static DeserialisableDataVersion baseDataVersion_;
+
+    public:
+    // Set current data version being deserialised by detecting it from the supplied string
+    static void setBaseDataVersionFromString(std::string_view s);
+    // Return current data version being deserialised
+    static DeserialisableDataVersion baseDataVersion();
     // Serialise all objects via the specified LineParser
     bool serialiseAll(LineParser &parser, std::string_view headerPrefix) const;
     // Deserialise an object from the LineParser into our map

--- a/src/genericitems/producers.cpp
+++ b/src/genericitems/producers.cpp
@@ -8,6 +8,7 @@
 #include "classes/partialset.h"
 #include "classes/partialsetaccumulator.h"
 #include "classes/xrayweights.h"
+#include "genericitems/legacy.h"
 #include "math/data1d.h"
 #include "math/data2d.h"
 #include "math/data3d.h"
@@ -52,6 +53,9 @@ GenericItemProducer::GenericItemProducer()
     // Containers of Custom Classes
     registerProducer<std::vector<BraggReflection>>("std::vector<BraggReflection>");
     registerProducer<std::vector<KVector>>("std::vector<KVector>");
+
+    // Legacy Classes
+    registerProducer<LegacyAtomTypeListItem>("AtomTypeList");
 }
 
 /*

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -411,6 +411,12 @@ bool Dissolve::loadRestart(std::string_view filename)
     if (!parser.openInput(restartFilename_))
         return false;
 
+    // Peek the first line and see if can determine a version
+    if (parser.readNextLine(LineParser::KeepComments) != LineParser::Success)
+        return false;
+    GenericList::setBaseDataVersionFromString(parser.line());
+    parser.rewind();
+
     // Variables
     Configuration *cfg;
     Module *module;
@@ -528,6 +534,12 @@ bool Dissolve::loadRestartAsReference(std::string_view filename, std::string_vie
     LineParser parser(&worldPool());
     if (!parser.openInput(filename))
         return false;
+
+    // Peek the first line and see if can determine a version
+    if (parser.readNextLine(LineParser::KeepComments) != LineParser::Success)
+        return false;
+    GenericList::setBaseDataVersionFromString(parser.line());
+    parser.rewind();
 
     // Variables
     std::string newName;

--- a/src/main/version.cpp
+++ b/src/main/version.cpp
@@ -10,7 +10,14 @@
 
 namespace Version
 {
+// Return semantic version number
+std::string_view semantic()
+{
+    static std::string versionString = fmt::format("{}", DISSOLVEVERSION);
+    return versionString;
+}
 
+// Return current version information, including short hash if defined
 std::string_view info()
 {
     static std::string versionString;

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -7,8 +7,9 @@
 
 namespace Version
 {
-
-// Return current version information
+// Return semantic version number
+std::string_view semantic();
+// Return current version information, including short hash if defined
 std::string_view info();
 // Return repo url
 std::string_view repoUrl();


### PR DESCRIPTION
This PR is intended to mitigate the majority of awkward problems encountered when loading restart files from old simulations, and which require hand-editing to fix.

Here, we implement:
- Data version awareness (at the restart file level) in order to allow class deserialisation routines to adjust based on the detected data version of the file.  This is used to permit the `PartialSet` class to read in data from the current and previous (0.8) versions.
- Production and deserialisation of legacy class objects in `GenericList` - this allows classes that are no longer used in the code (`AtomTypeList`) but which are present in older version' restart files to be effectively skipped on read.

With these two additions it is possible to transparently load in a restart file from 0.8.9 into the current 0.9.0 version of Dissolve with no hand-editing required.

One point for debate - should this be included as a general mechanism going forward, or kept just to the `release/0.9.X` branches? Class changes requiring use of the above is likely to happen again, but to a relatively small degree, and providing seamless transfer of simulation data between versions is of course a nice UX to have.