### PR TITLE
Fix IntraShake

### DIFF
--- a/src/modules/intrashake/intrashake.cpp
+++ b/src/modules/intrashake/intrashake.cpp
@@ -26,30 +26,29 @@ IntraShakeModule::IntraShakeModule() : Module("IntraShake")
                                termEnergyOnly_);
 
     // Bonds
-    keywords_.add<BoolKeyword>("Bonds", "AdjustBonds", "Whether Bonds in the molecule should be shaken", adjustBonds_);
-    keywords_.addRestartable<DoubleKeyword>("Bonds", "BondStepSize", "Step size for Bond adjustments (Angstroms)",
+    keywords_.add<BoolKeyword>("Control", "AdjustBonds", "Whether bonds in molecules should be shaken", adjustBonds_);
+    keywords_.addRestartable<DoubleKeyword>("Control", "BondStepSize", "Step size for bond adjustments (Angstroms)",
                                             bondStepSize_, 0.001, 1.0);
-    keywords_.add<DoubleKeyword>("Bonds", "BondStepSizeMin", "Minimum step size for Bond adjustments (Angstroms)",
+    keywords_.add<DoubleKeyword>("Control", "BondStepSizeMin", "Minimum step size for bond adjustments (Angstroms)",
                                  bondStepSizeMin_, 0.001, 1.0);
-    keywords_.add<DoubleKeyword>("Bonds", "BondStepSizeMax", "Maximum step size for Bond adjustments (Angstroms)",
+    keywords_.add<DoubleKeyword>("Control", "BondStepSizeMax", "Maximum step size for bond adjustments (Angstroms)",
                                  bondStepSizeMax_, 0.001, 1.0);
 
     // Angles
-    keywords_.add<BoolKeyword>("Angles", "AdjustAngles", "Whether Angles in the molecule should be shaken", adjustAngles_);
-    keywords_.addRestartable<DoubleKeyword>("Angles", "AngleStepSize", "Step size for Angle adjustments (degrees)",
+    keywords_.add<BoolKeyword>("Control", "AdjustAngles", "Whether angles in molecules should be shaken", adjustAngles_);
+    keywords_.addRestartable<DoubleKeyword>("Control", "AngleStepSize", "Step size for angle adjustments (degrees)",
                                             angleStepSize_, 0.01, 45.0);
-    keywords_.add<DoubleKeyword>("Angles", "AngleStepSizeMin", "Minimum step size for Angle adjustments (degrees)",
+    keywords_.add<DoubleKeyword>("Control", "AngleStepSizeMin", "Minimum step size for angle adjustments (degrees)",
                                  angleStepSizeMin_, 0.01, 45.0);
-    keywords_.add<DoubleKeyword>("Angles", "AngleStepSizeMax", "Maximum step size for Angle adjustments (degrees)",
+    keywords_.add<DoubleKeyword>("Control", "AngleStepSizeMax", "Maximum step size for angle adjustments (degrees)",
                                  angleStepSizeMax_, 0.01, 45.0);
 
     // Torsions
-    keywords_.add<BoolKeyword>("Torsions", "AdjustTorsions", "Whether Torsions in the molecule should be shaken",
-                               adjustTorsions_);
-    keywords_.addRestartable<DoubleKeyword>("Torsions", "TorsionStepSize", "Step size for Torsion adjustments (degrees)",
+    keywords_.add<BoolKeyword>("Control", "AdjustTorsions", "Whether torsions in molecules should be shaken", adjustTorsions_);
+    keywords_.addRestartable<DoubleKeyword>("Control", "TorsionStepSize", "Step size for torsion adjustments (degrees)",
                                             torsionStepSize_, 0.01, 45.0);
-    keywords_.add<DoubleKeyword>("Torsions", "TorsionStepSizeMin", "Minimum step size for Torsion adjustments (degrees)",
+    keywords_.add<DoubleKeyword>("Control", "TorsionStepSizeMin", "Minimum step size for torsion adjustments (degrees)",
                                  torsionStepSizeMin_, 0.01, 45.0);
-    keywords_.add<DoubleKeyword>("Torsions", "TorsionStepSizeMax", "Maximum step size for Torsion adjustments (degrees)",
+    keywords_.add<DoubleKeyword>("Control", "TorsionStepSizeMax", "Maximum step size for torsion adjustments (degrees)",
                                  torsionStepSizeMax_, 0.01, 45.0);
 }

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -42,8 +42,8 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                          torsionStepSize_, torsionStepSizeMin_, torsionStepSizeMax_);
     Messenger::print("IntraShake: Target acceptance rate is {}.\n", targetAcceptanceRate_);
     if (termEnergyOnly_)
-        Messenger::print("IntraShake: Only term energy will be considered (interatomic contributions with the "
-                         "system will be excluded).\n");
+        Messenger::print("IntraShake: Only term energy will be considered (interactions with the rest of the"
+                         "system will be ignored).\n");
     Messenger::print("\n");
 
     ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -200,7 +200,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
                         // Trial the transformed Molecule
                         delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                        accept = delta < 0 ? true : (randomBuffer.random() < exp(-delta * rRT));
+                        accept = delta < 0 || (randomBuffer.random() < exp(-delta * rRT));
 
                         // Accept new (current) positions of the Molecule's Atoms?
                         if (accept)

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -189,7 +189,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         transform.createRotationAxis(v.x, v.y, v.z, randomBuffer.randomPlusMinusOne() * angleStepSize_, true);
 
                         // Adjust the Atoms attached to the selected terminus
-                        mol->transform(box, transform, angle.j()->r(), angle.attachedAtoms(terminus));
+                        mol->transform(box, transform, j->r(), angle.attachedAtoms(terminus));
 
                         // Update Cell positions of the adjusted Atoms
                         targetConfiguration_->updateCellLocation(angle.attachedAtoms(terminus), indexOffset);


### PR DESCRIPTION
This PR addresses a bug with the `IntraShake` module affecting angle term adjustment, and also tidies up the keywords which were split into too many groups (bad UX).