### PR TITLE
979 Layer Awareness

### DIFF
--- a/src/gui/layertab.h
+++ b/src/gui/layertab.h
@@ -65,6 +65,8 @@ class LayerTab : public QWidget, public MainTab
     void on_ShowAvailableModulesButton_clicked(bool checked);
     void on_LayerEnabledButton_clicked(bool checked);
     void on_LayerFrequencySpin_valueChanged(int value);
+    void on_RunControlEnergyStabilityCheck_clicked(bool checked);
+    void on_RunControlSizeFactorsCheck_clicked(bool checked);
     void on_ModuleEnabledButton_clicked(bool checked);
     void on_ModuleFrequencySpin_valueChanged(int value);
     void moduleSelectionChanged(const QItemSelection &current, const QItemSelection &previous);

--- a/src/gui/layertab.ui
+++ b/src/gui/layertab.ui
@@ -72,7 +72,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Layer Control</string>
+           <string>Enabled?</string>
           </property>
          </widget>
         </item>
@@ -119,34 +119,22 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="LayerFrequencyLabel">
+         <widget class="QLabel" name="label_2">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="maximumSize">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
           <property name="text">
-           <string/>
-          </property>
-          <property name="pixmap">
-           <pixmap resource="main.qrc">:/general/icons/general_frequency.svg</pixmap>
-          </property>
-          <property name="scaledContents">
-           <bool>true</bool>
+           <string>Frequency</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QSpinBox" name="LayerFrequencySpin">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -169,9 +157,47 @@
       </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="RunControlGroup">
+       <property name="title">
+        <string>Run Control</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="RunControlEnergyStabilityCheck">
+          <property name="text">
+           <string>Energy stability</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="RunControlSizeFactorsCheck">
+          <property name="text">
+           <string>Size factors</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QGroupBox" name="ModulesGroup">
        <property name="title">
-        <string>Layer Modules</string>
+        <string>Modules</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
@@ -222,7 +248,7 @@
               </sizepolicy>
              </property>
              <property name="text">
-              <string>Module Control</string>
+              <string>Enabled?</string>
              </property>
             </widget>
            </item>
@@ -269,34 +295,22 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="ModuleFrequencyLabel">
+            <widget class="QLabel" name="label_4">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="maximumSize">
-              <size>
-               <width>20</width>
-               <height>20</height>
-              </size>
-             </property>
              <property name="text">
-              <string/>
-             </property>
-             <property name="pixmap">
-              <pixmap resource="main.qrc">:/general/icons/general_frequency.svg</pixmap>
-             </property>
-             <property name="scaledContents">
-              <bool>true</bool>
+              <string>Frequency</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QSpinBox" name="ModuleFrequencySpin">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -141,11 +141,16 @@ void LayerTab::on_LayerEnabledButton_clicked(bool checked)
     if (refreshLock_.isLocked() || (!moduleLayer_))
         return;
 
-    moduleLayer_->setEnabled(checked);
     if (checked)
+    {
         tabWidget_->setTabIcon(page_, QIcon(":/tabs/icons/tabs_layer.svg"));
+        moduleLayer_->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::Disabled);
+    }
     else
+    {
         tabWidget_->setTabIcon(page_, QIcon(":/tabs/icons/tabs_layer_disabled.svg"));
+        moduleLayer_->runControlFlags().setFlag(ModuleLayer::RunControlFlag::Disabled);
+    }
 
     updateModuleList();
 
@@ -349,7 +354,7 @@ void LayerTab::updateControls()
 
     Locker refreshLocker(refreshLock_);
 
-    ui_.LayerEnabledButton->setChecked(moduleLayer_->isEnabled());
+    ui_.LayerEnabledButton->setChecked(!moduleLayer_->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled));
     ui_.LayerFrequencySpin->setValue(moduleLayer_->frequency());
 
     auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->currentWidget());

--- a/src/gui/layertab_funcs.cpp
+++ b/src/gui/layertab_funcs.cpp
@@ -167,6 +167,26 @@ void LayerTab::on_LayerFrequencySpin_valueChanged(int value)
     dissolveWindow_->setModified();
 }
 
