### PR TITLE
1227 Reference data G(r)

### DIFF
--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -115,9 +115,9 @@ class Configuration : public Serialisable
     // Return the total atomic mass present in the Configuration
     double atomicMass() const;
     // Return the atomic density of the Configuration
-    double atomicDensity() const;
+    std::optional<double> atomicDensity() const;
     // Return the chemical density (g/cm3) of the Configuration
-    double chemicalDensity() const;
+    std::optional<double> chemicalDensity() const;
     // Return version of current contents
     int contentsVersion() const;
     // Increment version of current contents

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -75,10 +75,22 @@ double Configuration::atomicMass() const
 }
 
 // Return the atomic density of the Configuration
-double Configuration::atomicDensity() const { return nAtoms() / box_->volume(); }
+std::optional<double> Configuration::atomicDensity() const
+{
+    if (nAtoms() == 0)
+        return {};
+
+    return nAtoms() / box_->volume();
+}
 
 // Return the chemical density (g/cm3) of the Configuration
-double Configuration::chemicalDensity() const { return atomicMass() / (box_->volume() / 1.0E24); }
+std::optional<double> Configuration::chemicalDensity() const
+{
+    if (nAtoms() == 0)
+        return {};
+
+    return atomicMass() / (box_->volume() / 1.0E24);
+}
 
 // Return version of current contents
 int Configuration::contentsVersion() const { return contentsVersion_; }

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -100,8 +100,11 @@ void ConfigurationTab::updateDensityLabel()
     if (!configuration_)
         ui_.DensityUnitsLabel->setText("N/A");
     else
-        ui_.DensityUnitsLabel->setText(QString::number(
-            ui_.DensityUnitsCombo->currentIndex() == 0 ? configuration_->atomicDensity() : configuration_->chemicalDensity()));
+    {
+        auto rho =
+            ui_.DensityUnitsCombo->currentIndex() == 0 ? configuration_->atomicDensity() : configuration_->chemicalDensity();
+        ui_.DensityUnitsLabel->setText(rho ? QString::number(*rho) : "--");
+    }
 }
 
 // Update controls in tab

--- a/src/gui/importcifdialog_funcs.cpp
+++ b/src/gui/importcifdialog_funcs.cpp
@@ -571,7 +571,9 @@ bool ImportCIFDialog::createSupercellSpecies()
     ui_.SupercellBoxAlphaLabel->setText(QString::number(supercell->box()->axisAngles().x) + "&deg;");
     ui_.SupercellBoxBetaLabel->setText(QString::number(supercell->box()->axisAngles().y) + "&deg;");
     ui_.SupercellBoxGammaLabel->setText(QString::number(supercell->box()->axisAngles().z) + "&deg;");
-    ui_.SupercellDensityLabel->setText(QString::number(supercellConfiguration_->chemicalDensity()) + " g cm<sup>3</sup>");
+    auto chemicalDensity = supercellConfiguration_->chemicalDensity();
+    ui_.SupercellDensityLabel->setText(chemicalDensity ? QString::number(*chemicalDensity) + " g cm<sup>3</sup>"
+                                                       : "-- g cm<sup>3</sup>");
     ui_.SupercellVolumeLabel->setText(QString::number(supercellConfiguration_->box()->volume()) + " &#8491;<sup>3</sup>");
     ui_.SupercellNAtomsLabel->setText(QString::number(supercellConfiguration_->nAtoms()));
 

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -164,6 +164,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (!targetConfiguration_)
         return Messenger::error("No target configuration is set.\n");
 
+    if (!targetConfiguration_->atomicDensity())
+        return Messenger::error("No density available for target configuration '{}'\n", targetConfiguration_->name());
     auto rho = *targetConfiguration_->atomicDensity();
 
     /*

--- a/src/modules/neutronsq/process.cpp
+++ b/src/modules/neutronsq/process.cpp
@@ -225,8 +225,10 @@ bool NeutronSQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     Filters::trim(repGR, referenceFTQMin_.value_or(0.0), ftQMax);
     auto rMin = weightedGR.total().xAxis().front();
     auto rMax = weightedGR.total().xAxis().back();
-    auto rho = *rdfModule->effectiveDensity();
-    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), rMin, 0.05, rMax, WindowFunction(referenceWindowFunction_));
+    auto rho = rdfModule->effectiveDensity();
+    if (!rho)
+        return Messenger::error("No effective density available from RDF module '{}'\n", rdfModule->name());
+    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * *rho), rMin, 0.05, rMax, WindowFunction(referenceWindowFunction_));
 
     // Save data if requested
     if (saveRepresentativeGR_)

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -247,23 +247,33 @@ bool RDFModule::calculateGRCells(const ProcessPool &procPool, Configuration *cfg
  * Public Functions
  */
 
