### PR TITLE
IntegerSpin with Limits

### DIFF
--- a/src/gui/keywordwidgets/optionalint.hui
+++ b/src/gui/keywordwidgets/optionalint.hui
@@ -4,10 +4,10 @@
 #pragma once
 
 #include "gui/keywordwidgets/base.h"
-#include "gui/widgets/exponentialspin.hui"
+#include "gui/widgets/integerspin.hui"
 #include "keywords/optionalint.h"
 
-class OptionalIntegerKeywordWidget : public ExponentialSpin, public KeywordWidgetBase
+class OptionalIntegerKeywordWidget : public IntegerSpin, public KeywordWidgetBase
 {
     // All Qt declarations must include this macro
     Q_OBJECT

--- a/src/gui/keywordwidgets/optionalint_funcs.cpp
+++ b/src/gui/keywordwidgets/optionalint_funcs.cpp
@@ -6,10 +6,9 @@
 
 OptionalIntegerKeywordWidget::OptionalIntegerKeywordWidget(QWidget *parent, OptionalIntegerKeyword *keyword,
                                                            const CoreData &coreData)
-    : ExponentialSpin(parent), KeywordWidgetBase(coreData), keyword_(keyword)
+    : IntegerSpin(parent), KeywordWidgetBase(coreData), keyword_(keyword)
 {
     // Set minimum and maximum values and step size
-    setDecimals(0);
     setMinimum(keyword_->minimumLimit());
     if (keyword_->maximumLimit())
         setMaximum(keyword_->maximumLimit().value());

--- a/src/gui/widgets/CMakeLists.txt
+++ b/src/gui/widgets/CMakeLists.txt
@@ -9,6 +9,7 @@ set(widgets_MOC_HDRS
     elementselector.hui
     exponentialspin.hui
     gradientbar.hui
+    integerspin.hui
     mimetreewidget.hui
     superstackedwidget.hui
 )
@@ -25,6 +26,7 @@ set(widgets_SRCS
     elementselector_funcs.cpp
     exponentialspin_funcs.cpp
     gradientbar_funcs.cpp
+    integerspin_funcs.cpp
     mimestrings.cpp
     mimetreewidget_funcs.cpp
     mimetreewidgetitem.cpp

--- a/src/gui/widgets/integerspin.hui
+++ b/src/gui/widgets/integerspin.hui
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include <QAbstractSpinBox>
+
+// Integer SpinBox with Special Limit
+class IntegerSpin : public QAbstractSpinBox
+{
+    Q_OBJECT
+
+    public:
+    explicit IntegerSpin(QWidget *parent = 0);
+
+    /*
+     * Data
+     */
+    private:
+    // Current value
+    int value_;
+    // Text representation of current value
+    QString valueText_;
+    // Value step size
+    int stepSize_{1};
+    // Limiting values
+    std::optional<int> minimumValue_, maximumValue_;
+    // Validator for line edit
+    QIntValidator validator_;
+
+    public:
+    // Set value
+    void setValue(int value);
+    void setValue(std::optional<int> value);
+    // Return current value
+    int value() const;
+    // Set value step size
+    void setSingleStep(int stepSize);
+    // Set minimum value
+    void setMinimum(int value);
+    // Set maximum value
+    void setMaximum(int value);
+    // Set allowed value range
+    void setRange(int minValue, int maxValue);
+    // Remove range limits
+    void removeLimits();
+
+    /*
+     * Signals / Slots
+     */
+    private slots:
+    void valueEditingFinished();
+    void returnPressed();
+
+    signals:
+    void valueChanged(int);
+    void valueNullified();
+
+    /*
+     * Reimplementations
+     */
+    public:
+    void focusInEvent(QFocusEvent *e) override;
+    // Step value by specified number of increments
+    void stepBy(int steps) override;
+    // Return whether stepping is currently available
+    QAbstractSpinBox::StepEnabled stepEnabled() const override;
+    // Size Hint
+    QSize sizeHint() const override;
+};

--- a/src/gui/widgets/integerspin_funcs.cpp
+++ b/src/gui/widgets/integerspin_funcs.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "gui/widgets/integerspin.hui"
+#include <QFocusEvent>
+#include <QLineEdit>
+
+IntegerSpin::IntegerSpin(QWidget *parent) : QAbstractSpinBox(parent)
+{
+    // Set up validator
+    lineEdit()->setValidator(&validator_);
+
+    blockSignals(true);
+    setValue(value_);
+    blockSignals(false);
+
+    connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(valueEditingFinished()));
+    connect(lineEdit(), SIGNAL(returnPressed()), this, SLOT(returnPressed()));
+}
+
+/*
+ * Data
+ */
+
+// Set value
+void IntegerSpin::setValue(int value)
+{
+    // Copy the existing value for comparison
+    auto previousValueText = valueText_;
+
+    if (minimumValue_ && value <= minimumValue_.value())
+    {
+        value_ = minimumValue_.value();
+        valueText_ = specialValueText().isEmpty() ? QString::number(value_) : specialValueText();
+    }
+    else if (maximumValue_ && value >= maximumValue_)
+    {
+        value_ = maximumValue_.value();
+        valueText_ = QString::number(value_);
+    }
+    else
+    {
+        value_ = value;
+        valueText_ = QString::number(value_);
+    }
+
+    // Set the line edit's text
+    lineEdit()->setText(valueText_);
+
+    // If the new text is the same as the existing, don't emit any signals
+    if (previousValueText == valueText_)
+        return;
+
+    if (valueText_ == specialValueText())
+        emit(valueNullified());
+    else
+        emit(valueChanged(value_));
+}
+
+void IntegerSpin::setValue(std::optional<int> value)
+{
+    if (value)
+        setValue(value.value());
+    else
+        setValue(minimumValue_.value() - 1);
+}
+
+// Return current value
+int IntegerSpin::value() const { return value_; }
+
+// Set value step size
+void IntegerSpin::setSingleStep(int stepSize) { stepSize_ = stepSize; }
+
+// Set minimum value
+void IntegerSpin::setMinimum(int value) { minimumValue_ = value; }
+
+// Set minimum value
+void IntegerSpin::setMaximum(int value) { maximumValue_ = value; }
+
+// Set allowed value range
+void IntegerSpin::setRange(int minValue, int maxValue)
+{
+    minimumValue_ = minValue;
+    maximumValue_ = maxValue;
+}
+
+/*
+ * Signals / Slots
+ */
+
+// Line edit editing finished
+void IntegerSpin::valueEditingFinished()
+{
+    if (lineEdit()->text() == valueText_)
+        return;
+
+    setValue(lineEdit()->text().toInt());
+}
+
+void IntegerSpin::returnPressed()
+{
+    lineEdit()->selectAll();
+    valueEditingFinished();
+}
+
+/*
+ * Reimplementations
+ */
+
+void IntegerSpin::focusInEvent(QFocusEvent *event)
+{
+    if (valueText_ == specialValueText())
+        lineEdit()->setText(QString::number(value_));
+    QAbstractSpinBox::focusInEvent(event);
+}
+
+// Step value by specified number of increments
+void IntegerSpin::stepBy(int steps) { setValue(value_ + steps * stepSize_); }
+
+// Return whether stepping is currently available
+QAbstractSpinBox::StepEnabled IntegerSpin::stepEnabled() const
+{
+    auto atMin = minimumValue_ && value_ <= minimumValue_.value(), atMax = maximumValue_ && value_ >= maximumValue_.value();
+    if (atMin && atMax)
+        return QAbstractSpinBox::StepNone;
+    else if (atMin)
+        return QAbstractSpinBox::StepUpEnabled;
+    else if (atMax)
+        return QAbstractSpinBox::StepDownEnabled;
+
+    return QAbstractSpinBox::StepDownEnabled | QAbstractSpinBox::StepUpEnabled;
+}
+
+// Size Hint
+QSize IntegerSpin::sizeHint() const
+{
+    const QFontMetrics fm(fontMetrics());
+
+    int h = lineEdit()->sizeHint().height();
+    int w = fm.horizontalAdvance("1000000");
+
+    return {w, h};
+}

--- a/src/modules/bragg/bragg.cpp
+++ b/src/modules/bragg/bragg.cpp
@@ -5,7 +5,7 @@
 #include "keywords/bool.h"
 #include "keywords/configuration.h"
 #include "keywords/double.h"
-#include "keywords/integer.h"
+#include "keywords/optionalint.h"
 #include "keywords/stdstring.h"
 #include "keywords/vec3integer.h"
 
@@ -15,8 +15,9 @@ BraggModule::BraggModule() : Module("Bragg")
     keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
     // Control
-    keywords_.add<IntegerKeyword>("Control", "Averaging",
-                                  "Number of historical data sets to combine into final reflection data", averagingLength_, 0);
+    keywords_.add<OptionalIntegerKeyword>("Control", "Averaging",
+                                          "Number of historical data sets to combine into final reflection data",
+                                          averagingLength_, 1, std::nullopt, 1, "Off");
     keywords_.add<EnumOptionsKeyword<Averaging::AveragingScheme>>("Control", "AveragingScheme",
                                                                   "Weighting scheme to use when averaging reflection data",
                                                                   averagingScheme_, Averaging::averagingSchemes());

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -21,7 +21,7 @@ class BraggModule : public Module
     // Target configuration
     Configuration *targetConfiguration_{nullptr};
     // Number of historical data sets to combine into final reflection data
-    int averagingLength_{5};
+    std::optional<int> averagingLength_{5};
     // Weighting scheme to use when averaging reflection data
     Averaging::AveragingScheme averagingScheme_{Averaging::LinearAveraging};
     // Bragg intensity scaling factor accounting for number of repeat units in Configuration

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -26,11 +26,11 @@ bool BraggModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     Messenger::print("Bragg: Calculating Bragg S(Q) over {} < Q < {} Angstroms**-1 using bin size of {} Angstroms**-1.\n",
                      qMin_, qMax_, qDelta_);
     Messenger::print("Bragg: Multiplicity is ({} {} {}).\n", multiplicity_.x, multiplicity_.y, multiplicity_.z);
-    if (averagingLength_ <= 1)
-        Messenger::print("Bragg: No averaging of reflections will be performed.\n");
-    else
-        Messenger::print("Bragg: Reflections will be averaged over {} sets (scheme = {}).\n", averagingLength_,
+    if (averagingLength_)
+        Messenger::print("Bragg: Reflections will be averaged over {} sets (scheme = {}).\n", averagingLength_.value(),
                          Averaging::averagingSchemes().keyword(averagingScheme_));
+    else
+        Messenger::print("Bragg: No averaging of reflections will be performed.\n");
     Messenger::print("Multiplicity of unit cell in source configuration is [{} {} {}].\n", multiplicity_.x, multiplicity_.y,
                      multiplicity_.z);
     Messenger::print("\n");
@@ -62,9 +62,9 @@ bool BraggModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     }
 
     // Perform averaging of reflections data if requested
-    if (averagingLength_ > 1)
+    if (averagingLength_)
         Averaging::vectorAverage<std::vector<BraggReflection>>(dissolve.processingModuleData(), "Reflections", name(),
-                                                               averagingLength_, averagingScheme_);
+                                                               averagingLength_.value(), averagingScheme_);
 
     // Form partial and total reflection functions
     formReflectionFunctions(dissolve.processingModuleData(), procPool, targetConfiguration_, qMin_, qDelta_, qMax_);

--- a/src/modules/rdf/rdf.cpp
+++ b/src/modules/rdf/rdf.cpp
@@ -8,6 +8,7 @@
 #include "keywords/function1d.h"
 #include "keywords/integer.h"
 #include "keywords/module.h"
+#include "keywords/optionalint.h"
 
 RDFModule::RDFModule() : Module("RDF")
 {
@@ -21,8 +22,9 @@ RDFModule::RDFModule() : Module("RDF")
                                  requestedRange_, 1.0);
     keywords_.add<BoolKeyword>("Control", "UseHalfCellRange",
                                "Whether to use the maximal RDF range possible that avoids periodic images", useHalfCellRange_);
-    keywords_.add<IntegerKeyword>("Control", "Averaging", "Number of historical partial sets to combine into final partials",
-                                  averagingLength_, 0);
+    keywords_.add<OptionalIntegerKeyword>("Control", "Averaging",
+                                          "Number of historical partial sets to combine into final partials", averagingLength_,
+                                          1, std::nullopt, 1, "Off");
     keywords_.add<EnumOptionsKeyword<Averaging::AveragingScheme>>("Control", "AveragingScheme",
                                                                   "Weighting scheme to use when averaging partials",
                                                                   averagingScheme_, Averaging::averagingSchemes());
@@ -31,11 +33,11 @@ RDFModule::RDFModule() : Module("RDF")
     keywords_.add<EnumOptionsKeyword<RDFModule::PartialsMethod>>("Control", "Method",
                                                                  "Calculation method for partial radial distribution functions",
                                                                  partialsMethod_, RDFModule::partialsMethods());
-    keywords_.add<IntegerKeyword>(
+    keywords_.add<OptionalIntegerKeyword>(
         "Control", "Smoothing",
         "Specifies the degree of smoothing 'n' to apply to calculated g(r), where 2n+1 controls the length in "
         "the applied Spline smooth",
-        nSmooths_, 0, 100);
+        nSmooths_, 0, 100, 1, "Off");
 
     // Test
     keywords_.add<BoolKeyword>(

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -41,7 +41,7 @@ class RDFModule : public Module
     // Target configurations
     std::vector<Configuration *> targetConfigurations_;
     // Number of historical partial sets to combine into final partials
-    int averagingLength_{5};
+    std::optional<int> averagingLength_{5};
     // Weighting scheme to use when averaging partials
     Averaging::AveragingScheme averagingScheme_{Averaging::LinearAveraging};
     // Bin width (spacing in r) to use
@@ -51,7 +51,7 @@ class RDFModule : public Module
     // Type of broadening to apply to intramolecular g(r)
     Functions::Function1DWrapper intraBroadening_{Functions::Function1D::Gaussian, {0.18}};
     // Degree of smoothing to apply
-    int nSmooths_{0};
+    std::optional<int> nSmooths_;
     // Calculation method for partials
     RDFModule::PartialsMethod partialsMethod_{RDFModule::AutoMethod};
     // Maximum r to calculate g(r) out to, unless UseHalfCellRange is true

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -40,11 +40,11 @@ bool SQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     else
         Messenger::print("SQ: Window function to be applied in Fourier transforms is {}.",
                          WindowFunction::forms().keyword(windowFunction_));
-    if (averagingLength_ <= 1)
-        Messenger::print("SQ: No averaging of partials will be performed.\n");
-    else
-        Messenger::print("SQ: Partials will be averaged over {} sets (scheme = {}).\n", averagingLength_,
+    if (averagingLength_)
+        Messenger::print("SQ: Partials will be averaged over {} sets (scheme = {}).\n", averagingLength_.value(),
                          Averaging::averagingSchemes().keyword(averagingScheme_));
+    else
+        Messenger::print("SQ: No averaging of partials will be performed.\n");
     if (qBroadening_.type() == Functions::Function1D::None)
         Messenger::print("SQ: No broadening will be applied to calculated S(Q).");
     else
@@ -189,12 +189,12 @@ bool SQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     }
 
     // Perform averaging of unweighted partials if requested, and if we're not already up-to-date
-    if (averagingLength_ > 1)
+    if (averagingLength_)
     {
         // Store the current fingerprint, since we must ensure we retain it in the averaged data.
         std::string currentFingerprint{unweightedsq.fingerprint()};
 
-        Averaging::average<PartialSet>(dissolve.processingModuleData(), "UnweightedSQ", name_, averagingLength_,
+        Averaging::average<PartialSet>(dissolve.processingModuleData(), "UnweightedSQ", name_, averagingLength_.value(),
                                        averagingScheme_);
 
         // Re-set the object names and fingerprints of the partials

--- a/src/modules/sq/sq.cpp
+++ b/src/modules/sq/sq.cpp
@@ -5,8 +5,8 @@
 #include "keywords/bool.h"
 #include "keywords/double.h"
 #include "keywords/function1d.h"
-#include "keywords/integer.h"
 #include "keywords/module.h"
+#include "keywords/optionalint.h"
 #include "modules/bragg/bragg.h"
 #include "modules/rdf/rdf.h"
 
@@ -24,8 +24,9 @@ SQModule::SQModule() : Module("SQ")
     keywords_.add<EnumOptionsKeyword<WindowFunction::Form>>(
         "Control", "WindowFunction", "Window function to apply when Fourier-transforming reference S(Q) to g(r)",
         windowFunction_, WindowFunction::forms());
-    keywords_.add<IntegerKeyword>("Control", "Averaging", "Number of historical partial sets to combine into final partials",
-                                  averagingLength_, 1);
+    keywords_.add<OptionalIntegerKeyword>("Control", "Averaging",
+                                          "Number of historical partial sets to combine into final partials", averagingLength_,
+                                          1, std::nullopt, 1, "Off");
     keywords_.add<EnumOptionsKeyword<Averaging::AveragingScheme>>("Control", "AveragingScheme",
                                                                   "Weighting scheme to use when averaging partials",
                                                                   averagingScheme_, Averaging::averagingSchemes());

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -27,7 +27,7 @@ class SQModule : public Module
      */
     private:
     // Number of historical partial sets to combine into final partials
-    int averagingLength_{1};
+    std::optional<int> averagingLength_;
     // Weighting scheme to use when averaging partials
     Averaging::AveragingScheme averagingScheme_{Averaging::LinearAveraging};
     // Broadening function to apply to Bragg S(Q)


### PR DESCRIPTION
This PR set out to solve #946 by following the issue's suggestion that `ExponentialSpin` needed to be split into `double` and `int`-specific versions. Ultimately, the problem was easily solved just by creating an `int` analogue of our `ExponentialSpin` widget in order to provide the special text overload capability.

Closes #946.