### PR TITLE
Configuration & PairPotentials

### DIFF
--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -172,8 +172,8 @@ bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::sha
     }
 
     // Set charges
-    chargeI_ = atomTypeI_->charge();
-    chargeJ_ = atomTypeJ_->charge();
+    chargeI_ = includeAtomTypeCharges_ ? atomTypeI_->charge() : 0.0;
+    chargeJ_ = includeAtomTypeCharges_ ? atomTypeJ_->charge() : 0.0;
 
     return true;
 }

--- a/src/gui/forcefieldtab.h
+++ b/src/gui/forcefieldtab.h
@@ -62,6 +62,10 @@ class ForcefieldTab : public QWidget, public MainTab
     // Allow editing within tab
     void allowEditing() override;
 
+    public:
+    // Reset pair potential model
+    void resetPairPotentialModel();
+
     /*
      * Signals / Slots
      */
@@ -88,7 +92,7 @@ class ForcefieldTab : public QWidget, public MainTab
     void on_RegenerateAllPairPotentialsButton_clicked(bool checked);
     void on_AutoUpdatePairPotentialsCheck_clicked(bool checked);
     void pairPotentialDataChanged(const QModelIndex &current, const QModelIndex &previous, const QVector<int> &);
-    void pairPotentialTableRowChanged(const QModelIndex &current, const QModelIndex &previous);
+    void pairPotentialSelectionChanged(const QItemSelection &current, const QItemSelection &previous);
     // Master Terms
     void masterBondsDataChanged(const QModelIndex &, const QModelIndex &);
     void masterAnglesDataChanged(const QModelIndex &, const QModelIndex &);

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -66,6 +66,8 @@ class MainTabsWidget : public QTabWidget
     ModuleLayer *currentLayer() const;
     // Return MessagesTab
     MessagesTab *messagesTab();
+    // Return the ForcefieldTab
+    ForcefieldTab *forcefieldTab();
     // Find SpeciesTab containing specified page widget
     QPointer<SpeciesTab> speciesTab(QWidget *page);
     // Find ConfigurationTab containing specified page widget

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -88,6 +88,9 @@ ModuleLayer *MainTabsWidget::currentLayer() const
 // Return MessagesTab
 MessagesTab *MainTabsWidget::messagesTab() { return messagesTab_.data(); }
 
+// Return the ForcefieldTab
+ForcefieldTab *MainTabsWidget::forcefieldTab() { return forcefieldTab_.data(); }
+
 // Find SpeciesTab containing specified page widget
 QPointer<SpeciesTab> MainTabsWidget::speciesTab(QWidget *page)
 {

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -14,6 +14,8 @@ void DissolveWindow::on_SimulationCheckAction_triggered(bool checked)
 
     dissolve_.prepare();
 
+    ui_.MainTabs->forcefieldTab()->resetPairPotentialModel();
+
     fullUpdate();
 }
 

--- a/src/gui/models/pairPotentialModel.cpp
+++ b/src/gui/models/pairPotentialModel.cpp
@@ -29,33 +29,37 @@ PairPotential *PairPotentialModel::rawData(const QModelIndex index) { return pai
 
 QVariant PairPotentialModel::data(const QModelIndex &index, int role) const
 {
+    auto *pp = rawData(index);
+    if (!pp)
+        return {};
+
     if (role == Qt::DisplayRole || role == Qt::EditRole)
     {
         switch (index.column())
         {
             // Name
             case (0):
-                return QString::fromStdString(std::string(rawData(index)->atomTypeNameI()));
+                return QString::fromStdString(std::string(pp->atomTypeNameI()));
             // Element
             case (1):
-                return QString::fromStdString(std::string(rawData(index)->atomTypeNameJ()));
-            // Charge
+                return QString::fromStdString(std::string(pp->atomTypeNameJ()));
+            // Form
             case (2):
-                return QString::fromStdString(
-                    ShortRangeFunctions::forms().keyword(rawData(index)->interactionPotential().form()));
-            // Short Range Parameters
+                return QString::fromStdString(ShortRangeFunctions::forms().keyword(pp->interactionPotential().form()));
+            // Charges
             case (3):
-                return QString::number(rawData(index)->chargeI());
+                return pp->includeAtomTypeCharges() ? QString::number(pp->chargeI()) : QString();
             case (4):
-                return QString::number(rawData(index)->chargeJ());
+                return pp->includeAtomTypeCharges() ? QString::number(pp->chargeJ()) : QString();
+            // Short Range Parameters
             case (5):
-                return QString::fromStdString(rawData(index)->interactionPotential().parametersAsString());
+                return QString::fromStdString(pp->interactionPotential().parametersAsString());
             default:
                 return {};
         }
     }
     else if (role == Qt::UserRole)
-        return QVariant::fromValue(rawData(index));
+        return QVariant::fromValue(pp);
 
     return {};
 }

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -48,7 +48,6 @@ void Dissolve::clear()
     atomTypeChargeSource_ = true;
     pairPotentials_.clear();
     potentialMap_.clear();
-    pairPotentialAtomTypeVersion_ = -1;
 
     // Simulation
     Messenger::printVerbose("Clearing Simulation...\n");

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -106,8 +106,6 @@ class Dissolve : public Serialisable
     bool atomTypeChargeSource_;
     // Simulation PairPotentials
     std::vector<std::unique_ptr<PairPotential>> pairPotentials_;
-    // Version of AtomTypes at which PairPotentials were last generated
-    int pairPotentialAtomTypeVersion_;
     // Map for PairPotentials
     PotentialMap potentialMap_;
 
@@ -152,8 +150,6 @@ class Dissolve : public Serialisable
     const PotentialMap &potentialMap() const;
     // Clear and regenerate all PairPotentials, replacing those currently defined
     bool regeneratePairPotentials();
-    // Generate all necessary PairPotentials, adding missing terms where necessary
-    bool generatePairPotentials(const std::shared_ptr<AtomType> &onlyInvolving = nullptr);
     // Revert potentials to reference state, clearing additional potentials
     void revertPairPotentials();
 

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -53,14 +53,6 @@ bool Dissolve::loadInput(LineParser &parser)
                     error = true;
                     break;
                 }
