### PR TITLE
1179 SpeciesSite Mutation Signal

### DIFF
--- a/src/gui/keywordwidgets/speciessite.h
+++ b/src/gui/keywordwidgets/speciessite.h
@@ -6,6 +6,9 @@
 #include "gui/keywordwidgets/base.h"
 #include "gui/keywordwidgets/dropdown.h"
 #include "gui/keywordwidgets/ui_speciessite.h"
+#include "gui/models/speciesModel.h"
+#include "gui/models/speciesSiteFilterProxy.h"
+#include "gui/models/speciesSiteModel.h"
 #include "keywords/speciessite.h"
 #include <QWidget>
 
@@ -33,9 +36,15 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
     private:
     // Main form declaration
     Ui::SpeciesSiteWidget ui_;
+    // Model for species
+    SpeciesModel speciesModel_;
+    // Sites model and filter proxy
+    SpeciesSiteModel siteModel_;
+    SpeciesSiteFilterProxy siteFilterProxy_;
 
     private slots:
-    void siteRadioButton_clicked(bool checked);
+    void clearDataButton_clicked(bool checked);
+    void siteCombo_currentIndexChanged(int index);
 
     signals:
     // Keyword data changed
@@ -44,6 +53,11 @@ class SpeciesSiteKeywordWidget : public KeywordDropDown, public KeywordWidgetBas
     /*
      * Update
      */
+    private slots:
+    // Update combo boxes
+    void updateAvailableSpecies();
+    void updateAvailableSites(int speciesIndex = -1);
+
     private:
     // Reset widgets
     void resetWidgets();

--- a/src/gui/keywordwidgets/speciessite.ui
+++ b/src/gui/keywordwidgets/speciessite.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>143</width>
-    <height>21</height>
+    <width>198</width>
+    <height>62</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -41,14 +41,37 @@
     <number>4</number>
    </property>
    <item>
-    <widget class="QTabWidget" name="SpeciesTabs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+     <property name="spacing">
+      <number>4</number>
      </property>
-    </widget>
+     <item>
+      <widget class="QComboBox" name="SpeciesCombo"/>
+     </item>
+     <item>
+      <widget class="QToolButton" name="ClearButton">
+       <property name="toolTip">
+        <string>Clear selected</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../main.qrc">
+         <normaloff>:/general/icons/general_clear.svg</normaloff>:/general/icons/general_clear.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QComboBox" name="SiteCombo"/>
    </item>
   </layout>
  </widget>

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -78,7 +78,7 @@ void SpeciesSiteKeywordWidget::siteCombo_currentIndexChanged(int index)
 // Update value displayed in widget
 void SpeciesSiteKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    if (mutationFlags.isSet(DissolveSignals::SpeciesMutated))
+    if (mutationFlags.isSet(DissolveSignals::SpeciesMutated) || mutationFlags.isSet(DissolveSignals::SpeciesSiteMutated))
         resetWidgets();
 }
 
