### PR TITLE
1219 IntraShake Restrict to Species

### DIFF
--- a/src/modules/intrashake/intrashake.cpp
+++ b/src/modules/intrashake/intrashake.cpp
@@ -7,6 +7,7 @@
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
+#include "keywords/speciesvector.h"
 
 IntraShakeModule::IntraShakeModule() : Module("IntraShake")
 {
@@ -24,6 +25,8 @@ IntraShakeModule::IntraShakeModule() : Module("IntraShake")
     keywords_.add<BoolKeyword>("Control", "TermEnergyOnly",
                                "Whether only the energy of the intramolecular term is calculated and assessed",
                                termEnergyOnly_);
+    keywords_.add<SpeciesVectorKeyword>("Control", "RestrictToSpecies", "Restrict the calculation to the specified Species",
+                                        restrictToSpecies_);
 
     // Bonds
     keywords_.add<BoolKeyword>("Control", "AdjustBonds", "Whether bonds in molecules should be shaken", adjustBonds_);

--- a/src/modules/intrashake/intrashake.h
+++ b/src/modules/intrashake/intrashake.h
@@ -50,6 +50,8 @@ class IntraShakeModule : public Module
     double torsionStepSizeMin_{0.5};
     // Maximum step size for torsion adjustments (degrees)
     double torsionStepSizeMax_{45.0};
+    // Species to restrict calculation to
+    std::vector<const Species *> restrictToSpecies_;
 
     /*
      * Processing

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -281,7 +281,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
                         // Trial the transformed Molecule
                         delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                        accept = delta < 0 ? true : (randomBuffer.random() < exp(-delta * rRT));
+                        accept = delta < 0 || (randomBuffer.random() < exp(-delta * rRT));
 
                         // Accept new (current) positions of the Molecule's Atoms?
                         if (accept)

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -242,6 +242,10 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             if (adjustTorsions_)
                 for (const auto &torsion : mol->species()->torsions())
                 {
+                    // Refuse to change a torsion which is in a cycle
+                    if (torsion.inCycle())
+                        continue;
+
                     // Get Atom pointers
                     i = mol->atom(torsion.indexI());
                     j = mol->atom(torsion.indexJ());
@@ -249,8 +253,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     l = mol->atom(torsion.indexL());
 
                     // Store current energy of this intramolecular term
-                    intraEnergy =
-                        torsion.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(torsion, *i, *j, *k, *l);
+                    intraEnergy = kernel.energy(torsion, *i, *j, *k, *l);
 
                     // Select random terminus
                     terminus = randomBuffer.random() > 0.5 ? 1 : 0;
@@ -274,8 +277,7 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         // Calculate new energy
                         newPPEnergy =
                             termEnergyOnly_ ? 0.0 : kernel.energy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
-                        newIntraEnergy =
-                            torsion.inCycle() ? kernel.intramolecularEnergy(*mol) : kernel.energy(torsion, *i, *j, *k, *l);
+                        newIntraEnergy = kernel.energy(torsion, *i, *j, *k, *l);
 
                         // Trial the transformed Molecule
                         delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -48,12 +48,8 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     else
         Messenger::print("MD: Summary will not be written.\n");
     if (!restrictToSpecies_.empty())
-    {
-        std::string speciesNames;
-        for (auto *sp : restrictToSpecies_)
-            speciesNames += fmt::format("  {}", sp->name());
-        Messenger::print("MD: Calculation will be restricted to species:{}\n", speciesNames);
-    }
+        Messenger::print("MD: Calculation will be restricted to species:\n",
+                         joinStrings(restrictToSpecies_, "  ", [](const auto &sp) { return sp->name(); }));
     Messenger::print("\n");
 
     if (onlyWhenEnergyStable_)

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -33,12 +33,8 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     Messenger::print("MolShake: Step size for rotation adjustments is {:.5f} degrees (allowed range is {} <= delta <= {}).\n",
                      rotationStepSize_, rotationStepSizeMin_, rotationStepSizeMax_);
     if (!restrictToSpecies_.empty())
-    {
-        std::string speciesNames;
-        for (auto *sp : restrictToSpecies_)
-            speciesNames += fmt::format("  {}", sp->name());
-        Messenger::print("MolShake: Calculation will be restricted to species:{}\n", speciesNames);
-    }
+        Messenger::print("MolShake: Calculation will be restricted to species:\n",
+                         joinStrings(restrictToSpecies_, "  ", [](const auto &sp) { return sp->name(); }));
     Messenger::print("\n");
 
     ProcessPool::DivisionStrategy strategy = procPool.bestStrategy();


### PR DESCRIPTION
This PR adds the option to restrict the `IntraShake` module to a subset of species, and also fixes an issue with the adjustment of torsions within cycles.

Closes #1219.
Closes #1229.