+void LayerTab::on_RunControlEnergyStabilityCheck_clicked(bool checked)
+{
+    if (refreshLock_.isLocked() || (!moduleLayer_))
+        return;
+
+    moduleLayer_->runControlFlags().setState(ModuleLayer::RunControlFlag::EnergyStability, checked);
+
+    dissolveWindow_->setModified();
+}
+
+void LayerTab::on_RunControlSizeFactorsCheck_clicked(bool checked)
+{
+    if (refreshLock_.isLocked() || (!moduleLayer_))
+        return;
+
+    moduleLayer_->runControlFlags().setState(ModuleLayer::RunControlFlag::SizeFactors, checked);
+
+    dissolveWindow_->setModified();
+}
+
 void LayerTab::on_ModuleEnabledButton_clicked(bool checked)
 {
     if (refreshLock_.isLocked() || (!moduleLayer_))
@@ -356,6 +376,10 @@ void LayerTab::updateControls()
 
     ui_.LayerEnabledButton->setChecked(!moduleLayer_->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled));
     ui_.LayerFrequencySpin->setValue(moduleLayer_->frequency());
+
+    ui_.RunControlEnergyStabilityCheck->setChecked(
+        moduleLayer_->runControlFlags().isSet(ModuleLayer::RunControlFlag::EnergyStability));
+    ui_.RunControlSizeFactorsCheck->setChecked(moduleLayer_->runControlFlags().isSet(ModuleLayer::RunControlFlag::SizeFactors));
 
     auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->currentWidget());
     if (mcw)

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -27,7 +27,6 @@ void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checke
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Basic Atomic)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -53,7 +52,6 @@ void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Atomic)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -84,7 +82,6 @@ void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Standard)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -115,7 +112,6 @@ void DissolveWindow::on_LayerCreateEvolveMDAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (MD)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -144,7 +140,6 @@ void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (EPSR)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -174,9 +169,9 @@ void DissolveWindow::on_LayerCreateRefineEPSRAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Refine (EPSR)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-
     newLayer->setFrequency(5);
-    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::OnlyIfEnergyStable);
+    newLayer->runControlFlags().setFlags(ModuleLayer::RunControlFlag::EnergyStability,
+                                         ModuleLayer::RunControlFlag::SizeFactors);
 
     // Add the EPSR module
     auto *epsr = dynamic_cast<EPSRModule *>(ModuleRegistry::create("EPSR", newLayer));
