### PR TITLE
Configuration Generation Tidy

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -130,6 +130,9 @@ bool Configuration::initialiseContent(const ProcedureContext &procedureContext)
                                     name(), inputCoordinates_.filename());
     }
 
+    // Create cell array
+    updateCells(procedureContext.potentialMap().range());
+
     return true;
 }
 

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -164,8 +164,8 @@ class Configuration : public Serialisable
     double appliedSizeFactor_{defaultSizeFactor_};
     // Periodic Box
     std::unique_ptr<Box> box_{nullptr};
-    static constexpr double defaultCellDivisionLength_ = 7.0;
     // Requested side length for individual Cell
+    static constexpr double defaultCellDivisionLength_ = 7.0;
     double requestedCellDivisionLength_{defaultCellDivisionLength_};
     // Cell array
     CellArray cells_;
@@ -176,12 +176,11 @@ class Configuration : public Serialisable
     // Create Box definition from axes matrix
     void createBox(const Matrix3 axes);
     // Create Box definition with specified lengths and angles, and initialise cell array
-    void createBoxAndCells(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic, double cellSize,
-                           double pairPotentialRange);
+    void createBoxAndCells(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic, double pairPotentialRange);
     // Create Box definition from axes matrix, and initialise cell array
-    void createBoxAndCells(const Matrix3 axes, double cellSize, double pairPotentialRange);
+    void createBoxAndCells(const Matrix3 axes, double pairPotentialRange);
     // Update cell array, and reassign atoms to cells
-    void updateCells(double cellSize, double pairPotentialRange);
+    void updateCells(double pairPotentialRange);
     // Return Box
     const Box *box() const;
     // Scale Box lengths (and associated Cells) by specified factors

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -74,7 +74,7 @@ class Configuration : public Serialisable
     // Return import coordinates file / format
     CoordinateImportFileFormat &inputCoordinates();
     // Initialise (generate or load) the basic contents of the Configuration
-    bool initialiseContent(const ProcedureContext &procedureContext, bool emptyCurrentContent = false);
+    bool initialiseContent(const ProcedureContext &procedureContext);
     // Set configuration temperature
     void setTemperature(double t);
     // Return configuration temperature

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -34,24 +34,24 @@ void Configuration::createBox(const Matrix3 axes)
 }
 
 // Create Box definition with specified lengths and angles, and initialise cell array
-void Configuration::createBoxAndCells(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic, double cellSize,
+void Configuration::createBoxAndCells(const Vec3<double> lengths, const Vec3<double> angles, bool nonPeriodic,
                                       double pairPotentialRange)
 {
     createBox(lengths, angles, nonPeriodic);
-    cells_.generate(box_.get(), cellSize, pairPotentialRange);
+    cells_.generate(box_.get(), requestedCellDivisionLength_, pairPotentialRange);
 }
 
 // Create Box definition from axes matrix, and initialise cell array
-void Configuration::createBoxAndCells(const Matrix3 axes, double cellSize, double pairPotentialRange)
+void Configuration::createBoxAndCells(const Matrix3 axes, double pairPotentialRange)
 {
     createBox(axes);
-    cells_.generate(box_.get(), cellSize, pairPotentialRange);
+    cells_.generate(box_.get(), requestedCellDivisionLength_, pairPotentialRange);
 }
 
 // Update cell array, and reassign atoms to cells
-void Configuration::updateCells(double cellSize, double pairPotentialRange)
+void Configuration::updateCells(double pairPotentialRange)
 {
-    cells_.generate(box_.get(), cellSize, pairPotentialRange);
+    cells_.generate(box_.get(), requestedCellDivisionLength_, pairPotentialRange);
     updateCellContents(true);
 }
 

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -91,7 +91,7 @@ bool Configuration::deserialise(LineParser &parser, const std::vector<std::uniqu
     const auto angles = parser.arg3d(0);
     AtomChangeToken lock(*this);
 
-    createBoxAndCells(lengths, angles, nonPeriodic, requestedCellDivisionLength_, pairPotentialRange);
+    createBoxAndCells(lengths, angles, nonPeriodic, pairPotentialRange);
 
     // Read total number of Molecules to expect
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -191,7 +191,7 @@ void ConfigurationTab::on_GenerateButton_clicked(bool checked)
     dissolve_.regeneratePairPotentials();
 
     // Initialise the content
-    configuration_->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()}, true);
+    configuration_->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()});
 
     // Update
     updateControls();

--- a/src/gui/importcifdialog_funcs.cpp
+++ b/src/gui/importcifdialog_funcs.cpp
@@ -336,7 +336,7 @@ bool ImportCIFDialog::createStructuralSpecies()
         return false;
     crystalSpecies_->createBox(cellLengths.value(), cellAngles.value());
     auto *box = crystalSpecies_->box();
-    structureConfiguration_->createBoxAndCells(cellLengths.value(), cellAngles.value(), false, 7.0, 1.0);
+    structureConfiguration_->createBoxAndCells(cellLengths.value(), cellAngles.value(), false, 1.0);
     // -- Generate atoms
     auto symmetryGenerators = cifImporter_.spaceGroup().symmetryOperators();
     auto tolerance = ui_.NormalOverlapToleranceRadio->isChecked() ? 0.1 : 0.5;
@@ -438,7 +438,7 @@ bool ImportCIFDialog::createCleanedSpecies()
     if (!cellAngles)
         return false;
     cleanedSpecies_->createBox(cellLengths.value(), cellAngles.value());
