### PR TITLE
Fix OSX Pythonics

### DIFF
--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -21,6 +21,7 @@ steps:
     displayName: 'Install Prerequisites'
   - bash: |
       set -ex
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
       Qt6_DIR=/tmp/qt/${{ parameters.qtver }}/macos/lib/cmake/Qt6
       QT_BASE_DIR=/tmp/qt/${{ parameters.qtver }}/macos
       QTVER=${{ parameters.qtver }}

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -14,8 +14,11 @@ steps:
       brew install ftgl ninja
       curl https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr-4.9.3-complete.jar  --output antlr.jar
       # -- Qt
-      sudo pip3 install conan aqtinstall
+      pip3 install aqtinstall
       python3 -m aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
+      # -- Conan
+      pip3 install --user conan
+      ls -lart ~/.local/bin
     displayName: 'Install Prerequisites'
   - bash: |
       set -ex
@@ -26,7 +29,7 @@ steps:
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
       mkdir build
       cd build
-      python3 -m conan install .. --build missing
+      conan install .. --build missing
       cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ parameters.threading }} -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ parameters.extraflags }} -DQT_BASE_DIR=$QT_BASE_DIR ../
       cmake --build . --config Release
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -14,7 +14,8 @@ steps:
       brew install ftgl ninja
       curl https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr-4.9.3-complete.jar  --output antlr.jar
       # -- Qt
-      pip3 install aqtinstall
+      pip3 install --user aqtinstall
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
       python3 -m aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
       # -- Conan
       pip3 install --user conan

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -15,7 +15,7 @@ steps:
       curl https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr-4.9.3-complete.jar  --output antlr.jar
       # -- Qt
       sudo pip3 install conan aqtinstall
-      aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
+      python3 -m aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
     displayName: 'Install Prerequisites'
   - bash: |
       set -ex

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -16,7 +16,7 @@ steps:
       # -- Qt
       pip3 install --user aqtinstall
       export PATH="$(python3 -m site --user-base)/bin:$PATH"
-      python3 -m aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
+      aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
       # -- Conan
       pip3 install --user conan
     displayName: 'Install Prerequisites'

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -26,7 +26,7 @@ steps:
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
       mkdir build
       cd build
-      conan install .. --build missing
+      python3 -m conan install .. --build missing
       cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ parameters.threading }} -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ parameters.extraflags }} -DQT_BASE_DIR=$QT_BASE_DIR ../
       cmake --build . --config Release
     displayName: 'Build'

--- a/.azure-pipelines/templates/build-osx.yml
+++ b/.azure-pipelines/templates/build-osx.yml
@@ -18,7 +18,6 @@ steps:
       python3 -m aqt install-qt --outputdir /tmp/qt mac desktop ${{ parameters.qtver }}
       # -- Conan
       pip3 install --user conan
-      ls -lart ~/.local/bin
     displayName: 'Install Prerequisites'
   - bash: |
       set -ex

--- a/.azure-pipelines/templates/package-osx.yml
+++ b/.azure-pipelines/templates/package-osx.yml
@@ -11,6 +11,7 @@ steps:
   - bash: |
       set -ex
       Qt6_ROOT=/tmp/qt/${{ parameters.qtver }}/macos/
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
 
       # Get program version
       DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`

--- a/.azure-pipelines/templates/package-osx.yml
+++ b/.azure-pipelines/templates/package-osx.yml
@@ -4,7 +4,7 @@ parameters:
 
 steps:
   - bash: |
-      pip3 install dmgbuild biplist
+      pip3 install --user dmgbuild biplist
       wget https://raw.githubusercontent.com/disorderedmaterials/scripts/master/prep-dmg
       chmod u+x ./prep-dmg
     displayName: 'Install Prerequisites'
@@ -34,6 +34,7 @@ steps:
     displayName: 'Prepare DMG Dirs'
   - bash: |
       set -ex
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
       # Get program version
       DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed "s/.*\"\(.*\)\"/\1/g"`
       # Fix icon link


### PR DESCRIPTION
Fixes the OSX pipeline which now does not seem to recognise package scripts installed via `pip`, and so we must ~call the modules explicitly with `python3 -m`~ add the scripts dir to our `$PATH` manually (which seems totally reasonable and the completely expected behaviour).