### PR TITLE
Procedure Editing - Part 3

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -11,7 +11,7 @@
 #include "classes/species.h"
 #include "modules/energy/energy.h"
 
-Configuration::Configuration() : generator_(ProcedureNode::GenerationContext, "EndGenerator")
+Configuration::Configuration() : generator_(ProcedureNode::GenerationContext, "Generator")
 {
     createBox({1.0, 1.0, 1.0}, {90, 90, 90}, false);
 }

--- a/src/gui/models/isotopologueSetModel.cpp
+++ b/src/gui/models/isotopologueSetModel.cpp
@@ -13,6 +13,104 @@ void IsotopologueSetModel::setSourceData(IsotopologueSet &set)
     endResetModel();
 }
 
+std::vector<QModelIndex> IsotopologueSetModel::addMissingSpecies(const std::vector<std::unique_ptr<Species>> &species)
+{
+    if (!set_)
+        return {};
+
+    auto &set = set_->get();
+
+    auto nAdded = 0;
+    for (const auto &sp : species)
+    {
+        if (!set.contains(sp.get()))
+        {
+            beginInsertRows({}, set.nSpecies(), set.nSpecies());
+            set.add(sp->naturalIsotopologue(), 1.0);
+            endInsertRows();
+            ++nAdded;
+        }
+    }
+
+    if (nAdded > 0)
+    {
+        emit(dataChanged(createIndex(set.nSpecies() - nAdded, 0), createIndex(set.nSpecies() - 1, 0)));
+        std::vector<QModelIndex> newIndices;
+        for (auto n = set.nSpecies() - nAdded; n < set.nSpecies(); ++n)
+            newIndices.push_back(createIndex(n, 0));
+        return newIndices;
+    }
+
+    return {};
+}
+
+void IsotopologueSetModel::addIsotopologueWeight(const QModelIndex index)
+{
+    // Check index validity
+    if (!set_ || !index.isValid())
+        return;
+
+    auto &set = set_->get();
+    const auto topeIndex = index.parent().isValid() ? index.parent().row() : index.row();
+    auto &topes = set.isotopologues()[topeIndex];
+    const auto *sp = topes.species();
+
+    if (!topes.contains(sp->naturalIsotopologue()))
+    {
+        beginInsertRows(createIndex(topeIndex, 0), topes.nIsotopologues(), topes.nIsotopologues());
+        set.add(sp->naturalIsotopologue(), 1.0);
+        endInsertRows();
+    }
+    else
+    {
+        for (auto &tope : sp->isotopologues())
+        {
+            if (!topes.contains(tope.get()))
+            {
+                beginInsertRows(createIndex(topeIndex, 0), topes.nIsotopologues(), topes.nIsotopologues());
+                set.add(tope.get(), 1.0);
+                endInsertRows();
+                break;
+            }
+        }
+    }
+
+    emit(dataChanged(index, index));
+}
+
+void IsotopologueSetModel::removeIndex(const QModelIndex index)
+{
+    // Check index validity
+    if (!set_ || !index.isValid())
+        return;
+
+    auto &set = set_->get();
+
+    if (!index.parent().isValid())
+    {
+        // Root item (Isotopologues)
+        auto &topes = set.isotopologues()[index.row()];
+        beginRemoveRows({}, index.row(), index.row());
+        set.remove(topes.species());
+        endRemoveRows();
+    }
+    else
+    {
+        // Secondary item (IsotopologueWeight)
+        auto &topes = set.isotopologues()[index.parent().row()];
+        auto &mixItem = topes.mix()[index.row()];
+        beginRemoveRows(index.parent(), index.row(), index.row());
+        topes.remove(&mixItem);
+        endRemoveRows();
+    }
+
+    emit(dataChanged(index, index));
+}
+
+/*
+ * QAbstractItemModel overrides
+ */
+
 int IsotopologueSetModel::rowCount(const QModelIndex &parent) const
 {
     if (!set_)
@@ -163,98 +261,4 @@ bool IsotopologueSetModel::setData(const QModelIndex &index, const QVariant &val
     }
 
     return false;
-}
-
-std::vector<QModelIndex> IsotopologueSetModel::addMissingSpecies(const std::vector<std::unique_ptr<Species>> &species)
-{
-    if (!set_)
-        return {};
-
-    auto &set = set_->get();
-
-    auto nAdded = 0;
-    for (const auto &sp : species)
-    {
-        if (!set.contains(sp.get()))
-        {
-            beginInsertRows({}, set.nSpecies(), set.nSpecies());
-            set.add(sp->naturalIsotopologue(), 1.0);
-            endInsertRows();
-            ++nAdded;
-        }
-    }
-
-    if (nAdded > 0)
-    {
-        emit(dataChanged(createIndex(set.nSpecies() - nAdded, 0), createIndex(set.nSpecies() - 1, 0)));
-        std::vector<QModelIndex> newIndices;
-        for (auto n = set.nSpecies() - nAdded; n < set.nSpecies(); ++n)
-            newIndices.push_back(createIndex(n, 0));
-        return newIndices;
-    }
-
-    return {};
-}
-
-void IsotopologueSetModel::addIsotopologueWeight(const QModelIndex index)
-{
-    // Check index validity
-    if (!set_ || !index.isValid())
-        return;
-
-    auto &set = set_->get();
-    const auto topeIndex = index.parent().isValid() ? index.parent().row() : index.row();
-    auto &topes = set.isotopologues()[topeIndex];
-    const auto *sp = topes.species();
-
-    if (!topes.contains(sp->naturalIsotopologue()))
-    {
-        beginInsertRows(createIndex(topeIndex, 0), topes.nIsotopologues(), topes.nIsotopologues());
-        set.add(sp->naturalIsotopologue(), 1.0);
-        endInsertRows();
-    }
-    else
-    {
-        for (auto &tope : sp->isotopologues())
-        {
-            if (!topes.contains(tope.get()))
-            {
-                beginInsertRows(createIndex(topeIndex, 0), topes.nIsotopologues(), topes.nIsotopologues());
-                set.add(tope.get(), 1.0);
-                endInsertRows();
-                break;
-            }
-        }
-    }
-
-    emit(dataChanged(index, index));
-}
-
-void IsotopologueSetModel::removeIndex(const QModelIndex index)
-{
-    // Check index validity
-    if (!set_ || !index.isValid())
-        return;
-
-    auto &set = set_->get();
-
-    if (!index.parent().isValid())
-    {
-        // Root item (Isotopologues)
-        auto &topes = set.isotopologues()[index.row()];
-        beginRemoveRows({}, index.row(), index.row());
-        set.remove(topes.species());
-        endRemoveRows();
-    }
-    else
-    {
-        // Secondary item (IsotopologueWeight)
-        auto &topes = set.isotopologues()[index.parent().row()];
-        auto &mixItem = topes.mix()[index.row()];
-        beginRemoveRows(index.parent(), index.row(), index.row());
-        topes.remove(&mixItem);
-        endRemoveRows();
-    }
-
-    emit(dataChanged(index, index));
 }

