### PR TITLE
MD Step Reporting

### DIFF
--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -368,10 +368,11 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (capForces_)
         Messenger::print("A total of {} forces were capped over the course of the dynamics ({:9.3e} per step).\n", nCapped,
                          double(nCapped) / nSteps_);
-    Messenger::print("{} steps performed ({} work, {} comms)\n", step, timer.totalTimeString(), commsTimer.totalTimeString());
+    Messenger::print("{} steps performed ({} work, {} comms)\n", step-1, timer.totalTimeString(), commsTimer.totalTimeString());
 
     // Increment configuration changeCount
-    targetConfiguration_->incrementContentsVersion();
+    if (step > 1)
+        targetConfiguration_->incrementContentsVersion();
 
     /*
      * Calculation End

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -368,7 +368,8 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (capForces_)
         Messenger::print("A total of {} forces were capped over the course of the dynamics ({:9.3e} per step).\n", nCapped,
                          double(nCapped) / nSteps_);
-    Messenger::print("{} steps performed ({} work, {} comms)\n", step-1, timer.totalTimeString(), commsTimer.totalTimeString());
+    Messenger::print("{} steps performed ({} work, {} comms)\n", step - 1, timer.totalTimeString(),
+                     commsTimer.totalTimeString());
 
     // Increment configuration changeCount
     if (step > 1)


### PR DESCRIPTION
Tiny PR (good for a Friday) fixing the reporting of the number of MD timesteps actually performed, and also refusing to bump the configuration contents version if no steps were performed).