### PR TITLE
Data Mutation Fixes

### DIFF
--- a/src/classes/speciessite.cpp
+++ b/src/classes/speciessite.cpp
@@ -10,7 +10,7 @@
 #include <numeric>
 
 SpeciesSite::SpeciesSite(const Species *parent) : parent_(parent), originMassWeighted_(false) {}
-SpeciesSite::SpeciesSite(const Species *parent, std::string name) : parent_(parent), name_(name), originMassWeighted_(false) {}
+SpeciesSite::SpeciesSite(const Species *parent, std::string name) : name_(name), parent_(parent), originMassWeighted_(false) {}
 /*
  * Basic Information
  */

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -179,7 +179,7 @@ void DissolveWindow::closeTab(QWidget *page)
         auto *sp = dynamic_cast<SpeciesTab *>(tab)->species();
         ui_.MainTabs->removeByPage(page);
         dissolve_.removeSpecies(sp);
-        setModified();
+        setModified({DissolveSignals::DataMutations::SpeciesMutated, DissolveSignals::DataMutations::IsotopologuesMutated});
     }
     else
         return;

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -132,7 +132,7 @@ void IsotopologueSetKeywordWidget::updateSummaryText()
     std::string text;
     auto nNatural = 0;
     for (const auto &topes : keyword_->data().isotopologues())
-        // Check if this is completely "natural" specification
+        // Check if this is a completely "natural" specification
         if (std::count_if(topes.mix().begin(), topes.mix().end(), [&topes](const auto &part) {
                 return part.isotopologue() == topes.species()->naturalIsotopologue();
             }) == topes.nIsotopologues())

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -116,7 +116,8 @@ void IsotopologueSetKeywordWidget::currentItemChanged()
 // Update value displayed in widget
 void IsotopologueSetKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    if (mutationFlags.isSet(DissolveSignals::DataMutations::IsotopologuesMutated))
+        updateSummaryText();
 }
 
 // Update widget values data based on keyword data

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -120,8 +120,7 @@ void LayerTab::removeControlWidget(const Module *module)
             if (ui_.ModuleControlsStack->currentIndex() == n)
                 ui_.ModuleControlsStack->setCurrentIndex((n + 1) < ui_.ModuleControlsStack->count() ? n + 1 : n - 1);
             ui_.ModuleControlsStack->removeWidget(w);
-            w->setParent(nullptr);
-            w->deleteLater();
+            w->prepareForDeletion();
             return;
         }
     }
@@ -296,12 +295,12 @@ void LayerTab::on_AvailableModulesTree_doubleClicked(const QModelIndex &index)
 // Remove all module control widgets
 void LayerTab::removeModuleControlWidgets()
 {
-    for (auto n = 1; n < ui_.ModuleControlsStack->count(); ++n)
+    // Remove all stack pages but the first (which corresponds to the "No Module Selected" widget)
+    while (ui_.ModuleControlsStack->count() > 1)
     {
-        auto *w = ui_.ModuleControlsStack->widget(n);
+        auto *w = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(1));
         ui_.ModuleControlsStack->removeWidget(w);
-        w->setParent(nullptr);
-        w->deleteLater();
+        w->prepareForDeletion();
     }
 }
 

--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -71,6 +71,10 @@ class ModuleControlWidget : public QWidget
     void on_EnabledButton_clicked(bool checked);
     void on_FrequencySpin_valueChanged(int value);
 
+    public:
+    // Prepare widget for deletion
+    void prepareForDeletion();
+
     public slots:
     // Local keyword data changed
     void localKeywordChanged(int signalMask);

--- a/src/gui/modulecontrolwidget_funcs.cpp
+++ b/src/gui/modulecontrolwidget_funcs.cpp
@@ -171,6 +171,15 @@ void ModuleControlWidget::on_FrequencySpin_valueChanged(int value)
     emit(dataModified());
 }
 
+// Prepare widget for deletion
+void ModuleControlWidget::prepareForDeletion()
+{
+    // Nullify the module - this will flag to the update functions that they shouldn't proceed
+    module_ = nullptr;
+
+    deleteLater();
+}
+
 // Target keyword data changed
 void ModuleControlWidget::localKeywordChanged(int signalMask)
 {
@@ -195,8 +204,8 @@ void ModuleControlWidget::localKeywordChanged(int signalMask)
 // Global data mutated
 void ModuleControlWidget::globalDataMutated(int mutationFlags)
 {
-    // If we have no valid parent, don't try to update keyword data
-    if (!parent())
+    // If we have no valid module, don't try to update keyword data
+    if (!module_)
         return;
 
     Flags<DissolveSignals::DataMutations> dataMutations(mutationFlags);

--- a/src/gui/signals.h
+++ b/src/gui/signals.h
@@ -10,6 +10,7 @@ enum DataMutations
 {
     ConfigurationsMutated,
     IsotopologuesMutated,
-    ModulesMutated
+    ModulesMutated,
+    SpeciesMutated
 };
 }; // namespace DissolveSignals

--- a/src/gui/signals.h
+++ b/src/gui/signals.h
@@ -9,6 +9,7 @@ namespace DissolveSignals
 enum DataMutations
 {
     ConfigurationsMutated,
+    IsotopologuesMutated,
     ModulesMutated
 };
 }; // namespace DissolveSignals

--- a/src/gui/speciestab_isotopologues.cpp
+++ b/src/gui/speciestab_isotopologues.cpp
@@ -29,7 +29,7 @@ void SpeciesTab::isotopologuesChanged(const QModelIndex &, const QModelIndex &, 
 {
     updateIsotopologuesTab();
 
-    dissolveWindow_->setModified();
+    dissolveWindow_->setModified(DissolveSignals::DataMutations::IsotopologuesMutated);
 }
 
 void SpeciesTab::on_IsotopologueAddButton_clicked(bool checked)
@@ -52,6 +52,7 @@ void SpeciesTab::on_IsotopologueRemoveButton_clicked(bool checked)
 
     // Notify all keywords that our Isotopologue is about to be removed
     KeywordStore::objectNoLongerValid<Isotopologue>(iso);
+    dissolveWindow_->setModified(DissolveSignals::DataMutations::IsotopologuesMutated);
 
     // Finally, remove the Isotopologue from the Species
     isos_.removeIso(item);

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -18,8 +18,7 @@ Species *Dissolve::addSpecies()
 // Remove the specified Species from the list
 void Dissolve::removeSpecies(Species *sp)
 {
-    if (!sp)
-        return;
+    assert(sp);
 
     // Remove references to the Species itself
     removeReferencesTo(sp);


### PR DESCRIPTION
Quick PR to fix update of dependent data and the GUI when mutating isotopologues and species, and fix a nasty crash when deleting a layer arising from a schoolboy "loop deletion 101" error in `LayerTab::removeModuleControlWidgets()`.

Closes #1077.
Closes #1078.