-    cleanedConfiguration_->createBoxAndCells(cellLengths.value(), cellAngles.value(), false, 7.0, 1.0);
+    cleanedConfiguration_->createBoxAndCells(cellLengths.value(), cellAngles.value(), false, 1.0);
 
     // Atomics
     if (ui_.MoietyRemoveAtomicsCheck->isChecked())
@@ -560,7 +560,7 @@ bool ImportCIFDialog::createSupercellSpecies()
     auto supercellLengths = cleanedSpecies_->box()->axisLengths();
     supercellLengths.multiply(repeat.x, repeat.y, repeat.z);
     supercell->createBox(supercellLengths, cleanedSpecies_->box()->axisAngles(), false);
-    supercellConfiguration_->createBoxAndCells(supercellLengths, cleanedSpecies_->box()->axisAngles(), false, 7.0, 1.0);
+    supercellConfiguration_->createBoxAndCells(supercellLengths, cleanedSpecies_->box()->axisAngles(), false, 1.0);
 
     // Copy atoms from the Crystal species - we'll do the bonding afterwards
     supercell->atoms().reserve(repeat.x * repeat.y * repeat.z * cleanedSpecies_->nAtoms());
@@ -618,7 +618,7 @@ bool ImportCIFDialog::createPartitionedSpecies()
     // Set up the basic configuration
     auto *sp = temporaryCoreData_.findSpecies("Supercell");
     assert(sp);
-    partitioningConfiguration_->createBoxAndCells(sp->box()->axisLengths(), sp->box()->axisAngles(), false, 7.0, 1.0);
+    partitioningConfiguration_->createBoxAndCells(sp->box()->axisLengths(), sp->box()->axisAngles(), false, 1.0);
 
     auto validSpecies = true;
 

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -80,7 +80,7 @@ void DissolveWindow::on_ConfigurationCreateAction_triggered(bool checked)
         dissolve_.regeneratePairPotentials();
 
         // Initialise the content
-        newConfig->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()}, true);
+        newConfig->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()});
         newConfig->updateCells(dissolve_.pairPotentialRange());
     }
 }

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -81,7 +81,7 @@ void DissolveWindow::on_ConfigurationCreateAction_triggered(bool checked)
 
         // Initialise the content
         newConfig->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()}, true);
-        newConfig->updateCells(7.0, dissolve_.pairPotentialRange());
+        newConfig->updateCells(dissolve_.pairPotentialRange());
     }
 }
 

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -81,7 +81,6 @@ void DissolveWindow::on_ConfigurationCreateAction_triggered(bool checked)
 
         // Initialise the content
         newConfig->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()});
-        newConfig->updateCells(dissolve_.pairPotentialRange());
     }
 }
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -68,11 +68,12 @@ bool Dissolve::prepare()
     for (auto &cfg : configurations())
     {
         // If the configuration is empty, initialise it now
-        if (cfg->nMolecules() == 0 && !cfg->initialiseContent({worldPool_, potentialMap_}))
-            return Messenger::error("Failed to initialise content for configuration '{}'.\n", cfg->name());
-
-        // Regenerate cell array if the pair potential range has changed
-        if (newPairPotentialRange)
+        if (cfg->nMolecules() == 0)
+        {
+            if (!cfg->initialiseContent({worldPool_, potentialMap_}))
+                return Messenger::error("Failed to initialise content for configuration '{}'.\n", cfg->name());
+        }
+        else if (newPairPotentialRange)
             cfg->updateCells(*newPairPotentialRange);
 
         // Check Box extent against pair potential range

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -73,7 +73,7 @@ bool Dissolve::prepare()
 
         // Regenerate cell array if the pair potential range has changed
         if (newPairPotentialRange)
-            cfg->updateCells(7.0, *newPairPotentialRange);
+            cfg->updateCells(*newPairPotentialRange);
 
         // Check Box extent against pair potential range
         auto maxPPRange = cfg->box()->inscribedSphereRadius();

--- a/src/modules/import_trajectory/process.cpp
+++ b/src/modules/import_trajectory/process.cpp
@@ -49,8 +49,7 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
         if ((unitCell.value() - targetConfiguration_->box()->axes()).maxAbs() > 1.0e-8)
         {
             // Create new Box and cells for the configuration
-            targetConfiguration_->createBoxAndCells(unitCell.value(), targetConfiguration_->requestedCellDivisionLength(),
-                                                    dissolve.pairPotentialRange());
+            targetConfiguration_->createBoxAndCells(unitCell.value(), dissolve.pairPotentialRange());
 
             clearExistingAtoms = true;
         }

--- a/unit/classes/cells.cpp
+++ b/unit/classes/cells.cpp
@@ -59,7 +59,7 @@ TEST(CellsTest, Basic)
     // Setup Configuration
     auto *cfg = dissolve.addConfiguration();
     AtomChangeToken lock(*cfg);
-    cfg->createBoxAndCells({20, 20, 20}, {90, 90, 90}, false, 7.0, dissolve.pairPotentialRange());
+    cfg->createBoxAndCells({20, 20, 20}, {90, 90, 90}, false, dissolve.pairPotentialRange());
     cfg->cells().generate(cfg->box(), 7.0, dissolve.pairPotentialRange());
     cfg->addMolecule(lock, argon);
     for (auto n = 0; n < 267; ++n)


### PR DESCRIPTION
This PR performs a little cleanup and tidying around generation of cell arrays once a Configuration's contents have been created or re-initialised. Some magic numbers and extraneous arguments have been removed, and the process made more consistent and automatic..

Closes #1167.