### PR TITLE
985 Disallow Tab Renaming

### DIFF
--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -137,8 +137,8 @@ class MainTabsWidget : public QTabWidget
     void contextMenuRequested(const QPoint &pos);
     // Tab close button clicked
     void tabCloseButtonClicked(bool);
-    // Tab bar double-clicked
-    void tabBarDoubleClicked(int index);
+    // Tab double-clicked
+    void tabDoubleClicked(int index);
 
     signals:
     void dataModified();

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -74,8 +74,6 @@ class MainTabsWidget : public QTabWidget
     QPointer<ConfigurationTab> configurationTab(QWidget *page);
     // Find LayerTab containing specified page widget
     QPointer<LayerTab> processingLayerTab(QWidget *page);
-    // Find tab with title specified
-    MainTab *findTab(const QString title);
     // Find tab displaying specified page
     MainTab *findTab(const QWidget *page);
 
@@ -96,8 +94,6 @@ class MainTabsWidget : public QTabWidget
     public:
     // Return current tab
     MainTab *currentTab() const;
-    // Make specified tab the current one
-    void setCurrentTab(const MainTab *tab);
     // Make specified Species tab the current one
     void setCurrentTab(Species *species);
     // Make specified Configuration tab the current one

--- a/src/gui/maintabswidget.hui
+++ b/src/gui/maintabswidget.hui
@@ -78,8 +78,6 @@ class MainTabsWidget : public QTabWidget
     MainTab *findTab(const QString title);
     // Find tab displaying specified page
     MainTab *findTab(const QWidget *page);
-    // Generate unique tab name with base name provided
-    const QString uniqueTabName(const QString base);
 
     /*
      * Tab Management
@@ -122,8 +120,6 @@ class MainTabsWidget : public QTabWidget
      * Tab Styling
      */
     public:
-    // Set text colour for tab with specified page widget
-    void setTabTextColour(QWidget *pageWidget, QColor colour);
     // Set icon for tab with specified page widget
     void setTabIcon(QWidget *pageWidget, QIcon icon);
     // Add close button to specified tab

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -332,14 +332,12 @@ void MainTabsWidget::setCurrentTab(Species *species)
     if (!species)
         return;
 
-    for (auto &tab : speciesTabs_)
-        if (tab->species() == species)
-        {
-            setCurrentWidget(tab->page());
-            return;
-        }
-
-    Messenger::error("Can't display SpeciesTab for Species '{}' as it doesn't exist.\n", species->name());
+    auto it = std::find_if(speciesTabs_.begin(), speciesTabs_.end(),
+                           [species](const auto &tab) { return tab->species() == species; });
+    if (it != speciesTabs_.end())
+        setCurrentWidget((*it)->page());
+    else
+        Messenger::error("Can't display SpeciesTab for Species '{}' as it doesn't exist.\n", species->name());
 }
 
 // Make specified Configuration tab the current one
@@ -348,14 +346,12 @@ void MainTabsWidget::setCurrentTab(Configuration *cfg)
     if (!cfg)
         return;
 
-    for (auto tab : configurationTabs_)
-        if (tab->configuration() == cfg)
-        {
-            setCurrentWidget(tab->page());
-            return;
-        }
-
-    Messenger::error("Can't display ConfigurationTab for Configuration '{}' as it doesn't exist.\n", cfg->name());
+    auto it = std::find_if(configurationTabs_.begin(), configurationTabs_.end(),
+                           [cfg](const auto &tab) { return tab->configuration() == cfg; });
+    if (it != configurationTabs_.end())
+        setCurrentWidget((*it)->page());
+    else
+        Messenger::error("Can't display ConfigurationTab for Configuration '{}' as it doesn't exist.\n", cfg->name());
 }
 
 // Make specified processing layer tab the current one
@@ -364,14 +360,12 @@ void MainTabsWidget::setCurrentTab(ModuleLayer *layer)
     if (!layer)
         return;
 
