### PR TITLE
EPSR Delay

### DIFF
--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -39,8 +39,8 @@ EPSRModule::EPSRModule() : Module("EPSR")
     keywords_.add<DoubleKeyword>("Expansion Function", "GSigma2", "Width for Gaussian function in real space", gSigma2_, 0.001,
                                  1.0);
     keywords_.add<OptionalIntegerKeyword>("Expansion Function", "NCoeffP",
-                                          "Number of coefficients used to define the empirical potential (-1 for automatic)",
-                                          nCoeffP_, 0, std::nullopt, 100, "Automatic");
+                                          "Number of coefficients used to define the empirical potential", nCoeffP_, 0,
+                                          std::nullopt, 100, "Automatic");
     keywords_.add<OptionalIntegerKeyword>("Expansion Function", "NPItSs",
                                           "Number of steps for refining fits to delta functions", nPItSs_, 0, std::nullopt, 100,
                                           "Off (No Fitting - CAUTION!)");

--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -21,8 +21,9 @@ EPSRModule::EPSRModule() : Module("EPSR")
     keywords_.add<DoubleKeyword>("Control", "EReq", "Limit of magnitude of additional potential for any one pair potential",
                                  eReq_, 0.0);
     keywords_.add<DoubleKeyword>("Control", "Feedback", "Confidence factor", feedback_, 0.0, 1.0);
-    keywords_.add<BoolKeyword>("Control", "ModifyPotential",
-                               "Whether to apply generated perturbations to interatomic potentials", modifyPotential_);
+    keywords_.add<OptionalIntegerKeyword>("Control", "ModifyPotential",
+                                          "Frequency at which to apply generated perturbations to interatomic potentials",
+                                          modifyPotential_, 0, std::nullopt, 1, "Off");
     keywords_.add<DoubleKeyword>("Control", "QMax",
                                  "Maximum Q value over which to generate potentials from total scattering data", qMax_, 0.0);
     keywords_.add<DoubleKeyword>("Control", "QMin",

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -54,8 +54,8 @@ class EPSRModule : public Module
     double gSigma1_{0.1};
     // Width for Gaussian function in real space
     double gSigma2_{0.2};
-    // Whether to apply generated perturbations to interatomic potentials
-    bool modifyPotential_{true};
+    // Frequency at which to apply generated perturbations to interatomic potentials
+    std::optional<int> modifyPotential_{1};
     // Number of coefficients used to define the empirical potential
     std::optional<int> nCoeffP_;
     // Number of steps for refining the potential

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -56,7 +56,7 @@ class EPSRModule : public Module
     double gSigma2_{0.2};
     // Whether to apply generated perturbations to interatomic potentials
     bool modifyPotential_{true};
-    // Number of coefficients used to define the empirical potential (-1 for automatic)
+    // Number of coefficients used to define the empirical potential
     std::optional<int> nCoeffP_;
     // Number of steps for refining the potential
     std::optional<int> nPItSs_{1000};

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -132,7 +132,9 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                      expansionFunctionTypes().keyword(expansionFunction_));
     Messenger::print("EPSR: Number of functions used in approximation is {}, sigma(Q) = {}.\n", nCoeffP_.value(), pSigma2_);
     if (modifyPotential_)
-        Messenger::print("EPSR: Perturbations to interatomic potentials will be generated and applied.\n");
+        Messenger::print(
+            "EPSR: Perturbations to interatomic potentials will be generated and applied with a frequency of {}.\n",
+            *modifyPotential_);
     else
         Messenger::print("EPSR: Perturbations to interatomic potentials will be generated only (current potentials "
                          "will not be modified).\n");
@@ -167,6 +169,15 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (!targetConfiguration_->atomicDensity())
         return Messenger::error("No density available for target configuration '{}'\n", targetConfiguration_->name());
     auto rho = *targetConfiguration_->atomicDensity();
+
+    /*
+     * Realise and increase run counter
+     */
+    auto [runCount, runCountStatus] =
+        dissolve.processingModuleData().realiseIf<int>("RunCount", name(), GenericItem::InRestartFileFlag);
+    if (runCountStatus == GenericItem::ItemStatus::Created)
+        runCount = 0;
+    ++runCount;
 
     /*
      * EPSR Main
@@ -624,7 +635,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Generate new empirical potentials
     auto energabs = 0.0;
-    if (modifyPotential_)
+    if (modifyPotential_ && (runCount % *modifyPotential_ == 0))
     {
         // Sum fluctuation coefficients in to the potential coefficients
         auto &coefficients = potentialCoefficients(dissolve, nAtomTypes, nCoeffP_);


### PR DESCRIPTION
This PR adds a new feature to the `EPSR` module, permitting the empirical potential to be modified every N steps. This has proven useful as it allows the fit functions to react (and fit) the delta F(Q) before attempting to generate any new potential modifications.