### PR TITLE
Fix Add/CoordinateSets node crash

### DIFF
--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -44,7 +44,7 @@ std::vector<std::shared_ptr<AddProcedureNode>> createRelativeMix(const std::vect
             auto coordSets = generator.createRootNode<CoordinateSetsProcedureNode>(fmt::format("{}_Sets", sp->name()), sp);
 
             // Create the Add node
-            addNodes.emplace_back(generator.createRootNode<AddProcedureNode>(sp->name(), coordSets.get(),
+            addNodes.emplace_back(generator.createRootNode<AddProcedureNode>(sp->name(), coordSets,
                                                                              NodeValue(popString, paramsNode->parameters()),
                                                                              NodeValue("rho", paramsNode->parameters())));
         }
@@ -94,8 +94,7 @@ void DissolveWindow::on_ConfigurationCreateSimpleRandomMixAction_triggered(bool 
         if (sp->nAtoms() > 1)
         {
             auto coordSets = generator.createRootNode<CoordinateSetsProcedureNode>(fmt::format("{}_Sets", sp->name()), sp);
-            generator.createRootNode<AddProcedureNode>(sp->name(), coordSets.get(), 100,
-                                                       NodeValue("rho", paramsNode->parameters()));
+            generator.createRootNode<AddProcedureNode>(sp->name(), coordSets, 100, NodeValue("rho", paramsNode->parameters()));
         }
         else
             generator.createRootNode<AddProcedureNode>(sp->name(), sp, 100, NodeValue("rho", paramsNode->parameters()));

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -23,9 +23,9 @@ AddProcedureNode::AddProcedureNode(const Species *sp, const NodeValue &populatio
     setUpKeywords();
 }
 
-AddProcedureNode::AddProcedureNode(const CoordinateSetsProcedureNode *sets, const NodeValue &population,
+AddProcedureNode::AddProcedureNode(std::shared_ptr<const CoordinateSetsProcedureNode> sets, const NodeValue &population,
                                    const NodeValue &density, Units::DensityUnits densityUnits)
-    : ProcedureNode(ProcedureNode::NodeType::Add), coordinateSets_(sets), density_{density, densityUnits},
+    : ProcedureNode(ProcedureNode::NodeType::Add), coordinateSets_(std::move(sets)), density_{density, densityUnits},
       population_(population)
 {
     setUpKeywords();

--- a/src/procedure/nodes/add.h
+++ b/src/procedure/nodes/add.h
@@ -18,7 +18,7 @@ class AddProcedureNode : public ProcedureNode
     public:
     explicit AddProcedureNode(const Species *sp = nullptr, const NodeValue &population = 0, const NodeValue &density = 0.1,
                               Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
-    explicit AddProcedureNode(const CoordinateSetsProcedureNode *sets, const NodeValue &population = 0,
+    explicit AddProcedureNode(std::shared_ptr<const CoordinateSetsProcedureNode> sets, const NodeValue &population = 0,
                               const NodeValue &density = 0.1, Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
     ~AddProcedureNode() override = default;
 


### PR DESCRIPTION
Fixes a crash caused by the `CoordinateSet`-specific constructor of the `AddProcedureNode`, which was taking a raw pointer and creating a bogus `std::shared_ptr` object from it, leading to (at least) an immediate crash when attempting to clear that pointer in the keyword widget.

Closes #1143.
May also fix #1115 (testing required).