### PR TITLE
Unknown Module Types

### DIFF
--- a/examples/emim-oac/input.txt
+++ b/examples/emim-oac/input.txt
@@ -478,14 +478,8 @@ Layer  'Analyse RDF/CN'
     DistanceRange  0.000000e+00  1.400000e+01  5.000000e-02
     SiteA  '1-ethyl-3-methylimidazolium'  'RingNN'
     SiteB  'Acetate Anion'  'COM'
-  EndModule
-
-  Module  CalculateCN  'CN-CA'
-    Frequency  1
     RangeA  0.000000e+00  7.000000e+00
-    RangeB  3.000000e+00  6.000000e+00
-    RangeC  6.000000e+00  9.000000e+00
-    SourceRDF  'RDF-CA'
+    RangeAEnabled  True
   EndModule
 
   Module  CalculateRDF  'RDF-CC'

--- a/examples/water/input.txt
+++ b/examples/water/input.txt
@@ -192,12 +192,8 @@ Layer  'Analyse RDF/CN'
     SiteA  'Water'  'COM'
     SiteB  'Water'  'COM'
     ExcludeSameMolecule  True
-  EndModule
-
-  Module  CalculateCN  'CalculateCN01'
-    Frequency  1
-    SourceRDF  'CalculateRDF01'
     RangeA  0.000000e+00  3.400000e+00
+    RangeAEnabled  True
   EndModule
 EndLayer
 

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -58,11 +58,14 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                 layer->setFrequency(parser.argi(1));
                 break;
             case (LayerBlock::ModuleKeyword):
-                // The argument following the keyword is the module name, so try to create an instance of that
-                // Module
-                module = ModuleRegistry::create(parser.argsv(1), layer);
-                if (!module)
+                // The argument following the keyword is the module type, so try to create an instance of that type
+                try
                 {
+                    module = ModuleRegistry::create(parser.argsv(1), layer);
+                }
+                catch (...)
+                {
+                    Messenger::error("Module type '{}' does not exist.\n", parser.argsv(1));
                     error = true;
                     break;
                 }


### PR DESCRIPTION
Here's a tiddly tiny PR to address a UX issue and update the example files. If an input file was loaded which referenced an unknown module type, the GUI would complain that the file failed to load but didn't say why, and the CLI version would throw an exception. Now we report the error and exit nicely.

Also fixes two example input files which still referenced the recently-removed `CalculateCN` module (#1222).