--- a/src/gui/models/isotopologueSetModel.cpp
+++ b/src/gui/models/isotopologueSetModel.cpp
@@ -32,16 +32,12 @@ std::vector<QModelIndex> IsotopologueSetModel::addMissingSpecies(const std::vect
         }
     }
 
-    if (nAdded > 0)
-    {
+    std::vector<QModelIndex> newIndices;
+    for (auto n = set.nSpecies() - nAdded; n < set.nSpecies(); ++n)
+        newIndices.push_back(createIndex(n, 0));
+    if (!newIndices.empty())
         emit(dataChanged(createIndex(set.nSpecies() - nAdded, 0), createIndex(set.nSpecies() - 1, 0)));
-        std::vector<QModelIndex> newIndices;
-        for (auto n = set.nSpecies() - nAdded; n < set.nSpecies(); ++n)
-            newIndices.push_back(createIndex(n, 0));
-        return newIndices;
-    }
-
-    return {};
+    return newIndices;
 }
 
 void IsotopologueSetModel::addIsotopologueWeight(const QModelIndex index)

--- a/src/gui/models/isotopologueSetModel.h
+++ b/src/gui/models/isotopologueSetModel.h
@@ -18,26 +18,21 @@ class IsotopologueSetModel : public QAbstractItemModel
     public:
     IsotopologueSetModel(OptionalReferenceWrapper<IsotopologueSet> set = std::nullopt);
     void setSourceData(IsotopologueSet &set);
-
-    QModelIndex parent(const QModelIndex &index) const override;
-
-    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
-
-    bool hasChildren(const QModelIndex &parent) const override;
-
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-
-    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-
-    Qt::ItemFlags flags(const QModelIndex &index) const override;
-
-    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
-
     std::vector<QModelIndex> addMissingSpecies(const std::vector<std::unique_ptr<Species>> &species);
     void addIsotopologueWeight(const QModelIndex index);
     void removeIndex(const QModelIndex index);
+
+    /*
+     * QAbstractItemModel overrides
+     */
+    public:
+    QModelIndex parent(const QModelIndex &index) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    bool hasChildren(const QModelIndex &parent) const override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
 };

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -152,13 +152,14 @@ QModelIndex ProcedureModel::parent(const QModelIndex &index) const
     if (!nodeParentParent)
     {
         auto &proc = procedure_->get();
-        auto it = std::find(proc.nodes().begin(), proc.nodes().end(), nodeParent);
-        return createIndex(it - proc.nodes().begin(), 0, nodeParent.get());
+        auto it = std::find(proc.rootSequence().sequence().begin(), proc.rootSequence().sequence().end(), nodeParent);
+        return createIndex(it - proc.rootSequence().sequence().begin(), 0, nodeParent.get());
     }
     else
     {
-        auto it = std::find(nodeParentParent->children().begin(), nodeParentParent->children().end(), nodeParent);
-        return createIndex(it - nodeParentParent->children().begin(), 0, nodeParent.get());
+        auto children = nodeParentParent->children();
+        auto it = std::find(children.begin(), children.end(), nodeParent);
+        return createIndex(it - children.begin(), 0, nodeParent.get());
     }
 }
 

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -69,8 +69,8 @@ QVariant ProcedureModel::data(const QModelIndex &index, int role) const
                     return QString::fromStdString(std::string(node->nodeTypes().keyword(node->type())));
                 else
                     return QString("%1 (%2)").arg(
-                        QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(node->type()))),
-                        QString::fromStdString(std::string(node->name())));
+                        QString::fromStdString(std::string(node->name())),
+                        QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(node->type()))));
             case (Qt::UserRole):
                 return QVariant::fromValue(node->shared_from_this());
             case (Qt::DecorationRole):

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -81,17 +81,23 @@ QVariant ProcedureModel::data(const QModelIndex &index, int role) const
             default:
                 return {};
         }
