### PR TITLE
Procedure Editing - Part 5

### DIFF
--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -8,13 +8,14 @@ set(models_MOC_HDRS
     dataManagerSimulationModel.h
     enumOptionsModel.h
     isotopologueSetModel.h
-    pairPotentialModel.h
-    procedureModel.h
-    procedureNodeModel.h
     masterTermModel.h
     moduleLayerModel.h
     moduleModel.h
     modulePaletteModel.h
+    nodePaletteModel.h
+    pairPotentialModel.h
+    procedureModel.h
+    procedureNodeModel.h
     renderableGroupManagerModel.h
     sitesFilterProxy.h
     sitesModel.h
@@ -54,6 +55,7 @@ set(models_SRCS
     moduleLayerModel.cpp
     moduleModel.cpp
     modulePaletteModel.cpp
+    nodePaletteModel.cpp
     pairPotentialModel.cpp
     procedureModel.cpp
     procedureNodeModel.cpp

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -15,6 +15,7 @@ set(models_MOC_HDRS
     nodePaletteModel.h
     pairPotentialModel.h
     procedureModel.h
+    procedureModelMimeData.h
     procedureNodeModel.h
     renderableGroupManagerModel.h
     sitesFilterProxy.h
@@ -58,6 +59,7 @@ set(models_SRCS
     nodePaletteModel.cpp
     pairPotentialModel.cpp
     procedureModel.cpp
+    procedureModelMimeData.cpp
     procedureNodeModel.cpp
     renderableGroupManagerModel.cpp
     sitesFilterProxy.cpp

--- a/src/gui/models/nodePaletteModel.cpp
+++ b/src/gui/models/nodePaletteModel.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2022 Team Dissolve and contributors
 
 #include "gui/models/nodePaletteModel.h"
+#include "gui/models/procedureModelMimeData.h"
 #include "procedure/nodes/registry.h"
 #include <QIODevice>
 #include <QIcon>
@@ -54,14 +55,16 @@ QVariant NodePaletteModel::data(const QModelIndex &index, int role) const
         if (index.column() != 1)
             return {};
 
-        auto [nodeType, brief] = std::next(ProcedureNodeRegistry::categoryMap().begin(), index.parent().row())->second[index.row()];
+        auto [nodeType, brief] =
+            std::next(ProcedureNodeRegistry::categoryMap().begin(), index.parent().row())->second[index.row()];
         if (role == Qt::DisplayRole)
             return QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType)));
         else if (role == Qt::ToolTipRole)
             return QString::fromStdString(brief);
         else if (role == Qt::DecorationRole)
-            return QIcon(
-                (QPixmap(QString(":/nodes/icons/nodes_%1.svg").arg(QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType))).toLower()))));
+            return QIcon((QPixmap(
+                QString(":/nodes/icons/nodes_%1.svg")
+                    .arg(QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType))).toLower()))));
     }
     else if (role == Qt::DisplayRole && index.column() == 0)
         return QString::fromStdString(std::next(ProcedureNodeRegistry::categoryMap().begin(), index.row())->first);
@@ -100,20 +103,15 @@ Qt::DropActions NodePaletteModel::supportedDragActions() const { return Qt::Copy
 QStringList NodePaletteModel::mimeTypes() const
 {
     QStringList types;
-    types << "application/dissolve.node.create";
+    types << "application/dissolve.procedure.newNode";
     return types;
 }
 
 QMimeData *NodePaletteModel::mimeData(const QModelIndexList &indexes) const
 {
-    auto *mimeData = new QMimeData;
-    QByteArray encodedData;
-
-    QDataStream stream(&encodedData, QIODevice::WriteOnly);
     auto index = indexes.front();
     auto [nodeType, brief] = std::next(ProcedureNodeRegistry::categoryMap().begin(), index.parent().row())->second[index.row()];
-    stream << QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType)));
-    mimeData->setData("application/dissolve.node.create", encodedData);
+    auto *mimeData = new ProcedureModelMimeData(nodeType);
 
     return mimeData;
 }