-// Calculate and return effective density for based on the target Configurations
-double RDFModule::effectiveDensity() const
+// Calculate and return effective density based on target Configurations
+std::optional<double> RDFModule::effectiveDensity() const
 {
-    auto rho0 = 0.0, totalWeight = 0.0;
+    std::optional<double> rho0;
+    auto totalWeight = 0.0;
     for (auto *cfg : targetConfigurations_)
     {
+        auto cfgRho = cfg->atomicDensity();
+        if (!cfgRho)
+            continue;
+
         // TODO Get weight for configuration
         auto weight = 1.0;
 
         totalWeight += weight;
 
-        rho0 += weight / cfg->atomicDensity();
+        // ADd to sum
+        if (rho0)
+            *rho0 += weight / *cfg->atomicDensity();
+        else
+            rho0 = weight / *cfg->atomicDensity();
     }
-    rho0 /= totalWeight;
-    rho0 = 1.0 / rho0;
 
-    return rho0;
+    if (!rho0)
+        return {};
+
+    return 1.0 / (rho0.value() / totalWeight);
 }
 
 // Calculate and return used species populations based on target Configurations
@@ -517,7 +527,7 @@ bool RDFModule::sumUnweightedGR(GenericList &processingData, const ProcessPool &
 
     // Calculate overall density of combined system
     double rho0 = std::accumulate(configWeights.begin(), configWeights.end(), 0.0, [totalWeight](double acc, auto pair) {
-        return acc + pair.second / totalWeight / pair.first->atomicDensity();
+        return acc + pair.second / totalWeight / pair.first->atomicDensity().value();
     });
     rho0 = 1.0 / rho0;
 
@@ -530,7 +540,7 @@ bool RDFModule::sumUnweightedGR(GenericList &processingData, const ProcessPool &
             fingerprint.empty() ? fmt::format("{}", cfg->contentsVersion()) : fmt::format("_{}", cfg->contentsVersion());
 
         // Calculate weighting factor
-        double weight = ((cfgWeight / totalWeight) * cfg->atomicDensity()) / rho0;
+        double weight = ((cfgWeight / totalWeight) * *cfg->atomicDensity()) / rho0;
 
         // Grab partials for Configuration and add into our set
         if (!processingData.contains(fmt::format("{}//UnweightedGR", cfg->niceName()), targetPrefix))

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -517,6 +517,10 @@ bool RDFModule::sumUnweightedGR(GenericList &processingData, const ProcessPool &
     double totalWeight = 0.0;
     for (Configuration *cfg : parentCfgs)
     {
+        // Confirm atomic density is available (for the subsequent accumulator)
+        if (!cfg->atomicDensity())
+            return Messenger::error("No density available for target configuration '{}'\n", cfg->name());
+
         // TODO Assume weight of 1.0
         auto weight = 1.0;
 

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -535,6 +535,9 @@ bool RDFModule::sumUnweightedGR(GenericList &processingData, const ProcessPool &
     std::string fingerprint;
     for (auto [cfg, cfgWeight] : configWeights)
     {
+        if (!cfg->atomicDensity())
+            return Messenger::error("No density available for target configuration '{}'\n", cfg->name());
+
         // Update fingerprint
         fingerprint +=
             fingerprint.empty() ? fmt::format("{}", cfg->contentsVersion()) : fmt::format("_{}", cfg->contentsVersion());

--- a/src/modules/rdf/rdf.h
+++ b/src/modules/rdf/rdf.h
@@ -75,8 +75,8 @@ class RDFModule : public Module
     bool calculateGRCells(const ProcessPool &procPool, Configuration *cfg, PartialSet &partialSet, const double binWidth);
 
     public:
-    // Calculate and return effective density for based on the target Configurations
-    double effectiveDensity() const;
+    // Calculate and return effective density based on target Configurations
+    std::optional<double> effectiveDensity() const;
     // Calculate and return used species populations based on target Configurations
     std::vector<std::pair<const Species *, double>> speciesPopulations() const;
     // (Re)calculate partial g(r) for the specified Configuration

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -92,7 +92,7 @@ bool SQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     }
 
     // Transform g(r) into S(Q)
-    if (!calculateUnweightedSQ(procPool, unweightedgr, unweightedsq, qMin_, qDelta_, qMax_, rho,
+    if (!calculateUnweightedSQ(procPool, unweightedgr, unweightedsq, qMin_, qDelta_, qMax_, *rho,
                                WindowFunction(windowFunction_), qBroadening_))
         return false;
 

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -266,8 +266,10 @@ bool XRaySQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     Filters::trim(repGR, referenceFTQMin_.value_or(0.0), ftQMax);
     auto rMin = weightedGR.total().xAxis().front();
     auto rMax = weightedGR.total().xAxis().back();
-    auto rho = *rdfModule->effectiveDensity();
-    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), rMin, 0.05, rMax, WindowFunction(referenceWindowFunction_));
+    auto rho = rdfModule->effectiveDensity();
+    if (!rho)
+        return Messenger::error("No effective density available from RDF module '{}'\n", rdfModule->name());
+    Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * *rho), rMin, 0.05, rMax, WindowFunction(referenceWindowFunction_));
 
     // Save data if requested
     if (saveRepresentativeGR_)

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -90,10 +90,15 @@ bool XRaySQModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
         storedDataFT = referenceData;
         Filters::trim(storedDataFT, ftQMin, ftQMax);
         auto rho = rdfModule->effectiveDensity();
-        Messenger::print(
-            "[SETUP {}] Effective atomic density used in Fourier transform of reference data is {} atoms/Angstrom3.\n", name_,
-            rho);
-        Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho), referenceFTDeltaR_, referenceFTDeltaR_, 30.0,
+        if (rho)
+            Messenger::print(
+                "[SETUP {}] Effective atomic density used in Fourier transform of reference data is {} atoms/Angstrom3.\n",
+                name_, rho.value());
+        else
+            Messenger::warn("[SETUP {}] Effective atomic density used in Fourier transform of reference data not yet "
+                            "available, so a default of 0.1 atoms/Angstrom3 used.\n",
+                            name_);
+        Fourier::sineFT(storedDataFT, 1.0 / (2.0 * PI * PI * rho.value_or(0.1)), referenceFTDeltaR_, referenceFTDeltaR_, 30.0,
                         WindowFunction(referenceWindowFunction_));
 
         // Save data?
@@ -261,7 +266,7 @@ bool XRaySQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     Filters::trim(repGR, referenceFTQMin_.value_or(0.0), ftQMax);
     auto rMin = weightedGR.total().xAxis().front();
     auto rMax = weightedGR.total().xAxis().back();
-    auto rho = rdfModule->effectiveDensity();
+    auto rho = *rdfModule->effectiveDensity();
     Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * rho), rMin, 0.05, rMax, WindowFunction(referenceWindowFunction_));
 
     // Save data if requested

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -329,8 +329,8 @@ bool AddProcedureNode::execute(const ProcedureContext &procedureContext)
         }
     }
 
