### PR TITLE
Refactor vector keywords

### DIFF
--- a/src/gui/keywordwidgets/atomtypevector.h
+++ b/src/gui/keywordwidgets/atomtypevector.h
@@ -56,8 +56,6 @@ class AtomTypeVectorKeywordWidget : public KeywordDropDown, public KeywordWidget
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/atomtypevector.h
+++ b/src/gui/keywordwidgets/atomtypevector.h
@@ -58,8 +58,6 @@ class AtomTypeVectorKeywordWidget : public KeywordDropDown, public KeywordWidget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/atomtypevector.h
+++ b/src/gui/keywordwidgets/atomtypevector.h
@@ -49,6 +49,10 @@ class AtomTypeVectorKeywordWidget : public KeywordDropDown, public KeywordWidget
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -61,13 +61,7 @@ void AtomTypeVectorKeywordWidget::resetModelData()
 }
 
 // Update value displayed in widget
-void AtomTypeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
-{
-    updateWidgetValues(coreData_);
-}
-
-// Update widget values data based on keyword data
-void AtomTypeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
+void AtomTypeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) { resetModelData(); }
 
 // Update summary text
 void AtomTypeVectorKeywordWidget::updateSummaryText()

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -69,12 +69,6 @@ void AtomTypeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataM
 // Update widget values data based on keyword data
 void AtomTypeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
-// Update keyword data based on widget values
-void AtomTypeVectorKeywordWidget::updateKeywordData()
-{
-    // Handled by model
-}
-
 // Update summary text
 void AtomTypeVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/atomtypevector_funcs.cpp
+++ b/src/gui/keywordwidgets/atomtypevector_funcs.cpp
@@ -18,8 +18,11 @@ AtomTypeVectorKeywordWidget::AtomTypeVectorKeywordWidget(QWidget *parent, AtomTy
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
+
+    // Set up the model
     ui_.AtomTypeList->setModel(&atomTypeModel_);
     atomTypeModel_.setCheckStateData(keyword_->data());
+    resetModelData();
 
     // Connect signals / slots
     connect(&atomTypeModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
@@ -44,6 +47,19 @@ void AtomTypeVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, c
  * Update
  */
 
+// Reset model data
+void AtomTypeVectorKeywordWidget::resetModelData()
+{
+    refreshing_ = true;
+
+    atomTypeModel_.setData(coreData_.atomTypes());
+    atomTypeModel_.setCheckStateData(keyword_->data());
+
+    updateSummaryText();
+
+    refreshing_ = false;
+}
+
 // Update value displayed in widget
 void AtomTypeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
@@ -51,17 +67,7 @@ void AtomTypeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataM
 }
 
 // Update widget values data based on keyword data
-void AtomTypeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)
-{
-    refreshing_ = true;
-
-    atomTypeModel_.setData(coreData.atomTypes());
-    atomTypeModel_.setCheckStateData(keyword_->data());
-
-    updateSummaryText();
-
-    refreshing_ = false;
-}
+void AtomTypeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update keyword data based on widget values
 void AtomTypeVectorKeywordWidget::updateKeywordData()

--- a/src/gui/keywordwidgets/configurationvector.h
+++ b/src/gui/keywordwidgets/configurationvector.h
@@ -54,8 +54,6 @@ class ConfigurationVectorKeywordWidget : public KeywordDropDown, public KeywordW
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/configurationvector.h
+++ b/src/gui/keywordwidgets/configurationvector.h
@@ -47,6 +47,10 @@ class ConfigurationVectorKeywordWidget : public KeywordDropDown, public KeywordW
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/configurationvector.h
+++ b/src/gui/keywordwidgets/configurationvector.h
@@ -56,8 +56,6 @@ class ConfigurationVectorKeywordWidget : public KeywordDropDown, public KeywordW
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/configurationvector_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationvector_funcs.cpp
@@ -67,12 +67,6 @@ void ConfigurationVectorKeywordWidget::updateValue(const Flags<DissolveSignals::
 // Update widget values data based on keyword data
 void ConfigurationVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
-// Update keyword data based on widget values
-void ConfigurationVectorKeywordWidget::updateKeywordData()
-{
-    // Handled by model
-}
-
 // Update summary text
 void ConfigurationVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/configurationvector_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationvector_funcs.cpp
@@ -61,11 +61,8 @@ void ConfigurationVectorKeywordWidget::resetModelData()
 // Update value displayed in widget
 void ConfigurationVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    resetModelData();
 }