--- a/src/gui/models/nodePaletteModel.cpp
+++ b/src/gui/models/nodePaletteModel.cpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "gui/models/nodePaletteModel.h"
+#include "procedure/nodes/registry.h"
+#include <QIODevice>
+#include <QIcon>
+#include <QMimeData>
+
+/*
+ * QAbstractItemModel overrides
+ */
+
+int NodePaletteModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return std::next(ProcedureNodeRegistry::categoryMap().begin(), parent.row())->second.size();
+    return ProcedureNodeRegistry::categoryMap().size();
+}
+
+int NodePaletteModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return 2;
+}
+
+bool NodePaletteModel::hasChildren(const QModelIndex &parent) const { return !parent.internalId(); }
+
+QModelIndex NodePaletteModel::parent(const QModelIndex &index) const
+{
+    quintptr root = 0;
+    if (index.internalId() == 0)
+        return QModelIndex();
+    return createIndex(index.internalId() - 1, 0, root);
+}
+
+QModelIndex NodePaletteModel::index(int row, int column, const QModelIndex &parent) const
+{
+    quintptr child;
+    if (!parent.isValid())
+        child = 0;
+    else if (parent.internalId() == 0)
+        child = parent.row() + 1;
+    else
+        return {};
+
+    return createIndex(row, column, child);
+}
+
+QVariant NodePaletteModel::data(const QModelIndex &index, int role) const
+{
+    if (index.parent().isValid())
+    {
+        if (index.column() != 1)
+            return {};
+
+        auto [nodeType, brief] = std::next(ProcedureNodeRegistry::categoryMap().begin(), index.parent().row())->second[index.row()];
+        if (role == Qt::DisplayRole)
+            return QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType)));
+        else if (role == Qt::ToolTipRole)
+            return QString::fromStdString(brief);
+        else if (role == Qt::DecorationRole)
+            return QIcon(
+                (QPixmap(QString(":/nodes/icons/nodes_%1.svg").arg(QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType))).toLower()))));
+    }
+    else if (role == Qt::DisplayRole && index.column() == 0)
+        return QString::fromStdString(std::next(ProcedureNodeRegistry::categoryMap().begin(), index.row())->first);
+    return {};
+}
+
+Qt::ItemFlags NodePaletteModel::flags(const QModelIndex &index) const
+{
+    if (index.parent().isValid())
+        return Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled;
+    else
+        return Qt::ItemIsEnabled;
+}
+
+QVariant NodePaletteModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (role != Qt::DisplayRole)
+        return {};
+
+    if (orientation == Qt::Horizontal)
+        switch (section)
+        {
+            case 0:
+                return "Category";
+            case 1:
+                return "Node";
+            default:
+                return {};
+        }
+
+    return {};
+}
+
+Qt::DropActions NodePaletteModel::supportedDragActions() const { return Qt::CopyAction; }
+
+QStringList NodePaletteModel::mimeTypes() const
+{
+    QStringList types;
+    types << "application/dissolve.node.create";
+    return types;
+}
+
+QMimeData *NodePaletteModel::mimeData(const QModelIndexList &indexes) const
+{
+    auto *mimeData = new QMimeData;
+    QByteArray encodedData;
+
+    QDataStream stream(&encodedData, QIODevice::WriteOnly);
+    auto index = indexes.front();
+    auto [nodeType, brief] = std::next(ProcedureNodeRegistry::categoryMap().begin(), index.parent().row())->second[index.row()];
+    stream << QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType)));
+    mimeData->setData("application/dissolve.node.create", encodedData);
+
+    return mimeData;
+}

--- a/src/gui/models/nodePaletteModel.cpp
+++ b/src/gui/models/nodePaletteModel.cpp
@@ -57,14 +57,19 @@ QVariant NodePaletteModel::data(const QModelIndex &index, int role) const
 
         auto [nodeType, brief] =
             std::next(ProcedureNodeRegistry::categoryMap().begin(), index.parent().row())->second[index.row()];
-        if (role == Qt::DisplayRole)
-            return QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType)));
-        else if (role == Qt::ToolTipRole)
-            return QString::fromStdString(brief);
-        else if (role == Qt::DecorationRole)
-            return QIcon((QPixmap(
-                QString(":/nodes/icons/nodes_%1.svg")
-                    .arg(QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType))).toLower()))));
+        switch (role)
+        {
+            case (Qt::DisplayRole):
+                return QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType)));
+            case (Qt::ToolTipRole):
+                return QString::fromStdString(brief);
+            case (Qt::DecorationRole):
+                return QIcon((QPixmap(
+                    QString(":/nodes/icons/nodes_%1.svg")
+                        .arg(QString::fromStdString(std::string(ProcedureNode::nodeTypes().keyword(nodeType))).toLower()))));
+            default:
+                return {};
+        }
     }
     else if (role == Qt::DisplayRole && index.column() == 0)
         return QString::fromStdString(std::next(ProcedureNodeRegistry::categoryMap().begin(), index.row())->first);

