### PR TITLE
Include antlr4 in Windows installer

### DIFF
--- a/ci/windows/dissolve-gui.iss
+++ b/ci/windows/dissolve-gui.iss
@@ -67,6 +67,7 @@ Source: "C:\Windows\System32\D3DCompiler_47.dll"; DestDir: "{app}\bin"; Flags: i
 Source: "{#DeployDir}\tbb\bin\tbb.dll"; DestDir: "{app}\bin"
 Source: "{#DeployDir}\tbb\bin\tbbmalloc.dll"; DestDir: "{app}\bin"
 Source: "{#DeployDir}\tbb\bin\tbbmalloc_proxy.dll"; DestDir: "{app}\bin"
+Source: "{#DeployDir}\antlr4-cppruntime\bin\antlr4-runtime.dll"; DestDir: "{app}\bin"
 
 [Icons]
 Name: "{group}\{#MyAppName}"; IconFilename: "{app}\bin\Dissolve.ico"; Filename: "{app}\bin\{#MyAppExeName}"; WorkingDir: "{app}"


### PR DESCRIPTION
So we enabled the installer to pull in the dependencies from conan, but the Windows installer didn't realise that it needed antlr.  Now that we've lead the horse to water, this PR should make it drink.