### PR TITLE
Nice, unique names

### DIFF
--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -428,8 +428,8 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 }
                 break;
             case (Species::SpeciesKeyword::Isotopologue):
-                iso = addIsotopologue(
-                    DissolveSys::uniqueName(parser.argsv(1), isotopologues_, [](const auto &i) { return i->name(); }));
+                iso = addIsotopologue(DissolveSys::uniqueName(DissolveSys::niceName(parser.argsv(1)), isotopologues_,
+                                                              [](const auto &i) { return i->name(); }));
                 Messenger::printVerbose("Added Isotopologue '{}' to Species '{}'\n", iso->name(), name());
                 // Each parser argument is a string of the form ATOMTYPE=ISO
                 for (auto n = 2; n < parser.nArgs(); ++n)

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -81,6 +81,6 @@ void ModuleVectorKeywordWidget::updateSummaryText()
     if (keyword_->data().empty())
         setSummaryText("<None>");
     else
-        setSummaryText(QString::fromStdString(
-            joinStrings(keyword_->data(), ", ", [](const auto &module) { return module->uniqueName(); })));
+        setSummaryText(
+            QString::fromStdString(joinStrings(keyword_->data(), ", ", [](const auto &module) { return module->name(); })));
 }

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -268,13 +268,13 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
     {
         Renderable::invalidateAll();
         Renderable::setSourceDataAccessEnabled(false);
-        dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
+        dissolve_.processingModuleData().removeWithPrefix(module->name());
         Renderable::setSourceDataAccessEnabled(true);
     }
     else if (action == deleteModule)
     {
         // Remove the module's data, the module control widget, then the module itself
-        dissolve_.processingModuleData().removeWithPrefix(module->uniqueName());
+        dissolve_.processingModuleData().removeWithPrefix(module->name());
         removeControlWidget(module);
         moduleLayerModel_.removeRows(index.row(), 1, QModelIndex());
     }

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -78,9 +78,9 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
 
         // Ensure uniqueness of new name
         auto oldName = QString::fromStdString(std::string(module->uniqueName()));
-        auto newName = DissolveSys::uniqueName(value.toString().toStdString(), Module::instances(), [&](const auto &inst) {
-            return inst == module ? std::string() : inst->uniqueName();
-        });
+        auto newName =
+            DissolveSys::uniqueName(DissolveSys::niceName(value.toString().toStdString()), Module::instances(),
+                                    [&](const auto &inst) { return inst == module ? std::string() : inst->uniqueName(); });
         module->setUniqueName(newName);
 
         emit(dataChanged(index, index));

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -50,14 +50,14 @@ QVariant ModuleLayerModel::data(const QModelIndex &index, int role) const
     if (role == Qt::DisplayRole)
     {
         if (module->isDisabled())
-            return QString::fromStdString(fmt::format("{} (disabled)", module->uniqueName()));
+            return QString::fromStdString(fmt::format("{} (disabled)", module->name()));
         else if (!moduleLayer_->isEnabled())
-            return QString::fromStdString(fmt::format("{} (disabled via layer)", module->uniqueName()));
+            return QString::fromStdString(fmt::format("{} (disabled via layer)", module->name()));
         else
-            return QString::fromStdString(std::string(module->uniqueName()));
+            return QString::fromStdString(std::string(module->name()));
     }
     else if (role == Qt::EditRole)
-        return QString::fromStdString(std::string(module->uniqueName()));
+        return QString::fromStdString(std::string(module->name()));
     else if (role == Qt::UserRole)
         return QVariant::fromValue(module);
     else if (role == Qt::DecorationRole)
@@ -73,15 +73,14 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
         auto *module = rawData(index);
 
         // Check for identical old/new names
-        if (value.toString() == QString::fromStdString(std::string(module->uniqueName())))
+        if (value.toString() == QString::fromStdString(std::string(module->name())))
             return false;
 
         // Ensure uniqueness of new name
-        auto oldName = QString::fromStdString(std::string(module->uniqueName()));
-        auto newName =
-            DissolveSys::uniqueName(DissolveSys::niceName(value.toString().toStdString()), Module::instances(),
-                                    [&](const auto &inst) { return inst == module ? std::string() : inst->uniqueName(); });
-        module->setUniqueName(newName);
+        auto oldName = QString::fromStdString(std::string(module->name()));
+        auto newName = DissolveSys::uniqueName(DissolveSys::niceName(value.toString().toStdString()), Module::instances(),
+                                               [&](const auto &inst) { return inst == module ? std::string() : inst->name(); });
+        module->setName(newName);
 
         emit(dataChanged(index, index));
         emit(moduleNameChanged(index, oldName, QString::fromStdString(newName)));
@@ -94,7 +93,7 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
         // Find it in the list, taking care to avoid any nullptr vector data (i.e. where we're moving it to)
         auto moduleToMove = value.toString().toStdString();
         auto it = std::find_if(moduleLayer_->modules().begin(), moduleLayer_->modules().end(),
-                               [moduleToMove](const auto &m) { return m && moduleToMove == m->uniqueName(); });
+                               [moduleToMove](const auto &m) { return m && moduleToMove == m->name(); });
         if (it == moduleLayer_->modules().end())
             return false;
         moduleLayer_->modules()[index.row()] = std::move(*it);
@@ -159,7 +158,7 @@ QMimeData *ModuleLayerModel::mimeData(const QModelIndexList &indexes) const
     QByteArray encodedData;
 
     QDataStream stream(&encodedData, QIODevice::WriteOnly);
-    stream << QString::fromStdString(std::string(moduleLayer_->modules()[indexes.front().row()]->uniqueName()));
+    stream << QString::fromStdString(std::string(moduleLayer_->modules()[indexes.front().row()]->name()));
     mimeData->setData("application/dissolve.module.move", encodedData);
 
     return mimeData;

--- a/src/gui/models/moduleModel.cpp
+++ b/src/gui/models/moduleModel.cpp
@@ -37,7 +37,7 @@ int ModuleModel::rowCount(const QModelIndex &parent) const
 QVariant ModuleModel::data(const QModelIndex &index, int role) const
 {
     if (role == Qt::DisplayRole)
-        return QString::fromStdString(std::string(rawData(index)->uniqueName()));
+        return QString::fromStdString(std::string(rawData(index)->name()));
     else if (role == Qt::CheckStateRole && checkedItems_)
         return std::find(checkedItems_->get().begin(), checkedItems_->get().end(), rawData(index)) == checkedItems_->get().end()
                    ? Qt::Unchecked

--- a/src/gui/models/speciesIsoModel.cpp
+++ b/src/gui/models/speciesIsoModel.cpp
@@ -130,7 +130,8 @@ bool SpeciesIsoModel::setData(const QModelIndex &index, const QVariant &value, i
     if (!index.parent().isValid())
     {
         auto iso = species_.isotopologue(index.row());
-        iso->setName(value.toString().toStdString());
+        iso->setName(DissolveSys::uniqueName(DissolveSys::niceName(value.toString().toStdString()), species_.isotopologues(),
+                                             [&](const auto &i) { return iso == i.get() ? std::string() : i->name(); }));
         emit(dataChanged(index, index));
         return true;
     }

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -88,7 +88,7 @@ void ModuleControlWidget::updateControls(Flags<ModuleWidget::UpdateFlags> update
     Locker refreshLocker(refreshLock_);
 
     // Ensure module name is up to date
-    ui_.ModuleNameLabel->setText(QString("%1 (%2)").arg(QString::fromStdString(std::string(module_->uniqueName())),
+    ui_.ModuleNameLabel->setText(QString("%1 (%2)").arg(QString::fromStdString(std::string(module_->name())),
                                                         QString::fromStdString(std::string(module_->type()))));
 
     // Set 'enabled' button status

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -61,7 +61,7 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase
             if (module->type() != moduleType())
                 return Messenger::error("Module '{}' given to keyword {} is of the wrong type ({}) - only a module of "
                                         "type '{}' can be accepted.\n",
-                                        module->uniqueName(), KeywordBase::name(), module->type(), moduleType());
+                                        module->name(), KeywordBase::name(), module->type(), moduleType());
 
             data_ = dynamic_cast<const M *>(module);
             assert(data_);
@@ -91,7 +91,7 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase
         if (data_ == nullptr)
             return true;
 
-        if (!parser.writeLineF("{}{}  '{}'\n", prefix, KeywordBase::name(), data_->uniqueName()))
+        if (!parser.writeLineF("{}{}  '{}'\n", prefix, KeywordBase::name(), data_->name()))
             return false;
 
         return true;

--- a/src/keywords/modulevector.cpp
+++ b/src/keywords/modulevector.cpp
@@ -68,7 +68,7 @@ bool ModuleVectorKeyword::deserialise(LineParser &parser, int startArg, const Co
 bool ModuleVectorKeyword::serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     for (auto *module : data_)
-        if (!parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, module->uniqueName()))
+        if (!parser.writeLineF("{}{}  '{}'\n", prefix, keywordName, module->name()))
             return false;
 
     return true;

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -375,7 +375,7 @@ bool Dissolve::saveInput(std::string_view filename)
         for (auto &module : layer->modules())
         {
             if (!parser.writeLineF("\n  {}  {}  '{}'\n", BlockKeywords::keywords().keyword(BlockKeywords::ModuleBlockKeyword),
-                                   module->type(), module->uniqueName()))
+                                   module->type(), module->name()))
                 return false;
 
             // Write frequency and disabled keywords
@@ -622,7 +622,7 @@ bool Dissolve::saveRestart(std::string_view filename)
     for (const auto *module : Module::instances())
     {
         for (auto &keyword : module->keywords().restartables())
-            if (!keyword->serialise(parser, fmt::format("Keyword  {}  {}  ", module->uniqueName(), keyword->name())))
+            if (!keyword->serialise(parser, fmt::format("Keyword  {}  {}  ", module->name(), keyword->name())))
                 return false;
     }
 
@@ -642,7 +642,7 @@ bool Dissolve::saveRestart(std::string_view filename)
     // Module timing information
     for (const auto *module : Module::instances())
     {
-        if (!parser.writeLineF("Timing  {}\n", module->uniqueName()))
+        if (!parser.writeLineF("Timing  {}\n", module->name()))
             return false;
         if (!module->processTimes().serialise(parser))
             return false;

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -85,7 +85,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                         break;
                     }
                     else
-                        module->setUniqueName(niceName);
+                        module->setName(niceName);
                 }
 
                 // Parse rest of Module block

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -20,7 +20,7 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
                         bool moduleInConfiguration)
 {
     Messenger::print("\nParsing {} block '{}' ({})...\n", BlockKeywords::keywords().keyword(BlockKeywords::ModuleBlockKeyword),
-                     module->uniqueName(), module->type());
+                     module->name(), module->type());
 
     auto blockDone = false, error = false;
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -273,7 +273,7 @@ bool Dissolve::iterate(int nIterations)
                 if (!module->runThisIteration(layerExecutionCount))
                     continue;
 
-                Messenger::heading("{} ({})", module->type(), module->uniqueName());
+                Messenger::heading("{} ({})", module->type(), module->name());
 
                 if (!module->executeProcessing(*this, worldPool()))
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->type());
@@ -412,7 +412,7 @@ void Dissolve::printTiming()
     auto maxLength = 0;
     for (const auto *module : Module::instances())
     {
-        const auto length = module->uniqueName().size();
+        const auto length = module->name().size();
         if (length > maxLength)
             maxLength = length;
     }