@@ -197,8 +192,8 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("RDF", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
-
     newLayer->setFrequency(5);
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     // Add the RDF module
     newLayer->append("RDF", dissolve_.configurations());
@@ -217,6 +212,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggere
     newLayer->setName(DissolveSys::uniqueName("RDF / Unweighted S(Q)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     // Add the RDF module
     newLayer->append("RDF", dissolve_.configurations());
@@ -238,6 +234,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool c
     newLayer->setName(DissolveSys::uniqueName("RDF / Neutron S(Q)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     // Add the RDF module
     newLayer->append("RDF", dissolve_.configurations());
@@ -262,6 +259,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFXRayAction_triggered(bool chec
     newLayer->setName(DissolveSys::uniqueName("RDF / X-ray S(Q)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     // Add the RDF module
     newLayer->append("RDF", dissolve_.configurations());
@@ -286,6 +284,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bo
     newLayer->setName(DissolveSys::uniqueName("RDF / Neutron S(Q) / X-ray S(Q)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
     newLayer->setFrequency(5);
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     // Add the RDF module
     newLayer->append("RDF", dissolve_.configurations());
@@ -312,6 +311,7 @@ void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Analyse RDF/CN", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
@@ -336,6 +336,7 @@ void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Analyse AvgMol/SDF", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -27,6 +27,7 @@ void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checke
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Basic Atomic)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -52,6 +53,7 @@ void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Atomic)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -82,6 +84,7 @@ void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Standard)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -112,6 +115,7 @@ void DissolveWindow::on_LayerCreateEvolveMDAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (MD)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -140,6 +144,7 @@ void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
     auto *newLayer = dissolve_.addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (EPSR)", dissolve_.processingLayers(),
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+    newLayer->runControlFlags().removeFlag(ModuleLayer::RunControlFlag::OnlyIfSizeFactorsAreOne);
 
     Module *module;
     auto *firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
@@ -171,6 +176,7 @@ void DissolveWindow::on_LayerCreateRefineEPSRAction_triggered(bool checked)
                                               [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
 
     newLayer->setFrequency(5);
+    newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::OnlyIfEnergyStable);
 
     // Add the EPSR module
     auto *epsr = dynamic_cast<EPSRModule *>(ModuleRegistry::create("EPSR", newLayer));

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -51,7 +51,7 @@ QVariant ModuleLayerModel::data(const QModelIndex &index, int role) const
     {
         if (module->isDisabled())
             return QString::fromStdString(fmt::format("{} [{}] (disabled)", module->name(), module->frequency()));
-        else if (!moduleLayer_->isEnabled())
+        else if (moduleLayer_->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled))
             return QString::fromStdString(fmt::format("{} [{}] (disabled via layer)", module->name(), module->frequency()));
         else
             return QString::fromStdString(fmt::format("{} [{}]", module->name(), module->frequency()));

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -363,6 +363,12 @@ bool Dissolve::saveInput(std::string_view filename)
             return false;
         if (layer->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled) && (!parser.writeLineF("  Disabled\n")))
             return false;
+        if (layer->runControlFlags().isSet(ModuleLayer::RunControlFlag::EnergyStability) &&
+            (!parser.writeLineF("  {}\n", LayerBlock::keywords().keyword(LayerBlock::RequireEnergyStabilityKeyword))))
+            return false;
+        if (layer->runControlFlags().isSet(ModuleLayer::RunControlFlag::SizeFactors) &&
+            (!parser.writeLineF("  {}\n", LayerBlock::keywords().keyword(LayerBlock::RequireNoSizeFactorsKeyword))))
+            return false;
 
         for (auto &module : layer->modules())
         {

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -361,7 +361,7 @@ bool Dissolve::saveInput(std::string_view filename)
         // Write frequency and disabled lines
         if (!parser.writeLineF("  Frequency  {}\n", layer->frequency()))
             return false;
-        if (!layer->isEnabled() && (!parser.writeLineF("  Disabled\n")))
+        if (layer->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled) && (!parser.writeLineF("  Disabled\n")))
             return false;
 
         for (auto &module : layer->modules())

--- a/src/main/keywords.h
+++ b/src/main/keywords.h
@@ -68,10 +68,14 @@ namespace LayerBlock
 // Layer Block Keyword Enum
 enum LayerKeyword
 {
-    DisabledKeyword,  /* 'Disabled' - Specify that the layer is currently disabled */
-    EndLayerKeyword,  /* 'EndLayer' - Signals the end of the Layer block */
+    DisabledKeyword,               /* 'Disabled' - Specify that the layer is currently disabled */
+    EndLayerKeyword,               /* 'EndLayer' - Signals the end of the Layer block */
+    RequireEnergyStabilityKeyword, /* 'RequireEnergyStability' - Only run the layer if all relevant configurations have a stable
+                               energy */
     FrequencyKeyword, /* 'Frequency' - Frequency at which the layer is executed, relative to the main iteration counter */
-    ModuleKeyword     /* 'Module' - Begin a Module definition within this layer */
+    ModuleKeyword,    /* 'Module' - Begin a Module definition within this layer */
+    RequireNoSizeFactorsKeyword /* 'RequireNoSizeFactors' - Only run the layer if all relevant configurations have a stable
+                                   energy */
 };
 // Return enum option info for LayerKeyword
 EnumOptions<LayerBlock::LayerKeyword> keywords();

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -45,7 +45,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
         switch (kwd)
         {
             case (LayerBlock::DisabledKeyword):
-                layer->setEnabled(false);
+                layer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::Disabled);
                 break;
             case (LayerBlock::EndLayerKeyword):
                 Messenger::print("Found end of {} block.\n",

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -15,7 +15,9 @@ EnumOptions<LayerBlock::LayerKeyword> LayerBlock::keywords()
                                                  {{LayerBlock::DisabledKeyword, "Disabled"},
                                                   {LayerBlock::EndLayerKeyword, "EndLayer"},
                                                   {LayerBlock::FrequencyKeyword, "Frequency", 1},
-                                                  {LayerBlock::ModuleKeyword, "Module", OptionArguments::OptionalSecond}});
+                                                  {LayerBlock::ModuleKeyword, "Module", OptionArguments::OptionalSecond},
+                                                  {LayerBlock::RequireEnergyStabilityKeyword, "RequireEnergyStability"},
+                                                  {LayerBlock::RequireNoSizeFactorsKeyword, "RequireNoSizeFactors"}});
 }
 
 // Parse Layer block
@@ -93,6 +95,12 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                     error = true;
                 if (error)
                     break;
+                break;
+            case (LayerBlock::RequireEnergyStabilityKeyword):
+                layer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::EnergyStability);
+                break;
+            case (LayerBlock::RequireNoSizeFactorsKeyword):
+                layer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
                 break;
             default:
                 Messenger::error("{} block keyword '{}' not accounted for.\n",

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -274,13 +274,17 @@ bool Dissolve::iterate(int nIterations)
          */
         for (auto &layer : processingLayers_)
         {
-            // Check if this layer is due to run
+            // Check if this layer is due to run this iteration
             if (!layer->runThisIteration(iteration_))
                 continue;
 
             Messenger::banner("Layer '{}'", layer->name());
             auto layerExecutionCount = iteration_ / layer->frequency();
-            
+
+            // Check run-control settings
+            if (!layer->canRun(processingModuleData_))
+                continue;
+
             for (auto &module : layer->modules())
             {
                 if (!module->runThisIteration(layerExecutionCount))

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -232,7 +232,7 @@ bool Dissolve::iterate(int nIterations)
         {
             Messenger::print("Processing layer '{}'  ({}):\n\n", layer->name(), layer->frequencyDetails(iteration_));
 
-            if (!layer->isEnabled())
+            if (layer->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled))
                 continue;
 
             auto layerExecutionCount = iteration_ / layer->frequency();
@@ -280,7 +280,7 @@ bool Dissolve::iterate(int nIterations)
 
             Messenger::banner("Layer '{}'", layer->name());
             auto layerExecutionCount = iteration_ / layer->frequency();
-
+            
             for (auto &module : layer->modules())
             {
                 if (!module->runThisIteration(layerExecutionCount))
@@ -386,7 +386,7 @@ std::optional<double> Dissolve::estimateRequiredTime(int nIterations)
 
     for (const auto &layer : processingLayers_)
     {
-        if (!layer->isEnabled())
+        if (layer->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled))
             continue;
 
         // Determine how many times this layer will run in the provided number of iterations

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -17,12 +17,6 @@ void ModuleLayer::setName(std::string_view name) { name_ = name; }
 // Return name of layer
 std::string_view ModuleLayer::name() const { return name_; }
 
-// Set whether the layer is enabled
-void ModuleLayer::setEnabled(bool enabled) { enabled_ = enabled; }
-
-// Return whether the layer is enabled
-bool ModuleLayer::isEnabled() const { return enabled_; }
-
 // Frequency, relative to the main iteration counter, at which to execute the layer
 void ModuleLayer::setFrequency(int frequency) { frequency_ = frequency; }
 
@@ -35,7 +29,7 @@ std::string ModuleLayer::frequencyDetails(int iteration) const
     // Check edge cases
     if (frequency_ < 0)
         return "NEGATIVE?";
-    else if ((!enabled_) || (frequency_ == 0))
+    else if (runControlFlags_.isSet(ModuleLayer::RunControlFlag::Disabled) || (frequency_ == 0))
         return "disabled";
     else if (frequency_ == 1)
         return "every time";
@@ -53,13 +47,21 @@ std::string ModuleLayer::frequencyDetails(int iteration) const
 // Return whether the layer should execute this iteration
 bool ModuleLayer::runThisIteration(int iteration) const
 {
-    if ((frequency_ < 1) || (!enabled_))
+    if ((frequency_ < 1) || runControlFlags_.isSet(ModuleLayer::RunControlFlag::Disabled))
         return false;
     else if ((iteration % frequency_) == 0)
         return true;
     else
         return false;
 }
+
+/*
+ * Run Control
+ */
+
+// Return flags controlling run status
+Flags<ModuleLayer::RunControlFlag> &ModuleLayer::runControlFlags() { return runControlFlags_; }
+Flags<ModuleLayer::RunControlFlag> ModuleLayer::runControlFlags() const { return runControlFlags_; }
 
 /*
  * Modules

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -129,3 +129,27 @@ bool ModuleLayer::setUpAll(Dissolve &dissolve, const ProcessPool &procPool)
 
     return result;
 }
+
+// Return all configurations targeted by modules in the layer
+std::vector<Configuration *> ModuleLayer::allTargetedConfigurations() const
+{
+    std::vector<Configuration *> result;
+
+    for (auto &module : modules_)
+    {
+        if (module->keywords().find("Configuration"))
+        {
+            auto *cfg = module->keywords().getConfiguration("Configuration");
+            if (cfg)
+                result.push_back(cfg);
+        }
+
+        if (module->keywords().find("Configurations"))
+        {
+            auto cfgs = module->keywords().getVectorConfiguration("Configurations");
+            std::copy(cfgs.begin(), cfgs.end(), std::back_inserter(result));
+        }
+    }
+
+    return result;
+}

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "templates/flags.h"
 #include <map>
 #include <memory>
 #include <string>
@@ -28,8 +29,6 @@ class ModuleLayer
     private:
     // Name of layer
     std::string name_{"Untitled Layer"};
-    // Whether the layer is enabled
-    bool enabled_{true};
     // Frequency, relative to the main iteration counter, at which to execute the layer
     int frequency_{1};
 
@@ -38,10 +37,6 @@ class ModuleLayer
     void setName(std::string_view name);
     // Return name of layer
     std::string_view name() const;
-    // Set whether the layer is enabled
-    void setEnabled(bool enabled);
-    // Return whether the layer is enabled
-    bool isEnabled() const;
     // Frequency, relative to the main iteration counter, at which to execute the layer
     void setFrequency(int frequency);
     // Return frequency, relative to the main iteration counter, at which to execute the layer
@@ -50,6 +45,26 @@ class ModuleLayer
     std::string frequencyDetails(int iteration) const;
     // Return whether the layer should execute this iteration
     bool runThisIteration(int iteration) const;
+
+    /*
+     * Run Control
+     */
+    public:
+    // Run Control Flags
+    enum RunControlFlag
+    {
+        Disabled,          /* Layer is disabled and will never run */
+        OnlyIfEnergyStable /* Only run if the energy of all relevant configurations is stable */
+    };
+
+    private:
+    // Flags controlling run status
+    Flags<RunControlFlag> runControlFlags_;
+
+    public:
+    // Return flags controlling run status
+    Flags<RunControlFlag> &runControlFlags();
+    Flags<RunControlFlag> runControlFlags() const;
 
     /*
      * Modules

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -60,7 +60,7 @@ class ModuleLayer
 
     private:
     // Flags controlling run status
-    Flags<RunControlFlag> runControlFlags_;
+    Flags<RunControlFlag> runControlFlags_{OnlyIfSizeFactorsAreOne};
 
     public:
     // Return flags controlling run status

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -53,8 +53,9 @@ class ModuleLayer
     // Run Control Flags
     enum RunControlFlag
     {
-        Disabled,          /* Layer is disabled and will never run */
-        OnlyIfEnergyStable /* Only run if the energy of all relevant configurations is stable */
+        Disabled,               /* Layer is disabled and will never run */
+        OnlyIfEnergyStable,     /* Only run if the energy of all relevant configurations is stable */
+        OnlyIfSizeFactorsAreOne /* Only run if the size factors of all relevant configurations are 1.0 */
     };
 
     private:
@@ -65,6 +66,8 @@ class ModuleLayer
     // Return flags controlling run status
     Flags<RunControlFlag> &runControlFlags();
     Flags<RunControlFlag> runControlFlags() const;
+    // Return whether all run control flags are satisfied and permit the layer to be run
+    bool canRun(GenericList &processingModuleData) const;
 
     /*
      * Modules

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -53,14 +53,14 @@ class ModuleLayer
     // Run Control Flags
     enum RunControlFlag
     {
-        Disabled,               /* Layer is disabled and will never run */
-        OnlyIfEnergyStable,     /* Only run if the energy of all relevant configurations is stable */
-        OnlyIfSizeFactorsAreOne /* Only run if the size factors of all relevant configurations are 1.0 */
+        Disabled,        /* Layer is disabled and will never run */
+        EnergyStability, /* Only run if the energy of all relevant configurations is stable */
+        SizeFactors      /* Only run if the size factors of all relevant configurations are 1.0 */
     };
 
     private:
     // Flags controlling run status
-    Flags<RunControlFlag> runControlFlags_{OnlyIfSizeFactorsAreOne};
+    Flags<RunControlFlag> runControlFlags_;
 
     public:
     // Return flags controlling run status

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -93,4 +93,6 @@ class ModuleLayer
     public:
     // Run set-up stages for all modules
     bool setUpAll(Dissolve &dissolve, const ProcessPool &procPool);
+    // Return all configurations targeted by modules in the layer
+    std::vector<Configuration *> allTargetedConfigurations() const;
 };

--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -18,11 +18,6 @@ EPSRModule::EPSRModule() : Module("EPSR")
                                              targets_, std::vector<std::string>{"NeutronSQ", "XRaySQ"});
 
     // Control
-    keywords_.add<BoolKeyword>(
-        "Control", "OnlyWhenEnergyStable",
-        "Assesses the energy of all involved Configurations, refining the potential only when all their total "
-        "energies are stable",
-        onlyWhenEnergyStable_);
     keywords_.add<DoubleKeyword>("Control", "EReq", "Limit of magnitude of additional potential for any one pair potential",
                                  eReq_, 0.0);
     keywords_.add<DoubleKeyword>("Control", "Feedback", "Confidence factor", feedback_, 0.0, 1.0);

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -60,8 +60,6 @@ class EPSRModule : public Module
     std::optional<int> nCoeffP_;
     // Number of steps for refining the potential
     std::optional<int> nPItSs_{1000};
-    // Whether to only modify potentials if configuration energy(s) are stable
-    bool onlyWhenEnergyStable_{true};
     // Overwrite potentials each time rather than summing them
     bool overwritePotentials_{false};
     // EPSR pcof file from which to read starting coefficients from

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -134,9 +134,6 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     else
         Messenger::print("EPSR: Perturbations to interatomic potentials will be generated only (current potentials "
                          "will not be modified).\n");
-    if (onlyWhenEnergyStable_)
-        Messenger::print("EPSR: Potential refinement will only be performed if all related Configuration energies are "
-                         "stable.\n");
     Messenger::print("EPSR: Range for potential generation is {} < Q < {} Angstroms**-1.\n", qMin_, qMax_);
     Messenger::print("EPSR: Weighting factor used when applying fluctuation coefficients is {}\n", weighting_);
     if (saveDifferenceFunctions_)
@@ -161,20 +158,6 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     if (!targetConfiguration_)
         return Messenger::error("No target configuration is set.\n");
-
-    // Is the ctarget configuration's energy stable?
-    if (onlyWhenEnergyStable_)
-    {
-        auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), targetConfiguration_);
-        if (stabilityResult == EnergyModule::NotAssessable)
-            return false;
-        else if (stabilityResult > 0)
-        {
-            Messenger::print("Configuration energy is not yet stable. No potential refinement will be "
-                             "performed this iteration.\n");
-            return true;
-        }
-    }
 
     /*
      * EPSR Main

--- a/src/modules/rdf/process.cpp
+++ b/src/modules/rdf/process.cpp
@@ -49,15 +49,6 @@ bool RDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
      * for each.
      */
 
