### PR TITLE
Const correctness of deserialiser

### DIFF
--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -18,7 +18,14 @@ class Serialisable
     // Express as a tree node
     virtual SerialisedValue serialise() const = 0;
     // Read values from a tree node
-    virtual void deserialise(SerialisedValue &node) { return; }
+    virtual void deserialise(const SerialisedValue &node) { return; }
+
+    /* Functions that hook into the toml11 library */
+    // Wrapper for deserialise that toml11 will check for
+    void from_toml(const toml::value &node) { deserialise(node); }
+    // wrapper for serialise that toml11 will check for
+    toml::value into_toml() const { return serialise(); }
+
     // A helper function to add elements of a vector to a node under the named heading
     template <typename T>
     static void fromVectorToTable(const std::vector<std::shared_ptr<T>> &vector, std::string name, SerialisedValue &node)
@@ -72,18 +79,18 @@ class Serialisable
     }
 
     // Act over each value in a node table, if the key exists
-    template <typename Lambda> static void toMap(SerialisedValue &node, std::string key, Lambda action)
+    template <typename Lambda> static void toMap(const SerialisedValue &node, std::string key, Lambda action)
     {
         if (node.contains(key))
-            for (auto &[key, value] : node[key].as_table())
+            for (auto &[key, value] : toml::find<toml::table>(node, key))
                 action(key, value);
     }
 
     // Act over each value in a node table, if the key exists
-    template <typename Lambda> static void toVector(SerialisedValue &node, std::string key, Lambda action)
+    template <typename Lambda> static void toVector(const SerialisedValue &node, std::string key, Lambda action)
     {
         if (node.contains(key))
-            for (auto &item : node[key].as_array())
+            for (auto &item : toml::find<toml::array>(node, key))
                 action(item);
     }
 };

--- a/src/classes/coredata.h
+++ b/src/classes/coredata.h
@@ -79,7 +79,7 @@ class CoreData
 
         // Serialisation
         SerialisedValue serialise() const override;
-        void deserialise(SerialisedValue &node) override;
+        void deserialise(const SerialisedValue &node) override;
     };
     // Master terms
     Masters masters_;
@@ -88,7 +88,7 @@ class CoreData
     // Express Master terms as tree node
     SerialisedValue serialiseMaster() const;
     // Read Master values from tree node
-    void deserialiseMaster(SerialisedValue &node);
+    void deserialiseMaster(const SerialisedValue &node);
     // Add new master Bond parameters
     MasterBond &addMasterBond(std::string_view name);
     // Return number of master Bond parameters in list

--- a/src/classes/isotopologue.cpp
+++ b/src/classes/isotopologue.cpp
@@ -92,7 +92,7 @@ SerialisedValue Isotopologue::serialise() const
     return isotopologue;
 }
 
-void Isotopologue::deserialise(SerialisedValue &node, CoreData &coreData)
+void Isotopologue::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     for (auto &[name, value] : node.as_table())
     {

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -65,5 +65,5 @@ class Isotopologue : public Serialisable
 
     // Express as a tree node
     SerialisedValue serialise() const override;
-    void deserialise(SerialisedValue &node, CoreData &coreData);
+    void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/masters.cpp
+++ b/src/classes/masters.cpp
@@ -15,18 +15,18 @@ SerialisedValue CoreData::Masters::serialise() const
 
 void CoreData::Masters::deserialise(const SerialisedValue &node)
 {
-    Serialisable::toMap(node, "bonds",
-                        [this](const std::string &name, const SerialisedValue &bond)
-                        { bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond); });
-    Serialisable::toMap(node, "angles",
-                        [this](const std::string &name, const SerialisedValue &angle)
-                        { angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle); });
-    Serialisable::toMap(node, "torsions",
-                        [this](const std::string &name, const SerialisedValue &torsion)
-                        { torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion); });
-    Serialisable::toMap(node, "impropers",
-                        [this](const std::string &name, const SerialisedValue &improper)
-                        { impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper); });
+    Serialisable::toMap(node, "bonds", [this](const std::string &name, const SerialisedValue &bond) {
+        bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond);
+    });
+    Serialisable::toMap(node, "angles", [this](const std::string &name, const SerialisedValue &angle) {
+        angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle);
+    });
+    Serialisable::toMap(node, "torsions", [this](const std::string &name, const SerialisedValue &torsion) {
+        torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion);
+    });
+    Serialisable::toMap(node, "impropers", [this](const std::string &name, const SerialisedValue &improper) {
+        impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper);
+    });
     return;
 }
 

--- a/src/classes/masters.cpp
+++ b/src/classes/masters.cpp
@@ -13,24 +13,24 @@ SerialisedValue CoreData::Masters::serialise() const
     return node;
 }
 