-
-                // Need to update pair potentials in case they're needed in the generator
-                generatePairPotentials();
-                potentialMap_.initialise(coreData_.atomTypes(), pairPotentials_, pairPotentialRange_);
-
-                // Prepare the Configuration
-                if (!cfg->initialiseContent({worldPool_, potentialMap_}))
-                    error = true;
                 break;
             case (BlockKeywords::LayerBlockKeyword):
                 // Check to see if a processing layer with this name already exists...

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -167,11 +167,6 @@ bool Dissolve::prepare()
     if (!regeneratePairPotentials())
         return false;
 
-    // Create PairPotential matrix
-    Messenger::print("Creating PairPotential matrix ({}x{})...\n", coreData_.nAtomTypes(), coreData_.nAtomTypes());
-    if (!potentialMap_.initialise(coreData_.atomTypes(), pairPotentials_, pairPotentialRange_))
-        return false;
-
     // Generate attached atom lists if IntraShake modules are present and enabled
     auto intraShakeModules = Module::allOfType("IntraShake");
     if (!intraShakeModules.empty())

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -90,11 +90,11 @@ bool Dissolve::prepare()
     // Check pair potential style - first, determine which styles might be valid for use
     // -- Configuration charges must always be zero
     auto neutralConfigsWithPPCharges = std::all_of(configurations().begin(), configurations().end(),
-                                                   [](const auto &cfg) { return cfg->totalCharge(true) < 1.0e-5; });
+                                                   [](const auto &cfg) { return fabs(cfg->totalCharge(true)) < 1.0e-5; });
     Messenger::printVerbose("Configuration neutrality if using charges on atom types    : {}\n",
                             DissolveSys::btoa(neutralConfigsWithPPCharges));
     auto neutralConfigsWithSpeciesCharges = std::all_of(configurations().begin(), configurations().end(),
-                                                        [](const auto &cfg) { return cfg->totalCharge(false) < 1.0e-5; });
+                                                        [](const auto &cfg) { return fabs(cfg->totalCharge(false)) < 1.0e-5; });
     Messenger::printVerbose("Configuration neutrality if using charges on species atoms : {}\n",
                             DissolveSys::btoa(neutralConfigsWithSpeciesCharges));
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -59,6 +59,10 @@ bool Dissolve::prepare()
         newPairPotentialRange = pairPotentialRange_;
     }
 
+    // Make sure pair potentials are up-to-date
+    if (!regeneratePairPotentials())
+        return false;
+
     // Check Configurations
     std::set<const Species *> globalUsedSpecies;
     for (auto &cfg : configurations())

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -63,6 +63,10 @@ bool Dissolve::prepare()
     std::set<const Species *> globalUsedSpecies;
     for (auto &cfg : configurations())
     {
+        // If the configuration is empty, initialise it now
+        if (cfg->nMolecules() == 0 && !cfg->initialiseContent({worldPool_, potentialMap_}))
+            return Messenger::error("Failed to initialise content for configuration '{}'.\n", cfg->name());
+
         // Regenerate cell array if the pair potential range has changed
         if (newPairPotentialRange)
             cfg->updateCells(7.0, *newPairPotentialRange);

--- a/unit/gui/forcefieldTab.cpp
+++ b/unit/gui/forcefieldTab.cpp
@@ -32,7 +32,7 @@ TEST_F(ForcefieldTabTest, PairPotentials)
 
     dissolve.clear();
     ASSERT_TRUE(dissolve.loadInput("molshake/benzene.txt"));
-    ASSERT_TRUE(dissolve.generatePairPotentials());
+    ASSERT_TRUE(dissolve.regeneratePairPotentials());
 
     PairPotentialModel pairs(dissolve.pairPotentials());
     ASSERT_EQ(dissolve.nPairPotentials(), 3);


### PR DESCRIPTION
This PR started out addressing #1025, but this led to failures in the unit tests related to the ordering between `Configuration` and `PotentialMap` generation. While the somewhat circular usage relationship between these two object classes is not resolved, code related to `PairPotential` generation has been significantly tidied, and their update / display in the GUI on the forcefield tab improved.

This PR may also fix some random crashes observed when returning to the forcefield tab while a simulation is running, and which may be cause by the associated `PairPotential` model / update functions accessing invalid pointers.

Closes #1025.