### PR TITLE
AddPair node

### DIFF
--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -169,6 +169,17 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix)
         i->setCoordinates(transformationMatrix * (i->r() - cog) + cog);
 }
 
+// Transform molecule with supplied matrix about specified origin
+void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, const Vec3<double> &origin)
+{
+    // Unfold
+    unFold(box);
+
+    // Apply transform
+    for (auto &i : atoms())
+        i->setCoordinates(transformationMatrix * (i->r() - origin) + origin);
+}
+
 // Transform selected atoms with supplied matrix, around specified origin
 void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, const Vec3<double> &origin,
                          const std::vector<int> &targetAtoms)

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -73,6 +73,8 @@ class Molecule : public std::enable_shared_from_this<Molecule>
     Vec3<double> centreOfGeometry(const Box *box) const;
     // Transform molecule with supplied matrix, using centre of geometry as the origin
     void transform(const Box *box, const Matrix3 &transformationMatrix);
+    // Transform molecule with supplied matrix about specified origin
+    void transform(const Box *box, const Matrix3 &transformationMatrix, const Vec3<double> &origin);
     // Transform selected atoms with supplied matrix, around specified origin
     void transform(const Box *box, const Matrix3 &transformationMatrix, const Vec3<double> &origin,
                    const std::vector<int> &targetAtoms);

--- a/src/gui/icons/nodes_addpair.svg
+++ b/src/gui/icons/nodes_addpair.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="100"
+   height="100"
+   id="svg2"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"
+   sodipodi:docname="x.svg">
+  <metadata
+     id="metadata3050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1536"
+     id="namedview3048"
+     showgrid="false"
+     inkscape:zoom="8.0000002"
+     inkscape:cx="45.822968"
+     inkscape:cy="42.486439"
+     inkscape:window-x="1920"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="false" />
+  <defs
+     id="defs4" />
+  <rect
+     style="opacity:1;fill:#9c9c9c;fill-opacity:1;stroke:none;stroke-width:1.00157475;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect818"
+     width="10.518213"
+     height="100"
+     x="44.740894"
+     y="0"
+     rx="5"
+     ry="5" />
+  <circle
+     style="opacity:1;fill:#9c9c9c;fill-opacity:1;stroke:#ffffff;stroke-width:3;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path812"
+     cx="50"
+     cy="50"
+     r="20.903845" />
+</svg>

--- a/src/gui/main.qrc
+++ b/src/gui/main.qrc
@@ -22,6 +22,7 @@
     <file>icons/nodes_collect3d.svg</file>
     <file>icons/nodes_context.svg</file>
     <file>icons/nodes_coordinatesets.svg</file>
+    <file>icons/nodes_addpair.svg</file>
     <file>icons/nodes_cylindricalregion.svg</file>
     <file>icons/nodes_dynamicsite.svg</file>
     <file>icons/nodes_fit1d.svg</file>

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   procedurenodes
   add.cpp
+  addpair.cpp
   box.cpp
   calculateangle.cpp
   calculateaxisangle.cpp
