### PR TITLE
Mutable AtomType names

### DIFF
--- a/src/gui/addforcefieldtermsdialog_funcs.cpp
+++ b/src/gui/addforcefieldtermsdialog_funcs.cpp
@@ -12,8 +12,8 @@
 #include <set>
 
 AddForcefieldTermsDialog::AddForcefieldTermsDialog(QWidget *parent, Dissolve &dissolve, Species *sp)
-    : WizardDialog(parent), dissolve_(dissolve), temporaryDissolve_(temporaryCoreData_), targetSpecies_(sp),
-      intramolecularTermsAssigned_(false)
+    : WizardDialog(parent), atomTypeModel_(dissolve.coreData()), dissolve_(dissolve), temporaryDissolve_(temporaryCoreData_),
+      targetSpecies_(sp), intramolecularTermsAssigned_(false)
 {
     ui_.setupUi(this);
 

--- a/src/gui/forcefieldtab_funcs.cpp
+++ b/src/gui/forcefieldtab_funcs.cpp
@@ -18,7 +18,8 @@
 #include <QListWidgetItem>
 
 ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsWidget *parent, const QString title)
-    : MainTab(dissolveWindow, dissolve, parent, title, this), pairPotentialModel_(dissolve.pairPotentials())
+    : MainTab(dissolveWindow, dissolve, parent, title, this), atomTypesModel_(dissolve.coreData()),
+      pairPotentialModel_(dissolve.pairPotentials())
 {
     ui_.setupUi(this);
 

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -14,7 +14,7 @@
 
 AtomTypeVectorKeywordWidget::AtomTypeVectorKeywordWidget(QWidget *parent, AtomTypeVectorKeyword *keyword,
                                                          const CoreData &coreData)
-    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword)
+    : KeywordDropDown(this), KeywordWidgetBase(coreData), keyword_(keyword), atomTypeModel_(coreData)
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -7,10 +7,10 @@
 #include "templates/algorithms.h"
 
 // Set source AtomType data
-void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &species)
+void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes)
 {
     beginResetModel();
-    atomTypes_ = species;
+    atomTypes_ = atomTypes;
     endResetModel();
 }
 

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -6,9 +6,15 @@
 #include "classes/atomtype.h"
 #include "templates/algorithms.h"
 
+AtomTypeModel::AtomTypeModel(const CoreData &coreData) : coreData_(coreData) {}
+
 // Set source AtomType data
-void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes)
+void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes,
+                            OptionalReferenceWrapper<const CoreData> coreData)
 {
+    if (coreData)
+        coreData_ = coreData;
+
     beginResetModel();
     atomTypes_ = atomTypes;
     endResetModel();

--- a/src/gui/models/atomTypeModel.h
+++ b/src/gui/models/atomTypeModel.h
@@ -15,6 +15,14 @@ class AtomTypeModel : public QAbstractListModel
 {
     Q_OBJECT
 
+    public:
+    AtomTypeModel() = default;
+    explicit AtomTypeModel(const CoreData &coreData);
+
+    private:
+    // Optional CoreData reference
+    OptionalReferenceWrapper<const CoreData> coreData_;
+
     private:
     // Source AtomType data
     OptionalReferenceWrapper<const std::vector<std::shared_ptr<AtomType>>> atomTypes_;
@@ -25,7 +33,8 @@ class AtomTypeModel : public QAbstractListModel
 
     public:
     // Set source AtomType data
-    void setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes);
+    void setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes,
+                 OptionalReferenceWrapper<const CoreData> coreData = std::nullopt);
     // Set function to return QIcon for item
     void setIconFunction(std::function<QIcon(const std::shared_ptr<AtomType> &atomType)> func);
     // Set vector containing checked items

--- a/src/gui/selectatomtypedialog_funcs.cpp
+++ b/src/gui/selectatomtypedialog_funcs.cpp
@@ -11,7 +11,7 @@ SelectAtomTypeDialog::SelectAtomTypeDialog(QWidget *parent, const CoreData &core
 
     setWindowTitle(dialogTitle);
 
-    ui_.AtomTypeWidget->setAtomTypes(coreData.atomTypes());
+    ui_.AtomTypeWidget->setAtomTypes(coreData.atomTypes(), coreData);
 }
 
 void SelectAtomTypeDialog::on_AtomTypeWidget_atomTypeSelectionChanged(bool isValid) { ui_.SelectButton->setEnabled(isValid); }

--- a/src/gui/selectatomtypewidget.h
+++ b/src/gui/selectatomtypewidget.h
@@ -40,7 +40,8 @@ class SelectAtomTypeWidget : public QWidget
     // Clear filter element
     void clearFilterElement();
     // Set target AtomType data
-    void setAtomTypes(const std::vector<std::shared_ptr<AtomType>> &atomTypes);
+    void setAtomTypes(const std::vector<std::shared_ptr<AtomType>> &atomTypes,
+                      OptionalReferenceWrapper<const CoreData> coreData = std::nullopt);
     // Reset widget
     void reset();
 

--- a/src/gui/selectatomtypewidget_funcs.cpp
+++ b/src/gui/selectatomtypewidget_funcs.cpp
@@ -28,9 +28,10 @@ void SelectAtomTypeWidget::setFilterElement(Elements::Element Z) { atomTypeFilte
 void SelectAtomTypeWidget::clearFilterElement() { atomTypeFilterProxy_.clearFilterElement(); }
 
 // Set target AtomType data
-void SelectAtomTypeWidget::setAtomTypes(const std::vector<std::shared_ptr<AtomType>> &atomTypes)
+void SelectAtomTypeWidget::setAtomTypes(const std::vector<std::shared_ptr<AtomType>> &atomTypes,
+                                        OptionalReferenceWrapper<const CoreData> coreData)
 {
-    atomTypeModel_.setData(atomTypes);
+    atomTypeModel_.setData(atomTypes, coreData);
 }
 
 // Reset widget


### PR DESCRIPTION
This PR adjusts the existing `AtomTypeModel` to provide:
- Editing of atom type names (this was previously disabled via the `Qt::ItemFlags`
- Checking for name uniqueness when editing (by providing an optional `CoreData&` to the model