### PR TITLE
1162 AtomShake Fail

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,9 @@
 
 int main(int args, char **argv)
 {
+    // Initialise random seed before we do anything else - it might get re-initialised if a specific seed is provided
+    srand((unsigned)time(nullptr));
+
 #ifdef PARALLEL
     // Initialise parallel communication
     ProcessPool::initialiseMPI(&args, &argv);
@@ -27,8 +30,9 @@ int main(int args, char **argv)
         return 1;
 #endif
 
-    // Initialise random seed
-    srand(options.randomSeed().value_or((unsigned)time(nullptr)));
+    // Re-initialise random seed
+    if (options.randomSeed())
+        srand(*options.randomSeed());
 
     // Enable redirect if requested
     if (options.redirectionBasename())


### PR DESCRIPTION
Nice and simple PR to fix a lingering issue where the `AtomShake` system test would occasionally fail (perhaps once in every 50 tests).  The cause seems to be related to the fact that the random seed was initialised _after_ the call to `MPI_Init` - thus, the system time probed by individual processes could potentially be different, leading to different random number sequences and erroneous results / undefined behaviour.

Closes #1162.