### PR TITLE
1118 Fix Release Stage Execution

### DIFF
--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -82,6 +82,6 @@ stages:
   # Create Release
   - stage: 'release'
     displayName: 'Create Release'
-    condition: not(endsWith(variables['Build.SourceBranch'], 'pre'))
+    condition: and(succeeded(), not(endsWith(variables['Build.SourceBranch'], 'pre')))
     jobs:
       - template: templates/create-release.yml


### PR DESCRIPTION
Quick PR to fix logic behind running of the "Create Release" stage in our CI. Since this stage has an explicit `condition()` to check the name of the release branch (only creating the release proper on GitHub if the name does *not* end in `pre`) this overrides the default behaviour of sequential stage running on prior stage run success.

The present PR adjusts that logic to reproduce both the original sequential behaviour along with the branch name clause.

Closes #1118. 