@@ -101,15 +101,13 @@ void SpeciesSiteKeywordWidget::updateAvailableSites(int speciesIndex)
 {
     refreshing_ = true;
 
-    // Set filter proxy
-    siteFilterProxy_.setFlags(keyword_->axesRequired() ? SpeciesSiteFilterProxy::IsOriented : SpeciesSiteFilterProxy::None);
-
     if (speciesIndex == -1)
         siteModel_.setData(std::nullopt);
     else
     {
         auto &sites = coreData_.species()[speciesIndex]->sites();
         siteModel_.setData(sites);
+        siteFilterProxy_.setFlags(keyword_->axesRequired() ? SpeciesSiteFilterProxy::IsOriented : SpeciesSiteFilterProxy::None);
         if (keyword_->data())
             ui_.SiteCombo->setCurrentIndex(
                 std::find_if(sites.begin(), sites.end(), [&](const auto &site) { return site.get() == keyword_->data(); }) -

--- a/src/gui/keywordwidgets/speciessite_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessite_funcs.cpp
@@ -18,6 +18,15 @@ SpeciesSiteKeywordWidget::SpeciesSiteKeywordWidget(QWidget *parent, SpeciesSiteK
     // Create and set up the UI for our widget in the drop-down's widget container
     ui_.setupUi(dropWidget());
 
+    // Connect signals / slots
+    connect(ui_.ClearButton, SIGNAL(clicked(bool)), this, SLOT(clearDataButton_clicked(bool)));
+    connect(ui_.SpeciesCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(updateAvailableSites(int)));
+    connect(ui_.SiteCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(siteCombo_currentIndexChanged(int)));
+
+    ui_.SpeciesCombo->setModel(&speciesModel_);
+    siteFilterProxy_.setSourceModel(&siteModel_);
+    ui_.SiteCombo->setModel(&siteFilterProxy_);
+
     // Set current information
     resetWidgets();
 }
@@ -25,25 +34,41 @@ SpeciesSiteKeywordWidget::SpeciesSiteKeywordWidget(QWidget *parent, SpeciesSiteK
 /*
  * Widgets
  */
-void SpeciesSiteKeywordWidget::siteRadioButton_clicked(bool checked)
+
+void SpeciesSiteKeywordWidget::clearDataButton_clicked(bool checked)
 {
     if (refreshing_)
         return;
 
-    QRadioButton *radioButton = qobject_cast<QRadioButton *>(sender());
-    if (!radioButton)
-        return;
+    keyword_->data() = nullptr;
 
-    // Retrieve the SpeciesSite from the radioButton
-    SpeciesSite *site = VariantPointer<SpeciesSite>(radioButton->property("SpeciesSite"));
-    if (!site)
-        return;
-
-    keyword_->data() = site;
+    resetWidgets();
 
     updateSummaryText();
 
     emit(keywordDataChanged(keyword_->editSignals()));
+}
+
+void SpeciesSiteKeywordWidget::siteCombo_currentIndexChanged(int index)
+{
+    if (refreshing_)
+        return;
+
+    // Get the current site, which might be filtered via our proxy.
+    auto filteredModelIndex = siteFilterProxy_.index(index, 0);
+    if (filteredModelIndex.isValid())
+    {
+        auto siteIndex = siteFilterProxy_.mapToSource(filteredModelIndex);
+        auto *site = siteModel_.data(siteIndex, Qt::UserRole).value<const SpeciesSite *>();
+        if (site)
+        {
+            keyword_->data() = site;
+
+            updateSummaryText();
+
+            emit(keywordDataChanged(keyword_->editSignals()));
+        }
+    }
 }
 
 /*
@@ -57,60 +82,52 @@ void SpeciesSiteKeywordWidget::updateValue(const Flags<DissolveSignals::DataMuta
         resetWidgets();
 }
 
-// Reset widgets
-void SpeciesSiteKeywordWidget::resetWidgets()
+void SpeciesSiteKeywordWidget::updateAvailableSpecies()
 {
     refreshing_ = true;
 
-    // Clear all tabs from our tab widget
-    ui_.SpeciesTabs->clear();
-
-    // Create button group for the radio buttons
-    auto *buttonGroup = new QButtonGroup(this);
-
-    // Add new tabs in, one for each defined Species, and each containing checkboxes for each available site
-    for (const auto &sp : coreData_.species())
-    {
-        // Create the widget to hold our checkboxes for this Species
-        auto *widget = new QWidget();
-        auto *layout = new QVBoxLayout;
-        layout->setContentsMargins(4, 4, 4, 4);
-        layout->setSpacing(4);
-        widget->setLayout(layout);
-        widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
-
-        // Are there sites defined?
-        if (sp->nSites() == 0)
-            layout->addWidget(new QLabel("No sites defined."));
-        else
-        {
-            // Loop over sites defined in this Species
-            for (auto &site : sp->sites())
-            {
-                auto *radioButton = new QRadioButton(QString::fromStdString(std::string(site->name())));
-                if (keyword_->data() == site.get())
-                    radioButton->setChecked(true);
-                connect(radioButton, SIGNAL(clicked(bool)), this, SLOT(siteRadioButton_clicked(bool)));
-                radioButton->setProperty("SpeciesSite", VariantPointer<SpeciesSite>(site.get()));
-                layout->addWidget(radioButton);
-                buttonGroup->addButton(radioButton);
-
-                // If this keyword demands oriented sites, disable the radio button if the site has no axes
-                if (keyword_->axesRequired() && (!site->hasAxes()))
-                    radioButton->setDisabled(true);
-            }
-
-            // Add on a vertical spacer to take up any extra space at the foot of the widget
-            layout->addSpacing(0);
-        }
-
-        // Create the page in the tabs
-        ui_.SpeciesTabs->addTab(widget, QString::fromStdString(std::string(sp->name())));
-    }
-
-    updateSummaryText();
+    speciesModel_.setData(coreData_.species());
+    if (keyword_->data())
+        ui_.SpeciesCombo->setCurrentIndex(std::find_if(coreData_.species().begin(), coreData_.species().end(),
+                                                       [&](const auto &sp) { return sp.get() == keyword_->data()->parent(); }) -
+                                          coreData_.species().begin());
+    else
+        ui_.SpeciesCombo->setCurrentIndex(-1);
 
     refreshing_ = false;
+}
+
+void SpeciesSiteKeywordWidget::updateAvailableSites(int speciesIndex)
+{
+    refreshing_ = true;
+
+    // Set filter proxy
+    siteFilterProxy_.setFlags(keyword_->axesRequired() ? SpeciesSiteFilterProxy::IsOriented : SpeciesSiteFilterProxy::None);
+
+    if (speciesIndex == -1)
+        siteModel_.setData(std::nullopt);
+    else
+    {
+        auto &sites = coreData_.species()[speciesIndex]->sites();
+        siteModel_.setData(sites);
+        if (keyword_->data())
+            ui_.SiteCombo->setCurrentIndex(
+                std::find_if(sites.begin(), sites.end(), [&](const auto &site) { return site.get() == keyword_->data(); }) -
+                sites.begin());
+        else
+            ui_.SiteCombo->setCurrentIndex(-1);
+    }
+
+    refreshing_ = false;
+}
+
+// Reset widgets
+void SpeciesSiteKeywordWidget::resetWidgets()
+{
+    updateAvailableSpecies();
+    updateAvailableSites(ui_.SpeciesCombo->currentIndex());
+
+    updateSummaryText();
 }
 
 // Update summary text

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -60,7 +60,8 @@ void SpeciesSiteVectorKeywordWidget::resetModelData()
 // Update value displayed in widget
 void SpeciesSiteVectorKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutations> &mutationFlags)
 {
-    resetModelData();
+    if (mutationFlags.isSet(DissolveSignals::SpeciesMutated) || mutationFlags.isSet(DissolveSignals::SpeciesSiteMutated))
+        resetModelData();
 }
 
 // Update summary text

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -186,7 +186,7 @@ void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
     ui_.MainTabs->removeByPage(spTab->page());
     dissolve_.removeSpecies(spTab->species());
 
-    setModified();
+    setModified({DissolveSignals::DataMutations::SpeciesMutated, DissolveSignals::DataMutations::IsotopologuesMutated});
     fullUpdate();
 }
 

--- a/src/gui/models/speciesSiteModel.cpp
+++ b/src/gui/models/speciesSiteModel.cpp
@@ -13,7 +13,7 @@ SpeciesSiteModel::SpeciesSiteModel(OptionalReferenceWrapper<std::vector<std::uni
 }
 
 // Set source SpeciesSite data
-void SpeciesSiteModel::setData(std::vector<std::unique_ptr<SpeciesSite>> &sites)
+void SpeciesSiteModel::setData(OptionalReferenceWrapper<std::vector<std::unique_ptr<SpeciesSite>>> sites)
 {
     beginResetModel();
     sites_ = sites;
@@ -21,7 +21,7 @@ void SpeciesSiteModel::setData(std::vector<std::unique_ptr<SpeciesSite>> &sites)
 }
 
 // Set vector containing checked items
-void SpeciesSiteModel::setCheckStateData(std::vector<const SpeciesSite *> &checkedItemsVector)
+void SpeciesSiteModel::setCheckStateData(OptionalReferenceWrapper<std::vector<const SpeciesSite *>> checkedItemsVector)
 {
     beginResetModel();
     checkedItems_ = checkedItemsVector;

--- a/src/gui/models/speciesSiteModel.h
+++ b/src/gui/models/speciesSiteModel.h
@@ -28,9 +28,9 @@ class SpeciesSiteModel : public QAbstractListModel
 
     public:
     // Set source SpeciesSite data
-    void setData(std::vector<std::unique_ptr<SpeciesSite>> &sites);
+    void setData(OptionalReferenceWrapper<std::vector<std::unique_ptr<SpeciesSite>>> sites);
     // Set vector containing checked items
-    void setCheckStateData(std::vector<const SpeciesSite *> &checkedItemsVector);
+    void setCheckStateData(OptionalReferenceWrapper<std::vector<const SpeciesSite *>> checkedItemsVector);
 
     /*
      * QAbstractItemModel overrides

--- a/src/gui/signals.h
+++ b/src/gui/signals.h
@@ -11,6 +11,7 @@ enum DataMutations
     ConfigurationsMutated,
     IsotopologuesMutated,
     ModulesMutated,
-    SpeciesMutated
+    SpeciesMutated,
+    SpeciesSiteMutated
 };
 }; // namespace DissolveSignals

--- a/src/gui/speciestab_sites.cpp
+++ b/src/gui/speciestab_sites.cpp
@@ -49,7 +49,7 @@ void SpeciesTab::on_SiteAddButton_clicked(bool checked)
 
     sites_.setData(species_->sites());
 
-    dissolveWindow_->setModified();
+    dissolveWindow_->setModified(DissolveSignals::SpeciesSiteMutated);
 
     dissolveWindow_->fullUpdate();
 }
@@ -65,11 +65,12 @@ void SpeciesTab::on_SiteRemoveButton_clicked(bool checked)
     dissolveWindow_->dissolve().removeReferencesTo(site);
     ui_.SiteViewerWidget->setSite(nullptr);
 
-    // Remove the site proper, and update the sites tab
+    // Remove the site proper
+    dissolve_.removeReferencesTo(site);
     species_->removeSite(site);
     sites_.setData(species_->sites());
 
-    dissolveWindow_->setModified();
+    dissolveWindow_->setModified(DissolveSignals::SpeciesSiteMutated);
 
     dissolveWindow_->fullUpdate();
 }


### PR DESCRIPTION
This PR refactors the really quite nasty `SpeciesSiteKeywordWidget` to use a pair of model-backed `QComboBox`es rather than a dynamically-created set of tabs and radio buttons.  The latter was particularly unmaintainable given the need to dynamically update the widgets coupled with Qt's less-than-direct widget deletion mechanism.

Closes #1179.