--- a/src/gui/models/nodePaletteModel.h
+++ b/src/gui/models/nodePaletteModel.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include <QAbstractItemModel>
+#include <QMimeData>
+#include <QModelIndex>
+
+class NodePaletteModel : public QAbstractItemModel
+{
+    Q_OBJECT
+
+    public:
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent) const override;
+    bool hasChildren(const QModelIndex &parent) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    Qt::DropActions supportedDragActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+};

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -423,7 +423,7 @@ bool ProcedureModel::dropMimeData(const QMimeData *data, Qt::DropAction action, 
 
         // Create a new row to store the data. Don't use insertRows() here since creating a null node in the vector at this
         // point causes no end of issues.
-        beginInsertRows(parent, insertAtRow, insertAtRow);
+        beginInsertRows(parent.isValid() ? parent : QModelIndex(), insertAtRow, insertAtRow);
         scope->get().appendNode(mimeData->node(), insertAtRow);
         endInsertRows();
         auto idx = index(insertAtRow, 0, parent);

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -133,7 +133,7 @@ bool ProcedureModel::setData(const QModelIndex &index, const QVariant &value, in
 
     if (role == Qt::EditRole)
     {
-        auto *node = static_cast<ProcedureNode *>(index.internalPointer());
+        auto *node = rawData(index);
         if (!node)
             return false;
 

--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -59,6 +59,7 @@ class ProcedureModel : public QAbstractItemModel
                          const QModelIndex &parent) const override;
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
     bool insertRows(int row, int count, const QModelIndex &parent) override;
+    bool removeRows(int row, int count, const QModelIndex &parent) override;
 
     signals:
     void nodeNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);

--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -26,10 +26,21 @@ class ProcedureModel : public QAbstractItemModel
     void setData(Procedure &procedure);
     // Reset model data, forcing update
     void reset();
+    // Return raw data for supplied index
+    ProcedureNode *rawData(const QModelIndex &index) const;
+    // Return sequence scope for supplied index
+    OptionalReferenceWrapper<ProcedureNodeSequence> getScope(const QModelIndex &index) const;
 
     /*
      * QAbstractItemModel overrides
      */
+    private:
+    enum ProcedureModelAction
+    {
+        MoveInternal = Qt::UserRole,
+        CreateNew
+    };
+
     public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
@@ -37,6 +48,18 @@ class ProcedureModel : public QAbstractItemModel
     QModelIndex parent(const QModelIndex &index) const override;
     bool hasChildren(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
+    Qt::DropActions supportedDragActions() const override;
+    Qt::DropActions supportedDropActions() const override;
+    QStringList mimeTypes() const override;
+    QMimeData *mimeData(const QModelIndexList &indexes) const override;
+    bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column,
+                         const QModelIndex &parent) const override;
+    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    bool insertRows(int row, int count, const QModelIndex &parent) override;
+
+    signals:
+    void nodeNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
 };

--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -57,9 +57,8 @@ class ProcedureModel : public QAbstractItemModel
     QMimeData *mimeData(const QModelIndexList &indexes) const override;
     bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column,
                          const QModelIndex &parent) const override;
-    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
+    bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &newParent) override;
     bool insertRows(int row, int count, const QModelIndex &parent) override;
-    bool removeRows(int row, int count, const QModelIndex &parent) override;
 
     signals:
     void nodeNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);

--- a/src/gui/models/procedureModelMimeData.cpp
+++ b/src/gui/models/procedureModelMimeData.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#include "gui/models/procedureModelMimeData.h"
+#include "procedure/nodes/registry.h"
+
+ProcedureModelMimeData::ProcedureModelMimeData(const QModelIndex index) : nodeIndex_(index)
+{
+    auto *node = static_cast<ProcedureNode *>(index.internalPointer());
+    node_ = node ? node->shared_from_this() : nullptr;
+}
+
+ProcedureModelMimeData::ProcedureModelMimeData(ProcedureNode::NodeType nodeType) : nodeType_(nodeType)
+{
+    node_ = ProcedureNodeRegistry::create(*nodeType_);
+}
+
+// Return stored model index
+std::optional<const QModelIndex> ProcedureModelMimeData::nodeIndex() const { return nodeIndex_; }
+
+// Return stored procedure node type
+std::optional<ProcedureNode::NodeType> ProcedureModelMimeData::nodeType() const { return nodeType_; }
+
+// Return stored procedure node type
+NodeRef ProcedureModelMimeData::node() const { return node_; }
+
+bool ProcedureModelMimeData::hasFormat(const QString &mimeType) const
+{
+    return ((mimeType == "application/dissolve.procedure.existingNode" && nodeIndex_ && node_) ||
+            (mimeType == "application/dissolve.procedure.newNode" && nodeType_ && node_));
+}
+
+QStringList ProcedureModelMimeData::formats() const
+{
+    return QStringList() << "application/dissolve.procedure.existingNode"
+                         << "application/dissolve.procedure.newNode";
+}