-void CoreData::Masters::deserialise(SerialisedValue &node)
+void CoreData::Masters::deserialise(const SerialisedValue &node)
 {
-    Serialisable::toMap(node, "bonds", [this](const std::string &name, SerialisedValue &bond) {
-        bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond);
-    });
-    Serialisable::toMap(node, "angles", [this](const std::string &name, SerialisedValue &angle) {
-        angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle);
-    });
-    Serialisable::toMap(node, "torsions", [this](const std::string &name, SerialisedValue &torsion) {
-        torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion);
-    });
-    Serialisable::toMap(node, "impropers", [this](const std::string &name, SerialisedValue &improper) {
-        impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper);
-    });
+    Serialisable::toMap(node, "bonds",
+                        [this](const std::string &name, const SerialisedValue &bond)
+                        { bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond); });
+    Serialisable::toMap(node, "angles",
+                        [this](const std::string &name, const SerialisedValue &angle)
+                        { angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle); });
+    Serialisable::toMap(node, "torsions",
+                        [this](const std::string &name, const SerialisedValue &torsion)
+                        { torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion); });
+    Serialisable::toMap(node, "impropers",
+                        [this](const std::string &name, const SerialisedValue &improper)
+                        { impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper); });
     return;
 }
 
 // Express Master terms as tree node
 SerialisedValue CoreData::serialiseMaster() const { return masters_.serialise(); }
 // Read Master values from tree node
-void CoreData::deserialiseMaster(SerialisedValue &node) { masters_.deserialise(node); }
+void CoreData::deserialiseMaster(const SerialisedValue &node) { masters_.deserialise(node); }

--- a/src/classes/serializablepairpotential.cpp
+++ b/src/classes/serializablepairpotential.cpp
@@ -52,25 +52,22 @@ SerialisedValue SerializablePairPotential::serialise() const
 }
 
 // This method populates the object's members with values read from a 'pairPotentials' TOML node
-void SerializablePairPotential::deserialise(SerialisedValue &node)
+void SerializablePairPotential::deserialise(const SerialisedValue &node)
 {
     if (node.contains("range"))
-        range_ = node["range"].as_floating();
+        range_ = toml::find<double>(node, "range");
     if (node.contains("delta"))
-        delta_ = node["delta"].as_floating();
+        delta_ = toml::find<double>(node, "delta");
     if (node.contains("includeCoulomb"))
-        atomTypeChargeSource_ = node["includeCoulomb"].as_boolean();
+        atomTypeChargeSource_ = toml::find<bool>(node, "includeCoulomb");
     if (node.contains("coulombTruncation"))
-        coulombTruncationScheme_ =
-            PairPotential::coulombTruncationSchemes().enumeration(std::string(node["coulombTruncation"].as_string()));
+        coulombTruncationScheme_ = PairPotential::coulombTruncationSchemes().enumeration(
+            std::string(toml::find<std::string>(node, "coulombTruncation")));
     if (node.contains("shortRangeTruncation"))
-        shortRangeTruncationScheme_ =
-            PairPotential::shortRangeTruncationSchemes().enumeration(std::string(node["shortRangeTruncation"].as_string()));
+        shortRangeTruncationScheme_ = PairPotential::shortRangeTruncationSchemes().enumeration(
+            std::string(toml::find<std::string>(node, "shortRangeTruncation")));
 
     if (node.contains("atomTypes"))
-    {
-        toml::value atomTypesNode = node["atomTypes"];
-        for (auto &[name, data] : atomTypesNode.as_table())
+        for (auto &[name, data] : toml::find(node, "atomTypes").as_table())
             atomTypes_.emplace_back(std::make_unique<AtomType>(name))->deserialise(data);
-    }
 }

--- a/src/classes/serializablepairpotential.h
+++ b/src/classes/serializablepairpotential.h
@@ -46,5 +46,5 @@ class SerializablePairPotential : public Serialisable
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -223,39 +223,51 @@ SerialisedValue Species::serialise() const
 }
 
 // Read values from a tree node
-void Species::deserialise(SerialisedValue &node, CoreData &coreData)
+void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     auto tomlAtoms = toml::find(node, "atoms").as_array();
     for (auto &tomlAtom : tomlAtoms)
         atoms_.emplace_back().deserialise(tomlAtom);
 
