### PR TITLE
Isotopologues Context Menu

### DIFF
--- a/src/classes/isotopologue.cpp
+++ b/src/classes/isotopologue.cpp
@@ -81,6 +81,7 @@ Sears91::Isotope Isotopologue::atomTypeIsotope(std::shared_ptr<AtomType> at) con
 }
 
 // Return AtomType/Isotope pairs list
+std::vector<std::tuple<std::shared_ptr<AtomType>, Sears91::Isotope>> &Isotopologue::isotopes() { return isotopes_; }
 const std::vector<std::tuple<std::shared_ptr<AtomType>, Sears91::Isotope>> &Isotopologue::isotopes() const { return isotopes_; }
 
 // Express as a tree node

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -61,6 +61,7 @@ class Isotopologue : public Serialisable
     // Return Isotope for specified AtomType
     Sears91::Isotope atomTypeIsotope(std::shared_ptr<AtomType> at) const;
     // Return AtomType/Isotope pairs list
+    std::vector<std::tuple<std::shared_ptr<AtomType>, Sears91::Isotope>> &isotopes();
     const std::vector<std::tuple<std::shared_ptr<AtomType>, Sears91::Isotope>> &isotopes() const;
 
     // Express as a tree node

--- a/src/gui/speciestab.h
+++ b/src/gui/speciestab.h
@@ -111,6 +111,7 @@ class SpeciesTab : public QWidget, public MainTab
     private slots:
     void isotopologuesSelectionChanged(const QItemSelection &, const QItemSelection &);
     void isotopologuesChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &);
+    void on_IsotopologuesTree_customContextMenuRequested(const QPoint &pos);
     void on_IsotopologueAddButton_clicked(bool checked);
     void on_IsotopologueRemoveButton_clicked(bool checked);
     void on_IsotopologueGenerateButton_clicked(bool checked);

--- a/src/gui/speciestab.ui
+++ b/src/gui/speciestab.ui
@@ -837,7 +837,11 @@
         </layout>
        </item>
        <item>
-        <widget class="QTreeView" name="IsotopologuesTree"/>
+        <widget class="QTreeView" name="IsotopologuesTree">
+         <property name="contextMenuPolicy">
+          <enum>Qt::CustomContextMenu</enum>
+         </property>
+        </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_10">


### PR DESCRIPTION
This PR adds a context menu to the isotopologues tree in the species tab to provide the ability to batch set hydrogen isotopes across an isotopologue (covering the most common use case) and also to duplicate isotopologues.