--- a/src/gui/models/procedureModelMimeData.h
+++ b/src/gui/models/procedureModelMimeData.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2022 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/node.h"
+#include <QMimeData>
+#include <QModelIndex>
+
+// Procedure Model Mime Data
+class ProcedureModelMimeData : public QMimeData
+{
+    public:
+    explicit ProcedureModelMimeData(const QModelIndex index);
+    explicit ProcedureModelMimeData(ProcedureNode::NodeType nodeType);
+    ~ProcedureModelMimeData() override = default;
+
+    private:
+    // Stored model index
+    std::optional<const QModelIndex> nodeIndex_;
+    // Stored procedure node type
+    std::optional<ProcedureNode::NodeType> nodeType_;
+    // Stored procedure node (either new or existing)
+    NodeRef node_;
+
+    public:
+    // Return stored model index
+    std::optional<const QModelIndex> nodeIndex() const;
+    // Return stored procedure node type
+    std::optional<ProcedureNode::NodeType> nodeType() const;
+    // Return stored procedure node type
+    NodeRef node() const;
+
+    /*
+     * QMimeData Reimplementations
+     */
+    public:
+    bool hasFormat(const QString &mimeType) const override;
+    QStringList formats() const override;
+};

--- a/src/gui/models/procedureNodeModel.cpp
+++ b/src/gui/models/procedureNodeModel.cpp
@@ -3,7 +3,7 @@
 
 #include "gui/models/procedureNodeModel.h"
 
-// Set source Species data
+// Set source node data
 void ProcedureNodeModel::setData(const std::vector<ConstNodeRef> &nodes)
 {
     beginResetModel();

--- a/src/gui/procedurewidget.h
+++ b/src/gui/procedurewidget.h
@@ -53,7 +53,7 @@ class ProcedureWidget : public QWidget
     void selectedNodeChanged(const QModelIndex &);
     void on_ShowAvailableNodesButton_clicked(bool checked);
     void nodeNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
-    void layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);
+    void procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);
     void updateNodeTree();
     void on_NodesTree_customContextMenuRequested(const QPoint &pos);
     void on_AvailableNodesTree_doubleClicked(const QModelIndex &index);

--- a/src/gui/procedurewidget.h
+++ b/src/gui/procedurewidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "gui/models/nodePaletteModel.h"
 #include "gui/models/procedureModel.h"
 #include "gui/ui_procedurewidget.h"
 
@@ -32,6 +33,8 @@ class ProcedureWidget : public QWidget
     OptionalReferenceWrapper<Procedure> procedure_;
     // Model for procedure
     ProcedureModel procedureModel_;
+    // Model for node palette
+    NodePaletteModel nodePaletteModel_;
 
     public:
     // Set up widget

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -15,6 +15,8 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
     // Set up the procedure model
     ui_.NodesTree->setModel(&procedureModel_);
     connect(ui_.NodesTree, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
+    connect(&procedureModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
+            SLOT(procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
 
     // Set up the available nodes tree
     ui_.AvailableNodesTree->setModel(&nodePaletteModel_);
@@ -108,9 +110,15 @@ void ProcedureWidget::on_ShowAvailableNodesButton_clicked(bool checked)
                                                                               : "Show Available Nodes");
 }
 
-void ProcedureWidget::layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)
+void ProcedureWidget::procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)
 {
-    //    dissolveWindow_->setModified({DissolveSignals::nodesMutated});
+    if (!procedure_)
+        return;
+
+    // Node order may have changed, or node may have been deleted, so validate related data
+    procedure_.value().get().rootSequence().validateNodeKeywords();
+
+    dissolveWindow_->setModified();
 }
 
 void ProcedureWidget::nodeNameChanged(const QModelIndex &index, const QString &oldName, const QString &newName)

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -16,9 +16,10 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
     ui_.NodesTree->setModel(&procedureModel_);
     connect(ui_.NodesTree, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
 
-    // Hide the available nodes tree by default
+    // Set up the available nodes tree
+    ui_.AvailableNodesTree->setModel(&nodePaletteModel_);
+    ui_.AvailableNodesTree->expandAll();
     ui_.AvailableNodesTree->setVisible(false);
-    ui_.ShowAvailableNodesButton->setVisible(false);
 }
 
 // Set up widget

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -30,6 +30,16 @@ class NodeKeywordBase : public NodeKeywordUnderlay, public KeywordBase
     virtual ConstNodeRef baseNode() = 0;
     // Set base node data
     virtual bool setData(ConstNodeRef node) = 0;
