### PR TITLE
896 OSX dmgbuild

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -60,7 +60,7 @@ stages:
         displayName: "OSX, Threads, CLI/GUI"
         timeoutInMinutes: 120
         pool:
-          vmImage: "macOS-10.15"
+          vmImage: "macos-latest"
         steps:
           - checkout: self
             fetchDepth: 1

--- a/ci/osx/dmgbuild-settings.py
+++ b/ci/osx/dmgbuild-settings.py
@@ -139,19 +139,3 @@ list_column_sort_directions = {
     'comments': 'ascending',
     }
 
-license = {
-     'default-language': 'en_US',
-     'licenses': {
-         'en_GB': 'LICENSE.txt' },
-     'buttons': {
-         'en_US': (
-             b'English',
-             b'Agree',
-             b'Disagree',
-             b'Print',
-             b'Save',
-             b'If you agree with the terms of this license, press "Agree" to '
-             b'install the software.  If you do not agree, press "Disagree".'
-         ),
-     },
- }


### PR DESCRIPTION
Here we address errors in dmg creation on the latest OSX versions. The root of the problem seems to be the addition of a license to the generated dmg, which requires the native OSX utility `hdiutil` to use a now-deprecated keyword.

Simply not adding a license to the dmg solves the issue, but how do we feel about this?

Closes #1226.
Closes #896.