-    Messenger::print("[Add] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", cfg->atomicDensity(),
-                     cfg->chemicalDensity());
+    Messenger::print("[Add] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", *cfg->atomicDensity(),
+                     *cfg->chemicalDensity());
 
     return true;
 }

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -329,8 +329,8 @@ bool AddProcedureNode::execute(const ProcedureContext &procedureContext)
         }
     }
 
-    Messenger::print("[Add] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", *cfg->atomicDensity(),
-                     *cfg->chemicalDensity());
+    Messenger::print("[Add] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", cfg->atomicDensity().value_or(0.0),
+                     cfg->chemicalDensity().value_or(0.0));
 
     return true;
 }

--- a/src/procedure/nodes/addpair.cpp
+++ b/src/procedure/nodes/addpair.cpp
@@ -293,8 +293,8 @@ bool AddPairProcedureNode::execute(const ProcedureContext &procedureContext)
         }
     }
 
-    Messenger::print("[AddPair] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", cfg->atomicDensity(),
-                     cfg->chemicalDensity());
+    Messenger::print("[AddPair] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", cfg->atomicDensity().value_or(0.0),
+                     cfg->chemicalDensity().value_or(0.0));
 
     return true;
 }


### PR DESCRIPTION
This PR addresses #1227, which is a bug caused by a previous PR removing the automatic generation of configuration contents on file load.  Thus, when any module read in from the file tries to Fourier transform associated reference data, the density value retrieved from the associated `Configuration` is zero, leading to divide-by-zero errors in the Fourier transform and subsequent death of any graphed values.

We solve this issue by returning `std::optional<double>` from the relevant density routines, allowing checks against the validity of the value to be made.

Closes #1227.