### PR TITLE
Clarify PairPotential Charges

### DIFF
--- a/src/classes/pairpotential.cpp
+++ b/src/classes/pairpotential.cpp
@@ -92,7 +92,7 @@ void PairPotential::setData1DNames()
 }
 
 // Set up PairPotential parameters from specified AtomTypes
-bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ)
+bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges)
 {
     // Check for NULL pointers
     if (typeI == nullptr)
@@ -102,6 +102,7 @@ bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::sha
 
     atomTypeI_ = typeI;
     atomTypeJ_ = typeJ;
+    includeAtomTypeCharges_ = includeCharges;
     interactionPotential_.setFormAndParameters(ShortRangeFunctions::Form::None, "");
     setData1DNames();
     auto &paramsI = atomTypeI_->interactionPotential().parameters();
@@ -370,7 +371,7 @@ void PairPotential::calculateDUFull()
 }
 
 // Generate energy and force tables
-bool PairPotential::tabulate(double maxR, double delta, bool includeAtomTypeCharges)
+bool PairPotential::tabulate(double maxR, double delta)
 {
     // Check that AtomType pointers were set at some pointer
     if ((atomTypeI_ == nullptr) || (atomTypeJ_ == nullptr))
@@ -383,7 +384,6 @@ bool PairPotential::tabulate(double maxR, double delta, bool includeAtomTypeChar
     delta_ = delta;
     rDelta_ = 1.0 / delta_;
     range_ = maxR;
-    includeAtomTypeCharges_ = includeAtomTypeCharges;
     nPoints_ = range_ / delta_;
 
     // Calculate energies and forces at the cutoff distance, for later use in truncation schemes

--- a/src/classes/pairpotential.h
+++ b/src/classes/pairpotential.h
@@ -95,7 +95,7 @@ class PairPotential
 
     public:
     // Set up PairPotential parameters from specified AtomTypes
-    bool setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ);
+    bool setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges);
     // Return interaction potential
     InteractionPotential<ShortRangeFunctions> &interactionPotential();
     const InteractionPotential<ShortRangeFunctions> &interactionPotential() const;
@@ -153,7 +153,7 @@ class PairPotential
 
     public:
     // Generate energy and force tables
-    bool tabulate(double maxR, double delta, bool includeAtomTypeCharges);
+    bool tabulate(double maxR, double delta);
     // Return number of tabulated points in potential
     int nPoints() const;
     // Return range of potential

--- a/unit/classes/cells.cpp
+++ b/unit/classes/cells.cpp
@@ -72,7 +72,7 @@ TEST(CellsTest, Basic)
     EXPECT_TRUE(dissolve.prepare());
     auto *pp = dissolve.pairPotential(arType, oType);
     pp->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.35 sigma=2.166");
-    pp->tabulate(dissolve.pairPotentialRange(), dissolve.pairPotentialDelta(), false);
+    pp->tabulate(dissolve.pairPotentialRange(), dissolve.pairPotentialDelta());
 
     // Test consistency of energy calculation with DL_POLY reference energies
 

--- a/unit/math/geometryMin.cpp
+++ b/unit/math/geometryMin.cpp
@@ -18,9 +18,9 @@ TEST(GeometryMinimisationTest, Water)
     auto atH = coreData.addAtomType(Elements::H);
     atH->interactionPotential().setForm(ShortRangeFunctions::Form::None);
     std::vector<std::unique_ptr<PairPotential>> pairPotentials;
-    pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atO, atO);
-    pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atH, atH);
-    pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atO, atH);
+    pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atO, atO, false);
+    pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atH, atH, false);
+    pairPotentials.emplace_back(std::make_unique<PairPotential>())->setUp(atO, atH, false);
     PotentialMap potMap;
     potMap.initialise(coreData.atomTypes(), pairPotentials, 15.0);
 


### PR DESCRIPTION
Quick PR to clarify some small sections of the code related to `PairPotential` generation - specifically, whether charges from atom types are to be included in the potentials or not.  This was implemented in a somewhat confusing manner with possibilities for (severe) errors to creep in, so this has been tidied.