@@ -427,7 +427,7 @@ void Dissolve::printTiming()
         {
             SampledDouble timingInfo = module->processTimes();
             Messenger::print("      --> {:>20}  {:<{}}  {:7.2g} s/iter  ({} iterations)", module->type(),
-                             fmt::format("({})", module->uniqueName()), maxLength, timingInfo.value(), timingInfo.count());
+                             fmt::format("({})", module->name()), maxLength, timingInfo.value(), timingInfo.count());
         }
 
         Messenger::print("\n");

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -80,7 +80,7 @@ Module *ModuleLayer::append(std::string_view moduleType, const std::vector<std::
 Module *ModuleLayer::find(std::string_view uniqueName) const
 {
     auto it = std::find_if(modules_.begin(), modules_.end(),
-                           [uniqueName](const auto &m) { return DissolveSys::sameString(m->uniqueName(), uniqueName); });
+                           [uniqueName](const auto &m) { return DissolveSys::sameString(m->name(), uniqueName); });
     if (it != modules_.end())
         return it->get();
 

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -20,11 +20,11 @@ Module::~Module() { instances_.erase(std::remove(instances_.begin(), instances_.
 // Return type of Module
 const std::string_view Module::type() const { return typeName_; }
 
-// Set unique name of Module
-void Module::setUniqueName(std::string_view uniqueName) { uniqueName_ = uniqueName; }
+// Set name of Module
+void Module::setName(std::string_view uniqueName) { name_ = uniqueName; }
 
 // Return unique name of Module
-std::string_view Module::uniqueName() const { return uniqueName_; }
+std::string_view Module::name() const { return name_; }
 
 /*
  * Keywords
@@ -165,7 +165,7 @@ const std::vector<Module *> &Module::instances() { return instances_; }
 Module *Module::find(std::string_view uniqueName)
 {
     auto it = std::find_if(instances_.begin(), instances_.end(),
-                           [uniqueName](const auto *m) { return DissolveSys::sameString(m->uniqueName(), uniqueName); });
+                           [uniqueName](const auto *m) { return DissolveSys::sameString(m->name(), uniqueName); });
     if (it != instances_.end())
         return *it;
 

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -28,16 +28,16 @@ class Module
     protected:
     // Type name of module
     const std::string typeName_;
-    // Unique name of Module
-    std::string uniqueName_;
+    // Name of Module
+    std::string name_;
 
     public:
     // Return type of Module
     const std::string_view type() const;
-    // Set unique name of Module
-    void setUniqueName(std::string_view uniqueName);
-    // Return unique name of Module
-    std::string_view uniqueName() const;
+    // Set name of Module
+    void setName(std::string_view name);
+    // Return name of Module
+    std::string_view name() const;
 
     /*
      * Keywords

--- a/src/modules/accumulate/gui/accumulatewidget_funcs.cpp
+++ b/src/modules/accumulate/gui/accumulatewidget_funcs.cpp
@@ -59,17 +59,16 @@ void AccumulateModuleWidget::createPartialSetRenderables(std::string_view target
         auto id = DissolveSys::beforeChar(full.tag(), '/');
 
         // Full partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->uniqueName(), targetPrefix, full.tag()),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->name(), targetPrefix, full.tag()),
                                                    fmt::format("{} (Full)", id), "Full");
 
         // Bound partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->uniqueName(), targetPrefix, bound.tag()),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->name(), targetPrefix, bound.tag()),
                                                    fmt::format("{} (Bound)", id), "Bound");
 
         // Unbound partial
-        graph_->createRenderable<RenderableData1D>(
-            fmt::format("{}//{}//{}", module_->uniqueName(), targetPrefix, unbound.tag()), fmt::format("{} (Unbound)", id),
-            "Unbound");
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}", module_->name(), targetPrefix, unbound.tag()),
+                                                   fmt::format("{} (Unbound)", id), "Unbound");
     }
 }
 
@@ -92,12 +91,11 @@ void AccumulateModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlag
 
         if (ui_.PartialsButton->isChecked())
         {
-            targetPartials_ =
-                dissolve_.processingModuleData().valueIf<PartialSetAccumulator>("Accumulation", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSetAccumulator>("Accumulation", module_->name());
             createPartialSetRenderables("Accumulation");
         }
         else
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//Accumulation//Total", module_->uniqueName()), "Total",
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//Accumulation//Total", module_->name()), "Total",
                                                        "Calc");
     }
 

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -31,7 +31,7 @@ bool AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         return Messenger::error("No target module set.\n");
 
     // Print summary of parameters
-    Messenger::print("Accumulate: Source module is '{}'.\n", targetModule->uniqueName());
+    Messenger::print("Accumulate: Source module is '{}'.\n", targetModule->name());
     Messenger::print("Accumulate: Target data to accumulate is '{}'.\n", targetPartialSet().keyword(targetPartialSet_));
     Messenger::print("Accumulate: Save data is {}.\n", DissolveSys::onOff(save_));
     Messenger::print("\n");
@@ -47,17 +47,17 @@ bool AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                                 targetPartialSet().keyword(targetPartialSet_), targetModule->type());
 
     // Find the target data
-    auto targetSet = dissolve.processingModuleData().valueIf<PartialSet>(dataName, targetModule->uniqueName());
+    auto targetSet = dissolve.processingModuleData().valueIf<PartialSet>(dataName, targetModule->name());
     if (!targetSet)
     {
         Messenger::print("Target PartialSet data '{}' in module '{}' does not yet exist.\n",
-                         targetPartialSet().keyword(targetPartialSet_), targetModule->uniqueName());
+                         targetPartialSet().keyword(targetPartialSet_), targetModule->name());
         return true;
     }
 
     // Realise the accumulated partial set
     auto &accumulated = dissolve.processingModuleData().realise<PartialSetAccumulator>(
-        "Accumulation", uniqueName(), GenericItem::ItemFlag::InRestartFileFlag);
+        "Accumulation", name(), GenericItem::ItemFlag::InRestartFileFlag);
 
     accumulated += *targetSet;
 
@@ -66,8 +66,8 @@ bool AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     // Save data if requested
     std::vector<std::string> suffixes = {"gr", "sq", "gr"};
     std::vector<std::string> units = {"r, Angstroms", "Q, Angstroms**-1", "r, Angstroms"};
-    if (save_ && (!MPIRunMaster(
-                     procPool, accumulated.save(uniqueName_, dataName, suffixes[targetPartialSet_], units[targetPartialSet_]))))
+    if (save_ &&
+        (!MPIRunMaster(procPool, accumulated.save(name_, dataName, suffixes[targetPartialSet_], units[targetPartialSet_]))))
         return false;
 
     return true;

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -10,11 +10,11 @@ bool AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
-    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
         return Messenger::error("Analysis failed.\n");
 

--- a/src/modules/atomshake/process.cpp
+++ b/src/modules/atomshake/process.cpp
@@ -16,7 +16,7 @@ bool AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Retrieve control parameters from Configuration
     auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -16,7 +16,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Get options
     Messenger::print("Benchmark: Test timings will be averaged over {} {}.\n", nRepeats_, nRepeats_ == 1 ? "run" : "runs");
@@ -39,7 +39,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(fmt::format("{}_{}_{}.txt", uniqueName(), targetConfiguration_->niceName(), "Generator"),
+        printTimingResult(fmt::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "Generator"),
                           "Configuration generator", timing, save_);
     }
 
@@ -64,7 +64,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(fmt::format("{}_{}_{}.txt", uniqueName(), targetConfiguration_->niceName(), "RDFCells"),
+        printTimingResult(fmt::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "RDFCells"),
                           "RDF (Cells) to half-cell limit", timing, save_);
     }
 
@@ -89,7 +89,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(fmt::format("{}_{}_{}.txt", uniqueName(), targetConfiguration_->niceName(), "RDFSimple"),
+        printTimingResult(fmt::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "RDFSimple"),
                           "RDF (Simple) to half-cell limit", timing, save_);
     }
 
@@ -107,7 +107,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(fmt::format("{}_{}_{}.txt", uniqueName(), targetConfiguration_->niceName(), "IntraEnergy"),
+        printTimingResult(fmt::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "IntraEnergy"),
                           "Intramolecular energy", timing, save_);
     }
 
@@ -125,7 +125,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(fmt::format("{}_{}_{}.txt", uniqueName(), targetConfiguration_->niceName(), "InterEnergy"),
+        printTimingResult(fmt::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "InterEnergy"),
                           "Interatomic energy", timing, save_);
     }
 
@@ -163,7 +163,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(fmt::format("{}_{}_{}.txt", uniqueName(), targetConfiguration_->niceName(), "RegionalDist"),
+        printTimingResult(fmt::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "RegionalDist"),
                           "Distributor (regional)", timing, save_);
     }
 

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -22,7 +22,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, const ProcessPool
                                       bool &alreadyUpToDate)
 {
     // Check to see if the arrays are up-to-date
-    auto braggDataVersion = moduleData.valueOr<int>("Version", uniqueName_, -1);
+    auto braggDataVersion = moduleData.valueOr<int>("Version", name_, -1);
     alreadyUpToDate = braggDataVersion == cfg->contentsVersion();
     if (alreadyUpToDate)
         return true;
@@ -30,14 +30,14 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, const ProcessPool
     // Realise the arrays from the Configuration
     auto &braggKVectors = moduleData.realise<std::vector<KVector>>("KVectors", cfg->niceName());
     auto &braggReflections =
-        moduleData.realise<std::vector<BraggReflection>>("Reflections", uniqueName(), GenericItem::InRestartFileFlag);
-    auto &braggAtomVectorXCos = moduleData.realise<Array2D<double>>("AtomVectorXCos", uniqueName());
-    auto &braggAtomVectorYCos = moduleData.realise<Array2D<double>>("AtomVectorYCos", uniqueName());
-    auto &braggAtomVectorZCos = moduleData.realise<Array2D<double>>("AtomVectorZCos", uniqueName());
-    auto &braggAtomVectorXSin = moduleData.realise<Array2D<double>>("AtomVectorXSin", uniqueName());
-    auto &braggAtomVectorYSin = moduleData.realise<Array2D<double>>("AtomVectorYSin", uniqueName());
-    auto &braggAtomVectorZSin = moduleData.realise<Array2D<double>>("AtomVectorZSin", uniqueName());
-    auto &braggMaximumHKL = moduleData.realise<Vec3<int>>("MaximumHKL", uniqueName());
+        moduleData.realise<std::vector<BraggReflection>>("Reflections", name(), GenericItem::InRestartFileFlag);
+    auto &braggAtomVectorXCos = moduleData.realise<Array2D<double>>("AtomVectorXCos", name());
+    auto &braggAtomVectorYCos = moduleData.realise<Array2D<double>>("AtomVectorYCos", name());
+    auto &braggAtomVectorZCos = moduleData.realise<Array2D<double>>("AtomVectorZCos", name());
+    auto &braggAtomVectorXSin = moduleData.realise<Array2D<double>>("AtomVectorXSin", name());
+    auto &braggAtomVectorYSin = moduleData.realise<Array2D<double>>("AtomVectorYSin", name());
+    auto &braggAtomVectorZSin = moduleData.realise<Array2D<double>>("AtomVectorZSin", name());
+    auto &braggMaximumHKL = moduleData.realise<Vec3<int>>("MaximumHKL", name());
 
     // Grab some useful values
     const auto *box = cfg->box();
@@ -292,7 +292,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, const ProcessPool
     std::for_each(braggReflections.begin(), braggReflections.end(), [divisor](auto &reflxn) { reflxn *= divisor; });
 
     // Store the new version of the data
-    moduleData.realise<int>("Version", uniqueName_) = cfg->contentsVersion();
+    moduleData.realise<int>("Version", name_) = cfg->contentsVersion();
 
     return true;
 }
@@ -302,13 +302,12 @@ bool BraggModule::formReflectionFunctions(GenericList &moduleData, const Process
                                           const double qMin, const double qDelta, const double qMax)
 {
     // Retrieve BraggReflection data from the Configuration's module data
-    const auto &braggReflections = moduleData.value<std::vector<BraggReflection>>("Reflections", uniqueName());
+    const auto &braggReflections = moduleData.value<std::vector<BraggReflection>>("Reflections", name());
     const auto nReflections = braggReflections.size();
 
     // Realise / retrieve storage for the Bragg partial S(Q) and combined F(Q)
     const auto nTypes = cfg->nAtomTypes();
-    auto braggPartialsObject =
-        moduleData.realiseIf<Array2D<Data1D>>("OriginalBragg", uniqueName(), GenericItem::InRestartFileFlag);
+    auto braggPartialsObject = moduleData.realiseIf<Array2D<Data1D>>("OriginalBragg", name(), GenericItem::InRestartFileFlag);
     auto &braggPartials = braggPartialsObject.first;
     if (braggPartialsObject.second == GenericItem::ItemStatus::Created)
     {
@@ -328,7 +327,7 @@ bool BraggModule::formReflectionFunctions(GenericList &moduleData, const Process
         std::fill(braggPartials.begin(), braggPartials.end(), temp);
     }
 
-    auto &braggTotal = moduleData.realise<Data1D>("OriginalBragg//Total", uniqueName(), GenericItem::InRestartFileFlag);
+    auto &braggTotal = moduleData.realise<Data1D>("OriginalBragg//Total", name(), GenericItem::InRestartFileFlag);
     braggTotal.clear();
 
     // Zero Bragg partials
@@ -370,7 +369,7 @@ bool BraggModule::reBinReflections(GenericList &moduleData, const ProcessPool &p
                                    Array2D<Data1D> &braggPartials)
 {
     // Retrieve BraggReflection data
-    const auto &braggReflections = moduleData.value<std::vector<BraggReflection>>("Reflections", uniqueName());
+    const auto &braggReflections = moduleData.value<std::vector<BraggReflection>>("Reflections", name());
     const auto nReflections = braggReflections.size();
 
     const auto nTypes = cfg->nAtomTypes();

--- a/src/modules/bragg/gui/braggwidget_funcs.cpp
+++ b/src/modules/bragg/gui/braggwidget_funcs.cpp
@@ -47,7 +47,7 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
     // Check / update summed atom types data
     if (!reflectionAtomTypesData_)
         reflectionAtomTypesData_ =
-            dissolve_.processingModuleData().valueIf<const AtomTypeMix>("SummedAtomTypes", module_->uniqueName());
+            dissolve_.processingModuleData().valueIf<const AtomTypeMix>("SummedAtomTypes", module_->name());
 
     // Need to recreate renderables if requested as the updateType
     if (updateFlags.isSet(ModuleWidget::RecreateRenderablesFlag))
@@ -56,7 +56,7 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
 
         if (ui_.TotalsButton->isChecked())
         {
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//OriginalBragg//Total", module_->uniqueName()), "Total",
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//OriginalBragg//Total", module_->name()), "Total",
                                                        "Totals");
         }
         else if (ui_.PartialsButton->isChecked())
@@ -70,7 +70,7 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
                     const AtomTypeData &at2 = reflectionAtomTypesData_->get()[second];
                     const std::string id = fmt::format("{}-{}", at1.atomTypeName(), at2.atomTypeName());
 
-                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//OriginalBragg//{}", module_->uniqueName(), id),
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//OriginalBragg//{}", module_->name(), id),
                                                                fmt::format("{}", id), "Full");
                 };
             }
@@ -86,7 +86,7 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
     if (ui_.ReflectionsButton->isChecked())
     {
         auto optReflxns =
-            dissolve_.processingModuleData().valueIf<const std::vector<BraggReflection>>("Reflections", module_->uniqueName());
+            dissolve_.processingModuleData().valueIf<const std::vector<BraggReflection>>("Reflections", module_->name());
         if (!optReflxns)
         {
             reflectionData_ = std::nullopt;
@@ -94,11 +94,10 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
             braggModel_.setReflections(std::nullopt);
         }
         else if (!reflectionData_ || (&reflectionData_->get() != &optReflxns->get()) ||
-                 (reflectionDataDisplayVersion_ !=
-                  dissolve_.processingModuleData().version("Reflections", module_->uniqueName())))
+                 (reflectionDataDisplayVersion_ != dissolve_.processingModuleData().version("Reflections", module_->name())))
         {
             braggModel_.setReflections(optReflxns);
-            reflectionDataDisplayVersion_ = dissolve_.processingModuleData().version("Reflections", module_->uniqueName());
+            reflectionDataDisplayVersion_ = dissolve_.processingModuleData().version("Reflections", module_->name());
 
             // Retrieve the atom types list so we know which reflections correspond to which pairs
             if (reflectionAtomTypesData_)

--- a/src/modules/calculate_angle/angle.cpp
+++ b/src/modules/calculate_angle/angle.cpp
@@ -131,7 +131,7 @@ CalculateAngleModule::CalculateAngleModule() : Module("CalculateAngle"), analyse
     }
     catch (...)
     {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
     }
 
     /*

--- a/src/modules/calculate_angle/gui/calculateanglewidget_funcs.cpp
+++ b/src/modules/calculate_angle/gui/calculateanglewidget_funcs.cpp
@@ -122,24 +122,24 @@ void CalculateAngleModuleWidget::setGraphDataTargets(CalculateAngleModule *modul
 
     // Calculated A...B RDF
     auto rdfAB = rdfABGraph_->createRenderable<RenderableData1D>(
-        fmt::format("{}//Process1D//RDF(AB)", module_->uniqueName(), cfg->niceName()), "A...B g(r)");
+        fmt::format("{}//Process1D//RDF(AB)", module_->name(), cfg->niceName()), "A...B g(r)");
     rdfAB->setColour(StockColours::BlueStockColour);
 
     // Calculated B...C RDF
     auto rdfBC = rdfBCGraph_->createRenderable<RenderableData1D>(
-        fmt::format("{}//Process1D//RDF(BC)", module_->uniqueName(), cfg->niceName()), "B...C g(r)");
+        fmt::format("{}//Process1D//RDF(BC)", module_->name(), cfg->niceName()), "B...C g(r)");
     rdfBC->setColour(StockColours::BlueStockColour);
 
     // Calculated angle histogram
     auto angle = angleGraph_->createRenderable<RenderableData1D>(
-        fmt::format("{}//Process1D//Angle(ABC)", module_->uniqueName(), cfg->niceName()), "A-B...C Angle");
+        fmt::format("{}//Process1D//Angle(ABC)", module_->name(), cfg->niceName()), "A-B...C Angle");
     angle->setColour(StockColours::RedStockColour);
 
     // Calculated (A-B)-C distance-angle map
     dAngleABGraph_->createRenderable<RenderableData2D>(
-        fmt::format("{}//Process2D//DAngle((A-B)-C)", module_->uniqueName(), cfg->niceName()), "A-B vs A-B-C");
+        fmt::format("{}//Process2D//DAngle((A-B)-C)", module_->name(), cfg->niceName()), "A-B vs A-B-C");
 
     // Calculated A-(B-C) distance-angle map
     dAngleBCGraph_->createRenderable<RenderableData2D>(
-        fmt::format("{}//Process2D//DAngle(A-(B-C))", module_->uniqueName(), cfg->niceName()), "B-C vs A-B-C");
+        fmt::format("{}//Process2D//DAngle(A-(B-C))", module_->name(), cfg->niceName()), "B-C vs A-B-C");
 }

--- a/src/modules/calculate_angle/process.cpp
+++ b/src/modules/calculate_angle/process.cpp
@@ -16,7 +16,7 @@ bool CalculateAngleModule::process(Dissolve &dissolve, const ProcessPool &procPo
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Ensure any parameters in our nodes are set correctly
     selectB_->setDistanceReferenceSite(selectA_);
@@ -51,7 +51,7 @@ bool CalculateAngleModule::process(Dissolve &dissolve, const ProcessPool &procPo
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
-    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
         return Messenger::error("CalculateAngle experienced problems with its analysis.\n");
 

--- a/src/modules/calculate_avgmol/functions.cpp
+++ b/src/modules/calculate_avgmol/functions.cpp
@@ -15,9 +15,9 @@ void CalculateAvgMolModule::updateArrays(Dissolve &dissolve)
     auto requiredSize = targetSpecies_ ? targetSpecies_->nAtoms() : -1;
 
     // Retrieve / create the three data arrays, and size accordingly
-    auto &x = dissolve.processingModuleData().realise<SampledVector>("X", uniqueName(), GenericItem::InRestartFileFlag);
-    auto &y = dissolve.processingModuleData().realise<SampledVector>("Y", uniqueName(), GenericItem::InRestartFileFlag);
-    auto &z = dissolve.processingModuleData().realise<SampledVector>("Z", uniqueName(), GenericItem::InRestartFileFlag);
+    auto &x = dissolve.processingModuleData().realise<SampledVector>("X", name(), GenericItem::InRestartFileFlag);
+    auto &y = dissolve.processingModuleData().realise<SampledVector>("Y", name(), GenericItem::InRestartFileFlag);
+    auto &z = dissolve.processingModuleData().realise<SampledVector>("Z", name(), GenericItem::InRestartFileFlag);
 
     if (requiredSize > 0)
     {
@@ -54,9 +54,9 @@ void CalculateAvgMolModule::updateSpecies(const SampledVector &x, const SampledV
 void CalculateAvgMolModule::updateSpecies(const GenericList &moduleData)
 {
     // Retrieve data arrays
-    auto &x = moduleData.value<SampledVector>("X", uniqueName());
-    auto &y = moduleData.value<SampledVector>("Y", uniqueName());
-    auto &z = moduleData.value<SampledVector>("Z", uniqueName());
+    auto &x = moduleData.value<SampledVector>("X", name());
+    auto &y = moduleData.value<SampledVector>("Y", name());
+    auto &z = moduleData.value<SampledVector>("Z", name());
 
     // Update our Species
     updateSpecies(x, y, z);

--- a/src/modules/calculate_avgmol/process.cpp
+++ b/src/modules/calculate_avgmol/process.cpp
@@ -54,7 +54,7 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, const ProcessPool &procP
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Grab Box pointer
     const auto *box = targetConfiguration_->box();
@@ -75,9 +75,9 @@ bool CalculateAvgMolModule::process(Dissolve &dissolve, const ProcessPool &procP
     const auto *stack = targetConfiguration_->siteStack(targetSite_);
 
     // Retrieve data arrays
-    auto &sampledX = dissolve.processingModuleData().retrieve<SampledVector>("X", uniqueName());
-    auto &sampledY = dissolve.processingModuleData().retrieve<SampledVector>("Y", uniqueName());
-    auto &sampledZ = dissolve.processingModuleData().retrieve<SampledVector>("Z", uniqueName());
+    auto &sampledX = dissolve.processingModuleData().retrieve<SampledVector>("X", name());
+    auto &sampledY = dissolve.processingModuleData().retrieve<SampledVector>("Y", name());
+    auto &sampledZ = dissolve.processingModuleData().retrieve<SampledVector>("Z", name());
 
     // Loop over sites
     std::vector<double> rx(targetSpecies_->nAtoms()), ry(targetSpecies_->nAtoms()), rz(targetSpecies_->nAtoms());

--- a/src/modules/calculate_axisangle/axisangle.cpp
+++ b/src/modules/calculate_axisangle/axisangle.cpp
@@ -91,7 +91,7 @@ CalculateAxisAngleModule::CalculateAxisAngleModule() : Module("CalculateAxisAngl
     }
     catch (...)
     {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
     }
 
     /*

--- a/src/modules/calculate_axisangle/gui/calculateaxisanglewidget_funcs.cpp
+++ b/src/modules/calculate_axisangle/gui/calculateaxisanglewidget_funcs.cpp
@@ -70,22 +70,22 @@ void CalculateAxisAngleModuleWidget::updateControls(const Flags<ModuleWidget::Up
         // Calculated A...B RDF
         if (rdfGraph_->renderables().empty())
             rdfGraph_
-                ->createRenderable<RenderableData1D>(
-                    fmt::format("{}//Process1D//RDF(AB)", module_->uniqueName(), cfg->niceName()), "A...B g(r)")
+                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(AB)", module_->name(), cfg->niceName()),
+                                                     "A...B g(r)")
                 ->setColour(StockColours::BlueStockColour);
 
         // Calculated angle histogram
         if (angleGraph_->renderables().empty())
             angleGraph_
                 ->createRenderable<RenderableData1D>(
-                    fmt::format("{}//Process1D//AxisAngle(AB)", module_->uniqueName(), cfg->niceName()), "Axis Angle")
+                    fmt::format("{}//Process1D//AxisAngle(AB)", module_->name(), cfg->niceName()), "Axis Angle")
                 ->setColour(StockColours::RedStockColour);
 
         // Calculated distance-angle map
         if (dAngleGraph_->renderables().empty())
         {
             auto x = dAngleGraph_->createRenderable<RenderableData2D>(
-                fmt::format("{}//Process2D//DAxisAngle", module_->uniqueName(), cfg->niceName()), "A...B vs Axis Angle");
+                fmt::format("{}//Process2D//DAxisAngle", module_->name(), cfg->niceName()), "A...B vs Axis Angle");
             x->colour().setStyle(ColourDefinition::HSVGradientStyle);
         }
     }

--- a/src/modules/calculate_axisangle/process.cpp
+++ b/src/modules/calculate_axisangle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, const ProcessPool &pr
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Ensure any parameters in our nodes are set correctly
     calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
@@ -31,7 +31,7 @@ bool CalculateAxisAngleModule::process(Dissolve &dissolve, const ProcessPool &pr
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
-    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
         return Messenger::error("CalculateAxisAngle experienced problems with its analysis.\n");
 

--- a/src/modules/calculate_cn/cn.cpp
+++ b/src/modules/calculate_cn/cn.cpp
@@ -28,7 +28,7 @@ CalculateCNModule::CalculateCNModule() : Module("CalculateCN"), analyser_(Proced
     }
     catch (...)
     {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
     }
 
     /*

--- a/src/modules/calculate_cn/gui/calculatecnwidget_funcs.cpp
+++ b/src/modules/calculate_cn/gui/calculatecnwidget_funcs.cpp
@@ -37,15 +37,15 @@ void CalculateCNModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFla
 {
     // Update CN labels
     ui_.RegionAResultFrame->setText(
-        dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//A", module_->uniqueName(), SampledDouble()));
+        dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//A", module_->name(), SampledDouble()));
     auto rangeBOn = module_->isRangeBEnabled();
     ui_.RegionBResultFrame->setText(
-        rangeBOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//B", module_->uniqueName(), SampledDouble())
+        rangeBOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//B", module_->name(), SampledDouble())
                  : SampledDouble());
     ui_.RegionBResultFrame->setEnabled(rangeBOn);
     auto rangeCOn = module_->isRangeCEnabled();
     ui_.RegionCResultFrame->setText(
-        rangeCOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//C", module_->uniqueName(), SampledDouble())
+        rangeCOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//C", module_->name(), SampledDouble())
                  : SampledDouble());
     ui_.RegionCResultFrame->setEnabled(rangeCOn);
 
@@ -60,7 +60,7 @@ void CalculateCNModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFla
             return;
 
         const auto *rdfModule = optRDFModule->get();
-        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF", rdfModule->uniqueName()), "RDF");
+        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF", rdfModule->name()), "RDF");
     }
 
     // Validate renderables if they need it

--- a/src/modules/calculate_cn/process.cpp
+++ b/src/modules/calculate_cn/process.cpp
@@ -24,7 +24,7 @@ bool CalculateCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Execute the analysis on the Configuration targeted by the RDF module
     ProcedureContext context(procPool, sourceRDF_->keywords().get<Configuration *>("Configuration"));
-    context.setDataListAndPrefix(dissolve.processingModuleData(), fmt::format("{}//Analyser", uniqueName()));
+    context.setDataListAndPrefix(dissolve.processingModuleData(), fmt::format("{}//Analyser", name()));
     if (!analyser_.execute(context))
         return Messenger::error("CalculateCN experienced problems with its analysis.\n");
 

--- a/src/modules/calculate_dangle/dangle.cpp
+++ b/src/modules/calculate_dangle/dangle.cpp
@@ -92,7 +92,7 @@ CalculateDAngleModule::CalculateDAngleModule() : Module("CalculateDAngle"), anal
     }
     catch (...)
     {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
     }
 
     /*

--- a/src/modules/calculate_dangle/gui/calculatedanglewidget_funcs.cpp
+++ b/src/modules/calculate_dangle/gui/calculatedanglewidget_funcs.cpp
@@ -65,22 +65,20 @@ void CalculateDAngleModuleWidget::updateControls(const Flags<ModuleWidget::Updat
 
     // Calculated B...C RDF
     if (rdfGraph_->renderables().empty())
-        rdfGraph_
-            ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(BC)", module_->uniqueName()), "B...C g(r)")
+        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(BC)", module_->name()), "B...C g(r)")
             ->setColour(StockColours::BlueStockColour);
 
     // Calculated angle histogram
     if (angleGraph_->renderables().empty())
         angleGraph_
-            ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//Angle(ABC)", module_->uniqueName()),
-                                                 "A-B...C Angle")
+            ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//Angle(ABC)", module_->name()), "A-B...C Angle")
             ->setColour(StockColours::RedStockColour);
 
     // Calculated distance-angle map
     if (dAngleGraph_->renderables().empty())
     {
-        auto x = dAngleGraph_->createRenderable<RenderableData2D>(
-            fmt::format("{}//Process2D//DAngle(A-BC)", module_->uniqueName()), "B...C vs A-B...C");
+        auto x = dAngleGraph_->createRenderable<RenderableData2D>(fmt::format("{}//Process2D//DAngle(A-BC)", module_->name()),
+                                                                  "B...C vs A-B...C");
         x->colour().setStyle(ColourDefinition::HSVGradientStyle);
     }
 

--- a/src/modules/calculate_dangle/process.cpp
+++ b/src/modules/calculate_dangle/process.cpp
@@ -15,7 +15,7 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, const ProcessPool &procP
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Ensure any parameters in our nodes are set correctly
     calculateAngle_->keywords().set("Symmetric", symmetric_);
@@ -31,7 +31,7 @@ bool CalculateDAngleModule::process(Dissolve &dissolve, const ProcessPool &procP
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
-    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
         return Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
 

--- a/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
+++ b/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
@@ -39,7 +39,7 @@ void CalculateRDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFl
         auto *cfg = module_->keywords().get<Configuration *>("Configuration");
         if (cfg)
             rdfGraph_
-                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF", module_->uniqueName(), cfg->niceName()),
+                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF", module_->name(), cfg->niceName()),
                                                      fmt::format("RDF//{}", cfg->niceName()), cfg->niceName())
                 ->setColour(StockColours::BlueStockColour);
     }

--- a/src/modules/calculate_rdf/process.cpp
+++ b/src/modules/calculate_rdf/process.cpp
@@ -13,7 +13,7 @@ bool CalculateRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);
@@ -24,7 +24,7 @@ bool CalculateRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
-    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
         return Messenger::error("CalculateRDF experienced problems with its analysis.\n");
 

--- a/src/modules/calculate_rdf/rdf.cpp
+++ b/src/modules/calculate_rdf/rdf.cpp
@@ -49,7 +49,7 @@ CalculateRDFModule::CalculateRDFModule() : Module("CalculateRDF"), analyser_(Pro
     }
     catch (...)
     {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
     }
 
     /*

--- a/src/modules/calculate_sdf/gui/calculatesdfwidget_funcs.cpp
+++ b/src/modules/calculate_sdf/gui/calculatesdfwidget_funcs.cpp
@@ -78,7 +78,7 @@ void CalculateSDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFl
     // Create SDF renderable if it doesn't already exist
     if (!sdfRenderable_)
     {
-        sdfRenderable_ = sdfGraph_->createRenderable<RenderableData3D>(fmt::format("{}//Process3D//SDF", module_->uniqueName()),
+        sdfRenderable_ = sdfGraph_->createRenderable<RenderableData3D>(fmt::format("{}//Process3D//SDF", module_->name()),
                                                                        fmt::format("SDF"));
         sdfRenderable_->setColour(StockColours::BlueStockColour);
         auto *cfg = module_->keywords().get<Configuration *>("Configuration");

--- a/src/modules/calculate_sdf/process.cpp
+++ b/src/modules/calculate_sdf/process.cpp
@@ -14,7 +14,7 @@ bool CalculateSDFModule::process(Dissolve &dissolve, const ProcessPool &procPool
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Ensure any parameters in our nodes are set correctly
     collectVector_->keywords().set("RangeX", rangeX_);
@@ -27,7 +27,7 @@ bool CalculateSDFModule::process(Dissolve &dissolve, const ProcessPool &procPool
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
-    context.setDataListAndPrefix(dissolve.processingModuleData(), uniqueName());
+    context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
         return Messenger::error("CalculateSDF experienced problems with its analysis.\n");
 

--- a/src/modules/calculate_sdf/sdf.cpp
+++ b/src/modules/calculate_sdf/sdf.cpp
@@ -48,7 +48,7 @@ CalculateSDFModule::CalculateSDFModule() : Module("CalculateSDF"), analyser_(Pro
     }
     catch (...)
     {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", uniqueName_);
+        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
     }
 
     /*

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -17,7 +17,7 @@ bool ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     Messenger::print("Checks: Threshold for distance checks is {} Angstroms\n", distanceThreshold_);
     Messenger::print("Checks: Threshold for angle checks is {} degrees\n", angleThreshold_);

--- a/src/modules/energy/gui/energywidget_funcs.cpp
+++ b/src/modules/energy/gui/energywidget_funcs.cpp
@@ -59,7 +59,7 @@ void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
         // Clear any existing renderables
         energyGraph_->clearRenderables();
 
-        auto prefix = fmt::format("{}//{}", module_->uniqueName(), cfg->niceName());
+        auto prefix = fmt::format("{}//{}", module_->name(), cfg->niceName());
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Total", prefix), "Total", "Totals");
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Inter", prefix), "Inter", "Totals")
             ->setColour(StockColours::RedStockColour);

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -33,7 +33,7 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     auto strategy = procPool.bestStrategy();
 
@@ -332,27 +332,27 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
         // Store current energies in the Configuration in case somebody else needs them
         auto &interData = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Inter", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Inter", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         interData.addPoint(dissolve.iteration(), interEnergy);
         auto &intraData = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Intra", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Intra", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         intraData.addPoint(dissolve.iteration(), intraEnergy);
         auto &bondData = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Bond", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Bond", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         bondData.addPoint(dissolve.iteration(), bondEnergy);
         auto &angleData = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Angle", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Angle", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         angleData.addPoint(dissolve.iteration(), angleEnergy);
         auto &torsionData = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Torsions", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Torsions", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         torsionData.addPoint(dissolve.iteration(), torsionEnergy);
         auto &improperData = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Impropers", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Impropers", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         improperData.addPoint(dissolve.iteration(), improperEnergy);
 
         // Append to arrays of total energies
         auto &totalEnergyArray = dissolve.processingModuleData().realise<Data1D>(
-            fmt::format("{}//Total", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+            fmt::format("{}//Total", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
         totalEnergyArray.addPoint(dissolve.iteration(), interEnergy + intraEnergy);
 
         // Determine stability of energy

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -13,11 +13,11 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWra
 {
     // Find the relevant data if we were not provided them
     if (!optCalculatedSQ)
-        optCalculatedSQ = processingData.valueIf<Array2D<Data1D>>("UnweightedSQ", uniqueName_);
+        optCalculatedSQ = processingData.valueIf<Array2D<Data1D>>("UnweightedSQ", name_);
     if (!optCalculatedSQ)
         return;
     if (!optEstimatedSQ)
-        optEstimatedSQ = processingData.valueIf<Array2D<Data1D>>("EstimatedSQ", uniqueName_);
+        optEstimatedSQ = processingData.valueIf<Array2D<Data1D>>("EstimatedSQ", name_);
     if (!optEstimatedSQ)
         return;
 
@@ -26,7 +26,7 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWra
     assert(calculatedSQ.nRows() == estimatedSQ.nRows() && calculatedSQ.nColumns() == estimatedSQ.nColumns());
 
     // Realise the DeltaSQ array
-    auto [deltaSQ, status] = processingData.realiseIf<Array2D<Data1D>>("DeltaSQ", uniqueName_, GenericItem::ItemFlag::NoFlags);
+    auto [deltaSQ, status] = processingData.realiseIf<Array2D<Data1D>>("DeltaSQ", name_, GenericItem::ItemFlag::NoFlags);
     if (status == GenericItem::ItemStatus::Created)
         deltaSQ.initialise(calculatedSQ.nRows(), calculatedSQ.nRows(), true);
 
@@ -43,8 +43,8 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWra
 Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(Dissolve &dissolve, const int nAtomTypes,
                                                                 std::optional<int> ncoeffp)
 {
-    auto &coefficients = dissolve.processingModuleData().realise<Array2D<std::vector<double>>>(
-        "PotentialCoefficients", uniqueName_, GenericItem::InRestartFileFlag);
+    auto &coefficients = dissolve.processingModuleData().realise<Array2D<std::vector<double>>>("PotentialCoefficients", name_,
+                                                                                               GenericItem::InRestartFileFlag);
 
     auto arrayNCoeffP = (coefficients.nRows() && coefficients.nColumns() ? coefficients[{0, 0}].size() : 0);
     if ((coefficients.nRows() != nAtomTypes) || (coefficients.nColumns() != nAtomTypes) ||

--- a/src/modules/epsr/gui/epsrwidget_funcs.cpp
+++ b/src/modules/epsr/gui/epsrwidget_funcs.cpp
@@ -75,17 +75,17 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             for (auto *targetModule : module_->targets())
             {
                 // Reference data
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", targetModule->uniqueName()),
-                                                           fmt::format("{} (Exp)", targetModule->uniqueName()), "Exp");
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", targetModule->name()),
+                                                           fmt::format("{} (Exp)", targetModule->name()), "Exp");
 
                 // Calculated F(Q)
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedSQ//Total", targetModule->uniqueName()),
-                                                           fmt::format("{} (Calc)", targetModule->uniqueName()), "Calc");
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedSQ//Total", targetModule->name()),
+                                                           fmt::format("{} (Calc)", targetModule->name()), "Calc");
 
                 // F(Q) diff w.r.t. reference
                 graph_->createRenderable<RenderableData1D>(
-                    fmt::format("{}//Difference//{}", module_->uniqueName(), targetModule->uniqueName()),
-                    fmt::format("{} (Delta)", targetModule->uniqueName()), "Delta");
+                    fmt::format("{}//Difference//{}", module_->name(), targetModule->name()),
+                    fmt::format("{} (Delta)", targetModule->name()), "Delta");
             }
         }
         else if (ui_.DeltaFQButton->isChecked())
@@ -94,12 +94,12 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             for (auto *targetModule : module_->targets())
             {
                 graph_->createRenderable<RenderableData1D>(
-                    fmt::format("{}//DeltaFQ//{}", module_->uniqueName(), targetModule->uniqueName()),
-                    fmt::format("{} (Delta)", targetModule->uniqueName()), "Delta");
+                    fmt::format("{}//DeltaFQ//{}", module_->name(), targetModule->name()),
+                    fmt::format("{} (Delta)", targetModule->name()), "Delta");
 
                 graph_->createRenderable<RenderableData1D>(
-                    fmt::format("{}//DeltaFQFit//{}", module_->uniqueName(), targetModule->uniqueName()),
-                    fmt::format("{} (Fit)", targetModule->uniqueName()), "Fit");
+                    fmt::format("{}//DeltaFQFit//{}", module_->name(), targetModule->name()),
+                    fmt::format("{} (Fit)", targetModule->name()), "Fit");
             }
         }
         else if (ui_.EstimatedSQButton->isChecked())
@@ -112,15 +112,15 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
                 const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 
                 // Unweighted estimated partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedSQ//{}", module_->uniqueName(), id),
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedSQ//{}", module_->name(), id),
                                                            fmt::format("{} (Estimated)", id), "Estimated");
 
                 // Calculated / summed partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//{}", module_->uniqueName(), id),
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//{}", module_->name(), id),
                                                            fmt::format("{} (Calc)", id), "Calc");
 
                 // Deltas
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//DeltaSQ//{}", module_->uniqueName(), id),
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//DeltaSQ//{}", module_->name(), id),
                                                            fmt::format("{} (Delta)", id), "Delta");
             }
         }
@@ -135,14 +135,14 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
                 if (!optSQModule)
                     Messenger::error("Couldn't get any S(Q) data from the first target module, so underlying partial g(r) will "
                                      "be unavailable.",
-                                     module_->uniqueName());
+                                     module_->name());
                 else
                 {
                     auto optRDFModule =
                         optSQModule.value().get()->keywords().get<const RDFModule *, ModuleKeyword<const RDFModule>>(
                             "SourceRDFs");
                     if (optRDFModule)
-                        rdfModuleName = optRDFModule.value().get()->uniqueName();
+                        rdfModuleName = optRDFModule.value().get()->name();
                     else
                         rdfModuleName = "UNKNOWN_RDF_MODULE";
                 }
@@ -157,7 +157,7 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
                 const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 
                 // Experimentally-determined unweighted partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedGR//{}", module_->uniqueName(), id),
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedGR//{}", module_->name(), id),
                                                            fmt::format("{} (Estimated)", id), "Estimated");
 
                 // Calculated / summed partials, taken from the RDF module referenced by the first module target
@@ -170,13 +170,13 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             for (auto *targetModule : module_->targets())
             {
                 // Reference F(r) (from direct FT of input data)
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", targetModule->uniqueName()),
-                                                           fmt::format("{} (Exp)", targetModule->uniqueName()), "Exp");
+                graph_->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", targetModule->name()),
+                                                           fmt::format("{} (Exp)", targetModule->name()), "Exp");
 
                 // Simulated F(r) (from FT of the calculated F(Q))
                 graph_->createRenderable<RenderableData1D>(
-                    fmt::format("{}//SimulatedFR//{}", module_->uniqueName(), targetModule->uniqueName()),
-                    fmt::format("{} (Calc)", targetModule->uniqueName()), "Calc");
+                    fmt::format("{}//SimulatedFR//{}", module_->name(), targetModule->name()),
+                    fmt::format("{} (Calc)", targetModule->name()), "Calc");
             }
         }
         else if (ui_.PotentialsButton->isChecked())
@@ -197,26 +197,25 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             graph_->groupManager().removeVerticalShifts();
 
             // Add total R-factor followed by those for each target
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//RFactor", module_->uniqueName()), "Total", "Total")
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//RFactor", module_->name()), "Total", "Total")
                 ->lineStyle()
                 .setStipple(LineStipple::HalfDashStipple);
 
             for (auto *targetModule : module_->targets())
                 graph_->createRenderable<RenderableData1D>(
-                    fmt::format("{}//RFactor//{}", module_->uniqueName(), targetModule->uniqueName()),
-                    targetModule->uniqueName(), "RFactor");
+                    fmt::format("{}//RFactor//{}", module_->name(), targetModule->name()), targetModule->name(), "RFactor");
         }
         else if (ui_.EReqButton->isChecked())
         {
             // Add phi magnitude data
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//EPMag", module_->uniqueName()), "EReq", "EReq");
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//EPMag", module_->name()), "EReq", "EReq");
         }
     }
 
     // Set information labels
-    auto eReqArray = dissolve_.processingModuleData().valueIf<Data1D>("EPMag", module_->uniqueName());
+    auto eReqArray = dissolve_.processingModuleData().valueIf<Data1D>("EPMag", module_->name());
     ui_.EReqValueLabel->setText(eReqArray ? QString::number(eReqArray->get().values().back()) : "--");
-    auto rFactorArray = dissolve_.processingModuleData().valueIf<Data1D>("RFactor", module_->uniqueName());
+    auto rFactorArray = dissolve_.processingModuleData().valueIf<Data1D>("RFactor", module_->name());
     ui_.RFactorValueLabel->setText(rFactorArray ? QString::number(rFactorArray->get().values().back()) : "--");
 
     // Validate renderables if they need it

--- a/src/modules/epsr/io.cpp
+++ b/src/modules/epsr/io.cpp
@@ -121,7 +121,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, const ProcessPool &procPool, std::
 
     // Retrieve and zero the current potential coefficients file
     auto &potentialCoefficients = dissolve.processingModuleData().realise<Array2D<std::vector<double>>>(
-        "PotentialCoefficients", uniqueName_, GenericItem::InRestartFileFlag);
+        "PotentialCoefficients", name_, GenericItem::InRestartFileFlag);
     potentialCoefficients.initialise(dissolve.nAtomTypes(), dissolve.nAtomTypes(), true);
     for (auto &n : potentialCoefficients)
     {
@@ -196,7 +196,7 @@ bool EPSRModule::readFitCoefficients(Dissolve &dissolve, const ProcessPool &proc
         // Data file index
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return Messenger::error("Failed to read initial parameters from inpa file.\n");
-        Messenger::print("Reading fit coefficients for data file {} ({})...\n", parser.argi(0), target->uniqueName());
+        Messenger::print("Reading fit coefficients for data file {} ({})...\n", parser.argi(0), target->name());
 
         // Number of coefficients, stepsize in r, sigma2
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
@@ -210,7 +210,7 @@ bool EPSRModule::readFitCoefficients(Dissolve &dissolve, const ProcessPool &proc
             return Messenger::error("Number of potential coefficients ({}) does not match ncoeffp ({}).\n", parser.nArgs(),
                                     nCoeff);
         auto &fitCoefficients = dissolve.processingModuleData().realise<std::vector<double>>(
-            fmt::format("FitCoefficients_{}", target->uniqueName()), uniqueName_, GenericItem::InRestartFileFlag);
+            fmt::format("FitCoefficients_{}", target->name()), name_, GenericItem::InRestartFileFlag);
         fitCoefficients.resize(nCoeff);
         for (auto i = 0; i < nCoeff; ++i)
             fitCoefficients[i] = parser.argd(i);

--- a/src/modules/export_coordinates/process.cpp
+++ b/src/modules/export_coordinates/process.cpp
@@ -19,7 +19,7 @@ bool ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &pro
 
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Only the pool master saves the data
     if (procPool.isMaster())

--- a/src/modules/export_trajectory/process.cpp
+++ b/src/modules/export_trajectory/process.cpp
@@ -17,7 +17,7 @@ bool ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
 
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Only the pool master saves the data
     if (procPool.isMaster())

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -15,10 +15,10 @@ bool ForcesModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 {
     if (referenceForces_.hasFilename())
     {
-        Messenger::print("[SETUP {}] Reading test reference forces.\n", uniqueName_);
+        Messenger::print("[SETUP {}] Reading test reference forces.\n", name_);
 
         // Realise and read the force array
-        auto &f = dissolve.processingModuleData().realise<std::vector<Vec3<double>>>("ReferenceForces", uniqueName());
+        auto &f = dissolve.processingModuleData().realise<std::vector<Vec3<double>>>("ReferenceForces", name());
 
         // Read in the forces
         if (!referenceForces_.importData(f, &procPool))
@@ -33,7 +33,7 @@ bool ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Retrieve control parameters
     const auto saveData = exportedForces_.hasFilename();
@@ -390,10 +390,10 @@ bool ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Vec3<double> totalRatio;
         sumError = 0.0;
         GenericList &processingData = dissolve.processingModuleData();
-        if (processingData.contains("ReferenceForces", uniqueName()))
+        if (processingData.contains("ReferenceForces", name()))
         {
             // Grab reference force array and check size
-            const auto &fRef = processingData.value<std::vector<Vec3<double>>>("ReferenceForces", uniqueName());
+            const auto &fRef = processingData.value<std::vector<Vec3<double>>>("ReferenceForces", name());
             if (fRef.size() != targetConfiguration_->nAtoms())
                 return Messenger::error("Number of force components in ReferenceForces is {}, but the "
                                         "Configuration '{}' contains {} atoms.\n",
@@ -494,7 +494,7 @@ bool ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
         // Realise the force vector
         auto &f = dissolve.processingModuleData().realise<std::vector<Vec3<double>>>(
-            fmt::format("{}//Forces", targetConfiguration_->niceName()), uniqueName());
+            fmt::format("{}//Forces", targetConfiguration_->niceName()), name());
         f.resize(targetConfiguration_->nAtoms());
 
         // Calculate forces

--- a/src/modules/geomopt/process.cpp
+++ b/src/modules/geomopt/process.cpp
@@ -18,7 +18,7 @@ bool GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Initialise working arrays for coordinates and forces
     rRef_.resize(targetConfiguration_->nAtoms(), Vec3<double>());

--- a/src/modules/import_trajectory/process.cpp
+++ b/src/modules/import_trajectory/process.cpp
@@ -12,7 +12,7 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     Messenger::print("Import: Reading trajectory file frame from '{}' into Configuration '{}'...\n",
                      trajectoryFormat_.filename(), targetConfiguration_->name());
@@ -24,10 +24,10 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
 
     // Does a seek position exist in the processing module info?
     std::string streamPosName = fmt::format("TrajectoryPosition_{}", targetConfiguration_->niceName());
-    if (dissolve.processingModuleData().contains(streamPosName, uniqueName()))
+    if (dissolve.processingModuleData().contains(streamPosName, name()))
     {
         // Retrieve the streampos and go to it in the file
-        std::streampos trajPos = dissolve.processingModuleData().retrieve<std::streampos>(streamPosName, uniqueName());
+        std::streampos trajPos = dissolve.processingModuleData().retrieve<std::streampos>(streamPosName, name());
         parser.seekg(trajPos);
     }
 
@@ -38,7 +38,7 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
     targetConfiguration_->incrementContentsVersion();
 
     // Set the trajectory file position in the restart file
-    dissolve.processingModuleData().realise<std::streampos>(streamPosName, uniqueName(), GenericItem::InRestartFileFlag) =
+    dissolve.processingModuleData().realise<std::streampos>(streamPosName, name(), GenericItem::InRestartFileFlag) =
         parser.tellg();
 
     // Handle the unit cell if one was provided

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -19,7 +19,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Retrieve control parameters
     auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -16,7 +16,7 @@
 bool MDModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals)
 {
     if (actionSignals.isSet(KeywordBase::ClearModuleData))
-        dissolve.processingModuleData().removeWithPrefix(uniqueName());
+        dissolve.processingModuleData().removeWithPrefix(name());
 
     return true;
 }
@@ -26,7 +26,7 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Get control parameters
     const auto maxForce = capForcesAt_ * 100.0; // To convert from kJ/mol to 10 J/mol
@@ -117,7 +117,7 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Read in or assign random velocities
     auto [velocities, status] = dissolve.processingModuleData().realiseIf<std::vector<Vec3<double>>>(
-        fmt::format("{}//Velocities", targetConfiguration_->niceName()), uniqueName(), GenericItem::InRestartFileFlag);
+        fmt::format("{}//Velocities", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     if ((status == GenericItem::ItemStatus::Created || randomVelocities_) && !intramolecularForcesOnly_)
     {
         Messenger::print("Random initial velocities will be assigned.\n");

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -18,7 +18,7 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // Retrieve control parameters from Configuration
     auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());

--- a/src/modules/neutronsq/gui/neutronsqwidget_funcs.cpp
+++ b/src/modules/neutronsq/gui/neutronsqwidget_funcs.cpp
@@ -71,15 +71,15 @@ void NeutronSQModuleWidget::createPartialSetRenderables(std::string_view targetP
             continue;
 
         // Full partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->uniqueName(), targetPrefix, id),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->name(), targetPrefix, id),
                                                    fmt::format("{} (Full)", id), "Full");
 
         // Bound partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->uniqueName(), targetPrefix, id),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->name(), targetPrefix, id),
                                                    fmt::format("{} (Bound)", id), "Bound");
 
         // Unbound partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Unbound", module_->uniqueName(), targetPrefix, id),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Unbound", module_->name(), targetPrefix, id),
                                                    fmt::format("{} (Unbound)", id), "Unbound");
     }
 }
@@ -101,48 +101,48 @@ void NeutronSQModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags
 
         if (ui_.TotalFQButton->isChecked())
         {
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedSQ//Total", module_->uniqueName()),
-                                                       "Total F(Q)", "Calculated");
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedSQ//Total", module_->name()), "Total F(Q)",
+                                                       "Calculated");
             auto boundTotal = graph_->createRenderable<RenderableData1D>(
-                fmt::format("{}//WeightedSQ//BoundTotal", module_->uniqueName()), "Bound F(Q)", "Calculated");
+                fmt::format("{}//WeightedSQ//BoundTotal", module_->name()), "Bound F(Q)", "Calculated");
             boundTotal->setColour(StockColours::GreenStockColour);
             boundTotal->lineStyle().setStipple(LineStipple::DotStipple);
             auto unboundTotal = graph_->createRenderable<RenderableData1D>(
-                fmt::format("{}//WeightedSQ//UnboundTotal", module_->uniqueName()), "Unbound F(Q)", "Calculated");
+                fmt::format("{}//WeightedSQ//UnboundTotal", module_->name()), "Unbound F(Q)", "Calculated");
             unboundTotal->setColour(StockColours::GreenStockColour);
             unboundTotal->lineStyle().setStipple(LineStipple::HalfDashStipple);
 
             // Add on reference F(Q) data if present
             if (referenceFileAndFormat.hasFilename())
                 graph_
-                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", module_->uniqueName()),
-                                                         "Reference F(Q)", "Reference")
+                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", module_->name()), "Reference F(Q)",
+                                                         "Reference")
                     ->setColour(StockColours::RedStockColour);
         }
         else if (ui_.PartialSQButton->isChecked())
         {
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedSQ", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedSQ", module_->name());
             createPartialSetRenderables("WeightedSQ");
         }
         else if (ui_.TotalGRButton->isChecked())
         {
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedGR//Total", module_->uniqueName()),
-                                                       "Calculated", "Calculated");
-            auto repGR = graph_->createRenderable<RenderableData1D>(
-                fmt::format("{}//RepresentativeTotalGR", module_->uniqueName()), "Via FT", "Calculated");
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedGR//Total", module_->name()), "Calculated",
+                                                       "Calculated");
+            auto repGR = graph_->createRenderable<RenderableData1D>(fmt::format("{}//RepresentativeTotalGR", module_->name()),
+                                                                    "Via FT", "Calculated");
             repGR->lineStyle().setStipple(LineStipple::HalfDashStipple);
             repGR->setColour(StockColours::GreenStockColour);
 
             // Add on reference G(r) (from FT of F(Q)) if present
             if (referenceFileAndFormat.hasFilename())
                 graph_
-                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", module_->uniqueName()),
+                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", module_->name()),
                                                          "Reference G(r) (via FT)", "Reference")
                     ->setColour(StockColours::RedStockColour);
         }
         else if (ui_.PartialGRButton->isChecked())
         {
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedGR", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedGR", module_->name());
             createPartialSetRenderables("WeightedGR");
         }
     }

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -296,7 +296,7 @@ bool RDFModule::calculateGR(GenericList &processingData, const ProcessPool &proc
                             bool &alreadyUpToDate)
 {
     // Does a PartialSet already exist for this Configuration?
-    auto originalGRObject = processingData.realiseIf<PartialSet>(fmt::format("{}//OriginalGR", cfg->niceName()), uniqueName_,
+    auto originalGRObject = processingData.realiseIf<PartialSet>(fmt::format("{}//OriginalGR", cfg->niceName()), name_,
                                                                  GenericItem::InRestartFileFlag);
     auto &originalgr = originalGRObject.first;
     if (originalGRObject.second == GenericItem::ItemStatus::Created)

--- a/src/modules/rdf/gui/rdfwidget_funcs.cpp
+++ b/src/modules/rdf/gui/rdfwidget_funcs.cpp
@@ -74,17 +74,16 @@ void RDFModuleWidget::createPartialSetRenderables(std::string_view targetPrefix)
             continue;
 
         // Full partial
-        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->uniqueName(), targetPrefix, id),
+        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->name(), targetPrefix, id),
                                                       fmt::format("{} (Full)", id), "Full");
 
         // Bound partial
-        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->uniqueName(), targetPrefix, id),
+        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->name(), targetPrefix, id),
                                                       fmt::format("{} (Bound)", id), "Bound");
 
         // Unbound partial
-        rdfGraph_->createRenderable<RenderableData1D>(
-            fmt::format("{}//{}//{}//Unbound", module_->uniqueName(), targetPrefix, id), fmt::format("{} (Unbound)", id),
-            "Unbound");
+        rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Unbound", module_->name(), targetPrefix, id),
+                                                      fmt::format("{} (Unbound)", id), "Unbound");
     }
 }
 
@@ -107,20 +106,19 @@ void RDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &upd
 
         if (ui_.SummedPartialsButton->isChecked())
         {
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("UnweightedGR", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("UnweightedGR", module_->name());
             createPartialSetRenderables("UnweightedGR");
         }
         else if (ui_.ConfigurationPartialsButton->isChecked())
         {
             auto targetPrefix = fmt::format("{}//UnweightedGR", (*optConfig)->niceName());
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>(targetPrefix, module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>(targetPrefix, module_->name());
             createPartialSetRenderables(targetPrefix);
         }
         else
             for (auto *cfg : cfgs)
                 rdfGraph_->createRenderable<RenderableData1D>(
-                    fmt::format("{}//{}//UnweightedGR//Total", module_->uniqueName(), cfg->niceName()), cfg->niceName(),
-                    "Total");
+                    fmt::format("{}//{}//UnweightedGR//Total", module_->name(), cfg->niceName()), cfg->niceName(), "Total");
     }
 
     // Validate renderables if they need it

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -19,7 +19,7 @@ bool RDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Check for zero Configuration targets
     if (targetConfigurations_.empty())
-        return Messenger::error("No configuration targets set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration targets set for module '{}'.\n", name());
 
     // Print argument/parameter summary
     if (useHalfCellRange_)
@@ -82,7 +82,7 @@ bool RDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         bool alreadyUpToDate;
         calculateGR(dissolve.processingModuleData(), procPool, cfg, partialsMethod_, rdfRange, binWidth_, alreadyUpToDate);
         auto &originalgr =
-            dissolve.processingModuleData().retrieve<PartialSet>(fmt::format("{}//OriginalGR", cfg->niceName()), uniqueName_);
+            dissolve.processingModuleData().retrieve<PartialSet>(fmt::format("{}//OriginalGR", cfg->niceName()), name_);
 
         // Perform averagingLength_ of unweighted partials if requested, and if we're not already up-to-date
         if ((averagingLength_ > 1) && (!alreadyUpToDate))
@@ -91,7 +91,7 @@ bool RDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             std::string currentFingerprint{originalgr.fingerprint()};
 
             Averaging::average<PartialSet>(dissolve.processingModuleData(), fmt::format("{}//OriginalGR", cfg->niceName()),
-                                           uniqueName_, averagingLength_, averagingScheme_);
+                                           name_, averagingLength_, averagingScheme_);
 
             // Re-set the object names and fingerprints of the partials
             originalgr.setFingerprint(currentFingerprint);
@@ -110,21 +110,21 @@ bool RDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
         // Form unweighted g(r) from original g(r), applying any requested nSmooths_ / intramolecular broadening
         auto &unweightedgr = dissolve.processingModuleData().realise<PartialSet>(
-            fmt::format("{}//UnweightedGR", cfg->niceName()), uniqueName_, GenericItem::InRestartFileFlag);
+            fmt::format("{}//UnweightedGR", cfg->niceName()), name_, GenericItem::InRestartFileFlag);
         calculateUnweightedGR(procPool, cfg, originalgr, unweightedgr, intraBroadening_, nSmooths_);
 
         // Save data if requested
-        if (save_ && (!MPIRunMaster(procPool, unweightedgr.save(uniqueName_, "UnweightedGR", "gr", "r, Angstroms"))))
+        if (save_ && (!MPIRunMaster(procPool, unweightedgr.save(name_, "UnweightedGR", "gr", "r, Angstroms"))))
             return false;
     }
 
     // Create/retrieve PartialSet for summed unweighted g(r)
     auto &summedUnweightedGR =
-        dissolve.processingModuleData().realise<PartialSet>("UnweightedGR", uniqueName_, GenericItem::InRestartFileFlag);
+        dissolve.processingModuleData().realise<PartialSet>("UnweightedGR", name_, GenericItem::InRestartFileFlag);
 
     // Sum the partials from the associated Configurations
-    if (!RDFModule::sumUnweightedGR(dissolve.processingModuleData(), procPool, uniqueName(), uniqueName(),
-                                    targetConfigurations_, summedUnweightedGR))
+    if (!RDFModule::sumUnweightedGR(dissolve.processingModuleData(), procPool, name(), name(), targetConfigurations_,
+                                    summedUnweightedGR))
         return false;
 
     return true;

--- a/src/modules/registry.cpp
+++ b/src/modules/registry.cpp
@@ -125,9 +125,8 @@ const std::map<std::string, std::vector<ModuleRegistry::ModuleInfoData>> &Module
 std::unique_ptr<Module> ModuleRegistry::create(std::string_view moduleType)
 {
     auto m = std::unique_ptr<Module>(instance().produce(std::string(moduleType)));
-    m->setUniqueName(DissolveSys::uniqueName(m->type(), Module::instances(), [&](const auto &inst) {
-        return inst == m.get() ? std::string() : inst->uniqueName();
-    }));
+    m->setName(DissolveSys::uniqueName(m->type(), Module::instances(),
+                                       [&](const auto &inst) { return inst == m.get() ? std::string() : inst->name(); }));
     return m;
 }
 

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -10,7 +10,7 @@ bool SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // MODULE CODE
 

--- a/src/modules/sq/gui/sqwidget_funcs.cpp
+++ b/src/modules/sq/gui/sqwidget_funcs.cpp
@@ -70,17 +70,16 @@ void SQModuleWidget::createPartialSetRenderables(std::string_view targetPrefix)
             continue;
 
         // Full partial
-        sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->uniqueName(), targetPrefix, id),
+        sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->name(), targetPrefix, id),
                                                      fmt::format("{} (Full)", id), "Full");
 
         // Bound partial
-        sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->uniqueName(), targetPrefix, id),
+        sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->name(), targetPrefix, id),
                                                      fmt::format("{} (Bound)", id), "Bound");
 
         // Unbound partial
-        sqGraph_->createRenderable<RenderableData1D>(
-            fmt::format("{}//{}//{}//Unbound", module_->uniqueName(), targetPrefix, id), fmt::format("{} (Unbound)", id),
-            "Unbound");
+        sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Unbound", module_->name(), targetPrefix, id),
+                                                     fmt::format("{} (Unbound)", id), "Unbound");
     }
 }
 
@@ -97,11 +96,11 @@ void SQModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &upda
 
         if (ui_.PartialsButton->isChecked())
         {
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("UnweightedSQ", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("UnweightedSQ", module_->name());
             createPartialSetRenderables("UnweightedSQ");
         }
         else
-            sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//Total", module_->uniqueName()), "Total",
+            sqGraph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//Total", module_->name()), "Total",
                                                          "Calc");
     }
 

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -9,7 +9,7 @@ bool TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", uniqueName());
+        return Messenger::error("No configuration target set for module '{}'.\n", name());
 
     // MODULE CODE
 

--- a/src/modules/xraysq/gui/xraysqwidget_funcs.cpp
+++ b/src/modules/xraysq/gui/xraysqwidget_funcs.cpp
@@ -69,15 +69,15 @@ void XRaySQModuleWidget::createPartialSetRenderables(std::string_view targetPref
             continue;
 
         // Full partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->uniqueName(), targetPrefix, id),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Full", module_->name(), targetPrefix, id),
                                                    fmt::format("{} (Full)", id), "Full");
 
         // Bound partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->uniqueName(), targetPrefix, id),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Bound", module_->name(), targetPrefix, id),
                                                    fmt::format("{} (Bound)", id), "Bound");
 
         // Unbound partial
-        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Unbound", module_->uniqueName(), targetPrefix, id),
+        graph_->createRenderable<RenderableData1D>(fmt::format("{}//{}//{}//Unbound", module_->name(), targetPrefix, id),
                                                    fmt::format("{} (Unbound)", id), "Unbound");
     }
 }
@@ -99,48 +99,48 @@ void XRaySQModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
 
         if (ui_.TotalFQButton->isChecked())
         {
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedSQ//Total", module_->uniqueName()),
-                                                       "Calculated", "Calculated");
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedSQ//Total", module_->name()), "Calculated",
+                                                       "Calculated");
             auto boundTotal = graph_->createRenderable<RenderableData1D>(
-                fmt::format("{}//WeightedSQ//BoundTotal", module_->uniqueName()), "Bound F(Q)", "Calculated");
+                fmt::format("{}//WeightedSQ//BoundTotal", module_->name()), "Bound F(Q)", "Calculated");
             boundTotal->setColour(StockColours::GreenStockColour);
             boundTotal->lineStyle().setStipple(LineStipple::DotStipple);
             auto unboundTotal = graph_->createRenderable<RenderableData1D>(
-                fmt::format("{}//WeightedSQ//UnboundTotal", module_->uniqueName()), "Unbound F(Q)", "Calculated");
+                fmt::format("{}//WeightedSQ//UnboundTotal", module_->name()), "Unbound F(Q)", "Calculated");
             unboundTotal->setColour(StockColours::GreenStockColour);
             unboundTotal->lineStyle().setStipple(LineStipple::HalfDashStipple);
 
             // Add on reference F(Q) data if present
             if (referenceFileAndFormat.hasFilename())
                 graph_
-                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", module_->uniqueName()),
-                                                         "Reference F(Q)", "Reference")
+                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceData", module_->name()), "Reference F(Q)",
+                                                         "Reference")
                     ->setColour(StockColours::RedStockColour);
         }
         else if (ui_.PartialSQButton->isChecked())
         {
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedSQ", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedSQ", module_->name());
             createPartialSetRenderables("WeightedSQ");
         }
         else if (ui_.TotalGRButton->isChecked())
         {
-            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedGR//Total", module_->uniqueName()),
-                                                       "Calculated", "Calculated");
-            auto repGR = graph_->createRenderable<RenderableData1D>(
-                fmt::format("{}//RepresentativeTotalGR", module_->uniqueName()), "Via FT", "Calculated");
+            graph_->createRenderable<RenderableData1D>(fmt::format("{}//WeightedGR//Total", module_->name()), "Calculated",
+                                                       "Calculated");
+            auto repGR = graph_->createRenderable<RenderableData1D>(fmt::format("{}//RepresentativeTotalGR", module_->name()),
+                                                                    "Via FT", "Calculated");
             repGR->lineStyle().setStipple(LineStipple::HalfDashStipple);
             repGR->setColour(StockColours::GreenStockColour);
 
             // Add on reference G(r) (from FT of F(Q)) if present
             if (referenceFileAndFormat.hasFilename())
                 graph_
-                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", module_->uniqueName()),
+                    ->createRenderable<RenderableData1D>(fmt::format("{}//ReferenceDataFT", module_->name()),
                                                          "Reference G(r) (via FT)", "Reference")
                     ->setColour(StockColours::RedStockColour);
         }
         else if (ui_.PartialGRButton->isChecked())
         {
-            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedGR", module_->uniqueName());
+            targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>("WeightedGR", module_->name());
             createPartialSetRenderables("WeightedGR");
         }
     }

--- a/src/procedure/nodes/nodereference.cpp
+++ b/src/procedure/nodes/nodereference.cpp
@@ -94,7 +94,7 @@ bool ProcedureNodeReference::read(LineParser &parser, int startArg, const CoreDa
 bool ProcedureNodeReference::write(LineParser &parser, std::string_view prefix)
 {
     if (analyseModuleParent_)
-        return parser.writeLineF("{}  '{}'  '{}'\n", prefix, node_->name(), analyseModuleParent_->uniqueName());
+        return parser.writeLineF("{}  '{}'  '{}'\n", prefix, node_->name(), analyseModuleParent_->name());
     else
         return parser.writeLineF("{}  '{}'\n", prefix, node_->name());
 }


### PR DESCRIPTION
This PR is a simple fix to enforce "nice names" (i.e. no spaces or specific special characters) for modules and isotopologues, and to also enforce unique names for the latter, when edited through the GUI and when loaded in initially.

At the same time, the `Module` variable `uniqueName_` is renamed to just `name_`, since the uniqueness is implicit (and we don't call any other object names by the same convention).

Closes #1073.
Closes #1075.