@@ -44,6 +45,7 @@ add_library(
   sum1d.cpp
   transmute.cpp
   add.h
+  addpair.h
   box.h
   calculateangle.h
   calculateaxisangle.h

--- a/src/procedure/nodes/addpair.cpp
+++ b/src/procedure/nodes/addpair.cpp
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "procedure/nodes/addpair.h"
+#include "base/randombuffer.h"
+#include "classes/atomchangetoken.h"
+#include "classes/box.h"
+#include "classes/configuration.h"
+#include "classes/coredata.h"
+#include "classes/species.h"
+#include "keywords/bool.h"
+#include "keywords/node.h"
+#include "keywords/nodevalue.h"
+#include "keywords/nodevalueenumoptions.h"
+#include "keywords/species.h"
+#include "procedure/nodes/regionbase.h"
+
+AddPairProcedureNode::AddPairProcedureNode(const Species *spA, const Species *spB, const NodeValue &population,
+                                           const NodeValue &density, Units::DensityUnits densityUnits)
+    : ProcedureNode(ProcedureNode::NodeType::AddPair), density_{density, densityUnits}, population_(population), speciesA_(spA),
+      speciesB_(spB)
+{
+    setUpKeywords();
+}
+
+// Set up keywords for node
+void AddPairProcedureNode::setUpKeywords()
+{
+    // Set up keywords
+    keywords_.add<SpeciesKeyword>("Control", "SpeciesA", "Target species A to add", speciesA_);
+    keywords_.add<SpeciesKeyword>("Control", "SpeciesB", "Target species B to add", speciesB_);
+    keywords_.add<NodeValueKeyword>("Control", "Population", "Population of the target species to add", population_, this);
+    keywords_.add<EnumOptionsKeyword<AddPairProcedureNode::BoxActionStyle>>(
+        "Control", "BoxAction", "Action to take on the Box geometry / volume on addition of the species", boxAction_,
+        boxActionStyles());
+    keywords_.add<BoolKeyword>("Control", "ScaleA", "Scale box length A when modifying volume", scaleA_);
+    keywords_.add<BoolKeyword>("Control", "ScaleB", "Scale box length B when modifying volume", scaleB_);
+    keywords_.add<BoolKeyword>("Control", "ScaleC", "Scale box length C when modifying volume", scaleC_);
+    keywords_.add<NodeValueEnumOptionsKeyword<Units::DensityUnits>>(
+        "Control", "Density", "Density at which to add the target species", density_, this, Units::densityUnits());
+    keywords_.add<BoolKeyword>("Control", "Rotate", "Whether to randomly rotate molecules on insertion", rotate_);
+    keywords_.add<EnumOptionsKeyword<AddPairProcedureNode::PositioningType>>(
+        "Control", "Positioning", "Positioning type for individual molecules", positioningType_, positioningTypes());
+    keywords_.add<NodeKeyword<RegionProcedureNodeBase>>("Control", "Region", "Region into which to add the species", region_,
+                                                        this, ProcedureNode::NodeClass::Region, true);
+}
+
+/*
+ * Identity
+ */
+
+// Return whether specified context is relevant for this node type
+bool AddPairProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
+{
+    return (context == ProcedureNode::GenerationContext);
+}
+
+// Return whether a name for the node must be provided
+bool AddPairProcedureNode::mustBeNamed() const { return false; }
+
+/*
+ * Node Data
+ */
+
+// Return enum option info for PositioningType
+EnumOptions<AddPairProcedureNode::BoxActionStyle> AddPairProcedureNode::boxActionStyles()
+{
+    return EnumOptions<AddPairProcedureNode::BoxActionStyle>(
+        "BoxAction", {{AddPairProcedureNode::BoxActionStyle::None, "None"},
+                      {AddPairProcedureNode::BoxActionStyle::AddVolume, "AddVolume"},
+                      {AddPairProcedureNode::BoxActionStyle::ScaleVolume, "ScaleVolume"},
+                      {AddPairProcedureNode::BoxActionStyle::Set, "Set"}});
+}
+
+// Return enum option info for PositioningType
+EnumOptions<AddPairProcedureNode::PositioningType> AddPairProcedureNode::positioningTypes()
+{
+    return EnumOptions<AddPairProcedureNode::PositioningType>("PositioningType",
+                                                              {{AddPairProcedureNode::PositioningType::Central, "Central"},
+                                                               {AddPairProcedureNode::PositioningType::Current, "Current"},
+                                                               {AddPairProcedureNode::PositioningType::Random, "Random"},
+                                                               {AddPairProcedureNode::PositioningType::Region, "Region"}});
+}
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool AddPairProcedureNode::prepare(const ProcedureContext &procedureContext)
+{
+    if (!speciesA_ || !speciesB_)
+        return Messenger::error("One or both target species not specified in Add node.\n");
+
+    // If positioningType_ type is 'Region', must have a suitable node defined
+    if (positioningType_ == AddPairProcedureNode::PositioningType::Region && !region_)
+        return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
+    else if (positioningType_ != AddPairProcedureNode::PositioningType::Region && region_)
+        Messenger::warn("A region has been specified ({}) but the positioningType_ type is set to '{}'\n", region_->name(),
+                        AddPairProcedureNode::positioningTypes().keyword(positioningType_));
+
+    // Can't set box
+    if (boxAction_ == AddPairProcedureNode::BoxActionStyle::Set)
+        return Messenger::error("Can't set periodic box when using AddPair.\n");
+
+    // Can't do this for periodic species
+    if (speciesA_->box()->type() != Box::BoxType::NonPeriodic || speciesB_->box()->type() != Box::BoxType::NonPeriodic)
+        return Messenger::error("Can't use periodic species in AddPair.\n");
+
+    // Check scalable axes definitions
+    if (!scaleA_ && !scaleB_ && !scaleC_)
+        return Messenger::error("Must have at least one scalable box axis!\n");
+
+    return true;
+}
+
+// Execute node
+bool AddPairProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    // Can't add the Species if it has any missing core information
+    if (!speciesA_->checkSetUp())
+        return Messenger::error("Can't add Species '{}' because it is not set up correctly.\n", speciesA_->name());
+    if (!speciesB_->checkSetUp())
+        return Messenger::error("Can't add Species '{}' because it is not set up correctly.\n", speciesA_->name());
+
+    if (population_ > 0)
+        Messenger::print("[AddPair] Adding species pair '{}/{}' - population is {}.\n", speciesA_->name(), speciesB_->name(),
+                         population_.asInteger());
+    else
+    {
+        Messenger::print("[AddPair] Population of species pair '{}/{}' is zero so it will not be added.\n", speciesA_->name(),
+                         speciesB_->name());
+        return true;
+    }
+
+    auto *cfg = procedureContext.configuration();
+
+    const auto nAtomsToAdd = population_ * (speciesA_->nAtoms() + speciesB_->nAtoms());
+    auto [rho, rhoUnits] = density_;
+
+    // If a density was not given, just add new molecules to the current box without adjusting its size
+    Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
+    if (boxAction_ == AddPairProcedureNode::BoxActionStyle::None)
+        Messenger::print("[AddPair] Current box geometry / volume will remain as-is.\n");
+    else if (boxAction_ == AddPairProcedureNode::BoxActionStyle::AddVolume)
+    {
+        Messenger::print("[AddPair] Current box volume will be increased to accommodate volume of new species.\n");
+
+        // Get current cell volume
+        auto currentVolume = cfg->box()->volume();
+
+        // Determine volume required to contain the population of the specified Species at the requested density
+        auto requiredVolume = 0.0;
+        if (rhoUnits == Units::AtomsPerAngstromUnits)
+            requiredVolume = nAtomsToAdd / rho;
+        else
+            requiredVolume = (((speciesA_->mass() + speciesB_->mass()) * population_) / AVOGADRO) / (rho / 1.0E24);
+
+        Messenger::print("[AddPair] Density for new species is {} {}.\n", rho.asDouble(),
+                         Units::densityUnits().keyword(rhoUnits));
+        Messenger::print("[AddPair] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
+
+        // If the current box has no atoms in it, absorb the current volume rather than adding to it
+        if (cfg->nAtoms() > 0)
+            requiredVolume += currentVolume;
+        else
+            Messenger::print("[AddPair] Current box is empty, so new volume will be set to exactly {} cubic Angstroms.\n",
+                             requiredVolume);
+
+        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, scalableAxes);
+
+        // Scale existing contents
+        cfg->scaleContents(scaleFactors);
+
+        // Scale the current Box so there is enough space for our new species
+        cfg->scaleBox(scaleFactors);
+
+        Messenger::print("[AddPair] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
+                         cfg->box()->volume(), scaleFactors.x, scaleFactors.y, scaleFactors.z);
+    }
+    else if (boxAction_ == AddPairProcedureNode::BoxActionStyle::ScaleVolume)
+    {
+        Messenger::print("[AddPair] Box volume will be set to give supplied density.\n");
+
+        // Get volume required to hold current cell contents at the requested density
+        double existingRequiredVolume = 0.0;
+        if (rhoUnits == Units::AtomsPerAngstromUnits)
+            existingRequiredVolume = cfg->nAtoms() / rho;
+        else
+            existingRequiredVolume = cfg->atomicMass() / (rho / 1.0E24);
+        Messenger::print("[AddPair] Existing contents requires volume of {} cubic Angstroms at specified density.\n",
+                         existingRequiredVolume);
+
+        // Determine volume required to contain the population of the specified Species at the requested density
+        auto requiredVolume = 0.0;
+        if (rhoUnits == Units::AtomsPerAngstromUnits)
+            requiredVolume = nAtomsToAdd / rho;
+        else
+            requiredVolume = (((speciesA_->mass() + speciesB_->mass()) * population_) / AVOGADRO) / (rho / 1.0E24);
+
+        Messenger::print("[AddPair] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
+
+        // Add on required volume for existing box contents
+        if (cfg->nAtoms() > 0)
+            requiredVolume += existingRequiredVolume;
+
+        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, scalableAxes);
+
+        // Scale existing contents
+        cfg->scaleContents(scaleFactors);
+
+        // Scale the current Box so there is enough space for our new species
+        cfg->scaleBox(scaleFactors);
+
+        Messenger::print("[AddPair] Current box scaled by ({},{},{}) - new volume is {:e} cubic Angstroms.\n", scaleFactors.x,
+                         scaleFactors.y, scaleFactors.z, cfg->box()->volume());
+    }
+
+    // Get the positioningType_ type and rotation flag
+    Region region;
+
+    Messenger::print("[AddPair] Positioning type is '{}' and rotation is {}.\n",
+                     AddPairProcedureNode::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
+    if (positioningType_ == AddPairProcedureNode::PositioningType::Region)
+    {
+        if (!region_)
+            return Messenger::error("Positioning type set to '{}' but no region was given.\n",
+                                    AddPairProcedureNode::positioningTypes().keyword(positioningType_));
+
+        region = region_->generateRegion(procedureContext.configuration());
+        if (!region.isValid())
+            return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
+
+        Messenger::print("[AddPair] Target region ('{}') covers {:.2f}% of the box volume.\n", region_->name(),
+                         region.freeVoxelFraction() * 100.0);
+    }
+
+    // Now we add the molecules
+    RandomBuffer randomBuffer(procedureContext.processPool(), ProcessPool::PoolProcessesCommunicator);
+    Vec3<double> r, cog, newCentre;
+    Matrix3 transform;
+    const auto *box = cfg->box();
+    cfg->atoms().reserve(cfg->atoms().size() + population_ * (speciesA_->nAtoms() + speciesB_->nAtoms()));
+    for (auto n = 0; n < population_; ++n)
+    {
+        // Add the Molecule - use coordinate set if one is available
+        std::shared_ptr<Molecule> molA, molB;
+        {
+            // The atom pointers need to be updated before
+            // setCentreOfGeometry is called, or else there can be a
+            // segfault due to pointer invalidation.  It would be nice if
+            // we could have a single lock for the whole loop, but that
+            // will require some thought.
+            AtomChangeToken lock(*cfg);
+
+            molA = cfg->addMolecule(lock, speciesA_);
+            molB = cfg->addMolecule(lock, speciesB_);
+        }
+
+        // Set / generate position of pair
+        switch (positioningType_)
+        {
+            case (AddPairProcedureNode::PositioningType::Random):
+                newCentre = box->getReal({randomBuffer.random(), randomBuffer.random(), randomBuffer.random()});
+                break;
+            case (AddPairProcedureNode::PositioningType::Region):
+                newCentre = region.randomCoordinate();
+                break;
+            case (AddPairProcedureNode::PositioningType::Central):
+                newCentre = box->getReal({0.5, 0.5, 0.5});
+                break;
+            case (AddPairProcedureNode::PositioningType::Current):
+                break;
+            default:
+                Messenger::error("Unrecognised positioning type.\n");
+                break;
+        }
+
+        // Move the molecule pair
+        auto ref = (molA->centreOfGeometry(box) + molB->centreOfGeometry(box)) * 0.5;
+        molA->translate(newCentre - ref);
+        molB->translate(newCentre - ref);
+
+        // Generate and apply a random rotation matrix
+        if (rotate_)
+        {
+            transform.createRotationXY(randomBuffer.randomPlusMinusOne() * 180.0, randomBuffer.randomPlusMinusOne() * 180.0);
+            molA->transform(box, transform, newCentre);
+            molB->transform(box, transform, newCentre);
+        }
+    }
+
+    Messenger::print("[AddPair] New box density is {:e} cubic Angstroms ({} g/cm3).\n", cfg->atomicDensity(),
+                     cfg->chemicalDensity());
+
+    return true;
+}

--- a/src/procedure/nodes/addpair.h
+++ b/src/procedure/nodes/addpair.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/units.h"
+#include "procedure/nodes/node.h"
+#include "procedure/nodevalue.h"
+
+// Forward Declarations
+class Species;
+class RegionProcedureNodeBase;
+
+// AddPair Node
+class AddPairProcedureNode : public ProcedureNode
+{
+    public:
+    explicit AddPairProcedureNode(const Species *spA = nullptr, const Species *spB = nullptr, const NodeValue &population = 0,
+                                  const NodeValue &density = 0.1,
+                                  Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
+    ~AddPairProcedureNode() override = default;
+
+    private:
+    // Set up keywords for node
+    void setUpKeywords();
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether specified context is relevant for this node type
+    bool isContextRelevant(ProcedureNode::NodeContext context) override;
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Node Data
+     */
+    public:
+    // Box Action Style
+    enum class BoxActionStyle
+    {
+        None,        /* Box geometry / volume will remain unchanged */
+        AddVolume,   /* Increase Box volume to accommodate new species, according to supplied density */
+        ScaleVolume, /* Scale current Box volume to give, after addition of the current species, the supplied density */
+        Set          /* Set the Box geometry to that specified in the Species */
+    };
+    // Return enum option info for BoxActionStyle
+    static EnumOptions<BoxActionStyle> boxActionStyles();
+    // Positioning Type
+    enum class PositioningType
+    {
+        Central, /* Position the Species at the centre of the Box */
+        Current, /* Use current Species coordinates */
+        Random,  /* Set position randomly */
+        Region   /* Set position randomly within a specified region */
+    };
+    // Return enum option info for PositioningType
+    static EnumOptions<PositioningType> positioningTypes();
+
+    private:
+    // Action to take on the Box geometry / volume on addition of the species
+    AddPairProcedureNode::BoxActionStyle boxAction_{AddPairProcedureNode::BoxActionStyle::AddVolume};
+    // Target density when adding molecules
+    std::pair<NodeValue, Units::DensityUnits> density_{1.0, Units::GramsPerCentimetreCubedUnits};
+    // Population of molecules to add
+    NodeValue population_{1.0};
+    // Positioning type for individual molecules
+    AddPairProcedureNode::PositioningType positioningType_{AddPairProcedureNode::PositioningType::Random};
+    // Region into which we will add molecules (if any)
+    std::shared_ptr<const RegionProcedureNodeBase> region_{nullptr};
+    // Whether to rotate molecules on insertion
+    bool rotate_{true};
+    // Flags controlling box axis scaling
+    bool scaleA_{true}, scaleB_{true}, scaleC_{true};
+    // Species to be added
+    const Species *speciesA_{nullptr}, *speciesB_{nullptr};
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+};

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -26,6 +26,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
 {
     return EnumOptions<ProcedureNode::NodeType>(
         "NodeType", {{ProcedureNode::NodeType::Add, "Add"},
+                     {ProcedureNode::NodeType::AddPair, "AddPair"},
                      {ProcedureNode::NodeType::Box, "Box"},
                      {ProcedureNode::NodeType::CalculateAngle, "CalculateAngle"},
                      {ProcedureNode::NodeType::CalculateAxisAngle, "CalculateAxisAngle"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -39,6 +39,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
     enum class NodeType
     {
         Add,
+        AddPair,
         Box,
         CalculateAngle,
         CalculateAxisAngle,

--- a/src/procedure/nodes/nodes.h
+++ b/src/procedure/nodes/nodes.h
@@ -8,6 +8,7 @@
  */
 
 #include "procedure/nodes/add.h"
+#include "procedure/nodes/addpair.h"
 #include "procedure/nodes/box.h"
 #include "procedure/nodes/calculateangle.h"
 #include "procedure/nodes/calculatedistance.h"

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -7,6 +7,8 @@
 ProcedureNodeRegistry::ProcedureNodeRegistry()
 {
     registerProducer<AddProcedureNode>(ProcedureNode::NodeType::Add, "Add molecules to a configuration", "Build");
+    registerProducer<AddPairProcedureNode>(ProcedureNode::NodeType::AddPair,
+                                           "Add a correlated molecule pair to a configuration", "Build");
     registerProducer<BoxProcedureNode>(ProcedureNode::NodeType::Box, "Define containing box for a configuration", "Build");
     registerProducer<CalculateAngleProcedureNode>(ProcedureNode::NodeType::CalculateAngle,
                                                   "Calculate angle between three sites", "Calculate");

--- a/web/content/docs/procedures/nodes/addnode.md
+++ b/web/content/docs/procedures/nodes/addnode.md
@@ -16,7 +16,7 @@ description: Insert molecules into a box
 
 The `Add` node is a core component of nearly all configuration generators requiring the initial construction of a suitable starting point. It adds a number of copies of a given target species to the current box, either at specific or random coordinates. By default, the box is resized to accommodate the new population of molecules based on a supplied density.
 
-If the species is periodic, the box associated with that species can be copied to the model as part of the `Add` process. In that case, an initial [`Box`]({{< ref boxnode >}}) node is not necessary in the procedure.
+If the species is periodic, the box associated with that species can be copied to the model as part of the `Add` process. In that case, an initial {{< gui-node "Box" >}} node is not necessary in the procedure.
 
 ## Description
 

--- a/web/content/docs/procedures/nodes/addpairnode.md
+++ b/web/content/docs/procedures/nodes/addpairnode.md
@@ -1,0 +1,41 @@
+---
+title: AddPair (Node)
+linkTitle: AddPair
+description: Insert correlated molecule pair into a box
+---
+
+{{< htable >}}
+| | |
+|--------|----------|
+|Context|Generation|
+|Name Required?|No|
+|Branches|--|
+{{< /htable >}}
+
+## Overview
+
+The `AddPair` node is a companion to the {{< gui-node "Add" >}} node, but instead operates on a pair of species. The population refers to a population of pairs of species which are added at their current coordinates, then translated / rotated uniformly in order to maintain their relative coordinates.
+
+Periodic species cannot be used by this node, nor can {{< gui-node "CoordinateSets" >}}.
+
+## Description
+
+For full details on the possible options, see the {{< gui-node "Add" >}} node.
+
+## Configuration
+
+### Control
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`BoxAction`|[`BoxActionStyle`]({{< ref "boxactionstyle" >}})|`AddVolume`|Action to take on the Box geometry / volume on addition of the species|
+|`Density`|[`expr`]({{< ref "expressions" >}})<br/>[`DensityUnit`]({{< ref "densityunit" >}})|`0.1 atoms/A3`|Density at which to add the target species. Note that the use of this value differs according to the selected `BoxAction` (see above).|
+|`Population`|[`expr`]({{< ref "expressions" >}})|`0`|Population of the pairs to add.|
+|`Positioning`|[`PositioningType`]({{< ref "positioningtype" >}})|`Random`|Positioning type for the pair.|
+|`Region`|`name`|--|Region node controlling the location of inserted species into the configuration.|
+|`Rotate`|`bool`|`true`|Whether to randomly rotate the molecule pair on insertion.|
+|`ScaleA`|`bool`|`true`|Whether to scale the A cell axis when changing the cell volume.|
+|`ScaleB`|`bool`|`true`|Whether to scale the B cell axis when changing the cell volume.|
+|`ScaleC`|`bool`|`true`|Whether to scale the C cell axis when changing the cell volume.|
+|`SpeciesA`|`name`|--|{{< required-label >}} Target species A of the pair to add.|
+|`SpeciesB`|`name`|--|{{< required-label >}} Target species B of the pair to add.|


### PR DESCRIPTION
This PR introduces an `AddPair` procedure node. In a similar spirit to the `Add` node, the `AddPair` adds a pair of species into the box at once, retaining their relative position and orientation.

Closes #1136.