-
-// Update widget values data based on keyword data
-void ConfigurationVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update summary text
 void ConfigurationVectorKeywordWidget::updateSummaryText()

--- a/src/gui/keywordwidgets/configurationvector_funcs.cpp
+++ b/src/gui/keywordwidgets/configurationvector_funcs.cpp
@@ -17,8 +17,11 @@ ConfigurationVectorKeywordWidget::ConfigurationVectorKeywordWidget(QWidget *pare
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
+
+    // Set up the model
     ui_.ConfigurationList->setModel(&configurationModel_);
     configurationModel_.setCheckStateData(keyword_->data());
+    resetModelData();
 
     // Connect signals / slots
     connect(&configurationModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
@@ -43,6 +46,18 @@ void ConfigurationVectorKeywordWidget::modelDataChanged(const QModelIndex &topLe
  * Update
  */
 
+// Reset model data
+void ConfigurationVectorKeywordWidget::resetModelData()
+{
+    refreshing_ = true;
+
+    configurationModel_.setData(coreData_.configurations());
+
+    updateSummaryText();
+
+    refreshing_ = false;
+}
+
 // Update value displayed in widget
 void ConfigurationVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
@@ -50,17 +65,7 @@ void ConfigurationVectorKeywordWidget::updateValue(const Flags<DissolveSignals::
 }
 
 // Update widget values data based on keyword data
-void ConfigurationVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)
-{
-    refreshing_ = true;
-
-    configurationModel_.setData(coreData.configurations());
-    configurationModel_.setCheckStateData(keyword_->data());
-
-    updateSummaryText();
-
-    refreshing_ = false;
-}
+void ConfigurationVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update keyword data based on widget values
 void ConfigurationVectorKeywordWidget::updateKeywordData()

--- a/src/gui/keywordwidgets/dropdown.h
+++ b/src/gui/keywordwidgets/dropdown.h
@@ -46,8 +46,6 @@ class KeywordDropDown : public QWidget
     void setSummaryText(const QString s);
     // Set icon on call button
     void setSummaryIcon(QIcon icon);
-    // Update widget values data based on keyword data
-    virtual void updateWidgetValues(const CoreData &coreData) = 0;
     // Update keyword data based on widget values
     virtual void updateKeywordData();
 };

--- a/src/gui/keywordwidgets/dropdown.h
+++ b/src/gui/keywordwidgets/dropdown.h
@@ -49,5 +49,5 @@ class KeywordDropDown : public QWidget
     // Update widget values data based on keyword data
     virtual void updateWidgetValues(const CoreData &coreData) = 0;
     // Update keyword data based on widget values
-    virtual void updateKeywordData() = 0;
+    virtual void updateKeywordData();
 };

