### PR TITLE
EPSR Coefficient Smoothing

### DIFF
--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -135,17 +135,14 @@ void median(Data1D &data, int length)
     std::copy(newY.begin(), newY.end(), y.begin());
 }
 
-// Perform moving average smoothing
-void movingAverage(Data1D &data, const int length)
+// Perform moving average smoothing on vector
+void movingAverage(std::vector<double> &data, int length)
 {
     // Ensure average length (representing number of points averaged on one side of a given point) is positive non-zero
     if (length < 1)
         return;
 
-    // Grab y array
-    auto &y = data.values();
-
-    std::vector<double> newY(data.nValues());
+    std::vector<double> newY(data.size());
     std::fill(newY.begin(), newY.end(), 0.0);
     auto avgSize = length * 2 + 1;
 
@@ -153,28 +150,31 @@ void movingAverage(Data1D &data, const int length)
     for (auto n = 0; n < length; ++n)
     {
         for (auto m = 0; m <= n + length; ++m)
-            newY[n] += y[m];
+            newY[n] += data[m];
         newY[n] /= (length + 1 + n);
     }
 
     // Central region (full average width available)
-    for (auto n = length; n < data.nValues() - length; ++n)
+    for (auto n = length; n < data.size() - length; ++n)
     {
         for (auto m = n - length; m <= n + length; ++m)
-            newY[n] += y[m];
+            newY[n] += data[m];
         newY[n] /= avgSize;
     }
 
     // Right-most region of data
-    for (auto n = data.nValues() - length; n < data.nValues(); ++n)
+    for (auto n = data.size() - length; n < data.size(); ++n)
     {
-        for (auto m = n - length; m < data.nValues(); ++m)
-            newY[n] += y[m];
-        newY[n] /= (data.nValues() - n + length + 1);
+        for (auto m = n - length; m < data.size(); ++m)
+            newY[n] += data[m];
+        newY[n] /= (data.size() - n + length + 1);
     }
 
-    y = newY;
+    data = newY;
 }
+
+// Perform moving average smoothing
+void movingAverage(Data1D &data, const int length) { movingAverage(data.values(), length); }
 
 // Perform moving average smoothing, normalising area after smooth
 void normalisedMovingAverage(Data1D &data, int length)

--- a/src/math/filters.h
+++ b/src/math/filters.h
@@ -19,10 +19,11 @@ void convolve(double xCentre, double value, const Functions::Function1DWrapper f
 void kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised = false);
 // Apply median filter to data
 void median(Data1D &data, int length);
-// Perform moving average smoothing on data
-void movingAverage(Data1D &data, int avgSize);
+// Perform moving average smoothing
+void movingAverage(std::vector<double> &data, int length);
+void movingAverage(Data1D &data, int length);
 // Perform moving average smoothing on data, normalising area after smooth
-void normalisedMovingAverage(Data1D &data, int avgSize);
+void normalisedMovingAverage(Data1D &data, int length);
 // Subtract average level (starting at supplied x value) from data
 double subtractAverage(Data1D &data, double xStart);
 // Trim supplied data to specified range

--- a/src/modules/epsr/io.cpp
+++ b/src/modules/epsr/io.cpp
@@ -141,7 +141,7 @@ bool EPSRModule::readPCof(Dissolve &dissolve, const ProcessPool &procPool, std::
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return Messenger::error("Failed to read pair potential atom types from pcof file.\n");
 
-        // Find the atom types to which these cofficients relate
+        // Find the atom types to which these coefficients relate
         auto at1 = dissolve.findAtomType(parser.argsv(0));
         if (!at1)
             return Messenger::error("Unrecognised AtomType '{}' referenced in pcof file.\n", parser.argsv(0));

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -139,8 +139,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     Messenger::print("EPSR: Range for potential generation is {} < Q < {} Angstroms**-1.\n", qMin_, qMax_);
     Messenger::print("EPSR: Weighting factor used when applying fluctuation coefficients is {}\n", weighting_);
     if (fluctuationSmoothing_)
-        Messenger::print("EPSR: Fluctuation coefficients will be smoothed (average length = 2N+1, N = {})",
-                         *fluctuationSmoothing_);
+        Messenger::print("EPSR: Coefficients will be smoothed (average length = 2N+1, N = {})", *fluctuationSmoothing_);
     if (saveDifferenceFunctions_)
         Messenger::print("EPSR: Difference functions will be saved.\n");
     if (saveEmpiricalPotentials_)
@@ -320,6 +319,15 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
             // Store the new fit coefficients
             fitCoefficients = coeffMinimiser.C();
+
+            // Smooth coefficients?
+            if (fluctuationSmoothing_)
+            {
+                Filters::movingAverage(fitCoefficients, *fluctuationSmoothing_);
+
+                // Need to pass the smoothed parameters back into the minimiser so we generate the matching approximation
+                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_, fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
+            }
 
             deltaFQFit = coeffMinimiser.approximation();
         }
@@ -636,23 +644,9 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                                     if (overwritePotentials_)
                                         std::fill(potCoeff.begin(), potCoeff.end(), 0.0);
 
-                                    // Add in fluctuation coefficients, smoothing beforehand if requested
-                                    if (fluctuationSmoothing_)
-                                    {
-                                        // Perform smoothing of the fluctuation coefficients before we sum them into the
-                                        // potential (the un-smoothed coefficients are stored)
-                                        Data1D smoothedCoefficients;
-                                        for (auto n = 0; n < nCoeffP_; ++n)
-                                            smoothedCoefficients.addPoint(n, fluctuationCoefficients[{i, j, n}]);
-                                        Filters::normalisedMovingAverage(smoothedCoefficients, *fluctuationSmoothing_);
-
-                                        // Add in fluctuation coefficients
-                                        for (auto n = 0; n < nCoeffP_; ++n)
-                                            potCoeff[n] += weighting_ * smoothedCoefficients.value(n);
-                                    }
-                                    else
-                                        for (auto n = 0; n < nCoeffP_; ++n)
-                                            potCoeff[n] += weighting_ * fluctuationCoefficients[{i, j, n}];
+                                    // Add in fluctuation coefficients
+                                    for (auto n = 0; n < nCoeffP_; ++n)
+                                        potCoeff[n] += weighting_ * fluctuationCoefficients[{i, j, n}];
 
                                     // Set first term to zero (following EPSR)
                                     potCoeff[0] = 0.0;


### PR DESCRIPTION
A small PR to change the way EPSR smooths coefficients used in the potential generation. Previously this was performed just prior to potential generation, but this was not terribly good at eliminating noise from being carried over into the potentials. Now the smoothing is performed after the delta F(Q) fitting, and the smoothed parameters are stored for posterity.