### PR TITLE
Harbor Release fix

### DIFF
--- a/.azure-pipelines/templates/push-harbor.yml
+++ b/.azure-pipelines/templates/push-harbor.yml
@@ -5,8 +5,7 @@ parameters:
 steps:
   - bash: |
       source ~/.nix-profile/etc/profile.d/nix.sh
-      VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
-      nix run .#uploader ${HARBOR_USER} ${HARBOR_SECRET} $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-gui-$VERSION.sif  ${{ parameters.tag }}
+      nix run .#uploader ${HARBOR_USER} ${HARBOR_SECRET} $(System.ArtifactsDirectory)/singularity-gui-artifacts/dissolve-gui-*.sif  ${{ parameters.tag }}
     env:
       HARBOR_USER: $(HARBOR_USER)
       HARBOR_SECRET: $(HARBOR_SECRET)

--- a/ci/windows/dissolve-gui.iss
+++ b/ci/windows/dissolve-gui.iss
@@ -3,8 +3,8 @@
 
 #define MyAppName "Dissolve-GUI"
 #define MyAppVersion "0.9.0"
-#define MyAppPublisher "Tristan Youngs"
-#define MyAppURL "https://www.projectaten.com/"
+#define MyAppPublisher "Team Dissolve"
+#define MyAppURL "https://www.projectdissolve.com/"
 #define MyAppExeName "Dissolve-GUI.exe"
 
 ; Locations of bin directories of Dissolve, Qt, GnuWin, MinGW etc.


### PR DESCRIPTION
This should fix the issue with releases not getting pushed to harbor.  It's still a mystery why certain parts of the build process default to version 1.0.0, but this patch will indiscriminately push whatever version has been built.