-    Serialisable::toVector(node, "bonds", [this, &coreData](SerialisedValue &bond) {
-        bonds_.emplace_back(&atoms_[bond["i"].as_integer() - 1], &atoms_[bond["j"].as_integer() - 1])
-            .deserialise(bond, coreData);
-    });
-    Serialisable::toVector(node, "angles", [this, &coreData](SerialisedValue &angle) {
-        angles_
-            .emplace_back(&atoms_[angle["i"].as_integer() - 1], &atoms_[angle["j"].as_integer() - 1],
-                          &atoms_[angle["k"].as_integer() - 1])
-            .deserialise(angle, coreData);
-    });
-    Serialisable::toVector(node, "impropers", [this, &coreData](SerialisedValue &improper) {
-        impropers_
-            .emplace_back(&atoms_[improper["i"].as_integer() - 1], &atoms_[improper["j"].as_integer() - 1],
-                          &atoms_[improper["k"].as_integer() - 1], &atoms_[improper["l"].as_integer() - 1])
-            .deserialise(improper, coreData);
-    });
-    Serialisable::toVector(node, "torsions", [this, &coreData](SerialisedValue &torsion) {
-        torsions_
-            .emplace_back(&atoms_[torsion["i"].as_integer() - 1], &atoms_[torsion["j"].as_integer() - 1],
-                          &atoms_[torsion["k"].as_integer() - 1], &atoms_[torsion["l"].as_integer() - 1])
-            .deserialise(torsion, coreData);
-    });
+    Serialisable::toVector(
+        node, "bonds",
+        [this, &coreData](const SerialisedValue &bond)
+        {
+            bonds_.emplace_back(&atoms_[toml::find<int>(bond, "i") - 1], &atoms_[toml::find<int>(bond, "j") - 1])
+                .deserialise(bond, coreData);
+        });
+    Serialisable::toVector(node, "angles",
+                           [this, &coreData](const SerialisedValue &angle)
+                           {
+                               angles_
+                                   .emplace_back(&atoms_[toml::find<int>(angle, "i") - 1],
+                                                 &atoms_[toml::find<int>(angle, "j") - 1],
+                                                 &atoms_[toml::find<int>(angle, "k") - 1])
+                                   .deserialise(angle, coreData);
+                           });
+    Serialisable::toVector(node, "impropers",
+                           [this, &coreData](const SerialisedValue &improper)
+                           {
+                               impropers_
+                                   .emplace_back(
+                                       &atoms_[toml::find<int>(improper, "i") - 1], &atoms_[toml::find<int>(improper, "j") - 1],
+                                       &atoms_[toml::find<int>(improper, "k") - 1], &atoms_[toml::find<int>(improper, "l") - 1])
+                                   .deserialise(improper, coreData);
+                           });
+    Serialisable::toVector(node, "torsions",
+                           [this, &coreData](const SerialisedValue &torsion)
+                           {
+                               torsions_
+                                   .emplace_back(
+                                       &atoms_[toml::find<int>(torsion, "i") - 1], &atoms_[toml::find<int>(torsion, "j") - 1],
+                                       &atoms_[toml::find<int>(torsion, "k") - 1], &atoms_[toml::find<int>(torsion, "l") - 1])
+                                   .deserialise(torsion, coreData);
+                           });
 
-    Serialisable::toVector(node, "isotopologues", [this, &coreData](SerialisedValue &iso) {
-        isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData);
-    });
-    Serialisable::toVector(node, "sites", [this, &coreData](SerialisedValue &site) {
-        sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site);
-    });
+    Serialisable::toVector(node, "isotopologues",
+                           [this, &coreData](const SerialisedValue &iso)
+                           { isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData); });
+    Serialisable::toVector(node, "sites",
+                           [this, &coreData](const SerialisedValue &site)
+                           { sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site); });
 }

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -228,25 +228,25 @@ void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
     atoms_ = toml::find<std::vector<SpeciesAtom>>(node, "atoms");
 
     Serialisable::toVector(node, "bonds", [this, &coreData](const SerialisedValue &bond) {
-        bonds_.emplace_back(&atoms_[toml::find<int>(bond, "i") - 1], &atoms_[toml::find<int>(bond, "j") - 1])
+        bonds_.emplace_back(&atoms_.at(toml::find<int>(bond, "i") - 1), &atoms_.at(toml::find<int>(bond, "j") - 1))
             .deserialise(bond, coreData);
     });
     Serialisable::toVector(node, "angles", [this, &coreData](const SerialisedValue &angle) {
         angles_
-            .emplace_back(&atoms_[toml::find<int>(angle, "i") - 1], &atoms_[toml::find<int>(angle, "j") - 1],
-                          &atoms_[toml::find<int>(angle, "k") - 1])
+            .emplace_back(&atoms_.at(toml::find<int>(angle, "i") - 1), &atoms_.at(toml::find<int>(angle, "j") - 1),
+                          &atoms_.at(toml::find<int>(angle, "k") - 1))
             .deserialise(angle, coreData);
     });
     Serialisable::toVector(node, "impropers", [this, &coreData](const SerialisedValue &improper) {
         impropers_
-            .emplace_back(&atoms_[toml::find<int>(improper, "i") - 1], &atoms_[toml::find<int>(improper, "j") - 1],
-                          &atoms_[toml::find<int>(improper, "k") - 1], &atoms_[toml::find<int>(improper, "l") - 1])
+            .emplace_back(&atoms_.at(toml::find<int>(improper, "i") - 1), &atoms_.at(toml::find<int>(improper, "j") - 1),
+                          &atoms_.at(toml::find<int>(improper, "k") - 1), &atoms_.at(toml::find<int>(improper, "l") - 1))
             .deserialise(improper, coreData);
     });
     Serialisable::toVector(node, "torsions", [this, &coreData](const SerialisedValue &torsion) {
         torsions_
-            .emplace_back(&atoms_[toml::find<int>(torsion, "i") - 1], &atoms_[toml::find<int>(torsion, "j") - 1],
-                          &atoms_[toml::find<int>(torsion, "k") - 1], &atoms_[toml::find<int>(torsion, "l") - 1])
+            .emplace_back(&atoms_.at(toml::find<int>(torsion, "i") - 1), &atoms_.at(toml::find<int>(torsion, "j") - 1),
+                          &atoms_.at(toml::find<int>(torsion, "k") - 1), &atoms_.at(toml::find<int>(torsion, "l") - 1))
             .deserialise(torsion, coreData);
     });
 

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -264,9 +264,9 @@ void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
                                    .deserialise(torsion, coreData);
                            });
 
