### PR TITLE
Add QtSvg to Singularity

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
             nativeBuildInputs = pkgs.lib.optionals gui [
               pkgs.wrapGAppsHook
               pkgs.qt6Packages.wrapQtAppsHook
+              pkgs.qt6Packages.qtsvg
             ];
 
             TBB_DIR = "${pkgs.tbb}";


### PR DESCRIPTION
One-line PR which fixes display of svg icons in the Singularity image via addind QtSvg as a nix build dependency.

Closes #1166.