--- a/src/gui/keywordwidgets/dropdown_funcs.cpp
+++ b/src/gui/keywordwidgets/dropdown_funcs.cpp
@@ -54,3 +54,6 @@ void KeywordDropDown::setSummaryText(const QString s) { ui_.CallDropWidgetButton
 
 // Set icon on call button
 void KeywordDropDown::setSummaryIcon(QIcon icon) { ui_.CallDropWidgetButton->setIcon(icon); }
+
+// Update keyword data based on widget values
+void KeywordDropDown::updateKeywordData() {}

--- a/src/gui/keywordwidgets/function1d.h
+++ b/src/gui/keywordwidgets/function1d.h
@@ -49,8 +49,6 @@ class Function1DKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update keyword data based on widget values
     void updateKeywordData() override;
     // Update summary text

--- a/src/gui/keywordwidgets/isotopologueset.h
+++ b/src/gui/keywordwidgets/isotopologueset.h
@@ -57,8 +57,6 @@ class IsotopologueSetKeywordWidget : public KeywordDropDown, public KeywordWidge
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/isotopologueset.h
+++ b/src/gui/keywordwidgets/isotopologueset.h
@@ -55,8 +55,6 @@ class IsotopologueSetKeywordWidget : public KeywordDropDown, public KeywordWidge
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -123,9 +123,6 @@ void IsotopologueSetKeywordWidget::updateValue(const Flags<DissolveSignals::Data
 // Update widget values data based on keyword data
 void IsotopologueSetKeywordWidget::updateWidgetValues(const CoreData &coreData) {}
 
-// Update keyword data based on widget values
-void IsotopologueSetKeywordWidget::updateKeywordData() {}
-
 // Update summary text
 void IsotopologueSetKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -120,9 +120,6 @@ void IsotopologueSetKeywordWidget::updateValue(const Flags<DissolveSignals::Data
         updateSummaryText();
 }
 
-// Update widget values data based on keyword data
-void IsotopologueSetKeywordWidget::updateWidgetValues(const CoreData &coreData) {}
-
 // Update summary text
 void IsotopologueSetKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -50,8 +50,8 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
      * Update
      */
     private:
-    // Check / update allowed modules and displayed data
-    void updateAllowedModules();
+    // Reset model data
+    void resetModelData();
 
     public:
     // Update value displayed in widget

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -58,8 +58,6 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/modulevector.h
+++ b/src/gui/keywordwidgets/modulevector.h
@@ -56,8 +56,6 @@ class ModuleVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBa
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -72,11 +72,6 @@ void ModuleVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMut
 // Update widget values data based on keyword data
 void ModuleVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
-// Update keyword data based on widget values
-void ModuleVectorKeywordWidget::updateKeywordData()
-{ // Handled by model
-}
-
 // Update summary text
 void ModuleVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -17,9 +17,10 @@ ModuleVectorKeywordWidget::ModuleVectorKeywordWidget(QWidget *parent, ModuleVect
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
 
-    moduleModel_.setCheckStateData(keyword_->data());
+    // Set up the model
     ui_.ModuleList->setModel(&moduleModel_);
-    updateAllowedModules();
+    moduleModel_.setCheckStateData(keyword_->data());
+    resetModelData();
 
     // Connect signals / slots
     connect(&moduleModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
@@ -47,14 +48,16 @@ void ModuleVectorKeywordWidget::modelDataChanged(const QModelIndex &, const QMod
  * Update
  */
 
-// Check / update allowed modules and displayed data
-void ModuleVectorKeywordWidget::updateAllowedModules()
+// Reset model data
+void ModuleVectorKeywordWidget::resetModelData()
 {
     refreshing_ = true;
 
     // Update allowed modules
     allowedModules_ = Module::allOfType(keyword_->moduleTypes());
     moduleModel_.setData(allowedModules_);
+
+    updateSummaryText();
 
     refreshing_ = false;
 }
@@ -63,17 +66,16 @@ void ModuleVectorKeywordWidget::updateAllowedModules()
 void ModuleVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
     if (mutationFlags.isSet(DissolveSignals::ModulesMutated))
-    {
-        updateAllowedModules();
-        updateSummaryText();
-    }
+        resetModelData();
 }
 
 // Update widget values data based on keyword data
-void ModuleVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) {}
+void ModuleVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update keyword data based on widget values
-void ModuleVectorKeywordWidget::updateKeywordData() {}
+void ModuleVectorKeywordWidget::updateKeywordData()
+{ // Handled by model
+}
 
 // Update summary text
 void ModuleVectorKeywordWidget::updateSummaryText()

--- a/src/gui/keywordwidgets/modulevector_funcs.cpp
+++ b/src/gui/keywordwidgets/modulevector_funcs.cpp
@@ -69,9 +69,6 @@ void ModuleVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMut
         resetModelData();
 }
 
-// Update widget values data based on keyword data
-void ModuleVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
-
 // Update summary text
 void ModuleVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/nodevector.h
+++ b/src/gui/keywordwidgets/nodevector.h
@@ -46,6 +46,10 @@ class NodeVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/nodevector.h
+++ b/src/gui/keywordwidgets/nodevector.h
@@ -55,8 +55,6 @@ class NodeVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/nodevector.h
+++ b/src/gui/keywordwidgets/nodevector.h
@@ -53,8 +53,6 @@ class NodeVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetBase
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/nodevector_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevector_funcs.cpp
@@ -13,17 +13,18 @@ NodeVectorKeywordWidget::NodeVectorKeywordWidget(QWidget *parent, NodeVectorKeyw
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
+
+    // Set up the model
     ui_.NodeList->setModel(&nodeModel_);
+    allowedNodes_ = keyword_->allowedNodes();
+    nodeModel_.setNodeSelectedFunction([&](ConstNodeRef node) { return keyword_->addNode(node); });
+    nodeModel_.setNodeDeselectedFunction([&](ConstNodeRef node) { return keyword_->removeNode(node); });
+    nodeModel_.setNodePresenceFunction([&](ConstNodeRef node) { return keyword_->isPresent(node); });
+    resetModelData();
 
     // Connect signals / slots
     connect(&nodeModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-
-    allowedNodes_ = keyword_->allowedNodes();
-    nodeModel_.setData(allowedNodes_);
-    nodeModel_.setNodeSelectedFunction([&](ConstNodeRef node) { return keyword_->addNode(node); });
-    nodeModel_.setNodeDeselectedFunction([&](ConstNodeRef node) { return keyword_->removeNode(node); });
-    nodeModel_.setNodePresenceFunction([&](ConstNodeRef node) { return keyword_->isPresent(node); });
 
     // Summary text on KeywordDropDown button
     setSummaryText("Edit...");
@@ -47,26 +48,28 @@ void NodeVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, const
  * Update
  */
 
-// Update value displayed in widget
-void NodeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
-{
-    updateWidgetValues(coreData_);
-}
-
-// Update widget values data based on keyword data
-void NodeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)
+// Reset model data
+void NodeVectorKeywordWidget::resetModelData()
 {
     refreshing_ = true;
+
+    nodeModel_.setData(allowedNodes_);
 
     updateSummaryText();
 
     refreshing_ = false;
 }
 
+// Update value displayed in widget
+void NodeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) { resetModelData(); }
+
+// Update widget values data based on keyword data
+void NodeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
+
 // Update keyword data based on widget values
 void NodeVectorKeywordWidget::updateKeywordData()
 {
-    // Not relevant - Handled via widget callbacks
+    // Handled by model
 }
 
 // Update summary text

--- a/src/gui/keywordwidgets/nodevector_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevector_funcs.cpp
@@ -66,12 +66,6 @@ void NodeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutat
 // Update widget values data based on keyword data
 void NodeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
-// Update keyword data based on widget values
-void NodeVectorKeywordWidget::updateKeywordData()
-{
-    // Handled by model
-}
-
 // Update summary text
 void NodeVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/nodevector_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevector_funcs.cpp
@@ -63,9 +63,6 @@ void NodeVectorKeywordWidget::resetModelData()
 // Update value displayed in widget
 void NodeVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) { resetModelData(); }
 
-// Update widget values data based on keyword data
-void NodeVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
-
 // Update summary text
 void NodeVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/species.h
+++ b/src/gui/keywordwidgets/species.h
@@ -44,6 +44,10 @@ class SpeciesKeywordWidget : public QWidget, public KeywordWidgetBase
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/species_funcs.cpp
+++ b/src/gui/keywordwidgets/species_funcs.cpp
@@ -12,11 +12,10 @@ SpeciesKeywordWidget::SpeciesKeywordWidget(QWidget *parent, SpeciesKeyword *keyw
     ui_.setupUi(this);
 
     refreshing_ = true;
-    speciesModel_.setData(coreData.species());
+
+    // Set up the model
     ui_.SpeciesCombo->setModel(&speciesModel_);
-    auto it = std::find_if(coreData.species().begin(), coreData.species().end(),
-                           [keyword](const auto &sp) { return sp.get() == keyword->data(); });
-    ui_.SpeciesCombo->setCurrentIndex(it == coreData.species().end() ? -1 : it - coreData.species().begin());
+    resetModelData();
 
     // Set event filtering so that we do not blindly accept mouse wheel events (problematic since we will exist in a
     // QScrollArea)
@@ -54,6 +53,20 @@ void SpeciesKeywordWidget::on_ClearButton_clicked(bool checked)
 /*
  * Update
  */
+
+// Reset model data
+void SpeciesKeywordWidget::resetModelData()
+{
+    refreshing_ = true;
+
+    speciesModel_.setData(coreData_.species());
+
+    auto it = std::find_if(coreData_.species().begin(), coreData_.species().end(),
+                           [&](const auto &sp) { return sp.get() == keyword_->data(); });
+    ui_.SpeciesCombo->setCurrentIndex(it == coreData_.species().end() ? -1 : it - coreData_.species().begin());
+
+    refreshing_ = false;
+}
 
 // Update value displayed in widget
 void SpeciesKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) {}

--- a/src/gui/keywordwidgets/speciessite.h
+++ b/src/gui/keywordwidgets/speciessite.h
@@ -44,11 +44,13 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
     /*
      * Update
      */
+    private:
+    // Reset widgets
+    void resetWidgets();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/speciessite.h
+++ b/src/gui/keywordwidgets/speciessite.h
@@ -49,8 +49,6 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -19,7 +19,7 @@ SpeciesSiteKeywordWidget::SpeciesSiteKeywordWidget(QWidget *parent, SpeciesSiteK
     ui_.setupUi(dropWidget());
 
     // Set current information
-    updateWidgetValues(coreData_);
+    resetWidgets();
 }
 
 /*
@@ -53,11 +53,12 @@ void SpeciesSiteKeywordWidget::siteRadioButton_clicked(bool checked)
 // Update value displayed in widget
 void SpeciesSiteKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    if (mutationFlags.isSet(DissolveSignals::SpeciesMutated))
+        resetWidgets();
 }
 
-// Update widget values data based on keyword data
-void SpeciesSiteKeywordWidget::updateWidgetValues(const CoreData &coreData)
+// Reset widgets
+void SpeciesSiteKeywordWidget::resetWidgets()
 {
     refreshing_ = true;
 
@@ -80,9 +81,7 @@ void SpeciesSiteKeywordWidget::updateWidgetValues(const CoreData &coreData)
 
         // Are there sites defined?
         if (sp->nSites() == 0)
-        {
             layout->addWidget(new QLabel("No sites defined."));
-        }
         else
         {
             // Loop over sites defined in this Species

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -114,12 +114,6 @@ void SpeciesSiteKeywordWidget::updateWidgetValues(const CoreData &coreData)
     refreshing_ = false;
 }
 
-// Update keyword data based on widget values
-void SpeciesSiteKeywordWidget::updateKeywordData()
-{
-    // Not relevant - Handled via checkbox callbacks
-}
-
 // Update summary text
 void SpeciesSiteKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/speciessitevector.h
+++ b/src/gui/keywordwidgets/speciessitevector.h
@@ -60,8 +60,6 @@ class SpeciesSiteVectorKeywordWidget : public KeywordDropDown, public KeywordWid
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/speciessitevector.h
+++ b/src/gui/keywordwidgets/speciessitevector.h
@@ -51,6 +51,10 @@ class SpeciesSiteVectorKeywordWidget : public KeywordDropDown, public KeywordWid
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/speciessitevector.h
+++ b/src/gui/keywordwidgets/speciessitevector.h
@@ -58,8 +58,6 @@ class SpeciesSiteVectorKeywordWidget : public KeywordDropDown, public KeywordWid
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -63,11 +63,8 @@ void SpeciesSiteVectorKeywordWidget::resetModelData()
 // Update value displayed in widget
 void SpeciesSiteVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    resetModelData();
 }
-
-// Update widget values data based on keyword data
-void SpeciesSiteVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update summary text
 void SpeciesSiteVectorKeywordWidget::updateSummaryText()

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -69,12 +69,6 @@ void SpeciesSiteVectorKeywordWidget::updateValue(const Flags<DissolveSignals::Da
 // Update widget values data based on keyword data
 void SpeciesSiteVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
-// Update keyword data based on widget values
-void SpeciesSiteVectorKeywordWidget::updateKeywordData()
-{
-    // Handled by model
-}
-
 // Update summary text
 void SpeciesSiteVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -14,11 +14,15 @@ SpeciesSiteVectorKeywordWidget::SpeciesSiteVectorKeywordWidget(QWidget *parent, 
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
 
+    // Set up the model
     sitesFilterProxy_.setSourceModel(&sites_);
     if (keyword->axesRequired())
         sitesFilterProxy_.setFlag(SitesFilterProxy::HasAxes);
     ui_.SitesTree->setModel(&sitesFilterProxy_);
     sites_.setCheckStateData(keyword_->data());
+    resetModelData();
+
+    // Connect signals / slots
     connect(&sites_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
 
@@ -44,6 +48,18 @@ void SpeciesSiteVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft
  * Update
  */
 
+// Reset model data
+void SpeciesSiteVectorKeywordWidget::resetModelData()
+{
+    refreshing_ = true;
+
+    sites_.setData(coreData_.species());
+    ui_.SitesTree->expandAll();
+    updateSummaryText();
+
+    refreshing_ = false;
+}
+
 // Update value displayed in widget
 void SpeciesSiteVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
@@ -51,21 +67,12 @@ void SpeciesSiteVectorKeywordWidget::updateValue(const Flags<DissolveSignals::Da
 }
 
 // Update widget values data based on keyword data
-void SpeciesSiteVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)
-{
-    refreshing_ = true;
-
-    sites_.setData(coreData.species());
-    ui_.SitesTree->expandAll();
-    updateSummaryText();
-
-    refreshing_ = false;
-}
+void SpeciesSiteVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update keyword data based on widget values
 void SpeciesSiteVectorKeywordWidget::updateKeywordData()
 {
-    // Not relevant - Handled via checkbox callbacks
+    // Handled by model
 }
 
 // Update summary text

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -25,9 +25,6 @@ SpeciesSiteVectorKeywordWidget::SpeciesSiteVectorKeywordWidget(QWidget *parent, 
     // Connect signals / slots
     connect(&sites_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
             SLOT(modelDataChanged(const QModelIndex &, const QModelIndex &)));
-
-    // Summary text on KeywordDropDown button
-    setSummaryText("<None>");
 }
 
 /*

--- a/src/gui/keywordwidgets/speciesvector.h
+++ b/src/gui/keywordwidgets/speciesvector.h
@@ -56,8 +56,6 @@ class SpeciesVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetB
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
     // Update widget values data based on keyword data
     void updateWidgetValues(const CoreData &coreData) override;
-    // Update keyword data based on widget values
-    void updateKeywordData() override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/speciesvector.h
+++ b/src/gui/keywordwidgets/speciesvector.h
@@ -47,6 +47,10 @@ class SpeciesVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetB
     /*
      * Update
      */