-    else if (index.column() == 1 && role == Qt::DisplayRole)
-    {
-        if (node->scope()->owner())
-            return QString("%1 (%2 branch in %3)")
-                .arg(QString::fromStdString(std::string(ProcedureNode::nodeContexts().keyword(node->scopeContext()))),
-                     QString::fromStdString(std::string(node->scope()->blockKeyword())),
-                     QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(node->parent()->type()))));
-        else
-            return QString("%1 (in root sequence)")
-                .arg(QString::fromStdString(std::string(ProcedureNode::nodeContexts().keyword(node->scopeContext()))));
-    }
+    else if (index.column() == 1)
+        switch (role)
+        {
+            case (Qt::DisplayRole):
+                if (node->scope()->owner())
+                    return QString("%1 (%2 branch in %3)")
+                        .arg(QString::fromStdString(std::string(ProcedureNode::nodeContexts().keyword(node->scopeContext()))),
+                             QString::fromStdString(std::string(node->scope()->blockKeyword())),
+                             QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(node->parent()->type()))));
+                else
+                    return QString("%1 (in root sequence)")
+                        .arg(QString::fromStdString(std::string(ProcedureNode::nodeContexts().keyword(node->scopeContext()))));
+            case (Qt::UserRole):
+                return QVariant::fromValue(node->shared_from_this());
+            default:
+                return {};
+        }
 
     return {};
 }
@@ -170,10 +176,4 @@ bool ProcedureModel::hasChildren(const QModelIndex &parent) const
     return (node && node->hasBranch());
 }
 
-Qt::ItemFlags ProcedureModel::flags(const QModelIndex &index) const
-{
-    if (index.column() == 0)
-        return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
-
-    return Qt::ItemIsSelectable;
-}
+Qt::ItemFlags ProcedureModel::flags(const QModelIndex &index) const { return Qt::ItemIsSelectable | Qt::ItemIsEnabled; }

--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -38,4 +38,5 @@ class ProcedureModel : public QAbstractItemModel
     bool hasChildren(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
 };

--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -5,7 +5,7 @@
 
 #include "procedure/nodes/node.h"
 #include "templates/optionalref.h"
-#include <QAbstractTableModel>
+#include <QAbstractItemModel>
 #include <QModelIndex>
 
 #include <vector>
@@ -35,6 +35,7 @@ class ProcedureModel : public QAbstractItemModel
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
     QModelIndex parent(const QModelIndex &index) const override;
+    bool hasChildren(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 };

--- a/src/gui/procedurewidget.h
+++ b/src/gui/procedurewidget.h
@@ -51,8 +51,8 @@ class ProcedureWidget : public QWidget
     void on_ShowAvailableNodesButton_clicked(bool checked);
     void nodeNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
     void layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);
-    void updateNodeList();
-    void on_NodesList_customContextMenuRequested(const QPoint &pos);
+    void updateNodeTree();
+    void on_NodesTree_customContextMenuRequested(const QPoint &pos);
     void on_AvailableNodesTree_doubleClicked(const QModelIndex &index);
 
     public:

--- a/src/gui/procedurewidget.ui
+++ b/src/gui/procedurewidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>266</width>
+    <width>280</width>
     <height>659</height>
    </rect>
   </property>
@@ -61,7 +61,7 @@
          <number>4</number>
         </property>
         <item>
-         <widget class="QListView" name="NodesList">
+         <widget class="QTreeView" name="NodesTree">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
             <horstretch>0</horstretch>

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -13,8 +13,8 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
     ui_.setupUi(this);
 
     // Set up the procedure model
