### PR TITLE
1189 Push Harbor

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -35,7 +35,7 @@ stages:
               package: "checks.x86_64-linux.dissolve-mpi"
       - job: "test_linux_gui"
         displayName: "Testing GUI"
-        timeoutInMinutes: 90
+        timeoutInMinutes: 120
         pool:
           vmImage: "ubuntu-latest"
         steps:

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -55,7 +55,7 @@ stages:
             parameters:
               package: "checks.x86_64-linux.dissolve-mpi"
       - job: "test_linux_gui"
-        timeoutInMinutes: 90
+        timeoutInMinutes: 120
         displayName: "Testing GUI"
         pool:
           vmImage: "ubuntu-latest"

--- a/.azure-pipelines/templates/create-release.yml
+++ b/.azure-pipelines/templates/create-release.yml
@@ -95,13 +95,6 @@ jobs:
         env:
           GITHUB_TOKEN: $(REPO_SECRET)
         displayName: 'Create Continuous Release (GitHub)'
-      - bash: |
-          set -ex
-          ./ci/scripts/list-releases -r disorderedmaterials/dissolve -u -v $(Build.SourceBranchName)
-        condition: eq('${{ parameters.continuous }}', false)
-        env:
-          GITHUB_TOKEN: $(REPO_SECRET)
-        displayName: 'Update Web Release Info'
       - template: install-nix.yml
       - template: push-harbor.yml
         parameters:
@@ -109,3 +102,10 @@ jobs:
             tag: "continuous"
           ${{ if not(eq(variables['Build.SourceBranchName'], 'develop')) }}:
             tag: "latest"
+      - bash: |
+          set -ex
+          ./ci/scripts/list-releases -r disorderedmaterials/dissolve -u -v $(Build.SourceBranchName)
+        condition: eq('${{ parameters.continuous }}', false)
+        env:
+          GITHUB_TOKEN: $(REPO_SECRET)
+        displayName: 'Update Web Release Info'

--- a/ci/scripts/list-releases
+++ b/ci/scripts/list-releases
@@ -118,6 +118,9 @@ echo ""
 # Update web-side release info in development branch?
 if [ "${UPDATE_WEB}" == "true" ]
 then
+  # Get current checked out revision
+  CURRENTREV=$(git rev-parse HEAD)
+
   # Switch to development branch
   git checkout origin/develop
 
@@ -146,6 +149,9 @@ then
     git add ${OLD_RELEASES_FILE} web/config.toml README.md
     git commit -m "(Release Automation) Update version info."
     git push origin HEAD:develop
+
+    # Return to existing revision
+    git checkout $CURRENTREV
   else
     echo "No changes to be committed to develop."
   fi


### PR DESCRIPTION
This PR closes #1189.  The detection of the wrong version number in the singularity image file to push was caused by the actions of the `list-releases` script. When updating the historic release list the `list-releases` script forcibly checks out `origin/develop` since this is where the update needs to occur.  Of course, back in the CI stages afterwards any detection of version information from the source code reflects the continuous release rather than the (previously) checked out branch.