-    Serialisable::toMap(node, "isotopologues",
-                        [this, &coreData](std::string name, const SerialisedValue &iso)
-                        { isotopologues_.emplace_back(std::make_unique<Isotopologue>(name))->deserialise(iso, coreData); });
+    Serialisable::toVector(node, "isotopologues",
+                           [this, &coreData](const SerialisedValue &iso)
+                           { isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData); });
     Serialisable::toVector(node, "sites",
                            [this, &coreData](const SerialisedValue &site)
                            { sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site); });

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -225,7 +225,7 @@ SerialisedValue Species::serialise() const
 // Read values from a tree node
 void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
-    auto tomlAtoms = toml::find(node, "atoms").as_array();
+    auto tomlAtoms = toml::find<toml::array>(node, "atoms");
     for (auto &tomlAtom : tomlAtoms)
         atoms_.emplace_back().deserialise(tomlAtom);
 
@@ -264,9 +264,9 @@ void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
                                    .deserialise(torsion, coreData);
                            });
 
-    Serialisable::toVector(node, "isotopologues",
-                           [this, &coreData](const SerialisedValue &iso)
-                           { isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData); });
+    Serialisable::toMap(node, "isotopologues",
+                        [this, &coreData](std::string name, const SerialisedValue &iso)
+                        { isotopologues_.emplace_back(std::make_unique<Isotopologue>(name))->deserialise(iso, coreData); });
     Serialisable::toVector(node, "sites",
                            [this, &coreData](const SerialisedValue &site)
                            { sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site); });

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -225,9 +225,7 @@ SerialisedValue Species::serialise() const
 // Read values from a tree node
 void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
-    auto tomlAtoms = toml::find<toml::array>(node, "atoms");
-    for (auto &tomlAtom : tomlAtoms)
-        atoms_.emplace_back().deserialise(tomlAtom);
+    atoms_ = toml::find<std::vector<SpeciesAtom>>(node, "atoms");
 
     Serialisable::toVector(
         node, "bonds",

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -227,45 +227,33 @@ void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     atoms_ = toml::find<std::vector<SpeciesAtom>>(node, "atoms");
 
-    Serialisable::toVector(
-        node, "bonds",
-        [this, &coreData](const SerialisedValue &bond)
-        {
-            bonds_.emplace_back(&atoms_[toml::find<int>(bond, "i") - 1], &atoms_[toml::find<int>(bond, "j") - 1])
-                .deserialise(bond, coreData);
-        });
-    Serialisable::toVector(node, "angles",
-                           [this, &coreData](const SerialisedValue &angle)
-                           {
-                               angles_
-                                   .emplace_back(&atoms_[toml::find<int>(angle, "i") - 1],
-                                                 &atoms_[toml::find<int>(angle, "j") - 1],
-                                                 &atoms_[toml::find<int>(angle, "k") - 1])
-                                   .deserialise(angle, coreData);
-                           });
-    Serialisable::toVector(node, "impropers",
-                           [this, &coreData](const SerialisedValue &improper)
-                           {
-                               impropers_
-                                   .emplace_back(
-                                       &atoms_[toml::find<int>(improper, "i") - 1], &atoms_[toml::find<int>(improper, "j") - 1],
-                                       &atoms_[toml::find<int>(improper, "k") - 1], &atoms_[toml::find<int>(improper, "l") - 1])
-                                   .deserialise(improper, coreData);
-                           });
-    Serialisable::toVector(node, "torsions",
-                           [this, &coreData](const SerialisedValue &torsion)
-                           {
-                               torsions_
-                                   .emplace_back(
-                                       &atoms_[toml::find<int>(torsion, "i") - 1], &atoms_[toml::find<int>(torsion, "j") - 1],
-                                       &atoms_[toml::find<int>(torsion, "k") - 1], &atoms_[toml::find<int>(torsion, "l") - 1])
-                                   .deserialise(torsion, coreData);
-                           });
+    Serialisable::toVector(node, "bonds", [this, &coreData](const SerialisedValue &bond) {
+        bonds_.emplace_back(&atoms_[toml::find<int>(bond, "i") - 1], &atoms_[toml::find<int>(bond, "j") - 1])
+            .deserialise(bond, coreData);
+    });
+    Serialisable::toVector(node, "angles", [this, &coreData](const SerialisedValue &angle) {
+        angles_
+            .emplace_back(&atoms_[toml::find<int>(angle, "i") - 1], &atoms_[toml::find<int>(angle, "j") - 1],
+                          &atoms_[toml::find<int>(angle, "k") - 1])
+            .deserialise(angle, coreData);
+    });
+    Serialisable::toVector(node, "impropers", [this, &coreData](const SerialisedValue &improper) {
+        impropers_
+            .emplace_back(&atoms_[toml::find<int>(improper, "i") - 1], &atoms_[toml::find<int>(improper, "j") - 1],
+                          &atoms_[toml::find<int>(improper, "k") - 1], &atoms_[toml::find<int>(improper, "l") - 1])
+            .deserialise(improper, coreData);
+    });
+    Serialisable::toVector(node, "torsions", [this, &coreData](const SerialisedValue &torsion) {
+        torsions_
+            .emplace_back(&atoms_[toml::find<int>(torsion, "i") - 1], &atoms_[toml::find<int>(torsion, "j") - 1],
+                          &atoms_[toml::find<int>(torsion, "k") - 1], &atoms_[toml::find<int>(torsion, "l") - 1])
+            .deserialise(torsion, coreData);
+    });
 
-    Serialisable::toVector(node, "isotopologues",
-                           [this, &coreData](const SerialisedValue &iso)
-                           { isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData); });
-    Serialisable::toVector(node, "sites",
-                           [this, &coreData](const SerialisedValue &site)
-                           { sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site); });
+    Serialisable::toVector(node, "isotopologues", [this, &coreData](const SerialisedValue &iso) {
+        isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData);
+    });
+    Serialisable::toVector(node, "sites", [this, &coreData](const SerialisedValue &site) {
+        sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site);
+    });
 }

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -375,5 +375,5 @@ class Species : public Serialisable
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node, CoreData &coreData);
+    void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesangle.cpp
+++ b/src/classes/speciesangle.cpp
@@ -376,7 +376,7 @@ SerialisedValue SpeciesAngle::serialise() const
     return angle;
 }
 // This method populates the object's members with values read from an 'angle' TOML node