-    ui_.NodesList->setModel(&procedureModel_);
-    connect(ui_.NodesList, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
+    ui_.NodesTree->setModel(&procedureModel_);
+    connect(ui_.NodesTree, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
 
     // Hide the available nodes tree by default
     ui_.AvailableNodesTree->setVisible(false);
@@ -27,6 +27,9 @@ void ProcedureWidget::setUp(DissolveWindow *dissolveWindow, Procedure &proc)
     dissolveWindow_ = dissolveWindow;
     procedure_ = proc;
     procedureModel_.setData(proc);
+    ui_.NodesTree->expandAll();
+    ui_.NodesTree->resizeColumnToContents(0);
+    ui_.NodesTree->resizeColumnToContents(1);
     updateControls();
 }
 
@@ -120,21 +123,21 @@ void ProcedureWidget::nodeNameChanged(const QModelIndex &index, const QString &o
         ncw->updateControls();
 }
 
-// Update the node list
-void ProcedureWidget::updateNodeList()
+// Update the node tree
+void ProcedureWidget::updateNodeTree()
 {
     // Refresh the node list
     std::optional<QModelIndex> selectedIndex;
-    if (!ui_.NodesList->selectionModel()->selection().indexes().empty())
-        selectedIndex = ui_.NodesList->selectionModel()->selection().indexes().front();
+    if (!ui_.NodesTree->selectionModel()->selection().indexes().empty())
+        selectedIndex = ui_.NodesTree->selectionModel()->selection().indexes().front();
     procedureModel_.reset();
     if (selectedIndex)
-        ui_.NodesList->selectionModel()->select(selectedIndex.value(), QItemSelectionModel::ClearAndSelect);
+        ui_.NodesTree->selectionModel()->select(selectedIndex.value(), QItemSelectionModel::ClearAndSelect);
 }
 
-void ProcedureWidget::on_NodesList_customContextMenuRequested(const QPoint &pos)
+void ProcedureWidget::on_NodesTree_customContextMenuRequested(const QPoint &pos)
 {
-    auto index = ui_.NodesList->indexAt(pos);
+    auto index = ui_.NodesTree->indexAt(pos);
     if (!index.isValid())
         return;
     auto node = procedureModel_.data(index, Qt::UserRole).value<std::shared_ptr<ProcedureNode>>();
@@ -180,8 +183,8 @@ void ProcedureWidget::updateControls()
 // Prevent editing within tab
 void ProcedureWidget::preventEditing()
 {
-    ui_.NodesList->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    ui_.NodesList->setDragDropMode(QAbstractItemView::NoDragDrop);
+    ui_.NodesTree->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    ui_.NodesTree->setDragDropMode(QAbstractItemView::NoDragDrop);
     ui_.AvailableNodesTree->setEnabled(false);
     for (auto n = 0; n < ui_.NodeControlsStack->count(); ++n)
     {
@@ -195,8 +198,8 @@ void ProcedureWidget::preventEditing()
 void ProcedureWidget::allowEditing()
 {
     ui_.AvailableNodesTree->setEnabled(true);
-    ui_.NodesList->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
-    ui_.NodesList->setDragDropMode(QAbstractItemView::DragDrop);
+    ui_.NodesTree->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
+    ui_.NodesTree->setDragDropMode(QAbstractItemView::DragDrop);
     for (auto n = 0; n < ui_.NodeControlsStack->count(); ++n)
     {
         auto *ncw = dynamic_cast<NodeControlWidget *>(ui_.NodeControlsStack->widget(n));

--- a/src/keywords/dynamicsitenodes.cpp
+++ b/src/keywords/dynamicsitenodes.cpp
@@ -61,7 +61,7 @@ bool DynamicSiteNodesKeyword::deserialise(LineParser &parser, int startArg, cons
 bool DynamicSiteNodesKeyword::serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
     for (auto dynamicSite : data_)
-        if (!dynamicSite->write(parser, prefix))
+        if (!dynamicSite->serialise(parser, prefix))
             return false;
 
     return true;

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -49,7 +49,7 @@ bool NodeBranchKeyword::serialise(LineParser &parser, std::string_view keywordNa
         return false;
 
     // Write branch information
-    if (!data_->write(parser, fmt::format("{}  ", prefix)))
+    if (!data_->serialise(parser, fmt::format("{}  ", prefix)))
         return false;
 
     // Write end keyword based on the name

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -31,8 +31,7 @@ bool NodeBranchKeyword::deserialise(LineParser &parser, int startArg, const Core
                                 ProcedureNode::nodeTypes().keyword(parentNode_->type()));
 
     // Create and parse a new branch
-    data_ = std::make_shared<SequenceProcedureNode>(branchContext_, parentNode_->scope()->procedure(), parentNode_,
-                                                    fmt::format("End{}", name()));
+    data_ = std::make_shared<SequenceProcedureNode>(branchContext_, parentNode_->scope()->procedure(), parentNode_, name());
     if (!data_->deserialise(parser, coreData))
         return false;
 

--- a/src/keywords/procedure.cpp
+++ b/src/keywords/procedure.cpp
@@ -43,7 +43,7 @@ bool ProcedureKeyword::serialise(LineParser &parser, std::string_view keywordNam
     std::string newPrefix = fmt::format("{}  ", prefix);
 
     // Write the node data
-    if (!data_.write(parser, newPrefix))
+    if (!data_.serialise(parser, newPrefix))
         return false;
 
     // Write the end keyword (based on our name)

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -314,7 +314,7 @@ bool Dissolve::saveInput(std::string_view filename)
             return false;
         if (!parser.writeLineF("  {}\n", ConfigurationBlock::keywords().keyword(ConfigurationBlock::GeneratorKeyword)))
             return false;
-        if (!cfg->generator().write(parser, "    "))
+        if (!cfg->generator().serialise(parser, "    "))
             return false;
         if (!parser.writeLineF("  End{}\n", ConfigurationBlock::keywords().keyword(ConfigurationBlock::GeneratorKeyword)))
             return false;

--- a/src/modules/analyse/analyse.cpp
+++ b/src/modules/analyse/analyse.cpp
@@ -5,7 +5,7 @@
 #include "keywords/configuration.h"
 #include "keywords/procedure.h"
 
-AnalyseModule::AnalyseModule() : Module("Analyse"), analyser_(ProcedureNode::AnalysisContext, "EndAnalyser")
+AnalyseModule::AnalyseModule() : Module("Analyse"), analyser_(ProcedureNode::AnalysisContext, "Analyser")
 {
     // Targets
     keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);

--- a/src/procedure/nodes/collect1d.cpp
+++ b/src/procedure/nodes/collect1d.cpp
@@ -66,7 +66,7 @@ const Data1D &Collect1DProcedureNode::accumulatedData() const
 std::shared_ptr<SequenceProcedureNode> Collect1DProcedureNode::addSubCollectBranch(ProcedureNode::NodeContext context)
 {
     if (!subCollectBranch_)
-        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
+        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this(), "SubCollect");
 
     return subCollectBranch_;
 }

--- a/src/procedure/nodes/collect1d.cpp
+++ b/src/procedure/nodes/collect1d.cpp
@@ -66,9 +66,7 @@ const Data1D &Collect1DProcedureNode::accumulatedData() const
 std::shared_ptr<SequenceProcedureNode> Collect1DProcedureNode::addSubCollectBranch(ProcedureNode::NodeContext context)
 {
     if (!subCollectBranch_)
-        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure());
-
-    subCollectBranch_->setParent(shared_from_this());
+        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
 
     return subCollectBranch_;
 }

--- a/src/procedure/nodes/collect2d.cpp
+++ b/src/procedure/nodes/collect2d.cpp
@@ -63,9 +63,7 @@ const Data2D &Collect2DProcedureNode::accumulatedData() const
 std::shared_ptr<SequenceProcedureNode> Collect2DProcedureNode::addSubCollectBranch(ProcedureNode::NodeContext context)
 {
     if (!subCollectBranch_)
-        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure());
-
-    subCollectBranch_->setParent(shared_from_this());
+        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
 
     return subCollectBranch_;
 }

--- a/src/procedure/nodes/collect2d.cpp
+++ b/src/procedure/nodes/collect2d.cpp
@@ -63,7 +63,7 @@ const Data2D &Collect2DProcedureNode::accumulatedData() const
 std::shared_ptr<SequenceProcedureNode> Collect2DProcedureNode::addSubCollectBranch(ProcedureNode::NodeContext context)
 {
     if (!subCollectBranch_)
-        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
+        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this(), "SubCollect");
 
     return subCollectBranch_;
 }

--- a/src/procedure/nodes/collect3d.cpp
+++ b/src/procedure/nodes/collect3d.cpp
@@ -101,9 +101,7 @@ const Data3D &Collect3DProcedureNode::accumulatedData() const
 std::shared_ptr<SequenceProcedureNode> Collect3DProcedureNode::addSubCollectBranch(ProcedureNode::NodeContext context)
 {
     if (!subCollectBranch_)
-        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure());
-
-    subCollectBranch_->setParent(shared_from_this());
+        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
 
     return subCollectBranch_;
 }

--- a/src/procedure/nodes/collect3d.cpp
+++ b/src/procedure/nodes/collect3d.cpp
@@ -101,7 +101,7 @@ const Data3D &Collect3DProcedureNode::accumulatedData() const
 std::shared_ptr<SequenceProcedureNode> Collect3DProcedureNode::addSubCollectBranch(ProcedureNode::NodeContext context)
 {
     if (!subCollectBranch_)
-        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
+        subCollectBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this(), "SubCollect");
 
     return subCollectBranch_;
 }

--- a/src/procedure/nodes/fit1d.cpp
+++ b/src/procedure/nodes/fit1d.cpp
@@ -277,7 +277,7 @@ bool Fit1DProcedureNode::deserialise(LineParser &parser, const CoreData &coreDat
 }
 
 // Write structure to specified LineParser
-bool Fit1DProcedureNode::write(LineParser &parser, std::string_view prefix)
+bool Fit1DProcedureNode::serialise(LineParser &parser, std::string_view prefix)
 {
     // Block Start
     if (!parser.writeLineF("{}{}\n", prefix, ProcedureNode::nodeTypes().keyword(type_)))

--- a/src/procedure/nodes/fit1d.h
+++ b/src/procedure/nodes/fit1d.h
@@ -96,5 +96,5 @@ class Fit1DProcedureNode : public ProcedureNode
     // Read structure from specified LineParser
     bool deserialise(LineParser &parser, const CoreData &coreData) override;
     // Write structure to specified LineParser
-    bool write(LineParser &parser, std::string_view prefix) override;
+    bool serialise(LineParser &parser, std::string_view prefix) override;
 };

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -74,7 +74,7 @@ EnumOptions<ProcedureNode::NodeContext> ProcedureNode::nodeContexts()
 }
 
 ProcedureNode::ProcedureNode(ProcedureNode::NodeType nodeType, ProcedureNode::NodeClass classType)
-    : class_(classType), type_(nodeType), scope_(nullptr), parent_(nullptr)
+    : class_(classType), type_(nodeType), scope_(nullptr)
 {
 }
 
@@ -115,11 +115,8 @@ const KeywordStore &ProcedureNode::keywords() const { return keywords_; }
 // Set scope
 void ProcedureNode::setScope(std::shared_ptr<SequenceProcedureNode> scopeNode) { scope_ = scopeNode; }
 
-// Find the node which owns this node.
-NodeRef ProcedureNode::parent() const { return parent_; }
-
-// Update the parentage
-void ProcedureNode::setParent(NodeRef parent) { parent_ = parent; }
+// Return the parent non-sequence node which owns this node
+NodeRef ProcedureNode::parent() const { return scope_ ? scope_->owner() : NodeRef(); }
 
 // Find the nodes owned by this node
 std::vector<ConstNodeRef> ProcedureNode::children() const { return {}; }

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -286,7 +286,7 @@ bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
 }
 
 // Write node data to specified LineParser
-bool ProcedureNode::write(LineParser &parser, std::string_view prefix)
+bool ProcedureNode::serialise(LineParser &parser, std::string_view prefix)
 {
     // Block Start - node type and name (if specified)
     if (name_.empty())

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -134,14 +134,10 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
     private:
     // Scope (SequenceNode) in which this node exists
     std::shared_ptr<SequenceProcedureNode> scope_;
-    // The owner of this node
-    NodeRef parent_;
 
     public:
-    // Find the node which owns this node.
+    // Return the parent non-sequence node which owns this node
     NodeRef parent() const;
-    // Update the parentage
-    void setParent(NodeRef parent);
     // Find the nodes owned by this node
     virtual std::vector<ConstNodeRef> children() const;
     // Set scope

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -208,5 +208,5 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
     // Read node data from specified LineParser
     virtual bool deserialise(LineParser &parser, const CoreData &coreData);
     // Write node data to specified LineParser
-    virtual bool write(LineParser &parser, std::string_view prefix);
+    virtual bool serialise(LineParser &parser, std::string_view prefix);
 };

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -83,9 +83,8 @@ std::string Process1DProcedureNode::xAxisLabel() const { return labelX_; }
 std::shared_ptr<SequenceProcedureNode> Process1DProcedureNode::addNormalisationBranch()
 {
     if (!normalisationBranch_)
-        normalisationBranch_ = std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure());
-
-    normalisationBranch_->setParent(shared_from_this());
+        normalisationBranch_ =
+            std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(), shared_from_this());
 
     return normalisationBranch_;
 }

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -79,12 +79,12 @@ std::string Process1DProcedureNode::xAxisLabel() const { return labelX_; }
  * Branches
  */
 
