### PR TITLE
Keyword deprecation

### DIFF
--- a/src/io/fileandformat.cpp
+++ b/src/io/fileandformat.cpp
@@ -95,9 +95,9 @@ bool FileAndFormat::read(LineParser &parser, int startArg, std::string_view endK
 
         // Can we parse the keyword?
         auto result = keywords_.deserialise(parser, coreData);
-        if (result == KeywordBase::Unrecognised)
+        if (result == KeywordBase::ParseResult::Unrecognised)
             return Messenger::error("Unrecognised option '{}' found in file and format block.\n", parser.argsv(0));
-        else if (result == KeywordBase::Failed)
+        else if (result == KeywordBase::ParseResult::Failed)
             return Messenger::error("Error reading option '{}'.\n", parser.argsv(0));
     }
 

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -76,6 +76,7 @@ class KeywordBase
     enum class ParseResult
     {
         Unrecognised,
+        Deprecated,
         Failed,
         Success
     };

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -73,11 +73,11 @@ class KeywordBase
      */
     public:
     // Keyword Parse Result
-    enum ParseResult
+    enum class ParseResult
     {
-        Unrecognised = -1,
-        Failed = 0,
-        Success = 1
+        Unrecognised,
+        Failed,
+        Success
     };
 
     /*

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -58,23 +58,28 @@ const std::vector<std::pair<std::string_view, std::vector<KeywordBase *>>> &Keyw
 KeywordBase::ParseResult KeywordStore::deserialise(LineParser &parser, const CoreData &coreData, int startArg)
 {
     // Do we recognise the first item (the 'keyword')?
-    auto it = keywords_.find(parser.argsv(startArg));
+    auto deprecated = false;
+    auto it = deprecatedKeywords_.find(parser.argsv(startArg));
+    if (it != deprecatedKeywords_.end())
+        deprecated = true;
+    else
+        it = keywords_.find(parser.argsv(startArg));
     if (it == keywords_.end())
         return KeywordBase::ParseResult::Unrecognised;
     auto *keyword = it->second;
 
     // We recognised the keyword - check the number of arguments we have against the min / max for the keyword
     if (!keyword->validNArgs(parser.nArgs() - startArg - 1))
-        return KeywordBase::ParseResult::Failed;
+        return deprecated ? KeywordBase::ParseResult::Deprecated : KeywordBase::ParseResult::Failed;
 
     // All OK, so parse the keyword
     if (!keyword->deserialise(parser, startArg + 1, coreData))
     {
         Messenger::error("Failed to parse arguments for keyword '{}'.\n", keyword->name());
-        return KeywordBase::ParseResult::Failed;
+        return deprecated ? KeywordBase::ParseResult::Deprecated : KeywordBase::ParseResult::Failed;
     }
 
-    return KeywordBase::ParseResult::Success;
+    return deprecated ? KeywordBase::ParseResult::Deprecated : KeywordBase::ParseResult::Success;
 }
 
 // Write all keywords to specified LineParser

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -60,21 +60,21 @@ KeywordBase::ParseResult KeywordStore::deserialise(LineParser &parser, const Cor
     // Do we recognise the first item (the 'keyword')?
     auto it = keywords_.find(parser.argsv(startArg));
     if (it == keywords_.end())
-        return KeywordBase::Unrecognised;
+        return KeywordBase::ParseResult::Unrecognised;
     auto *keyword = it->second;
 
     // We recognised the keyword - check the number of arguments we have against the min / max for the keyword
     if (!keyword->validNArgs(parser.nArgs() - startArg - 1))
-        return KeywordBase::Failed;
+        return KeywordBase::ParseResult::Failed;
 
     // All OK, so parse the keyword
     if (!keyword->deserialise(parser, startArg + 1, coreData))
     {
         Messenger::error("Failed to parse arguments for keyword '{}'.\n", keyword->name());
-        return KeywordBase::Failed;
+        return KeywordBase::ParseResult::Failed;
     }
 
-    return KeywordBase::Success;
+    return KeywordBase::ParseResult::Success;
 }
 
 // Write all keywords to specified LineParser

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -41,7 +41,7 @@ class KeywordStore
      */
     private:
     // Defined keywords
-    std::map<std::string_view, KeywordBase *> keywords_;
+    std::map<std::string_view, KeywordBase *> keywords_, deprecatedKeywords_;
     // Targets group
     std::vector<KeywordBase *> targetsGroup_;
     // Keyword group mappings