+    // Validate current data, returning false if invalid data had to be pruned
+    bool validate() override
+    {
+        if (validNode(baseNode().get(), name()))
+            return true;
+
+        setData(nullptr);
+
+        return false;
+    }
 };
 
 // Keyword managing ProcedureNode

--- a/src/keywords/nodeandinteger.h
+++ b/src/keywords/nodeandinteger.h
@@ -35,6 +35,16 @@ class NodeAndIntegerKeywordBase : public NodeKeywordUnderlay, public KeywordBase
     virtual void setInteger(int i) = 0;
     // Return integer
     virtual int integer() const = 0;
+    // Validate current data, returning false if invalid data had to be pruned
+    bool validate() override
+    {
+        if (validNode(baseNode().get(), name()))
+            return true;
+
+        setNode(nullptr);
+
+        return false;
+    }
 };
 
 // Keyword managing ProcedureNode and integer index

--- a/src/keywords/nodeunderlay.cpp
+++ b/src/keywords/nodeunderlay.cpp
@@ -47,6 +47,10 @@ ConstNodeRef NodeKeywordUnderlay::findNode(std::string_view name) const
 // Return whether the node has valid class or type
 bool NodeKeywordUnderlay::validNode(const ProcedureNode *node, std::string_view keywordName) const
 {
+    // A null node is valid
+    if (!node)
+        return true;
+
     // Check class (if specified) then type (if specified)
     if (nodeClass_ && node->nodeClass() != nodeClass_.value())
         return Messenger::error("Node '{}' is of class {}, but the {} keyword requires a node of class {}.\n", node->name(),

--- a/src/keywords/nodeunderlay.h
+++ b/src/keywords/nodeunderlay.h
@@ -41,4 +41,6 @@ class NodeKeywordUnderlay
     ConstNodeRef findNode(std::string_view name) const;
     // Return whether the supplied node has valid class or type
     bool validNode(const ProcedureNode *node, std::string_view keywordName) const;
+    // Validate current data, returning false if invalid data had to be pruned
+    virtual bool validate() = 0;
 };

--- a/src/keywords/nodevector.h
+++ b/src/keywords/nodevector.h
@@ -35,6 +35,16 @@ class NodeVectorKeywordBase : public NodeKeywordUnderlay, public KeywordBase
     virtual bool isPresent(ConstNodeRef node) const = 0;
     // Return plain ProcedureNode vector
     virtual std::vector<ConstNodeRef> nodes() const = 0;
+    // Validate current data, returning false if invalid data had to be pruned
+    bool validate() override
+    {
+        auto oldData = nodes();
+        for (auto &oldNode : oldData)
+            if (!validNode(oldNode.get(), name()))
+                removeNode(oldNode);
+
+        return oldData.size() == nodes().size();
+    }
 };
 
 // Keyword managing vector of ProcedureNode

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -64,6 +64,7 @@ void ProcedureNodeSequence::insertEmpty(int index)
 }
 
 // Return sequential node list
