### PR TITLE
1062 Copy Configuration Node

### DIFF
--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -126,6 +126,8 @@ class Configuration : public Serialisable
     std::shared_ptr<Molecule>
     addMolecule(AtomChangeToken &lock, const Species *sp,
                 OptionalReferenceWrapper<const std::vector<Vec3<double>>> sourceCoordinates = std::nullopt);
+    // Copy molecule
+    std::shared_ptr<Molecule> copyMolecule(AtomChangeToken &lock, const std::shared_ptr<Molecule> &sourceMolecule);
     // Remove all Molecules of the target Species from the Configuration
     void removeMolecules(const Species *sp);
     // Remove specified Molecules from the Configuration

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -115,6 +115,25 @@ Configuration::addMolecule(AtomChangeToken &lock, const Species *sp,
     return newMolecule;
 }
 
+// Copy molecule
+std::shared_ptr<Molecule> Configuration::copyMolecule(AtomChangeToken &lock, const std::shared_ptr<Molecule> &sourceMolecule)
+{
+    std::shared_ptr<Molecule> newMolecule = std::make_shared<Molecule>();
+    newMolecule->setArrayIndex(molecules_.size());
+    molecules_.push_back(newMolecule);
+    auto *sp = sourceMolecule->species();
+    newMolecule->setSpecies(sp);
+
+    // Update the relevant Species population
+    adjustSpeciesPopulation(sp, 1);
+
+    // Copy the source molecule's coordinates
+    for (const auto *atom : sourceMolecule->atoms())
+        addAtom(lock, atom->speciesAtom(), newMolecule, atom->r());
+
+    return newMolecule;
+}
+
 // Remove all Molecules of the target Species from the Configuration
 void Configuration::removeMolecules(const Species *sp)
 {

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -41,14 +41,17 @@ const std::vector<Atom *> &Molecule::atoms() const { return atoms_; }
 // Return nth Atom pointer
 Atom *Molecule::atom(int n) const { return atoms_[n]; }
 
+// Update atoms array from indices
 void Molecule::updateAtoms(std::vector<Atom> &source)
 {
     if (!atoms_.empty() && atoms_[0] != &source[atomIndices_[0]])
         std::transform(atomIndices_.begin(), atomIndices_.end(), atoms_.begin(),
                        [&source](const auto idx) { return &source[idx]; });
 }
+
 // Sets the index of the object within the parent DynamicArray
 void Molecule::setArrayIndex(int index) { arrayIndex_ = index; }
+
 // Gets the index of the object within the parent DynamicArray
 int Molecule::arrayIndex() const { return arrayIndex_; }
 

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -44,6 +44,7 @@ class Molecule : public std::enable_shared_from_this<Molecule>
     const std::vector<Atom *> &atoms() const;
     // Return nth Atom pointer
     Atom *atom(int n) const;
+    // Update atoms array from indices
     void updateAtoms(std::vector<Atom> &source);
     // Sets the index of the object within the parent DynamicArray
     void setArrayIndex(int index);

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -310,7 +310,7 @@ bool Dissolve::saveInput(std::string_view filename)
             return false;
 
         // Generator
-        if (!parser.writeLineF("\n  # Modules\n"))
+        if (!parser.writeLineF("\n  # Generator\n"))
             return false;
         if (!parser.writeLineF("  {}\n", ConfigurationBlock::keywords().keyword(ConfigurationBlock::GeneratorKeyword)))
             return false;

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
   collect3d.cpp
   context.cpp
   coordinatesets.cpp
+  copy.cpp
   cylindricalregion.cpp
   dynamicsite.cpp
   fit1d.cpp
@@ -57,6 +58,7 @@ add_library(
   collect3d.h
   context.h
   coordinatesets.h
+  copy.h
   cylindricalregion.h
   dynamicsite.h
   fit1d.h

--- a/src/procedure/nodes/copy.cpp
+++ b/src/procedure/nodes/copy.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "procedure/nodes/copy.h"
+#include "classes/atomchangetoken.h"
+#include "classes/configuration.h"
+#include "classes/coredata.h"
+#include "classes/species.h"
+#include "keywords/configuration.h"
+#include "keywords/speciesvector.h"
+#include <algorithm>
+
+CopyProcedureNode::CopyProcedureNode(Configuration *cfg) : ProcedureNode(ProcedureNode::NodeType::Copy), source_(cfg)
+{
+    keywords_.add<ConfigurationKeyword>("Control", "Source", "Source configuration to copy", source_);
+    keywords_.add<SpeciesVectorKeyword>("Control", "Exclude", "Species types to exclude from copy", excludedSpecies_);
+}
+
+/*
+ * Identity
+ */
+
+// Return whether specified context is relevant for this node type
+bool CopyProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
+{
+    return (context == ProcedureNode::GenerationContext);
+}
+
+// Return whether a name for the node must be provided
+bool CopyProcedureNode::mustBeNamed() const { return false; }
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool CopyProcedureNode::prepare(const ProcedureContext &procedureContext)
+{
+    // Check for valid source configuration
+    if (!source_)
+        return Messenger::error("No source configuration set in node '{}'.\n", name());
+    if (source_ == procedureContext.configuration())
+        return Messenger::error("Source configuration set in node '{}' is the same as the context target.\n", name());
+
+    return true;
+}
+
+// Execute node
+bool CopyProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    auto *cfg = procedureContext.configuration();
+
+    // Raise error if the destination configuration is not empty
+    if (cfg->nMolecules() != 0)
+        return Messenger::error("Context configuration for copy must be empty.\n");
+
+    // Copy the source box
+    cfg->createBox(source_->box()->axes());
+
+    // Pre-determine array sizes
+    auto nAtoms = source_->nAtoms();
+    if (!excludedSpecies_.empty())
+    {
+        nAtoms = 0;
+        for (const auto &mol : source_->molecules())
+            if (std::find(excludedSpecies_.begin(), excludedSpecies_.end(), mol->species()) == excludedSpecies_.end())
+                nAtoms += mol->nAtoms();
+    }
+    procedureContext.configuration()->atoms().reserve(nAtoms);
+
+    // Copy molecules
+    {
+        AtomChangeToken lock(*cfg);
+        for (const auto &mol : source_->molecules())
+        {
+            // Check for exclusion
+            if (std::find(excludedSpecies_.begin(), excludedSpecies_.end(), mol->species()) != excludedSpecies_.end())
+                continue;
+
+            // Copy the molecule
+            auto newMol = cfg->copyMolecule(lock, mol);
+        }
+    }
+
+    return true;
+}

--- a/src/procedure/nodes/copy.cpp
+++ b/src/procedure/nodes/copy.cpp
@@ -78,7 +78,7 @@ bool CopyProcedureNode::execute(const ProcedureContext &procedureContext)
                 continue;
 
             // Copy the molecule
-            auto newMol = cfg->copyMolecule(lock, mol);
+            cfg->copyMolecule(lock, mol);
         }
     }
 

