### PR TITLE
Move to GitHub Actions

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -1,20 +1,6 @@
 trigger: none
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - "*"
-  paths:
-    exclude:
-    - examples/*
-    - scripts/*
-    - web/*
-    - README.md
-    - .azure-pipelines/continuous.yml
-    - .azure-pipelines/release.yml
-    - .azure-pipelines/web.yml
-    - .azure-pipelines/templates/build-web.yml
+pr: none
 
 stages:
   - template: templates/code-quality-checks.yml

--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -1,15 +1,18 @@
 name: Build
 
+inputs:
+  target:
+    default: "dissolve"
+
 runs:
   using: "composite"
   steps:
 
   - name: Build ??? (Linux)
     if: runner.os == 'Linux'
-    shell: bash
-    run: |
-      VERSION=$(grep "VERSION =" gudpy.spec | sed "s/.*\"\(.*\)\"/\1/g")
-      mv dist/GudPy-${VERSION} dist/GudPy-${VERSION}-Linux
+    uses: "./.github/workflows/build/linux"
+    with:
+      target: ${{ inputs.target }}
 
   - name: Build (OSX)
     if: runner.os == 'MacOS'

--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -1,0 +1,20 @@
+name: Build
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Build ??? (Linux)
+    if: runner.os == 'Linux'
+    shell: bash
+    run: |
+      VERSION=$(grep "VERSION =" gudpy.spec | sed "s/.*\"\(.*\)\"/\1/g")
+      mv dist/GudPy-${VERSION} dist/GudPy-${VERSION}-Linux
+
+  - name: Build (OSX)
+    if: runner.os == 'MacOS'
+    uses: "./.github/workflows/build/osx"
+
+  - name: Build (Windows)
+    if: runner.os == 'Windows'
+    uses: "./.github/workflows/build/windows"

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -42,8 +42,6 @@ runs:
       nix build --json .#${{ inputs.target }} > archive.json
 
   - name: "Push to Cachix"
-    env:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_TOKEN }}
     shell: bash
     run: |
       set -ex

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -1,0 +1,74 @@
+name: Build
+
+inputs:
+  extraCMakeFlags:
+    default: ""
+  target:
+    default: "dissolve"
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Install nix
+    uses: "./.github/workflows/get-nix"
+
+  - name: Install cachix
+    shell: bash
+    run: |
+      set -ex
+
+      source ~/.nix-profile/etc/profile.d/nix.sh
+
+      nix-channel --add https://nixos.org/channels/nixos-${{ env.nixOSVersion }} nixos
+      nix-channel --update
+
+      mkdir -p .config/cachix
+      nix-env -iA cachix -f https://cachix.org/api/v1/install
+      nix-env -iA nixos.jq
+
+  - name: Build
+    shell: bash
+    run: |
+      set -ex
+
+      source ~/.nix-profile/etc/profile.d/nix.sh
+
+      # Prep cachix
+      cachix use dissolve-nix
+
+      # Build
+      nix build -L .#${{ inputs.target }}
+      nix build --json .#${{ inputs.target }} > archive.json
+
+  - name: "Push to Cachix"
+    env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_TOKEN }}
+    shell: bash
+    run: |
+      set -ex
+
+      source ~/.nix-profile/etc/profile.d/nix.sh
+      cat archive.json | jq -r '.[].outputs | to_entries[].value' | cachix push dissolve-nix
+      nix-collect-garbage -d
+
+  - name: Bundle
+    shell: bash
+    run: |
+      set -ex
+
+      source ~/.nix-profile/etc/profile.d/nix.sh
+
+      nix bundle -L .#${{ inputs.target }} -o ${{ inputs.target }}
+      ls -R ${{ inputs.target }}
+
+      # Assemble artifacts
+      mkdir build
+      cp -v ${{ inputs.target }} build/${{ inputs.target }}-${{ env.dissolveVersion }}
+
+  - name: Upload Raw Build Artifacts
+    uses: actions/upload-artifact@v3
+    with:
+      name: linux-build-artifacts-${{ inputs.target }}
+      path: ${{ github.workspace }}/build
+      retention-days: 1

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -64,10 +64,17 @@ runs:
       conan install .. --build missing
       cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ inputs.extraCMakeFlags }} -DQT_BASE_DIR=$QT_BASE_DIR ../
       cmake --build . --config Release
+      cd ../
+
+      # Deploy Conan dependencies for ease
+      mkdir deploy && cd deploy
+      conan install .. -g deploy
 
   - name: Upload Raw Build Artifacts
     uses: actions/upload-artifact@v3
     with:
       name: osx-build-artifacts
-      path: ${{ github.workspace }}/build
+      path: |
+        ${{ github.workspace }}/build
+        ${{ github.workspace }}/deploy
       retention-days: 1

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -1,0 +1,73 @@
+name: Build
+
+inputs:
+  threading:
+    default: true
+  extraCMakeFlags:
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Setup Python
+    uses: actions/setup-python@v4
+    with:
+      python-version: ${{ env.pythonVersion }}
+
+  - name: Install Homebrew Dependencies
+    shell: bash
+    run: |
+      set -ex
+      brew update-reset
+      brew install ftgl ninja
+
+  - name: Acquire ANTLR Java
+    shell: bash
+    run: |
+      set -ex
+      curl https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr-4.9.3-complete.jar  --output antlr.jar
+
+  - name: Install Python Dependencies
+    shell: bash
+    run: |
+      pip3 install --user aqtinstall conan
+
+  - name: Retrieve Qt Cache
+    id: cache-qt
+    uses: actions/cache@v3
+    with:
+      key: osx-qt-${{ env.qtVersion }}
+      path: ${{ runner.temp }}/qt
+
+  - name: Install Qt
+    if: ${{ steps.cache-qt.outputs.cache-hit != 'true' }}
+    shell: bash
+    run: |
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
+      aqt install-qt --outputdir ${{ runner.temp }}/qt mac desktop ${{ env.qtVersion }}
+
+  - name: Build
+    shell: bash
+    run: |
+      set -ex
+
+      # Setup paths
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
+      Qt6_DIR=${{ runner.temp }}/qt/${{ env.qtVersion }}/macos/lib/cmake/Qt6
+      QT_BASE_DIR=${{ runner.temp }}/qt/${{ env.qtVersion }}/macos
+      ANTLR_EXE=`pwd`/antlr.jar
+      echo "Detected ANTLR exe as [$ANTLR_EXE]"
+
+      # Build
+      mkdir build && cd build
+      conan install .. --build missing
+      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DANTLR_EXECUTABLE:string=$ANTLR_EXE ${{ inputs.extraCMakeFlags }} -DQT_BASE_DIR=$QT_BASE_DIR ../
+      cmake --build . --config Release
+
+  - name: Upload Raw Build Artifacts
+    uses: actions/upload-artifact@v3
+    with:
+      name: osx-build-artifacts
+      path: ${{ github.workspace }}/build
+      retention-days: 1

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -114,7 +114,8 @@ runs:
     run: |
       set -ex
       mkdir ftgl-build && cd ftgl-build
-      FREETYPE_DIR="${{ runner.temp }}/freetype-install"
+      INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
+      LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
       cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
       cmake --build . --target install --config Release
 

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -1,0 +1,173 @@
+name: Build
+
+inputs:
+  threading:
+    default: true
+  extraCMakeFlags:
+    default: ""
+  freeTypeArchive:
+    default: https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.gz
+  ftglRepo:
+    default: https://github.com/frankheckenbach/ftgl.git
+
+runs:
+  using: "composite"
+  steps:
+
+  #
+  # Setup / Install Dependencies
+  #
+
+  - name: Setup Python
+    uses: actions/setup-python@v4
+    with:
+      python-version: ${{ env.pythonVersion }}
+
+  - name: Install Chocolatey Dependencies
+    shell: bash
+    run: choco install -y antlr4 ninja wget
+
+  - name: Install Python Dependencies
+    shell: bash
+    run: pip3 install --user aqtinstall conan
+
+  #
+  # Retrieve Qt cache (or install it)
+  #
+
+  - name: Retrieve Qt Cache
+    id: cache-qt
+    uses: actions/cache@v3
+    with:
+      key: windows-qt-${{ env.qtVersion }}
+      path: ${{ runner.temp }}\qt
+
+  - name: Install Qt
+    if: ${{ steps.cache-qt.outputs.cache-hit != 'true' }}
+    shell: bash
+    run: |
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
+      aqt install-qt --outputdir ${RUNNER_TEMP}/qt windows desktop ${{ env.qtVersion }} win64_msvc2019_64
+
+  - name: Setup MSVC Compiler
+    uses: ilammy/msvc-dev-cmd@v1
+
+  #
+  # Build / Retrieve Freetype
+  #
+
+  - name: Retrieve FreeType Cache
+    id: cache-freetype
+    uses: actions/cache@v3
+    with:
+      key: windows-freetype
+      path: |
+        ${{ runner.temp }}\freetype-latest
+        ${{ runner.temp }}\freetype-install
+
+  - name: Download FreeType
+    if: ${{ steps.cache-freetype.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      wget ${{ inputs.freeTypeArchive }} -Ofreetype.tgz
+      tar -zxvf freetype.tgz
+      rm freetype.tgz
+      mv freetype-* freetype-latest
+
+  - name: Build FreeType
+    if: ${{ steps.cache-freetype.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      mkdir freetype-build && cd freetype-build
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install
+      cmake --build . --target install --config Release
+
+  #
+  # Build / Retrieve FTGL
+  #
+
+  - name: Retrieve FTGL Cache
+    id: cache-ftgl
+    uses: actions/cache@v3
+    with:
+      key: windows-ftgl
+      path: |
+        ${{ runner.temp }}\ftgl-latest
+        ${{ runner.temp }}\ftgl-install
+
+  - name: Download FTGL
+    if: ${{ steps.cache-ftgl.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      git clone ${{ inputs.ftglRepo }} ftgl-latest
+
+  - name: Build FTGL
+    if: ${{ steps.cache-ftgl.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      mkdir ftgl-build && cd ftgl-build
+      FREETYPE_DIR="${{ runner.temp }}/freetype-install"
+      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
+      cmake --build . --target install --config Release
+
+  #
+  # Main Build
+  #
+
+  - name: Retrieve Conan Cache
+    id: cache-conan
+    uses: actions/cache@v3
+    with:
+      key: windows-conan
+      path: |
+        ~\.conan
+        ~\.conancache
+
+  - name: Install Conan Dependencies
+    if: ${{ steps.cache-conan.outputs.cache-hit != 'true' }}
+    shell: bash
+    run: |
+      conan profile new default --detect
+      conan profile update settings.compiler="Visual Studio" default
+      conan profile update settings.compiler.version=17 default
+
+  - name: Build
+    shell: bash
+    run: |
+      # Setup environment
+      Qt6_DIR="${RUNNER_TEMP}\qt\${{ env.qtVersion }}\msvc2019_64"
+      export PATH="${Qt6_DIR}\bin;$PATH"
+      INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
+      LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
+      INCLUDE="${RUNNER_TEMP}\ftgl-latest\src;$INCLUDE"
+      LIB="${RUNNER_TEMP}\ftgl-install\lib;$LIB"
+
+      # Build
+      mkdir build && cd build
+      conan config set storage.download_cache="${GITHUB_WORKSPACE}/.conancache"
+      conan install .. --build missing
+      cmake ../ -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DMULTI_THREADING:bool=${{ inputs.threading }} -DGUI:bool=true ${{ inputs.extraCMakeFlags }}
+      cmake --build . --config Release --target keywordwidgets
+      cmake --build . --config Release
+      cd ../
+
+      # Deploy Conan dependencies for ease
+      mkdir deploy && cd deploy
+      conan install .. -g deploy
+
+  - name: Upload Raw Build Artifacts
+    uses: actions/upload-artifact@v3
+    with:
+      name: windows-build-artifacts
+      path: |
+        ${{ github.workspace }}\build
+        ${{ github.workspace }}\deploy
+      retention-days: 1

--- a/.github/workflows/get-nix/action.yml
+++ b/.github/workflows/get-nix/action.yml
@@ -1,0 +1,29 @@
+name: Get Externals
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Install Dependencies
+    shell: bash
+    run: |
+      set -ex
+
+      sudo apt-get update -q
+      sudo apt-get install curl gpg
+      
+  - name: Retrieve nix
+    shell: bash
+    run: |
+      curl -o install-nix${{ env.nixVersion }} https://releases.nixos.org/nix/nix-${{ env.nixVersion }}/install
+      curl -o install-nix${{ env.nixVersion }}.asc https://releases.nixos.org/nix/nix-${{ env.nixVersion }}/install.asc
+      gpg2 --keyserver hkps://keyserver.ubuntu.com --recv-keys B541D55301270E0BCF15CA5D8170B4726D7198DE
+      gpg2 --verify ./install-nix${{ env.nixVersion }}.asc
+      
+  - name: Install / Setup nix
+    shell: bash
+    run: |
+      sh ./install-nix${{ env.nixVersion }}
+      mkdir -p ~/.config/nix/
+      echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+      echo "system-features = kvm" >> ~/.config/nix/nix.conf

--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -1,0 +1,13 @@
+name: Get Code Version
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Grep Version
+    shell: bash
+    run: |
+      set -ex
+      DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed 's/.*\"\(.*\)\"/\1/g'`
+      echo "Dissolve code version is ${DISSOLVE_VERSION}"
+      echo "dissolveVersion=${DISSOLVE_VERSION}" >> ${GITHUB_ENV}

--- a/.github/workflows/package/action.yml
+++ b/.github/workflows/package/action.yml
@@ -1,0 +1,20 @@
+name: Package
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Package ??? (Linux)
+    if: runner.os == 'Linux'
+    shell: bash
+    run: |
+      VERSION=$(grep "VERSION =" gudpy.spec | sed "s/.*\"\(.*\)\"/\1/g")
+      mv dist/GudPy-${VERSION} dist/GudPy-${VERSION}-Linux
+
+  - name: Package (OSX)
+    if: runner.os == 'MacOS'
+    uses: "./.github/workflows/package/osx"
+
+  - name: Package (Windows)
+    if: runner.os == 'Windows'
+    uses: "./.github/workflows/package/windows"

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -1,0 +1,73 @@
+name: Package
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Setup Python
+    uses: actions/setup-python@v4
+    with:
+      python-version: ${{ env.pythonVersion }}
+
+  - name: Retrieve Qt Cache
+    uses: actions/cache@v3
+    with:
+      key: osx-qt-${{ env.qtVersion }}
+      path: ${{ runner.temp }}/qt
+
+  - name: Download Raw Build Artifacts
+    uses: actions/download-artifact@v3
+    with:
+      name: osx-build-artifacts
+      path: ${{ github.workspace }}
+
+  - name: Install Python Dependencies
+    shell: bash
+    run: |
+      pip3 install --user dmgbuild biplist
+
+  - name: Install Custom Dependencies
+    shell: bash
+    run: |
+      set -ex
+      wget https://raw.githubusercontent.com/disorderedmaterials/scripts/master/prep-dmg
+      chmod u+x ./prep-dmg
+
+  - name: Prepare DMG Dirs
+    shell: bash
+    run: |
+      set -ex
+      Qt6_ROOT=${{ runner.temp }}/qt/${{ env.qtVersion }}/macos/
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
+
+      # Handle ANTLR
+      cp ./deploy/antlr4-cppruntime/lib/*.dylib /usr/local/lib/
+      cp ./deploy/tbb/lib/*.dylib /usr/local/lib/
+
+      install_name_tool -add_rpath "@executable_path/../Frameworks/" build/bin/dissolve-gui.app/Contents/MacOS/dissolve-gui
+      install_name_tool -add_rpath "/usr/local/lib" build/bin/dissolve-gui.app/Contents/MacOS/dissolve-gui
+
+      ./prep-dmg -a Dissolve-GUI -v ${{ env.dissolveVersion }} -b build/bin/dissolve-gui.app/Contents/MacOS/dissolve-gui -d ${Qt6_ROOT} -i icon/icon-1024x1024.png -p build/bin/dissolve-gui.app/Contents/Info.plist -L /usr/local/lib
+
+  - name: Create Disk Image
+    shell: bash
+    run: |
+      set -ex
+      export PATH="$(python3 -m site --user-base)/bin:$PATH"
+
+      # Fix icon link
+      sed -i -e "s/Dissolve.icns/Dissolve-GUI.icns/g" Dissolve-GUI-${dissolveVersion}/Dissolve-GUI.app/Contents/Info.plist
+
+      # Create DMG
+      dmgbuild -s ci/osx/dmgbuild-settings.py -D app=./Dissolve-GUI-${dissolveVersion}/Dissolve-GUI.app -D icon=./Dissolve-GUI-${dissolveVersion}/Dissolve-GUI.app/Contents/Resources/Dissolve-GUI.icns "Dissolve GUI" Dissolve-GUI-${dissolveVersion}.dmg
+
+      # Collect artifacts
+      mkdir packages
+      mv Dissolve-GUI-${dissolveVersion}.dmg packages/
+
+  - name: Upload Package Artifacts
+    uses: actions/upload-artifact@v3
+    with:
+      name: osx-package-artifacts
+      path: |
+        ${{ github.workspace }}/packages

--- a/.github/workflows/package/windows/action.yml
+++ b/.github/workflows/package/windows/action.yml
@@ -14,6 +14,20 @@ runs:
       key: windows-qt-${{ env.qtVersion }}
       path: ${{ runner.temp }}\qt
 
+  - name: Retrieve FTGL Cache
+    id: cache-ftgl
+    uses: actions/cache@v3
+    with:
+      key: windows-ftgl
+      path: ${{ runner.temp }}\ftgl-install
+
+  - name: Retrieve FreeType Cache
+    id: cache-freetype
+    uses: actions/cache@v3
+    with:
+      key: windows-freetype
+      path: ${{ runner.temp }}\freetype-install
+
   - name: Download Raw Build Artifacts
     uses: actions/download-artifact@v3
     with:

--- a/.github/workflows/package/windows/action.yml
+++ b/.github/workflows/package/windows/action.yml
@@ -1,0 +1,67 @@
+name: Package
+
+runs:
+  using: "composite"
+  steps:
+
+  #
+  # Setup / Install Dependencies
+  #
+
+  - name: Retrieve Qt Cache
+    uses: actions/cache@v3
+    with:
+      key: windows-qt-${{ env.qtVersion }}
+      path: ${{ runner.temp }}\qt
+
+  - name: Download Raw Build Artifacts
+    uses: actions/download-artifact@v3
+    with:
+      name: windows-build-artifacts
+      path: ${{ github.workspace }}
+
+  - name: Install Chocolatey Dependencies
+    shell: bash
+    run: choco install -y zip innoextract
+
+  #
+  # Create Packages
+  #
+
+  - name: Create Installers
+    shell: bash
+    run: |
+      set -ex
+
+      # Setup environment
+      export Qt6_DIR="${RUNNER_TEMP}\qt\${{ env.qtVersion }}\msvc2019_64"
+      export PATH="${Qt6_DIR}\bin;$PATH"
+      export FREETYPE_DIR="${RUNNER_TEMP}\freetype-install\bin"
+      export FTGL_DIR="${RUNNER_TEMP}\ftgl-install\bin"
+      export DISSOLVE_DIR="${GITHUB_WORKSPACE}\build\bin"
+      export DEPLOY_DIR="${GITHUB_WORKSPACE}\deploy"
+
+      # Run Inno Setup Compiler
+      iscc.exe -O./ ./ci/windows/dissolve-gui.iss
+      exe=${ls *.exe}
+      exeBase=${basename $exe}
+      echo "Executable installer is $exe, basename is $exeBase"
+      
+      # Create Zip from Exe
+      innoextract.exe $exe -d $exeBase
+      mv "$exeBase/app/bin/*" $exeBase
+      mv "$exeBase/app" ./
+      zipFile="${exeBaseName}.zip"
+      zip -r $zipFile $exeBase
+      
+      # Collect artifacts
+      mkdir packages
+      mv $zipFile packages
+      mv $exe packages
+
+  - name: Upload Package Artifacts
+    uses: actions/upload-artifact@v3
+    with:
+      name: windows-package-artifacts
+      path: |
+        ${{ github.workspace }}\packages

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   pythonVersion: 3.9
+  qtVersion: 6.2.2
 
 jobs:
 
@@ -28,6 +29,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Acquire Code Version
+        shell: bash
+        run: |
+          DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed 's/.*\"\(.*\)\"/\1/g'`
+          echo "Dissolve code version is ${DISSOLVE_VERSION}"
+          echo "DISSOLVE_VERSION=${DISSOLVE_VERSION}" >> ${GITHUB_ENV}
       - name: "Build (${{ matrix.os }})"
         uses: "./.github/workflows/build"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,11 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Acquire Code Version
-        shell: bash
-        run: |
-          DISSOLVE_VERSION=`grep "#define DISSOLVEVERSION" src/main/version.cpp | sed 's/.*\"\(.*\)\"/\1/g'`
-          echo "Dissolve code version is ${DISSOLVE_VERSION}"
-          echo "DISSOLVE_VERSION=${DISSOLVE_VERSION}" >> ${GITHUB_ENV}
+        uses: "./.github/workflows/get-version"
       - name: "Build (${{ matrix.os }})"
         uses: "./.github/workflows/build"
 
@@ -61,5 +57,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
       - name: "Package (${{ matrix.os }})"
         uses: "./.github/workflows/package"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,58 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches:
+    - '*'
+
+env:
+  pythonVersion: 3.9
+
+jobs:
+
+  QC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Quality Control
+      uses: "./.github/workflows/qc"
+
+  Build:
+    needs: QC
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: "Build (${{ matrix.os }})"
+        uses: "./.github/workflows/build"
+
+  Test:
+    needs: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: "Test (${{ matrix.os }})"
+      uses: "./.github/workflows/test"
+
+  Package:
+    needs: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: "Package (${{ matrix.os }})"
+        uses: "./.github/workflows/package"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Acquire Code Version
         uses: "./.github/workflows/get-version"
+      - name: Set Short Hash
+        uses: "./.github/workflows/set-short-hash"
       - name: "Build (${{ matrix.os }})"
         uses: "./.github/workflows/build"
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,8 @@ jobs:
         uses: "./.github/workflows/get-version"
       - name: "Build (${{ matrix.os }})"
         uses: "./.github/workflows/build"
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_TOKEN }}
         with:
           target: ${{ matrix.target }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ on:
 env:
   pythonVersion: 3.9
   qtVersion: 6.2.2
+  nixVersion: 2.4
+  nixOSVersion: 21.11
 
 jobs:
 
@@ -24,28 +26,38 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        target: [dissolve-gui]
+        include:
+          - os: ubuntu-latest
+            target: dissolve
+          - os: ubuntu-latest
+            target: dissolve-threadless
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Acquire Code Version
         uses: "./.github/workflows/get-version"
       - name: "Build (${{ matrix.os }})"
         uses: "./.github/workflows/build"
+        with:
+          target: ${{ matrix.target }}
 
   Test:
     needs: Build
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        target: [ dissolve, dissolve-threadless ]
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    - name: "Test (${{ matrix.os }})"
+      uses: actions/checkout@v3
+    - name: "Test (${{ matrix.target }})"
       uses: "./.github/workflows/test"
+      with:
+        target: ${{ matrix.target }}
 
   Package:
     needs: Test
@@ -56,7 +68,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Acquire Code Version
         uses: "./.github/workflows/get-version"
       - name: "Package (${{ matrix.os }})"

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Quality Control
 
 runs:
   using: "composite"

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -1,0 +1,46 @@
+name: Lint
+
+runs:
+  using: "composite"
+  steps:
+  - name: Setup Python
+    uses: actions/setup-python@v4
+    with:
+      python-version: ${{ env.pythonVersion }}
+
+  - name: Install Dependencies
+    shell: bash
+    run: |
+      set -ex
+      sudo apt-get update
+      sudo apt-get install --yes clang-format-13
+      pip install cmake_format==0.6.9
+
+  - name: C++ Formatting
+    shell: bash
+    run: |
+      set -ex
+      clang-format-13 --version
+      find . -type f -regex '.*\.\(c\|cpp\|h\|hpp\|hui\)' -exec clang-format-13 -i {} +
+      git diff
+      git diff --quiet
+
+  - name: CMake Formatting
+    shell: bash
+    run: |
+      set -ex
+      cmake-format --version
+      find . -type f -name CMakeLists.txt -exec cmake-format -i '{}' \;
+      git diff
+      git diff --quiet
+
+  - name: Copyright Year
+    shell: bash
+    run: |
+      set -ex
+      # Find all occurances of "YYYY Team Dissolve and contributors" and replace YYYY with the current year
+      find . -type f -not -path '.git/*' -exec sed -ri "s/[0-9]{4} (Team Dissolve and contributors)/$(date +%Y) \1/g" {} +
+      # Show the diff to give an indication of the issues in the CI log
+      git diff
+      # Run quiet diff to fail the job if any changes were made (see man git-diff)
+      git diff --quiet

--- a/.github/workflows/set-short-hash/action.yml
+++ b/.github/workflows/set-short-hash/action.yml
@@ -9,6 +9,6 @@ runs:
     run: |
       set -ex
       SHORT_HASH=$(git rev-parse --short HEAD)
-      echo "Current short hash is ${shortHash}"
-      sed -i "s/DISSOLVESHORTHASH \".*\"/DISSOLVESHORTHASH \"${shortHash}\"/g" src/main/version.cpp
+      echo "Current short hash is ${SHORT_HASH}"
+      sed -i "s/DISSOLVESHORTHASH \".*\"/DISSOLVESHORTHASH \"${SHORT_HASH}\"/g" src/main/version.cpp
       cat src/main/version.cpp

--- a/.github/workflows/set-short-hash/action.yml
+++ b/.github/workflows/set-short-hash/action.yml
@@ -1,0 +1,14 @@
+name: Set Short Hash
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Set Short Hash
+    shell: bash
+    run: |
+      set -ex
+      SHORT_HASH=$(git rev-parse --short HEAD)
+      echo "Current short hash is ${shortHash}"
+      sed -i "s/DISSOLVESHORTHASH \".*\"/DISSOLVESHORTHASH \"${shortHash}\"/g" src/main/version.cpp
+      cat src/main/version.cpp

--- a/.github/workflows/set-short-hash/action.yml
+++ b/.github/workflows/set-short-hash/action.yml
@@ -10,5 +10,5 @@ runs:
       set -ex
       SHORT_HASH=$(git rev-parse --short HEAD)
       echo "Current short hash is ${SHORT_HASH}"
-      sed -i "s/DISSOLVESHORTHASH \".*\"/DISSOLVESHORTHASH \"${SHORT_HASH}\"/g" src/main/version.cpp
+      sed -i -e "s/DISSOLVESHORTHASH \".*\"/DISSOLVESHORTHASH \"${SHORT_HASH}\"/g" src/main/version.cpp
       cat src/main/version.cpp

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -1,0 +1,40 @@
+name: Test
+
+inputs:
+  target:
+    default: "dissolve"
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Install nix
+    uses: "./.github/workflows/get-nix"
+
+  - name: Install cachix
+    shell: bash
+    run: |
+      set -ex
+
+      source ~/.nix-profile/etc/profile.d/nix.sh
+
+      nix-channel --add https://nixos.org/channels/nixos-${{ env.nixOSVersion }} nixos
+      nix-channel --update
+
+      mkdir -p .config/cachix
+      nix-env -iA cachix -f https://cachix.org/api/v1/install
+      nix-env -iA nixos.jq
+
+  - name: Test
+    shell: bash
+    run: |
+      set -ex
+
+      source ~/.nix-profile/etc/profile.d/nix.sh
+
+      # Prep cachix
+      cachix use dissolve-nix
+
+      # Build
+      nix build -L .#checks.x86_64-linux.${{ inputs.target }}
+      nix build --json .#checks.x86_64-linux.${{ inputs.target }} > archive.json


### PR DESCRIPTION
This PR moves us from Azure to GitHub Actions, primarily for reasons of collaboration - Dissolve is a community project with an increasing number of external (to STFC) collaborators, but it is not possible to add external collaborators to Azure projects.

Moving to GitHub actions now provides:
- A clear separation between build, test, and package steps
- Improved performance via extensive use of caching in Windows and Mac builds
- A far more integrated experience, and the ability for any collaborator to access the pipeline information and artifacts

### ToDo
- [x] Mac build / package (complete)
- [x] Windows build / package (complete)
- [x] Linux compilation via nix
- [x] Set short hash

### Next Steps
- [x] Update cachix token secret (@rprospero)
- [x] Cleanly separate Linux build / testing / packaging (store binary artifacts and pass through?)  (@rprospero)
- [x] (Related) Don't build Linux test artifacts in Debug mode and just use release?  (@rprospero)
- [x] Linux packaging

### Moved to #1295
- [ ] ~Release automation~
- [ ] ~Introduce Release pipeline~
- [ ] ~Introduce Continuous pipeline~
- [ ] ~Automate opening of PR following push to version update branch (`automation/release-version-X.X.X`)~
- [ ] ~Reimplement `ci/scripts/list-releases` as an action to be run as part of `release` CI? Note incorrect use of `${CURRENT_VERSION}` in that script in `release/0.9.12` branch - should be `${CURRENT_RELEASE}`.~