### PR TITLE
Scattering matrix inversion

### DIFF
--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -391,7 +391,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
                                         usedTypes.atomType(n)->name(), usedTypes.atomType(m)->name());
 
             // Now have the local column index of the AtomType pair in our matrix A_.
-            // Since this is X-ray data, we will just store the product of the concentrtion weights and the factor
+            // Since this is X-ray data, we will just store the product of the concentration weights and the factor
             A_[{rowIndex, colIndex}] = dataWeights.preFactor(n, m) * factor;
         }
     }

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -286,12 +286,13 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
             return false;
 
         // Generate new partials (nPartials = nColumns)
-        for (auto partialIndex = 0; partialIndex < A_.nColumns(); ++partialIndex)
+        for (auto refDataIndex = 0; refDataIndex < data_.size(); ++refDataIndex)
         {
-            // Add in contribution from each dataset (row).
-            for (auto refDataIndex = 0; refDataIndex < data_.size(); ++refDataIndex)
-                Interpolator::addInterpolated(data_[refDataIndex], estimatedSQ[partialIndex],
-                                              inverseA[{partialIndex, refDataIndex}]);
+            // Generate interpolation for this dataset (row).
+            Interpolator I(data_[refDataIndex]);
+
+            for (auto partialIndex = 0; partialIndex < A_.nColumns(); ++partialIndex)
+                Interpolator::addInterpolated(I, estimatedSQ[partialIndex], inverseA[{partialIndex, refDataIndex}]);
         }
     }
 

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -405,6 +405,19 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
     return true;
 }
 
+// Update reference data)
+bool ScatteringMatrix::updateReferenceData(const Data1D &weightedData, double factor)
+{
+    auto it = std::find_if(data_.begin(), data_.end(), [weightedData](auto &data) { return weightedData.tag() == data.tag(); });
+    if (it == data_.end())
+        return false;
+
+    *it = weightedData;
+    *it *= factor;
+
+    return true;
+}
+
 // Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
 bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const std::shared_ptr<AtomType> &at1,
                                                const std::shared_ptr<AtomType> &at2, double dataWeight, double factor)
@@ -431,3 +444,6 @@ bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const std::
 
     return true;
 }
+
+// Return number of currently-defined reference data sets (== matrix rows)
+int ScatteringMatrix::nReferenceData() const { return A_.nRows(); }

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -239,8 +239,8 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
      */
 
     // Template the estimatedSQ from the first data item
-    for (auto &n : estimatedSQ)
-        n.initialise(data_[0]);
+    for (auto &estSQ : estimatedSQ)
+        estSQ.initialise(data_[0]);
 
     Array2D<double> inverseA;
     auto qDependentMatrix =

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -288,7 +288,7 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
         // Generate new partials (nPartials = nColumns)
         for (auto partialIndex = 0; partialIndex < A_.nColumns(); ++partialIndex)
         {
-            // Add in contribution from each datset (row).
+            // Add in contribution from each dataset (row).
             for (auto refDataIndex = 0; refDataIndex < data_.size(); ++refDataIndex)
                 Interpolator::addInterpolated(data_[refDataIndex], estimatedSQ[partialIndex],
                                               inverseA[{partialIndex, refDataIndex}]);

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -17,9 +17,6 @@ ScatteringMatrix::ScatteringMatrix() = default;
  * Data
  */
 
-// Return number of reference AtomType pairs
-int ScatteringMatrix::nPairs() const { return typePairs_.size(); }
-
 // Return index of specified AtomType pair
 int ScatteringMatrix::pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const
 {
@@ -298,9 +295,6 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
 
     return true;
 }
-
-// Return if the scattering matrix is underdetermined
-bool ScatteringMatrix::underDetermined() const { return (data_.size() < A_.nColumns()); }
 
 // Return the product of inverseA_ and A_ (which should be the identity matrix) at the specified Q value
 Array2D<double> ScatteringMatrix::matrixProduct(double q) const { return inverse(q) * matrix(q); }

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -36,7 +36,7 @@ int ScatteringMatrix::pairIndex(const std::shared_ptr<AtomType> &typeI, const st
     return -1;
 }
 
-// Return weight of the specified AtomType pair in the inverse matrix
+// Return weight of the specified AtomType pair in the inverse matrix at the specified Q value
 double ScatteringMatrix::pairWeightInverse(double q, std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomType> typeJ,
                                            int dataIndex) const
 {

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -71,18 +71,8 @@ void ScatteringMatrix::generateMatrices()
     }
 }
 