-void SpeciesAngle::deserialise(SerialisedValue &node, CoreData &coreData)
+void SpeciesAngle::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     deserialiseForm(node, [&coreData](auto &form) { return coreData.getMasterAngle(form); });
 }

--- a/src/classes/speciesangle.h
+++ b/src/classes/speciesangle.h
@@ -103,7 +103,7 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node, CoreData &coreData);
+    void deserialise(const SerialisedValue &node, CoreData &coreData);
 };
 
 // MasterAngle Definition

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -474,7 +474,7 @@ void SpeciesAtom::deserialise(const SerialisedValue &node)
     index_ = toml::find<int>(node, "index") - 1;
     Z_ = Elements::element(toml::find<std::string>(node, "z"));
 
-    auto r = toml::find<std::vector<int>>(node, "r");
+    auto r = toml::find<std::vector<double>>(node, "r");
     r_ = Vec3<double>(r[0], r[1], r[2]);
 
     charge_ = toml::find_or<double>(node, "charge", 0);

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -463,7 +463,7 @@ SerialisedValue SpeciesAtom::serialise() const
     SerialisedValue atom;
     atom["index"] = userIndex();
     atom["z"] = Elements::symbol(Z_).data();
-    atom["r"] = toml::array{r_.x, r_.y, r_.z};
+    atom["r"] = r_;
     atom["charge"] = charge_;
     atom["type"] = atomType_->name().data();
     return atom;
@@ -474,8 +474,7 @@ void SpeciesAtom::deserialise(const SerialisedValue &node)
     index_ = toml::find<int>(node, "index") - 1;
     Z_ = Elements::element(toml::find<std::string>(node, "z"));
 
-    auto r = toml::find<std::vector<double>>(node, "r");
-    r_ = Vec3<double>(r[0], r[1], r[2]);
+    r_ = toml::find<Vec3<double>>(node, "r");
 
     charge_ = toml::find_or<double>(node, "charge", 0);
 

--- a/src/classes/speciesatom.cpp
+++ b/src/classes/speciesatom.cpp
@@ -468,20 +468,20 @@ SerialisedValue SpeciesAtom::serialise() const
     atom["type"] = atomType_->name().data();
     return atom;
 }