-// Add and return subcollection sequence branch
+// Add and return normalisation sequence branch
 std::shared_ptr<SequenceProcedureNode> Process1DProcedureNode::addNormalisationBranch()
 {
     if (!normalisationBranch_)
-        normalisationBranch_ =
-            std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(), shared_from_this());
+        normalisationBranch_ = std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(),
+                                                                       shared_from_this(), "Normalisation");
 
     return normalisationBranch_;
 }

--- a/src/procedure/nodes/process2d.cpp
+++ b/src/procedure/nodes/process2d.cpp
@@ -75,12 +75,12 @@ std::string Process2DProcedureNode::yAxisLabel() const { return labelY_; }
  * Branches
  */
 
-// Add and return subcollection sequence branch
+// Add and return normalisation sequence branch
 std::shared_ptr<SequenceProcedureNode> Process2DProcedureNode::addNormalisationBranch()
 {
     if (!normalisationBranch_)
-        normalisationBranch_ =
-            std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(), shared_from_this());
+        normalisationBranch_ = std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(),
+                                                                       shared_from_this(), "Normalisation");
 
     return normalisationBranch_;
 }

--- a/src/procedure/nodes/process2d.cpp
+++ b/src/procedure/nodes/process2d.cpp
@@ -79,9 +79,8 @@ std::string Process2DProcedureNode::yAxisLabel() const { return labelY_; }
 std::shared_ptr<SequenceProcedureNode> Process2DProcedureNode::addNormalisationBranch()
 {
     if (!normalisationBranch_)
-        normalisationBranch_ = std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure());
-
-    normalisationBranch_->setParent(shared_from_this());
+        normalisationBranch_ =
+            std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(), shared_from_this());
 
     return normalisationBranch_;
 }

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -79,12 +79,12 @@ std::string Process3DProcedureNode::zAxisLabel() const { return labelZ_; }
  * Branches
  */
 
