### PR TITLE
Procedure Editing - Part 2

### DIFF
--- a/src/gui/modulecontrolwidget.h
+++ b/src/gui/modulecontrolwidget.h
@@ -12,6 +12,7 @@ class Dissolve;
 class DissolveWindow;
 class Module;
 class ModuleWidget;
+class ProcedureWidget;
 
 // Module Control Widget
 class ModuleControlWidget : public QWidget
@@ -60,11 +61,16 @@ class ModuleControlWidget : public QWidget
     // Reference vector of "Target" keywords
     std::vector<KeywordWidgetBase *> targetKeywordWidgets_;
     // Additional controls widget for the Module (if any)
-    ModuleWidget *moduleWidget_;
+    ModuleWidget *moduleWidget_{nullptr};
+    // Procedure widget for the module (if any)
+    ProcedureWidget *procedureWidget_{nullptr};
+    // Stack indices for module and procedure widgets
+    int moduleWidgetStackIndex_{0}, procedureWidgetStackIndex_{0};
 
     private slots:
     void on_ModuleControlsButton_clicked(bool checked);
-    void on_ModuleOutputButton_clicked(bool checked);
+    void on_ModuleWidgetButton_clicked(bool checked);
+    void on_ProcedureWidgetButton_clicked(bool checked);
 
     public:
     // Prepare widget for deletion

--- a/src/gui/modulecontrolwidget.ui
+++ b/src/gui/modulecontrolwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>833</width>
-    <height>433</height>
+    <width>474</width>
+    <height>328</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -112,9 +112,35 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="ModuleOutputButton">
+          <widget class="QPushButton" name="ProcedureWidgetButton">
            <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Procedure</string>
+           </property>
+           <property name="icon">
+            <iconset resource="main.qrc">
+             <normaloff>:/general/icons/general_screen.svg</normaloff>:/general/icons/general_screen.svg</iconset>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
             <bool>false</bool>
+           </property>
+           <property name="autoExclusive">
+            <bool>true</bool>
+           </property>
+           <property name="flat">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="ModuleWidgetButton">
+           <property name="enabled">
+            <bool>true</bool>
            </property>
            <property name="text">
             <string>Output</string>
@@ -144,7 +170,7 @@
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>209</width>
+             <width>5</width>
              <height>20</height>
             </size>
            </property>
@@ -204,7 +230,7 @@
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>209</width>
+             <width>5</width>
              <height>20</height>
             </size>
            </property>

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -111,6 +111,15 @@ class KeywordStore
     // Find named keyword
     KeywordBase *find(std::string_view name);
     const KeywordBase *find(std::string_view name) const;
+    // Find all keywords of specified type
+    template <class K> std::vector<K *> allOfType()
+    {
+        std::vector<K *> result;
+        for (auto &kwd : keywords_)
+            if (kwd.second->typeIndex() == typeid(K *))
+                result.push_back(dynamic_cast<K *>(kwd.second));
+        return result;
+    }
     // Return keywords
     const std::map<std::string_view, KeywordBase *> &keywords() const;
     // Return "Target" group keywords


### PR DESCRIPTION
This PR follows on from #1177 and implements the display of a `ProcedureWidget` for a relevant keyword in a module.

Previously, `ProcedureKeyword`s had no associated control widget in the GUI, meaning that no editability of the procedure was possible. It is not possible to simply add a `ProcedureKeywordWidget` which displays a `ProcedureWidget` editor since this creates a circular dependency between the keyword widgets and the main GUI lib.  Therefore, an alternative solution is implemented here, detailed below. Suggestions for other, neater approaches are welcome!

A `ModuleControlWidget` has two buttons to access "Options" (i.e. target and control keywords, the latter via a `KeywordsWidget`) and "Output" (which constituted the `ModuleWidget` associated with the module, if one existed).  A third button, "Procedure", has been added, offering access to the procedure targeted by (currently) the first `ProcedureKeyword` defined in the keywords for the module.

If the module does not have a module control widget and/or a procedure keyword, the relevant button(s) is/are hidden.

Works towards #1176.