-void SpeciesAtom::deserialise(SerialisedValue &node)
+void SpeciesAtom::deserialise(const SerialisedValue &node)
 {
-    index_ = node["index"].as_integer() - 1;
-    Z_ = Elements::element(std::string(node["z"].as_string()));
 
-    std::vector r = node["r"].as_array();
-    r_ = Vec3<double>(r[0].as_floating(), r[1].as_floating(), r[2].as_floating());
+    index_ = toml::find<int>(node, "index") - 1;
+    Z_ = Elements::element(toml::find<std::string>(node, "z"));
 
-    if (node.contains("charge"))
-        charge_ = node["charge"].as_floating();
+    auto r = toml::find<std::vector<int>>(node, "r");
+    r_ = Vec3<double>(r[0], r[1], r[2]);
+
+    charge_ = toml::find_or<double>(node, "charge", 0);
 
     if (node.contains("type") && Z_ != Elements::Unknown)
     {
         atomType_ = std::make_shared<AtomType>(AtomType(Z_));
-        atomType_->setName(std::string(node["type"].as_string()));
+        atomType_->setName(toml::find<std::string>(node, "type"));
     }
 }

--- a/src/classes/speciesatom.h
+++ b/src/classes/speciesatom.h
@@ -191,5 +191,5 @@ class SpeciesAtom : public Serialisable
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -347,7 +347,7 @@ SerialisedValue SpeciesBond::serialise() const
     return bond;
 }
 // This method populates the object's members with values read from a 'bond' TOML node
-void SpeciesBond::deserialise(SerialisedValue &node, CoreData &coreData)
+void SpeciesBond::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     deserialiseForm(node, [&coreData](auto &form) { return coreData.getMasterBond(form); });
 }

--- a/src/classes/speciesbond.cpp
+++ b/src/classes/speciesbond.cpp
@@ -346,6 +346,7 @@ SerialisedValue SpeciesBond::serialise() const
 
     return bond;
 }
+
 // This method populates the object's members with values read from a 'bond' TOML node
 void SpeciesBond::deserialise(const SerialisedValue &node, CoreData &coreData)
 {

--- a/src/classes/speciesbond.h
+++ b/src/classes/speciesbond.h
@@ -129,7 +129,7 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node, CoreData &coreData);
+    void deserialise(const SerialisedValue &node, CoreData &coreData);
 };
 
 // MasterBond Definition

--- a/src/classes/speciesimproper.cpp
+++ b/src/classes/speciesimproper.cpp
@@ -241,7 +241,7 @@ SerialisedValue SpeciesImproper::serialise() const
     return improper;
 }
 // This method populates the object's members with values read from an 'improper' TOML node
-void SpeciesImproper::deserialise(SerialisedValue &node, CoreData &coreData)
+void SpeciesImproper::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     deserialiseForm(node, [&coreData](auto &form) { return coreData.getMasterImproper(form); });
 }