-// Add and return subcollection sequence branch
+// Add and return normalisation sequence branch
 std::shared_ptr<SequenceProcedureNode> Process3DProcedureNode::addNormalisationBranch()
 {
     if (!normalisationBranch_)
-        normalisationBranch_ =
-            std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(), shared_from_this());
+        normalisationBranch_ = std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(),
+                                                                       shared_from_this(), "Normalisation");
 
     return normalisationBranch_;
 }

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -83,9 +83,8 @@ std::string Process3DProcedureNode::zAxisLabel() const { return labelZ_; }
 std::shared_ptr<SequenceProcedureNode> Process3DProcedureNode::addNormalisationBranch()
 {
     if (!normalisationBranch_)
-        normalisationBranch_ = std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure());
-
-    normalisationBranch_->setParent(shared_from_this());
+        normalisationBranch_ =
+            std::make_shared<SequenceProcedureNode>(ProcedureNode::OperateContext, procedure(), shared_from_this());
 
     return normalisationBranch_;
 }

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -173,7 +173,7 @@ std::shared_ptr<SequenceProcedureNode> SelectProcedureNode::branch() { return fo
 std::shared_ptr<SequenceProcedureNode> SelectProcedureNode::addForEachBranch(ProcedureNode::NodeContext context)
 {
     if (!forEachBranch_)
-        forEachBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this());
+        forEachBranch_ = std::make_shared<SequenceProcedureNode>(context, procedure(), shared_from_this(), "ForEach");
 
     return forEachBranch_;
 }

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -456,14 +456,14 @@ bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &core
 }
 
 // Write structure to specified LineParser
