### PR TITLE
Accumulate Targets

### DIFF
--- a/web/content/docs/modules/correlation/accumulate/_index.md
+++ b/web/content/docs/modules/correlation/accumulate/_index.md
@@ -18,7 +18,7 @@ A target module containing partial set data must be provided, along with the typ
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
-|`Data`|`Module`|--|{{< required-label >}}Name of the source module from which to take partial set data|
+|`Data`|`Module`...|--|{{< required-label >}}Name of the source module(s) from which to take partial set data to accumulate. If multiple modules are specified then each is accumulated separately, rather than them all being accumulated into one final dataset.|
 |`Target`|`RDF|SQ|OriginalRDF`|`RDF`|Partial set type to take from the target module. Not all partial set types are relevant to all target module types - e.g. `SQ` has no meaning for an {{< gui-module "RDF" >}} module, but both `RDF` and `SQ` are relevant for an {{< gui-module "XRaySQ" >}} module. The `OriginalRDF` option is specific to the {{< gui-module "RDF" >}} module, and refers to the as-calculated partials before any intramolecular broadening has been applied.
 
 ### Export


### PR DESCRIPTION
The  `Accumulate` module allowed the specification of multiple module targets, yet only accumulated the data of the first one. This PR adjusts its behaviour to accumulate, separately, multiple module targets.

Closes #1248.