+std::vector<NodeRef> &ProcedureNodeSequence::sequence() { return sequence_; }
 const std::vector<NodeRef> &ProcedureNodeSequence::sequence() const { return sequence_; }
 
 // Return number of nodes in sequence

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -141,12 +141,13 @@ OptionalReferenceWrapper<ProcedureNode> ProcedureNodeSequence::owner() const { r
 ProcedureNode::NodeContext ProcedureNodeSequence::sequenceContext() const { return context_; }
 
 // Return named node if present in this sequence, and which matches the (optional) type given
-ConstNodeRef ProcedureNodeSequence::node(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType,
+ConstNodeRef ProcedureNodeSequence::node(std::string_view name, ConstNodeRef excludeNode,
+                                         std::optional<ProcedureNode::NodeType> optNodeType,
                                          std::optional<ProcedureNode::NodeClass> optNodeClass) const
 {
     for (auto node : sequence_)
     {
-        if (DissolveSys::sameString(node->name(), name))
+        if (node != excludeNode && DissolveSys::sameString(node->name(), name))
         {
             // Check type / class
             if ((!optNodeType && !optNodeClass) || (optNodeType && optNodeType.value() == node->type()) ||
@@ -157,7 +158,7 @@ ConstNodeRef ProcedureNodeSequence::node(std::string_view name, std::optional<Pr
         // If the node has a branch, recurse in to that
         if (node->branch())
         {
-            auto branchNode = node->branch()->get().node(name, optNodeType, optNodeClass);
+            auto branchNode = node->branch()->get().node(name, excludeNode, optNodeType, optNodeClass);
             if (branchNode)
                 return branchNode;
         }

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -56,6 +56,7 @@ class ProcedureNodeSequence
     // Insert empty node at specified position
     void insertEmpty(int index);
     // Return sequential node list
+    std::vector<NodeRef> &sequence();
     const std::vector<NodeRef> &sequence() const;
     // Return number of nodes in sequence
     int nNodes() const;

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -34,13 +34,11 @@ class ProcedureNodeSequence
         void next();
     };
 
-    private:
-    // Add (own) node into sequence
-    void addNode(NodeRef nodeToAdd);
-
     public:
     // Clear all data
     void clear();
+    // Append specified node to the sequence, or optionally insert at index
+    void appendNode(NodeRef nodeToAdd, std::optional<int> insertAtIndex = std::nullopt);
     // Create new node
     template <class N, typename... Args> std::shared_ptr<N> create(std::string_view name, Args &&... args)
     {
@@ -51,12 +49,12 @@ class ProcedureNodeSequence
         node->setName(name);
 
         // Add node to our sequence, checking context / naming
-        addNode(node);
+        appendNode(node);
 
         return node;
     }
-    // Create new node by enumerated type
-    std::shared_ptr<ProcedureNode> create(ProcedureNode::NodeType nodeType, std::string_view name);
+    // Insert empty node at specified position
+    void insertEmpty(int index);
     // Return sequential node list
     const std::vector<NodeRef> &sequence() const;
     // Return number of nodes in sequence

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -87,7 +87,8 @@ class ProcedureNodeSequence
     // Return the context of the sequence
     ProcedureNode::NodeContext sequenceContext() const;
     // Return named node if present (and matches the type / class given)
-    ConstNodeRef node(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
+    ConstNodeRef node(std::string_view name, ConstNodeRef excludeNode = nullptr,
+                      std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
                       std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;
     // Return list of nodes (of specified type / class) present in the Procedure
     std::vector<ConstNodeRef> nodes(std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -112,6 +112,8 @@ class ProcedureNodeSequence
     parameterExists(std::string_view name, const std::shared_ptr<ExpressionVariable> &excludeParameter = nullptr) const;
     // Create and return reference list of parameters in scope
     std::vector<std::shared_ptr<ExpressionVariable>> parametersInScope(ConstNodeRef queryingNode);
+    // Validate node-related keywords ensuring invalid (out-of-scope) data are un-set
+    bool validateNodeKeywords();
     // Check for node consistency
     bool check() const;
 

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -25,10 +25,11 @@ void Procedure::clear() { rootSequence_.clear(); }
 ProcedureNodeSequence &Procedure::rootSequence() { return rootSequence_; }
 
 // Return named node if present (and matches the type / class given)
-ConstNodeRef Procedure::node(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType,
+ConstNodeRef Procedure::node(std::string_view name, ConstNodeRef excludeNode,
+                             std::optional<ProcedureNode::NodeType> optNodeType,
                              std::optional<ProcedureNode::NodeClass> optNodeClass) const
 {
-    return rootSequence_.node(name, optNodeType, optNodeClass);
+    return rootSequence_.node(name, std::move(excludeNode), optNodeType, optNodeClass);
 }
 
 // Return all nodes (matching the type / class given)

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -37,7 +37,8 @@ class Procedure
     // Return root sequence
     ProcedureNodeSequence &rootSequence();
     // Return named node if present (and matches the type / class given)
-    ConstNodeRef node(std::string_view name, std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
+    ConstNodeRef node(std::string_view name, ConstNodeRef excludeNode = nullptr,
+                      std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
                       std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;
     // Return all nodes (matching the type / class given)
     std::vector<ConstNodeRef> nodes(std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,


### PR DESCRIPTION
This PR adds in full editability (addition of new nodes, rearrangement of existing nodes) within a `Procedure` via the `ProcedureModel`.

Additional testing / checking is also added.

Works towards #1176.