-// Return weight of the specified AtomType pair in the inverse matrix at the specified Q value
-double ScatteringMatrix::pairWeightInverse(double q, std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomType> typeJ,
-                                           int dataIndex) const
-{
-    /*
-     * The required row of the inverse matrix is the index of the AtomType pair.
-     * The required column of the inverse matrix is the original (row) index of the supplied data.
-     */
-
-    auto index = pairIndex(std::move(typeI), std::move(typeJ));
-    return inverse(q)[{index, dataIndex}];
-}
+// Return the precalculated Q = 0.0 scattering matrix inverse
+const Array2D<double> &ScatteringMatrix::qZeroMatrixInverse() const { return qZeroInverse_; }
 
 // Calculate and return the scattering matrix at the specified Q value
 Array2D<double> ScatteringMatrix::matrix(double q) const

--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -17,6 +17,12 @@ ScatteringMatrix::ScatteringMatrix() = default;
  * Data
  */
 
+// Return whether Q-dependent weighting is required
+bool ScatteringMatrix::qDependentWeighting() const
+{
+    return std::find_if(xRayData_.begin(), xRayData_.end(), [](auto data) { return std::get<0>(data); }) != xRayData_.end();
+}
+
 // Return index of specified AtomType pair
 int ScatteringMatrix::pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const
 {
@@ -240,10 +246,8 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
         estSQ.initialise(data_[0]);
 
     Array2D<double> inverseA;
-    auto qDependentMatrix =
-        std::find_if(xRayData_.begin(), xRayData_.end(), [](auto data) { return std::get<0>(data); }) != xRayData_.end();
 
-    if (qDependentMatrix)
+    if (qDependentWeighting())
     {
         // Generate interpolations for each dataset
         std::vector<Interpolator> interpolations;

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -40,6 +40,10 @@ class ScatteringMatrix
     std::vector<Data1D> data_;
     // X-ray specification for reference data (if relevant)
     std::vector<std::tuple<bool, std::optional<XRayWeights>, StructureFactors::NormalisationType>> xRayData_;
+    // Scattering matrix and inverse at Q = 0
+    Array2D<double> qZeroMatrix_, qZeroInverse_;
+    // Scattering matrix / inverse pairs at specific Q values
+    std::vector<std::tuple<double, Array2D<double>, Array2D<double>>> qMatrices_;
 
     private:
     // Return whether Q-dependent weighting is required
@@ -48,6 +52,8 @@ class ScatteringMatrix
     public:
     // Return index of specified AtomType pair
     int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
+    // Generate matrices
+    void generateMatrices();
     // Return weight of the specified AtomType pair in the inverse matrix at the specified Q value
     double pairWeightInverse(double q, std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomType> typeJ, int dataIndex) const;
     // Calculate and return the scattering matrix at the specified Q value

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -54,8 +54,8 @@ class ScatteringMatrix
     int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Generate matrices
     void generateMatrices();
-    // Return weight of the specified AtomType pair in the inverse matrix at the specified Q value
-    double pairWeightInverse(double q, std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomType> typeJ, int dataIndex) const;
+    // Return the precalculated Q = 0.0 scattering matrix inverse
+    const Array2D<double> &qZeroMatrixInverse() const;
     // Calculate and return the scattering matrix at the specified Q value
     Array2D<double> matrix(double q = 0.0) const;
     // Calculate and return the inverse matrix at the specified Q value

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -41,6 +41,10 @@ class ScatteringMatrix
     // X-ray specification for reference data (if relevant)
     std::vector<std::tuple<bool, std::optional<XRayWeights>, StructureFactors::NormalisationType>> xRayData_;
 
+    private:
+    // Return whether Q-dependent weighting is required
+    bool qDependentWeighting() const;
+
     public:
     // Return index of specified AtomType pair
     int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "classes/neutronweights.h"
+#include "classes/xrayweights.h"
 #include "data/formfactors.h"
 #include "data/structurefactors.h"
 #include "math/data1d.h"
@@ -13,8 +15,6 @@
 
 // Forward Declarations
 class AtomType;
-class NeutronWeights;
-class XRayWeights;
 
 // Scattering Matrix Container
 class ScatteringMatrix

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -46,7 +46,7 @@ class ScatteringMatrix
     int nPairs() const;
     // Return index of specified AtomType pair
     int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
-    // Return weight of the specified AtomType pair in the inverse matrix
+    // Return weight of the specified AtomType pair in the inverse matrix at the specified Q value
     double pairWeightInverse(double q, std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomType> typeJ, int dataIndex) const;
     // Calculate and return the scattering matrix at the specified Q value
     Array2D<double> matrix(double q = 0.0) const;

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -73,7 +73,11 @@ class ScatteringMatrix
     bool addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor = 1.0);
     // Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself
     bool addReferenceData(const Data1D &weightedData, const XRayWeights &dataWeights, double factor = 1.0);
+    // Update reference data)
+    bool updateReferenceData(const Data1D &weightedData, double factor = 1.0);
     // Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
     bool addPartialReferenceData(Data1D &weightedData, const std::shared_ptr<AtomType> &at1,
                                  const std::shared_ptr<AtomType> &at2, double dataWeight, double factor = 1.0);
+    // Return number of currently-defined reference data sets (== matrix rows)
+    int nReferenceData() const;
 };

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -42,8 +42,6 @@ class ScatteringMatrix
     std::vector<std::tuple<bool, std::optional<XRayWeights>, StructureFactors::NormalisationType>> xRayData_;
 
     public:
-    // Return number of reference AtomType pairs
-    int nPairs() const;
     // Return index of specified AtomType pair
     int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Return weight of the specified AtomType pair in the inverse matrix at the specified Q value
@@ -58,8 +56,6 @@ class ScatteringMatrix
     void printInverse(double q = 0.0) const;
     // Generate partials from reference data using inverse matrix
     bool generatePartials(Array2D<Data1D> &estimatedSQ);
-    // Return if the scattering matrix is underdetermined
-    bool underDetermined() const;
     // Return the product of inverseA_ and A_ (which should be the identity matrix) at the specified Q value
     Array2D<double> matrixProduct(double q = 0.0) const;
 

--- a/src/math/svd.cpp
+++ b/src/math/svd.cpp
@@ -92,7 +92,7 @@ bool decompose(const Array2D<double> &A, Array2D<double> &U, Array2D<double> &S,
         {
             for (k = l; k < nCols; k++)
                 scale += fabs(U[{i, k}]);
-            if (scale)
+            if (scale != 0.0)
             {
                 for (k = l; k < nCols; k++)
                 {
@@ -127,7 +127,7 @@ bool decompose(const Array2D<double> &A, Array2D<double> &U, Array2D<double> &S,
     {
         if (i < nCols - 1)
         {
-            if (g)
+            if (g != 0.0)
             {
                 for (j = l; j < nCols; j++)
                     Vt[{j, i}] = (U[{i, j}] / U[{i, l}]) / g;
@@ -160,7 +160,7 @@ bool decompose(const Array2D<double> &A, Array2D<double> &U, Array2D<double> &S,
         if (i < (nCols - 1))
             for (j = l; j < nCols; j++)
                 U[{i, j}] = 0.0;
-        if (g)
+        if (g != 0.0)
         {
             g = 1.0 / g;
             if (i != (nCols - 1)) // TGAY

--- a/src/math/svd.cpp
+++ b/src/math/svd.cpp
@@ -151,7 +151,7 @@ bool decompose(const Array2D<double> &A, Array2D<double> &U, Array2D<double> &S,
         l = i;
     }
 
-    // Assumulate left-hand transformation
+    // Accumulate left-hand transformation
     //   for(i=min(nRows,nCols) - 1;i >= 0;i--) {
     for (i = nCols - 1; i >= 0; i--)
     {

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -29,7 +29,7 @@ class EPSRModule : public Module
     enum ExpansionFunctionType
     {
         PoissonExpansionFunction,  /* Fit difference functions using Poisson (power exponential) functions */
-        GaussianExpansionFunction, /* Fit difference functiuns using Gaussian functions */
+        GaussianExpansionFunction, /* Fit difference functions using Gaussian functions */
         nExpansionFunctionTypes
     };
     // Return enum option info for ExpansionFunctionType

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -5,6 +5,7 @@
 
 #include "base/enumoptions.h"
 #include "classes/data1dstore.h"
+#include "classes/scatteringmatrix.h"
 #include "math/data1d.h"
 #include "module/groups.h"
 #include "module/module.h"
@@ -42,6 +43,8 @@ class EPSRModule : public Module
     EPSRModule::ExpansionFunctionType expansionFunction_{EPSRModule::PoissonExpansionFunction};
     // Confidence factor
     double feedback_{0.9};
+    // Scattering matrix
+    ScatteringMatrix scatteringMatrix_;
     // EPSR 'inpa' file from which to read deltaFQ fit coefficients from
     std::string inpaFilename_;
     // Maximum Q value over which to generate potentials from total scattering data

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -529,6 +529,10 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             return EarlyReturn<bool>::Continue;
         });
 
+    // If the scattering matrix was not set-up, need to generate the necessary inverse matrix or matrices here
+    if (!scatteringMatrixSetUp)
+        scatteringMatrix_.generateMatrices();
+
     scatteringMatrix_.print();
 
     if (Messenger::isVerbose())


### PR DESCRIPTION
This PR addresses #1270 which stems from the fact that, at present, scattering matrices from the functions `ScatteringMatrix::matrix(double)` and `ScatteringMatrix::inverse(double)` are generated on the fly each call, which quickly becomes a significant performance overhead for modestly-sized systems (in terms of atom types).

Here we change the behaviour of the `ScatteringMatrix` class to remove that bottleneck entirely, simply by precalculating and storing the matrices in the `ScatteringMatrix` object.  This information is generated on first use and then remains static.

Closes #1270.