--- a/src/procedure/nodes/copy.h
+++ b/src/procedure/nodes/copy.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/node.h"
+#include <memory>
+#include <set>
+
+// Forward Declarations
+class DynamicSiteProcedureNode;
+class SequenceProcedureNode;
+class Element;
+class Molecule;
+class SiteStack;
+class Species;
+class SpeciesSite;
+
+// Copy Node
+class CopyProcedureNode : public ProcedureNode
+{
+    public:
+    explicit CopyProcedureNode(Configuration *cfg = nullptr);
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether specified context is relevant for this node type
+    bool isContextRelevant(ProcedureNode::NodeContext context) override;
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Copy Target
+     */
+    private:
+    // Source configuration
+    Configuration *source_{nullptr};
+    // Vector of Species to exclude from copy
+    std::vector<const Species *> excludedSpecies_;
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+};

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -36,6 +36,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Collect2D, "Collect2D"},
                      {ProcedureNode::NodeType::Collect3D, "Collect3D"},
                      {ProcedureNode::NodeType::CoordinateSets, "CoordinateSets"},
+                     {ProcedureNode::NodeType::Copy, "Copy"},
                      {ProcedureNode::NodeType::CylindricalRegion, "CylindricalRegion"},
                      {ProcedureNode::NodeType::DynamicSite, "DynamicSite"},
                      {ProcedureNode::NodeType::Fit1D, "Fit1D"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -49,6 +49,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
         Collect2D,
         Collect3D,
         CoordinateSets,
+        Copy,
         CylindricalRegion,
         DynamicSite,
         Fit1D,

--- a/src/procedure/nodes/nodes.h
+++ b/src/procedure/nodes/nodes.h
@@ -17,6 +17,7 @@
 #include "procedure/nodes/collect2d.h"
 #include "procedure/nodes/collect3d.h"
 #include "procedure/nodes/coordinatesets.h"
+#include "procedure/nodes/copy.h"
 #include "procedure/nodes/cylindricalregion.h"
 #include "procedure/nodes/dynamicsite.h"
 #include "procedure/nodes/fit1d.h"

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -21,6 +21,7 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
     registerProducer<Collect3DProcedureNode>(ProcedureNode::NodeType::Collect3D, "Bin 3D quantity into a histogram", "Data");
     registerProducer<CoordinateSetsProcedureNode>(ProcedureNode::NodeType::CoordinateSets,
                                                   "Generate coordinate sets for a species", "Build");
+    registerProducer<CopyProcedureNode>(ProcedureNode::NodeType::Copy, "Copy the contents of a configuration", "Build");
     registerProducer<CylindricalRegionProcedureNode>(ProcedureNode::NodeType::CylindricalRegion,
                                                      "Define a cylindrical region in a configuration", "Regions");
     registerProducer<Fit1DProcedureNode>(ProcedureNode::NodeType::Fit1D, "Fit a function to 1D data", "Fitting");

--- a/web/content/docs/procedures/nodes/copy.md
+++ b/web/content/docs/procedures/nodes/copy.md
@@ -1,0 +1,26 @@
+---
+title: Copy (Node)
+linkTitle: Copy
+description: Copy a configuration
+---
+
+{{< htable >}}
+| | |
+|--------|----------|
+|Context|Generation|
+|Name Required?|No|
+|Branches|--|
+{{< /htable >}}
+
+## Overview
+
+The `Copy` node copies the box and all molecules from a source configuration into the current one, providing e.g. a basis for further editing.
+
+## Configuration
+
+### Control
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Source`|`Configuration`|--|Source configuration to copy.|
+|`Exclude`|`Species ...`|--|Species to exclude from the copy.|


### PR DESCRIPTION
This PR introduces a new procedure node `Copy` whose job is to copy the box and molecule contents from an existing configuration to a new one. This provides the basis for workflows where creating the final configuration depends on the inline editing of one or more precursor configurations.

Closes #1062.