+    private:
+    // Reset model data
+    void resetModelData();
+
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;

--- a/src/gui/keywordwidgets/speciesvector.h
+++ b/src/gui/keywordwidgets/speciesvector.h
@@ -54,8 +54,6 @@ class SpeciesVectorKeywordWidget : public KeywordDropDown, public KeywordWidgetB
     public:
     // Update value displayed in widget
     void updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags) override;
-    // Update widget values data based on keyword data
-    void updateWidgetValues(const CoreData &coreData) override;
     // Update summary text
     void updateSummaryText();
 };

--- a/src/gui/keywordwidgets/speciesvector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesvector_funcs.cpp
@@ -65,12 +65,6 @@ void SpeciesVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMu
 // Update widget values data based on keyword data
 void SpeciesVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
-// Update keyword data based on widget values
-void SpeciesVectorKeywordWidget::updateKeywordData()
-{
-    // Handled by model
-}
-
 // Update summary text
 void SpeciesVectorKeywordWidget::updateSummaryText()
 {

--- a/src/gui/keywordwidgets/speciesvector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesvector_funcs.cpp
@@ -59,11 +59,9 @@ void SpeciesVectorKeywordWidget::resetModelData()
 // Update value displayed in widget
 void SpeciesVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    updateWidgetValues(coreData_);
+    if (mutationFlags.isSet(DissolveSignals::SpeciesMutated))
+        resetModelData();
 }
