### PR TITLE
AvgMol - Check for data arrays

### DIFF
--- a/src/modules/calculate_avgmol/functions.cpp
+++ b/src/modules/calculate_avgmol/functions.cpp
@@ -53,6 +53,10 @@ void CalculateAvgMolModule::updateSpecies(const SampledVector &x, const SampledV
 // Update average Species with coordinates from processing data
 void CalculateAvgMolModule::updateSpecies(const GenericList &moduleData)
 {
+    // Check for presence of data arrays
+    if (!moduleData.contains("X", name()) || !moduleData.contains("Y", name()) || !moduleData.contains("Z", name()))
+        return;
+
     // Retrieve data arrays
     auto &x = moduleData.value<SampledVector>("X", name());
     auto &y = moduleData.value<SampledVector>("Y", name());


### PR DESCRIPTION
Fixes a crash in the `CalculateAvgMol` module where data arrays were accessed blindly even if they didn't exist, causing an exception.

Closes #1149.
