### PR TITLE
Fix intrashake energy

### DIFF
--- a/benchmark/energy/energy_benchmark.cpp
+++ b/benchmark/energy/energy_benchmark.cpp
@@ -44,7 +44,7 @@ template <ProblemType problem, Population population> static void BM_CalculateEn
     const auto mol = problemDef.cfg_->molecules().front();
     for (auto _ : state)
     {
-        double molecularEnergy = energyKernel.energy(*mol, ProcessPool::PoolStrategy);
+        double molecularEnergy = energyKernel.energy(*mol, false, ProcessPool::PoolStrategy);
         benchmark::DoNotOptimize(molecularEnergy);
     }
 }

--- a/src/classes/energykernel.h
+++ b/src/classes/energykernel.h
@@ -71,7 +71,7 @@ class EnergyKernel
     // Return molecular correction energy related to intramolecular terms involving supplied atom
     double correct(const Atom &i);
     // Return PairPotential energy of Molecule with world
-    double energy(const Molecule &mol, ProcessPool::DivisionStrategy strategy);
+    double energy(const Molecule &mol, bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy);
     // Return total interatomic PairPotential energy of the system
     double energy(const CellArray &cellArray, bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy);
 

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -229,7 +229,7 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                                   cutoff);
         auto molecularEnergy = 0.0;
         for (const auto &mol : targetConfiguration_->molecules())
-            molecularEnergy += energyKernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+            molecularEnergy += energyKernel.energy(*mol, false, ProcessPool::subDivisionStrategy(strategy));
         // In the typical case where there is more than one molecule, our sum will contain double the intermolecular
         // pairpotential energy, and zero intramolecular energy
         if (targetConfiguration_->nMolecules() > 1)

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -107,7 +107,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             changeStore.add(mol);
 
             // Calculate reference pairpotential energy for Molecule
-            ppEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+            ppEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
 
             // Loop over defined bonds
             if (adjustBonds_)
@@ -139,7 +139,8 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         targetConfiguration_->updateCellLocation(bond.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                        newPPEnergy =
+                            termEnergyOnly_ ? 0.0 : kernel.energy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
                         newIntraEnergy = bond.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(bond, *i, *j);
 
                         // Trial the transformed Molecule
@@ -195,7 +196,8 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         targetConfiguration_->updateCellLocation(angle.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                        newPPEnergy =
+                            termEnergyOnly_ ? 0.0 : kernel.energy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
                         newIntraEnergy = angle.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(angle, *i, *j, *k);
 
                         // Trial the transformed Molecule
@@ -252,7 +254,8 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         targetConfiguration_->updateCellLocation(torsion.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                        newPPEnergy =
+                            termEnergyOnly_ ? 0.0 : kernel.energy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
                         newIntraEnergy =
                             torsion.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(torsion, *i, *j, *k, *l);
 

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -115,7 +115,7 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             changeStore.add(mol);
 
             // Calculate reference energy for Molecule, including intramolecular terms
-            currentEnergy = kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+            currentEnergy = kernel.energy(*mol, false, ProcessPool::subDivisionStrategy(strategy));
 
             // Loop over number of shakes per atom
             for (shake = 0; shake < nShakesPerMolecule_; ++shake)
@@ -158,7 +158,7 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                 targetConfiguration_->updateCellLocation(mol);
 
                 // Calculate new energy
-                newEnergy = kernel.energy(*mol, ProcessPool::subDivisionStrategy(strategy));
+                newEnergy = kernel.energy(*mol, false, ProcessPool::subDivisionStrategy(strategy));
 
                 // Trial the transformed atom position
                 delta = newEnergy - currentEnergy;


### PR DESCRIPTION
This PR fixes an issue with the energies calculated in the `IntraShake` processing, which failed to include the internal molecule pair potential contributions. This resulted in bad overlaps between atoms within molecules, which obviously ain't a good thing.