--- a/src/classes/speciesimproper.h
+++ b/src/classes/speciesimproper.h
@@ -90,7 +90,7 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node, CoreData &coreData);
+    void deserialise(const SerialisedValue &node, CoreData &coreData);
 };
 
 // MasterImproper Definition

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -174,7 +174,7 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
         if (node.contains("form"))
         {
             auto form = toml::find<std::string>(node, "form");
-            if (form.find("@") != std::string::npos)
+            if (form.find("@") == 0)
             {
                 auto master = lambda(form);
                 if (!master)

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -173,7 +173,7 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     {
         if (node.contains("form"))
         {
-            std::string form = toml::find<std::string>(node, "form");
+            auto form = toml::find<std::string>(node, "form");
             if (form.find("@") != std::string::npos)
             {
                 auto master = lambda(form);

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -156,23 +156,20 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     // Return identifying name (if a master term)
     virtual std::string_view name() const { return ""; };
     // Load parameters from tree node
-    void deserialiseParameters(SerialisedValue &node)
+    void deserialiseParameters(const SerialisedValue &node)
     {
         if (node.contains("parameters"))
         {
             std::vector<std::string> parameters = Functions::parameters(interactionForm());
-            std::vector<double> values;
-            for (auto parameter : parameters)
-                values.push_back(node["parameters"][parameter].as_floating());
-            setInteractionFormAndParameters(interactionForm(), values);
+            setInteractionFormAndParameters(interactionForm(), toml::find<std::vector<double>>(node, "parameters"));
         }
     }
     // Load form from tree node
-    template <typename Lambda> void deserialiseForm(SerialisedValue &node, Lambda lambda)
+    template <typename Lambda> void deserialiseForm(const SerialisedValue &node, Lambda lambda)
     {
         if (node.contains("form"))
         {
-            std::string form = node["form"].as_string();
+            std::string form = toml::find<std::string>(node, "form");
             if (form.find("@") != std::string::npos)
             {
                 auto master = lambda(form);
@@ -186,11 +183,11 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
         deserialiseParameters(node);
     }
     // Deserialise the form and parameters
-    void deserialise(SerialisedValue &node) override
+    void deserialise(const SerialisedValue &node) override
     {
         if (node.contains("form"))
         {
-            std::string form = node["form"].as_string();
+            auto form = toml::find<std::string>(node, "form");
             setInteractionForm(Functions::forms().enumeration(form));
         }
         deserialiseParameters(node);

--- a/src/classes/speciesintra.h
+++ b/src/classes/speciesintra.h
@@ -160,8 +160,12 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     {
         if (node.contains("parameters"))
         {
-            std::vector<std::string> parameters = Functions::parameters(interactionForm());
-            setInteractionFormAndParameters(interactionForm(), toml::find<std::vector<double>>(node, "parameters"));
+            auto names = Functions::parameters(interactionForm());
+            auto map = toml::find<std::map<std::string, double>>(node, "parameters");
+            std::vector<double> values;
+            std::transform(names.begin(), names.end(), std::back_inserter(values),
+                           [&map](const auto &name) { return map[name]; });
+            setInteractionFormAndParameters(interactionForm(), values);
         }
     }
     // Load form from tree node

--- a/src/classes/speciessite.cpp
+++ b/src/classes/speciessite.cpp
@@ -435,12 +435,11 @@ SerialisedValue SpeciesSite::serialise() const
     return site;
 }
 
-void SpeciesSite::deserialise(SerialisedValue &node)
+void SpeciesSite::deserialise(const SerialisedValue &node)
 {
     toVector(node, "originAtoms", [this](const auto &originAtom) { addOriginAtom(originAtom.as_integer()); });
     toVector(node, "xAxisAtoms", [this](const auto &xAxisAtom) { addXAxisAtom(xAxisAtom.as_integer()); });
     toVector(node, "yAxisAtoms", [this](const auto &yAxisAtom) { addYAxisAtom(yAxisAtom.as_integer()); });
 
-    if (node.contains("originMassWeighted"))
-        originMassWeighted_ = node["originMassWeighted"].as_boolean();
+    originMassWeighted_ = toml::find_or<bool>(node, "originMassWeighted", false);
 }

--- a/src/classes/speciessite.h
+++ b/src/classes/speciessite.h
@@ -128,5 +128,5 @@ class SpeciesSite : public Serialisable
     bool write(LineParser &parser, std::string_view prefix);
 
     SerialisedValue serialise() const override;
-    void deserialise(SerialisedValue &node) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/speciestorsion.cpp
+++ b/src/classes/speciestorsion.cpp
@@ -610,7 +610,7 @@ SerialisedValue SpeciesTorsion::serialise() const
     return torsion;
 }
 // This method populates the object's members with values read from a 'torsion' TOML node
-void SpeciesTorsion::deserialise(SerialisedValue &node, CoreData &coreData)
+void SpeciesTorsion::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
     deserialiseForm(node, [&coreData](auto &form) { return coreData.getMasterTorsion(form); });
 }

--- a/src/classes/speciestorsion.h
+++ b/src/classes/speciestorsion.h
@@ -118,7 +118,7 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node
-    void deserialise(SerialisedValue &node, CoreData &coreData);
+    void deserialise(const SerialisedValue &node, CoreData &coreData);
 };
 
 // MasterTorsion Definition

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -263,7 +263,7 @@ class Dissolve : public Serialisable
     // Load input file
     bool loadInput(std::string_view filename);
     // Read values from a tree node
-    void deserialise(SerialisedValue &node) override;
+    void deserialise(const SerialisedValue &node) override;
     // Load input from supplied string
     bool loadInputFromString(std::string_view inputString);
     // Save input file

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -173,9 +173,9 @@ void Dissolve::deserialise(const SerialisedValue &node)
         if (!mastersNode.is_uninitialized())
             coreData_.deserialiseMaster(mastersNode);
     }
-    Serialisable::toMap(node, "species",
-                        [this](const std::string &name, const SerialisedValue &data)
-                        { species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_); });
+    Serialisable::toMap(node, "species", [this](const std::string &name, const SerialisedValue &data) {
+        species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_);
+    });
 }
 
 // Load input from supplied file

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -159,7 +159,7 @@ SerialisedValue Dissolve::serialise() const
 }
 
 // Read values from a tree node
-void Dissolve::deserialise(SerialisedValue &node)
+void Dissolve::deserialise(const SerialisedValue &node)
 {
     if (node.contains("pairPotentials"))
     {
@@ -173,9 +173,9 @@ void Dissolve::deserialise(SerialisedValue &node)
         if (!mastersNode.is_uninitialized())
             coreData_.deserialiseMaster(mastersNode);
     }
-    Serialisable::toMap(node, "species", [this](const std::string &name, SerialisedValue &data) {
-        species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_);
-    });
+    Serialisable::toMap(node, "species",
+                        [this](const std::string &name, const SerialisedValue &data)
+                        { species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_); });
 }
 
 // Load input from supplied file

--- a/src/procedure/nodevalue.cpp
+++ b/src/procedure/nodevalue.cpp
@@ -144,3 +144,30 @@ SerialisedValue NodeValue::serialise() const
             return expression_.expressionString();
     }
 }