-    // Check that Configurations have unmodified size factor
-    if (std::all_of(targetConfigurations_.begin(), targetConfigurations_.end(), [](const auto *cfg) {
-            return std::abs(cfg->appliedSizeFactor() - 1.0) > 2 * std::numeric_limits<double>::epsilon();
-        }))
-    {
-        Messenger::print("One or more configurations have an applied size factor, so RDF calculation will be skipped.\n");
-        return true;
-    }
-
     for (auto *cfg : targetConfigurations_)
     {
         // Check RDF range

--- a/src/templates/flags.h
+++ b/src/templates/flags.h
@@ -42,6 +42,8 @@ template <class EnumClass> class Flags
     void setFlag(EnumClass flag) { flags_.set(flag); }
     // Unset specified flag
     void removeFlag(EnumClass flag) { flags_.reset(flag); }
+    // Set state of flag
+    void setState(EnumClass flag, bool state) { state ? flags_.set(flag) : flags_.reset(flag); }
     // Set a pack of flags
     template <typename... Args> void setFlags(Args... flags) { (setFlag(flags), ...); }
     // Return whether any flags are set

--- a/src/templates/flags.h
+++ b/src/templates/flags.h
@@ -40,6 +40,8 @@ template <class EnumClass> class Flags
     public:
     // Set specified flag
     void setFlag(EnumClass flag) { flags_.set(flag); }
+    // Unset specified flag
+    void removeFlag(EnumClass flag) { flags_.reset(flag); }
     // Set a pack of flags
     template <typename... Args> void setFlags(Args... flags) { (setFlag(flags), ...); }
     // Return whether any flags are set

--- a/tests/epsr/benzene.txt
+++ b/tests/epsr/benzene.txt
@@ -266,7 +266,6 @@ Module  EPSR  'EPSR01'
   Target  'C6H6'
   Target  'C6D6'
   Target  '5050'
-  OnlyWhenEnergyStable  False
   Frequency  1
   EReq 3.0
   InpAFile  '../_data/epsr25/benzene200-neutron/benzene.EPSR.inpa'

--- a/tests/epsr/pcof.txt
+++ b/tests/epsr/pcof.txt
@@ -189,7 +189,6 @@ Module  EPSR
   Target  'C6H6'
   Target  'C6D6'
   Target  '5050'
-  OnlyWhenEnergyStable  False
   Frequency  1
   NPItSs  10
   Feedback  0.9

--- a/tests/epsr/water-neutron-xray.txt
+++ b/tests/epsr/water-neutron-xray.txt
@@ -286,7 +286,6 @@ Layer  'Refine (EPSR)'
     QMin  0.5
     QMax  30.0
     NPItSs  0
-    OnlyWhenEnergyStable  False
     #SaveSimulatedFR  On
     SaveEstimatedPartials  On
   EndModule

--- a/tests/epsr/water-poisson.txt
+++ b/tests/epsr/water-poisson.txt
@@ -161,7 +161,6 @@ Layer  'Refine (EPSR)'
     EReq  1.0
     ExpansionFunction  Poisson
     Feedback  0.9
-    OnlyWhenEnergyStable  False
     OverwritePotentials  True
     InpAFile  '../_data/epsr25/water1000-neutron/water.EPSR.inpa'
     QMin  1.5

--- a/web/content/docs/inputfile/layerblock.md
+++ b/web/content/docs/inputfile/layerblock.md
@@ -17,6 +17,8 @@ The block keyword itself takes a single (required) argument - the name of the la
 |`EndLayer`|--|--|Indicates the end of the current `Layer` block.|
 |`Frequency`|`int`|`1`|Frequency at which this layer will run, relative to the main iteration counter. A value of `1` means the layer will run on every iteration, a value of `10` means the layer will only run every 10th iteration, etc.|
 |`Module`|[`Module`]({{< ref "modules" >}})<br/>`[name]`|--|Begins a [`Module`]({{< ref "moduleblock" >}}) block setting up an instance of a module of the type specified, with the optional unique `name`. If a `name` is not provided, a unique one will be generated automatically.|
+|`RequireEnergyStability`|--|--|States that the layer will not be run if any configuration target of any of its modules does not yet have a stable energy. This is useful for only running a layer when a configuration or configurations are at (pseudo-)equilibrium.|
+|`RequireNoSizeFactors`|--|--|States that the layer will not be run if any configuration target of any of its modules has an applied size factor (i.e. is greater than 1.0). This option is useful to prevent a layer from running when a configuration or configurations are still undergoing size factor treatment in the early stages of a simulation.|
 
 ## Example
 
@@ -24,6 +26,7 @@ The block keyword itself takes a single (required) argument - the name of the la
 Layer  'MyLayer'
 
   Frequency  5
+  RequireNoSizeFactors
 
   Module  'A'
     ...


### PR DESCRIPTION
This PR introduces additional run control flags at the layer level, allowing them to be skipped if the energies of all module-targeted configurations are not yet stable, or their size factors are anything other than 1.0.

Existing code in the `RDFModule` and `EPSRModule` has been removed since it is now redundant.

Closes #979.