-    for (auto tab : processingLayerTabs_)
-        if (tab->moduleLayer() == layer)
-        {
-            setCurrentWidget(tab->page());
-            return;
-        }
-
-    Messenger::error("Can't display LayerTab for processing layer '{}' as it doesn't exist.\n", layer->name());
+    auto it = std::find_if(processingLayerTabs_.begin(), processingLayerTabs_.end(),
+                           [layer](const auto &tab) { return tab->moduleLayer() == layer; });
+    if (it != processingLayerTabs_.end())
+        setCurrentWidget((*it)->page());
+    else
+        Messenger::error("Can't display LayerTab for processing layer '{}' as it doesn't exist.\n", layer->name());
 }
 
 /*

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -136,25 +136,6 @@ MainTab *MainTabsWidget::findTab(const QWidget *page)
     return result == allTabs_.end() ? nullptr : *result;
 }
 
-// Generate unique tab name with base name provided
-const QString MainTabsWidget::uniqueTabName(const QString base)
-{
-    static QString uniqueName;
-    QString baseName = base;
-    uniqueName = baseName;
-    auto suffix = 0;
-
-    // Must always have a baseName
-    if (baseName.isEmpty())
-        baseName = "Unnamed";
-
-    // Find an unused name starting with the baseName provided
-    while (findTab(uniqueName))
-        uniqueName = QStringLiteral("%1%2").arg(baseName, ++suffix);
-
-    return uniqueName;
-}
-
 /*
  * Tab Management
  */
@@ -445,18 +426,6 @@ void MainTabsWidget::allowEditing()
 /*
  * Tab Styling
  */
-
-// Set text colour for tab with specified page widget
-void MainTabsWidget::setTabTextColour(QWidget *pageWidget, QColor colour)
-{
-    // Find the tab containing the specified page
-    auto tabIndex = indexOf(pageWidget);
-    if (tabIndex == -1)
-        return;
-
-    // Set the style via the tab bar
-    mainTabsBar_->setTabTextColor(tabIndex, colour);
-}
 
 // Set icon for tab with specified page widget
 void MainTabsWidget::setTabIcon(QWidget *pageWidget, QIcon icon)

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -395,8 +395,8 @@ void MainTabsWidget::preventEditing()
     for (auto &[button, page] : closeButtons_)
         button->setDisabled(true);
 
-    // Prevent the context menu from being raised
-    mainTabsBar_->setContextMenuPolicy(Qt::NoContextMenu);
+    // Block the tab bar signals to prevent editing and context menu
+    mainTabsBar_->blockSignals(true);
 }
 
 // Allow editing in all tabs
@@ -409,8 +409,8 @@ void MainTabsWidget::allowEditing()
     for (auto &[button, page] : closeButtons_)
         button->setEnabled(true);
 
-    // Re-enable the context menu from being raised
-    mainTabsBar_->setContextMenuPolicy(Qt::CustomContextMenu);
+    // Re-enable the tab bar signals
+    mainTabsBar_->blockSignals(false);
 }
 
 /*

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -122,13 +122,6 @@ QPointer<LayerTab> MainTabsWidget::processingLayerTab(QWidget *page)
     return nullptr;
 }
 
-// Find tab with title specified
-MainTab *MainTabsWidget::findTab(const QString title)
-{
-    auto result = std::find_if(allTabs_.begin(), allTabs_.end(), [&title](auto tab) { return tab->title() == title; });
-    return result == allTabs_.end() ? nullptr : *result;
-}
-
 // Find tab displaying specified page
 MainTab *MainTabsWidget::findTab(const QWidget *page)
 {
@@ -332,9 +325,6 @@ MainTab *MainTabsWidget::currentTab() const
 
     return *result;
 }
-
-// Make specified tab the current one
-void MainTabsWidget::setCurrentTab(const MainTab *tab) { setCurrentWidget(tab->page()); }
 
 // Make specified Species tab the current one
 void MainTabsWidget::setCurrentTab(Species *species)

--- a/src/gui/maintabswidget_funcs.cpp
+++ b/src/gui/maintabswidget_funcs.cpp
@@ -15,7 +15,7 @@ MainTabsWidget::MainTabsWidget(QWidget *parent) : QTabWidget(parent)
     // Create our own tab bar
     mainTabsBar_ = new MainTabsBar(this);
     setTabBar(mainTabsBar_);
-    connect(mainTabsBar_, SIGNAL(tabBarDoubleClicked(int)), this, SLOT(tabBarDoubleClicked(int)));
+    connect(mainTabsBar_, SIGNAL(tabBarDoubleClicked(int)), this, SLOT(tabDoubleClicked(int)));
     connect(mainTabsBar_, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(contextMenuRequested(const QPoint &)));
 
     // Always show scroll buttons when there are many tabs
@@ -558,8 +558,8 @@ void MainTabsWidget::tabCloseButtonClicked(bool checked)
     emit(tabClosed(page));
 }
 
-// Tab bar double-clicked
-void MainTabsWidget::tabBarDoubleClicked(int index)
+// Tab double-clicked
+void MainTabsWidget::tabDoubleClicked(int index)
 {
     if (index == -1)
         return;


### PR DESCRIPTION
Small PR to disallow tab renaming when Dissolve is running.  Bit of tidying of the tab bar class is also performed.

Closes #985.