### PR TITLE
Data Mutation

### DIFF
--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -116,7 +116,8 @@ void IsotopologueSetKeywordWidget::currentItemChanged()
 // Update value displayed in widget
 void IsotopologueSetKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    if (mutationFlags.isSet(DissolveSignals::DataMutations::IsotopologuesMutated))
+        updateSummaryText();
 }
 
 // Update widget values data based on keyword data

--- a/src/gui/signals.h
+++ b/src/gui/signals.h
@@ -9,6 +9,7 @@ namespace DissolveSignals
 enum DataMutations
 {
     ConfigurationsMutated,
+    IsotopologuesMutated,
     ModulesMutated
 };
 }; // namespace DissolveSignals

--- a/src/gui/speciestab_isotopologues.cpp
+++ b/src/gui/speciestab_isotopologues.cpp
@@ -29,7 +29,7 @@ void SpeciesTab::isotopologuesChanged(const QModelIndex &, const QModelIndex &, 
 {
     updateIsotopologuesTab();
 
-    dissolveWindow_->setModified();
+    dissolveWindow_->setModified(DissolveSignals::DataMutations::IsotopologuesMutated);
 }
 
 void SpeciesTab::on_IsotopologueAddButton_clicked(bool checked)
@@ -52,6 +52,7 @@ void SpeciesTab::on_IsotopologueRemoveButton_clicked(bool checked)
 
     // Notify all keywords that our Isotopologue is about to be removed
     KeywordStore::objectNoLongerValid<Isotopologue>(iso);
+    dissolveWindow_->setModified(DissolveSignals::DataMutations::IsotopologuesMutated);
 
     // Finally, remove the Isotopologue from the Species
     isos_.removeIso(item);


### PR DESCRIPTION
Quick PR to fix update of dependent data and the GUI when mutating isotopologues and species.

Closes #1077.
Closes #1078.