+
+void NodeValue::deserialise(const SerialisedValue &node)
+{
+    toml::visit(
+        [this](auto &arg)
+        {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, int>)
+            {
+                type_ = IntegerNodeValue;
+                valueI_ = arg;
+            }
+            else if constexpr (std::is_same_v<T, double>)
+            {
+                type_ = DoubleNodeValue;
+                valueD_ = arg;
+            }
+            else if constexpr (std::is_same_v<T, std::string>)
+            {
+                type_ = ExpressionNodeValue;
+                // FIXME: This needs to be handled properly when we
+                // start serialising expressions.
+                expression_.create(arg, {});
+            }
+        },
+        node);
+}

--- a/src/procedure/nodevalue.cpp
+++ b/src/procedure/nodevalue.cpp
@@ -131,3 +131,16 @@ std::string NodeValue::asString(bool addQuotesIfRequired) const
             return fmt::format("{}", expression_.expressionString());
     }
 }
+
+SerialisedValue NodeValue::serialise() const
+{
+    switch (type_)
+    {
+        case IntegerNodeValue:
+            return valueI_;
+        case DoubleNodeValue:
+            return valueD_;
+        case ExpressionNodeValue:
+            return expression_.expressionString();
+    }
+}

--- a/src/procedure/nodevalue.cpp
+++ b/src/procedure/nodevalue.cpp
@@ -148,8 +148,7 @@ SerialisedValue NodeValue::serialise() const
 void NodeValue::deserialise(const SerialisedValue &node)
 {
     toml::visit(
-        [this](auto &arg)
-        {
+        [this](auto &arg) {
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, int>)
             {

--- a/src/procedure/nodevalue.h
+++ b/src/procedure/nodevalue.h
@@ -3,11 +3,12 @@
 
 #pragma once
 
+#include "base/serialiser.h"
 #include "expression/expression.h"
 #include "templates/optionalref.h"
 
 // Node Value
-class NodeValue
+class NodeValue : public Serialisable
 {
     public:
     NodeValue();
@@ -61,4 +62,7 @@ class NodeValue
     double asDouble();
     // Return value represented as a string
     std::string asString(bool addQuotesIfRequired = false) const;
+
+    // Express as a tree node
+    SerialisedValue serialise() const override;
 };

--- a/src/procedure/nodevalue.h
+++ b/src/procedure/nodevalue.h
@@ -65,4 +65,6 @@ class NodeValue : public Serialisable
 
     // Express as a tree node
     SerialisedValue serialise() const override;
+    // Read values from a tree node
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/procedure/nodevalue.h
+++ b/src/procedure/nodevalue.h
@@ -63,6 +63,10 @@ class NodeValue : public Serialisable
     // Return value represented as a string
     std::string asString(bool addQuotesIfRequired = false) const;
 
+    /*
+     * Serialisable
+     */
+    public:
     // Express as a tree node
     SerialisedValue serialise() const override;
     // Read values from a tree node

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/serialiser.h"
 #include "math/constants.h"
 #include "math/mathfunc.h"
 #include <cmath>
@@ -10,7 +11,7 @@
 #include <stdexcept>
 
 // 3D vector
-template <class T> class Vec3
+template <class T> class Vec3 : public Serialisable
 {
     public:
     Vec3<T>() : x(T()), y(T()), z(T()){};
@@ -409,5 +410,20 @@ template <class T> class Vec3
         T temp = get(a);
         set(a, get(b));
         set(b, temp);
+    }
+
+    SerialisedValue serialise() const override
+    {
+        toml::array result;
+        result.push_back(x);
+        result.push_back(y);
+        result.push_back(z);
+        return result;
+    }
+    void deserialise(const SerialisedValue &node) override
+    {
+        x = toml::get<T>(node[0]);
+        y = toml::get<T>(node[1]);
+        z = toml::get<T>(node[2]);
     }
 };

--- a/unit/io/toml.cpp
+++ b/unit/io/toml.cpp
@@ -20,7 +20,7 @@ TEST(TOMLTest, Parse)
             initial.loadInput(input);
             auto toml = initial.serialise();
             Dissolve repeat(coreData2);
-            repeat.deserialise(toml);
+            EXPECT_NO_THROW(repeat.deserialise(toml));
             auto toml2 = repeat.serialise();
 
             EXPECT_EQ(toml, toml2);


### PR DESCRIPTION
This started as just a small PR to get the Vec3 class to support TOML serialisation.  However, it kind of spiraled out a bit from there due to some convenience issues and `const` correctness.

The major points are as follows

1. the `deserialise` function of the `Serialisable` class now takes a `const Serialised&` instead of just a `Serialisaed&`.  This was the right choice in general, so it putting this off was only going to make things more painful.
2. Remove calls to `operator[]` on `SerialisedValue`.  Unfortunately, for reasons I cannot quite comprehend, the oeprator overload isn't supported on const objects by the library.  I'm honestly looking at submitting a PR upstream to fix the issue, because it seems to just be an oversight.
3. Add the `from_toml` and `into_toml` members to the `Serialisable` class.  The library has some templates that hook into these members and will save us quite a bit of boilerplate, as well as making the code more readable.
4. Make Vec3 serialisable
5. Use clean up a couple of deserialiser using the new possibilities from `from_toml` and `into_toml`.