-bool SequenceProcedureNode::write(LineParser &parser, std::string_view prefix)
+bool SequenceProcedureNode::serialise(LineParser &parser, std::string_view prefix)
 {
     // Block Start - should have already been written by the calling function, since we don't know the keyword we are linked
     // to
 
     // Loop over nodes in this sequence
     for (auto node : sequence_)
-        if (!node->write(parser, prefix))
+        if (!node->serialise(parser, prefix))
             return false;
 
     // Block End - will be written by the calling function, since we don't know the keyword we are linked to

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -7,13 +7,13 @@
 #include "procedure/nodes/registry.h"
 
 SequenceProcedureNode::SequenceProcedureNode(ProcedureNode::NodeContext context, const Procedure *procedure, NodeRef owner,
-                                             std::string_view blockTerminationKeyword)
+                                             std::string_view blockKeyword)
     : ProcedureNode(ProcedureNode::NodeType::Sequence)
 {
     context_ = context;
     procedure_ = procedure;
     owner_ = std::move(owner);
-    blockTerminationKeyword_ = blockTerminationKeyword;
+    blockKeyword_ = blockKeyword;
 }
 
 SequenceProcedureNode::~SequenceProcedureNode() { clear(); }
@@ -392,15 +392,14 @@ bool SequenceProcedureNode::finalise(const ProcedureContext &procedureContext)
  * Read / Write
  */
 
