### PR TITLE
1215 Instantaneous CN

### DIFF
--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -90,7 +90,8 @@ class KeywordBase
     {
         RecreateRenderables,
         ReloadExternalData,
-        ClearModuleData
+        ClearModuleData,
+        RunSetUp
     };
 
     private:

--- a/src/modules/calculate_cn/cn.cpp
+++ b/src/modules/calculate_cn/cn.cpp
@@ -47,6 +47,10 @@ CalculateCNModule::CalculateCNModule() : Module("CalculateCN"), analyser_(Proced
     keywords_.add<BoolKeyword>("Ranges", "RangeCEnabled", "Whether calculation of the third coordination number is enabled",
                                sum1D_->rangeEnabled(2));
     keywords_.add<RangeKeyword>("Ranges", "RangeC", "Distance range for third coordination number", sum1D_->range(2));
+    keywords_
+        .add<BoolKeyword>("Ranges", "Instantaneous", "Calculate instantaneous coordination numbers rather than an average",
+                          instantaneous_)
+        ->setEditSignals(KeywordBase::RunSetUp);
 
     // Test
     keywords_.add<OptionalDoubleKeyword>(

--- a/src/modules/calculate_cn/cn.cpp
+++ b/src/modules/calculate_cn/cn.cpp
@@ -18,7 +18,7 @@ CalculateCNModule::CalculateCNModule() : Module("CalculateCN"), analyser_(Proced
     {
         // Process1D - targets Collect1D in source RDF module
         process1D_ = analyser_.createRootNode<Process1DProcedureNode>("HistogramNorm");
-        process1D_->keywords().set("CurrentDataOnly", true);
+        process1D_->keywords().set("Instantaneous", true);
         auto rdfNormalisation = process1D_->addNormalisationBranch();
         siteNormaliser_ =
             rdfNormalisation->create<OperateSitePopulationNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>());

--- a/src/modules/calculate_cn/cn.cpp
+++ b/src/modules/calculate_cn/cn.cpp
@@ -52,6 +52,12 @@ CalculateCNModule::CalculateCNModule() : Module("CalculateCN"), analyser_(Proced
                           instantaneous_)
         ->setEditSignals(KeywordBase::RunSetUp);
 
+    // Export
+    keywords_.add<BoolKeyword>(
+        "Export", "ExportInstantaneous",
+        "Export instantaneous coordination numbers to disk (only if 'Instantaneous' option is enabled)\n",
+        exportInstantaneous_);
+
     // Test
     keywords_.add<OptionalDoubleKeyword>(
         "Test", "TestRangeA", "Reference coordination number for range A against which calculated value should be tested",

--- a/src/modules/calculate_cn/cn.h
+++ b/src/modules/calculate_cn/cn.h
@@ -31,6 +31,8 @@ class CalculateCNModule : public Module
     std::optional<double> testRangeB_;
     // Reference coordination number for range C against which calculated value should be tested
     std::optional<double> testRangeC_;
+    // Whether to calculate the instantaneous coordination numbers rather than forming an average
+    bool instantaneous_{false};
     // Threshold difference at which test comparisons will fail
     double testThreshold_{0.1};
     // Analysis procedure to be run
@@ -54,4 +56,8 @@ class CalculateCNModule : public Module
     private:
     // Run main processing
     bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+
+    public:
+    // Run set-up stage
+    bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals = {}) override;
 };

--- a/src/modules/calculate_cn/cn.h
+++ b/src/modules/calculate_cn/cn.h
@@ -33,6 +33,8 @@ class CalculateCNModule : public Module
     std::optional<double> testRangeC_;
     // Whether to calculate the instantaneous coordination numbers rather than forming an average
     bool instantaneous_{false};
+    // Whether to export instantaneous coordination numbers to disk
+    bool exportInstantaneous_{false};
     // Threshold difference at which test comparisons will fail
     double testThreshold_{0.1};
     // Analysis procedure to be run

--- a/src/modules/calculate_cn/process.cpp
+++ b/src/modules/calculate_cn/process.cpp
@@ -37,6 +37,42 @@ bool CalculateCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (!analyser_.execute(context))
         return Messenger::error("CalculateCN experienced problems with its analysis.\n");
 
+    // Accumulate instantaneous coordination number data
+    if (instantaneous_)
+    {
+        auto &sumA = dissolve.processingModuleData().realise<Data1D>("SumA", name(), GenericItem::InRestartFileFlag);
+        sumA.addPoint(dissolve.iteration(), sum1D_->sum(0).value());
+        if (exportInstantaneous_)
+        {
+            Data1DExportFileFormat exportFormat(fmt::format("{}_SumA.txt", name()));
+            if (!exportFormat.exportData(sumA))
+                return Messenger::error("Failed to write instantaneous coordination number data for range A.\n");
+        }
+
+        if (isRangeBEnabled())
+        {
+            auto &sumB = dissolve.processingModuleData().realise<Data1D>("SumB", name(), GenericItem::InRestartFileFlag);
+            sumB.addPoint(dissolve.iteration(), sum1D_->sum(1).value());
+            if (exportInstantaneous_)
+            {
+                Data1DExportFileFormat exportFormat(fmt::format("{}_SumB.txt", name()));
+                if (!exportFormat.exportData(sumB))
+                    return Messenger::error("Failed to write instantaneous coordination number data for range B.\n");
+            }
+        }
+        if (isRangeCEnabled())
+        {
+            auto &sumC = dissolve.processingModuleData().realise<Data1D>("SumC", name(), GenericItem::InRestartFileFlag);
+            sumC.addPoint(dissolve.iteration(), sum1D_->sum(2).value());
+            if (exportInstantaneous_)
+            {
+                Data1DExportFileFormat exportFormat(fmt::format("{}_SumC.txt", name()));
+                if (!exportFormat.exportData(sumC))
+                    return Messenger::error("Failed to write instantaneous coordination number data for range C.\n");
+            }
+        }
+    }
+
     // Test?
     if (testRangeA_)
     {

--- a/src/modules/calculate_cn/process.cpp
+++ b/src/modules/calculate_cn/process.cpp
@@ -11,6 +11,15 @@
 #include "procedure/nodes/select.h"
 #include "procedure/nodes/sum1d.h"
 
+// Run set-up stage
+bool CalculateCNModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals)
+{
+    // Propagate the flag for instantaneous calculation of the CN
+    sum1D_->keywords().set("Instantaneous", instantaneous_);
+
+    return true;
+}
+
 // Run main processing
 bool CalculateCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -20,8 +20,8 @@ Process1DProcedureNode::Process1DProcedureNode(std::shared_ptr<Collect1DProcedur
                                                        "Collect1D node containing the histogram data to process", sourceData_,
                                                        this, ProcedureNode::NodeType::Collect1D, false);
     keywords_.add<BoolKeyword>(
-        "Control", "CurrentDataOnly",
-        "Whether to use only the current binned data of the histogram, rather than the accumulated average", currentDataOnly_);
+        "Control", "Instantaneous",
+        "Whether to use only the current binned data of the histogram, rather than the accumulated average", instantaneous_);
     keywords_.add<StringKeyword>("Control", "LabelValue", "Label for the value axis", labelValue_);
     keywords_.add<StringKeyword>("Control", "LabelX", "Label for the x axis", labelX_);
     keywords_.add<FileAndFormatKeyword>("Export", "Export", "File format and file name under which to save processed data",
@@ -124,7 +124,7 @@ bool Process1DProcedureNode::finalise(const ProcedureContext &procedureContext)
     data.setTag(name());
 
     // Copy the averaged data from the associated Process1D node
-    if (currentDataOnly_)
+    if (instantaneous_)
         data = sourceData_->data();
     else
         data = sourceData_->accumulatedData();

--- a/src/procedure/nodes/process1d.h
+++ b/src/procedure/nodes/process1d.h
@@ -30,7 +30,7 @@ class Process1DProcedureNode : public ProcedureNode
      */
     private:
     // Whether to use only the current binned data of the histogram, rather than the accumulated average
-    bool currentDataOnly_{false};
+    bool instantaneous_{false};
     // Collect1D node that we are processing
     std::shared_ptr<const Collect1DProcedureNode> sourceData_;
     // Export file and format for processed data

--- a/src/procedure/nodes/sum1d.cpp
+++ b/src/procedure/nodes/sum1d.cpp
@@ -24,6 +24,7 @@ Sum1DProcedureNode::Sum1DProcedureNode(std::shared_ptr<Process1DProcedureNode> t
     keywords_.add<BoolKeyword>("Control", "RangeCEnabled", "Whether the second summation region is enabled", rangeEnabled_[2]);
     keywords_.add<RangeKeyword>("Control", "RangeC", "X range for third summation region", range_[2],
                                 Vec3Labels::MinMaxDeltaLabels);
+    keywords_.add<BoolKeyword>("Control", "Instantaneous", "Calculate instantaneous sums rather than averages", instantaneous_);
 }
 
 /*
@@ -93,7 +94,10 @@ bool Sum1DProcedureNode::finalise(const ProcedureContext &procedureContext)
                 sum_[i] = procedureContext.dataList().realise<SampledDouble>(
                     fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), procedureContext.dataPrefix(),
                     GenericItem::InRestartFileFlag);
-            sum_[i]->get() += Integrator::sum(sourceData_->processedData(), range_[i]);
+            if (instantaneous_)
+                sum_[i]->get() = Integrator::sum(sourceData_->processedData(), range_[i]);
+            else
+                sum_[i]->get() += Integrator::sum(sourceData_->processedData(), range_[i]);
         }
 
     // Print info

--- a/src/procedure/nodes/sum1d.h
+++ b/src/procedure/nodes/sum1d.h
@@ -31,6 +31,8 @@ class Sum1DProcedureNode : public ProcedureNode
     private:
     // Process1D node that we are targetting
     std::shared_ptr<const Process1DProcedureNode> sourceData_{nullptr};
+    // Whether to calculate the instantaneous sum rather than forming an average
+    bool instantaneous_{false};
     // Ranges for sums
     Range range_[3] = {{0.0, 3.0}, {3.0, 6.0}, {6.0, 9.0}};
     // Flags for ranges

--- a/web/content/docs/modules/analysis/calculatecn/_index.md
+++ b/web/content/docs/modules/analysis/calculatecn/_index.md
@@ -20,11 +20,18 @@ The `CalculateCN` module calculates up to three coordination numbers from the ou
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
+|`Instantaneous`|`bool`|`false`|Whether to calculate only the instantaneous coordination numbers, rather than the running average.|
 |`RangeA`|`double`<br/>`double`|`0.0`<br/>`3.0`|Specifies the distance range over which to calculate the first coordination number.|
 |`RangeB`|`double`<br/>`double`|`3.0`<br/>`6.0`|Specifies the distance range over which to calculate the second coordination number.|
 |`RangeBEnabled`|`bool`|`false`|Whether calculation of the second coordination number is enabled.|
 |`RangeC`|`double`<br/>`double`|`6.0`<br/>`9.0`|Specifies the distance range over which to calculate the third coordination number.|
 |`RangeCEnabled`|`bool`|`false`|Whether calculation of the third coordination number is enabled.|
+
+### Export
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`ExportInstantaneous`|`bool`|`false`|Whether to export instantaneous coordination numbers to disk. Only valid if the `Instantaneous` option is enabled.|
 
 ### Test
 

--- a/web/content/docs/procedures/nodes/process1dnode.md
+++ b/web/content/docs/procedures/nodes/process1dnode.md
@@ -34,6 +34,7 @@ The `Process*` nodes all have a branch with the "Operate" context (accessed thro
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
+|`Instantaneous`|`bool`|`false`|Whether the processed data should reflect the accumulated histogram data (`false`) or the "instantaneous" data from the last iteration only (`true`).|
 |`SourceData`|`name`|--|{{< required-label >}} The `name` of a {{< gui-node "Collect1D" >}} node containing the histogram data to process.|
 |`LabelValue`|`label`|`"Y"`|Label for the value axis|
 |`LabelX`|`label`|`"X"`|Label for the x axis|

--- a/web/content/docs/procedures/nodes/sum1dnode.md
+++ b/web/content/docs/procedures/nodes/sum1dnode.md
@@ -1,0 +1,37 @@
+---
+title: Sum1D (Node)
+linkTitle: Sum1D
+description: Sum 1D data over ranges
+---
+
+{{< htable >}}
+| | |
+|-|-|
+|Context|Analysis|
+|Name Required?|No|
+|Branches|--|
+{{< /htable >}}
+
+## Overview
+
+The `Sum1D` node is used to form summations over up to three defined regions of data produced by a {{< gui-node "Process1D" >}} node.
+
+## Description
+
+Once a {{< gui-node "Process1D" >}} node has processed data into something meaningful the `Sum1D` node can perform a summation of that data over defined ranges, providing an averaged value of the quantity.
+
+Note that, of the three ranges, the first ("A") is always calculated.
+
+## Configuration
+
+### Control
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`Instantaneous`|`bool`|`false`|Whether the processed data should reflect the accumulated average over the defined ranges (`false`) or the "instantaneous" value (`true`).|
+|`SourceData`|`name`|--|{{< required-label >}} The `name` of a {{< gui-node "Process1D" >}} node containing the target data.|
+|`RangeA`|`min`</br>`max`|`0.0`</br>`3.0`|First range to target.|
+|`RangeB`|`min`</br>`max`|`3.0`</br>`6.0`|Second range to target.|
+|`RangeC`|`min`</br>`max`|`6.0`</br>`9.0`|Third range to target.|
+|`RangeBEnabled`|`bool`|`false`|Whether the second range is enabled for calculation.|
+|`RangeCEnabled`|`bool`|`false`|Whether the third range is enabled for calculation.|


### PR DESCRIPTION
This PR adds the facility to calculate the instantaneous coordination numbers in the `CalculateCN` module, as opposed to the "time-averaged" coordination number.  A few places in the code are touched, namely the `Sum1DProcedureNode` and `CalculateCNModule` where relevant options / checks are made. An option for saving the instantaneous data is also added to the module.

Closes #1215.
Closes #1214.