@@ -96,6 +96,16 @@ class KeywordStore
                                 Args &&... args)
     {
         return restartables_.emplace_back(add<K>(displayGroup, name, description, args...));
+    }
+    // Add deprecated keyword
+    template <class K, typename... Args>
+    KeywordBase *addDeprecated(std::string_view name, std::string_view description, Args &&... args)
+    {
+        auto *k = addKeyword<K>(name, description, args...);
+
+        deprecatedKeywords_.emplace(name, k);
+
+        return k;
     }
     // Find named keyword
     KeywordBase *find(std::string_view name);

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -442,13 +442,13 @@ bool Dissolve::loadRestart(std::string_view filename)
 
             // Does the Module have a keyword by this name?
             auto result = module->keywords().deserialise(parser, coreData_, 2);
-            if (result == KeywordBase::Unrecognised)
+            if (result == KeywordBase::ParseResult::Unrecognised)
             {
                 Messenger::error("Module '{}' has no keyword '{}'.\n", parser.argsv(2));
                 error = true;
                 break;
             }
-            else if (result == KeywordBase::Failed)
+            else if (result == KeywordBase::ParseResult::Failed)
             {
                 Messenger::error("Failed to read keyword data '{}' from restart file.\n", parser.argsv(2));
                 error = true;

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -73,6 +73,8 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
                 module->printValidKeywords();
                 error = true;
             }
+            else if (result == KeywordBase::ParseResult::Deprecated)
+                Messenger::warn("The '{}' keyword is deprecated and will be removed in a future version.\n", parser.argsv(0));
             else if (result == KeywordBase::ParseResult::Failed)
                 error = true;
         }

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -63,7 +63,7 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
         {
             // Might be a keyword defined in the Module itself?
             auto result = module->keywords().deserialise(parser, dissolve->coreData());
-            if (result == KeywordBase::Unrecognised)
+            if (result == KeywordBase::ParseResult::Unrecognised)
             {
                 Messenger::error("Unrecognised {} block keyword '{}' found, and the Module '{}' contains no "
                                  "option with this name.\n",
@@ -73,7 +73,7 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
                 module->printValidKeywords();
                 error = true;
             }
-            else if (result == KeywordBase::Failed)
+            else if (result == KeywordBase::ParseResult::Failed)
                 error = true;
         }
 

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -275,11 +275,11 @@ bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
 
         // Try to parse this line as a keyword
         KeywordBase::ParseResult result = keywords_.deserialise(parser, coreData);
-        if (result == KeywordBase::Failed)
+        if (result == KeywordBase::ParseResult::Failed)
             return Messenger::error("Failed to parse keyword '{}'.\n", parser.argsv(0));
-        else if (result == KeywordBase::Success)
+        else if (result == KeywordBase::ParseResult::Success)
             continue;
-        else if (result == KeywordBase::Unrecognised)
+        else if (result == KeywordBase::ParseResult::Unrecognised)
             return Messenger::error("Unrecognised keyword '{}' found while parsing {} node.\n", parser.argsv(0),
                                     nodeTypes().keyword(type_));
     }

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -275,13 +275,13 @@ bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
 
         // Try to parse this line as a keyword
         KeywordBase::ParseResult result = keywords_.deserialise(parser, coreData);
-        if (result == KeywordBase::ParseResult::Failed)
-            return Messenger::error("Failed to parse keyword '{}'.\n", parser.argsv(0));
-        else if (result == KeywordBase::ParseResult::Success)
-            continue;
-        else if (result == KeywordBase::ParseResult::Unrecognised)
+        if (result == KeywordBase::ParseResult::Unrecognised)
             return Messenger::error("Unrecognised keyword '{}' found while parsing {} node.\n", parser.argsv(0),
                                     nodeTypes().keyword(type_));
+        else if (result == KeywordBase::ParseResult::Deprecated)
+            Messenger::warn("The '{}' keyword is deprecated and will be removed in a future version.\n", parser.argsv(0));
+        else if (result == KeywordBase::ParseResult::Failed)
+            return Messenger::error("Failed to parse keyword '{}'.\n", parser.argsv(0));
     }
 
     return true;


### PR DESCRIPTION
This PR provides a simple facility for deprecating keywords in modules and nodes, allowing them to be recognised and deserialised, but which are not serialised when saving a new file.  This allows compatibility with old input files to be temporarily retained until the next significant version comes around.