-// Set block termination keyword for current context when reading
-void SequenceProcedureNode::setBlockTerminationKeyword(std::string_view endKeyword) { blockTerminationKeyword_ = endKeyword; }
-
-// Return block termination keyword for current context
-std::string_view SequenceProcedureNode::blockTerminationKeyword() const { return blockTerminationKeyword_; }
+// Return block keyword for current context
+std::string_view SequenceProcedureNode::blockKeyword() const { return blockKeyword_; }
 
 // Read structure from specified LineParser
 bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
 {
+    const auto blockTerminationKeyword = fmt::format("End{}", blockKeyword_);
+
     // Read until we encounter the block-ending keyword, or we fail for some reason
     while (!parser.eofOrBlank())
     {
@@ -409,7 +408,7 @@ bool SequenceProcedureNode::deserialise(LineParser &parser, const CoreData &core
             return false;
 
         // Is the first argument the block termination keyword for the current context?
-        if (DissolveSys::sameString(parser.argsv(0), blockTerminationKeyword_))
+        if (DissolveSys::sameString(parser.argsv(0), blockTerminationKeyword))
             break;
 
         // Is the first argument on the current line a valid control keyword?

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -203,7 +203,7 @@ ConstNodeRef SequenceProcedureNode::nodeInScope(ConstNodeRef queryingNode, std::
                                                 std::optional<ProcedureNode::NodeType> optNodeType,
                                                 std::optional<ProcedureNode::NodeClass> optNodeClass) const
 {
-    // If one was give, start from the querying node and work backwards...
+    // If one was given, start from the querying node and work backwards...
     if (queryingNode)
     {
         auto range = QueryRange(queryingNode, sequence_);
@@ -239,7 +239,7 @@ std::vector<ConstNodeRef> SequenceProcedureNode::nodesInScope(ConstNodeRef query
 {
     std::vector<ConstNodeRef> matches;
 
-    // If one was give, start from the querying node and work backwards...
+    // If one was given, start from the querying node and work backwards...
     if (queryingNode)
     {
         auto range = QueryRange(queryingNode, sequence_);

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -14,7 +14,7 @@ class SequenceProcedureNode : public ProcedureNode
 {
     public:
     SequenceProcedureNode(ProcedureNode::NodeContext context, const Procedure *procedure, NodeRef owner,
-                          std::string_view blockTerminationKeyword = "");
+                          std::string_view blockKeyword);
     ~SequenceProcedureNode() override;
 
     /*
@@ -153,14 +153,12 @@ class SequenceProcedureNode : public ProcedureNode
      * Read / Write
      */
     private:
-    // Block termination keyword for current context when reading
-    std::string blockTerminationKeyword_;
+    // Block keyword for current context when reading
+    std::string blockKeyword_;
 
     public:
-    // Set block termination keyword for current context when reading
-    void setBlockTerminationKeyword(std::string_view endKeyword);
-    // Return block termination keyword for current context
-    std::string_view blockTerminationKeyword() const;
+    // Return block keyword for current context
+    std::string_view blockKeyword() const;
     // Read structure from specified LineParser
     bool deserialise(LineParser &parser, const CoreData &coreData) override;
     // Write structure to specified LineParser

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -162,5 +162,5 @@ class SequenceProcedureNode : public ProcedureNode
     // Read structure from specified LineParser
     bool deserialise(LineParser &parser, const CoreData &coreData) override;
     // Write structure to specified LineParser
-    bool write(LineParser &parser, std::string_view prefix) override;
+    bool serialise(LineParser &parser, std::string_view prefix) override;
 };

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -13,7 +13,7 @@ class Procedure;
 class SequenceProcedureNode : public ProcedureNode
 {
     public:
-    SequenceProcedureNode(ProcedureNode::NodeContext context, const Procedure *procedure, NodeRef parentNode = nullptr,
+    SequenceProcedureNode(ProcedureNode::NodeContext context, const Procedure *procedure, NodeRef owner,
                           std::string_view blockTerminationKeyword = "");
     ~SequenceProcedureNode() override;
 
@@ -90,8 +90,8 @@ class SequenceProcedureNode : public ProcedureNode
     private:
     // Parent Procedure to which this sequence belongs
     const Procedure *procedure_;
-    // Parent ProcedureNode in which this sequence exists
-    NodeRef parentNode_;
+    // ProcedureNode which owns this sequence
+    NodeRef owner_;
     // Context of the sequence
     ProcedureNode::NodeContext context_;
 
@@ -107,6 +107,8 @@ class SequenceProcedureNode : public ProcedureNode
     public:
     // Return parent Procedure to which this sequence belongs
     const Procedure *procedure() const override;
+    // Return this sequences owner
+    NodeRef owner() const;
     // Return the context of the sequence
     ProcedureNode::NodeContext sequenceContext() const;
     // Return named node if present (and matches the type / class given)

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -6,8 +6,8 @@
 #include "base/sysfunc.h"
 #include "classes/configuration.h"
 
-Procedure::Procedure(ProcedureNode::NodeContext context, std::string_view blockTerminationKeyword)
-    : rootSequence_(std::make_shared<SequenceProcedureNode>(context, this, nullptr, blockTerminationKeyword))
+Procedure::Procedure(ProcedureNode::NodeContext context, std::string_view blockKeyword)
+    : rootSequence_(std::make_shared<SequenceProcedureNode>(context, this, nullptr, blockKeyword))
 {
     context_ = context;
 }
@@ -23,9 +23,6 @@ void Procedure::clear() { rootSequence_->clear(); }
 
 // Return root sequence
 const SequenceProcedureNode &Procedure::rootSequence() const { return *rootSequence_; }
-
-// Return the block termination keyword for the Procedure
-std::string_view Procedure::blockTerminationKeyword() const { return rootSequence_->blockTerminationKeyword(); }
 
 // Return named node if present (and matches the type / class given)
 ConstNodeRef Procedure::node(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType,

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -96,4 +96,4 @@ bool Procedure::deserialise(LineParser &parser, const CoreData &coreData)
 }
 
 // Write structure to specified LineParser
-bool Procedure::write(LineParser &parser, std::string_view prefix) { return rootSequence_->write(parser, prefix); }
+bool Procedure::serialise(LineParser &parser, std::string_view prefix) { return rootSequence_->serialise(parser, prefix); }

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -36,8 +36,6 @@ class Procedure
     }
     // Return root sequence
     const SequenceProcedureNode &rootSequence() const;
-    // Return the block termination keyword for the Procedure
-    std::string_view blockTerminationKeyword() const;
     // Return named node if present (and matches the type / class given)
     ConstNodeRef node(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
                       std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -61,5 +61,5 @@ class Procedure
     // Read procedure from specified LineParser
     bool deserialise(LineParser &parser, const CoreData &coreData);
     // Write procedure to specified LineParser
-    bool write(LineParser &parser, std::string_view prefix);
+    bool serialise(LineParser &parser, std::string_view prefix);
 };


### PR DESCRIPTION
This PR follows #1180 and addresses the most tedious part of the procedure editing work - transitioning `ProcedureModel` from a simple list to a tree. As you can readily imagine this was generally a pain, but after some light refactoring the results are rather nice:

![image](https://user-images.githubusercontent.com/11457350/179286165-d5cf875f-7fde-4667-a5e3-7cb9ec1c95e8.png)

Some modest simplification work was undertaken on `ProcedureNode`s in order to clarify the clashing roles of the `ProcedureNode::parent_` and `SequenceProcedureNode::parentNode_`. All nodes exist in a `SequenceProcedureNode` (either the `Procedure::rootSequenceNode_` or a branch local to another node, but the parent/child relationship that we want in order to aid representation in any model is the one between a given node and the parent node which owns the `SequenceProcedureNode` it exists in. Thus, `SequenceProcedureNode::parentNode_` is renamed to `owner_`, and `ProcedureNode::parent_` is removed completely. The `ProcedureNode::parent()` function now uses the stored sequence `scope_` variable to determine ownership at the higher level.

Works towards #1176.