-
-// Update widget values data based on keyword data
-void SpeciesVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update summary text
 void SpeciesVectorKeywordWidget::updateSummaryText()

--- a/src/gui/keywordwidgets/speciesvector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciesvector_funcs.cpp
@@ -15,8 +15,11 @@ SpeciesVectorKeywordWidget::SpeciesVectorKeywordWidget(QWidget *parent, SpeciesV
 {
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
+
+    // Set up the model
     ui_.SpeciesList->setModel(&speciesModel_);
     speciesModel_.setCheckStateData(keyword_->data());
+    resetModelData();
 
     // Connect signals / slots
     connect(&speciesModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &)), this,
@@ -41,6 +44,18 @@ void SpeciesVectorKeywordWidget::modelDataChanged(const QModelIndex &topLeft, co
  * Update
  */
 
+// Reset model data
+void SpeciesVectorKeywordWidget::resetModelData()
+{
+    refreshing_ = true;
+
+    speciesModel_.setData(coreData_.species());
+
+    updateSummaryText();
+
+    refreshing_ = false;
+}
+
 // Update value displayed in widget
 void SpeciesVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
@@ -48,17 +63,7 @@ void SpeciesVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMu
 }
 
 // Update widget values data based on keyword data
-void SpeciesVectorKeywordWidget::updateWidgetValues(const CoreData &coreData)
-{
-    refreshing_ = true;
-
-    speciesModel_.setData(coreData.species());
-    speciesModel_.setCheckStateData(keyword_->data());
-
-    updateSummaryText();
-
-    refreshing_ = false;
-}
+void SpeciesVectorKeywordWidget::updateWidgetValues(const CoreData &coreData) { resetModelData(); }
 
 // Update keyword data based on widget values
 void SpeciesVectorKeywordWidget::updateKeywordData()


### PR DESCRIPTION
An impromptu PR to tidy up and refactor most of the `std::vector`-based keyword widgets, which had unused functions and several different styles of code achieving the same thing.