### PR TITLE
Update LLVM Repo

### DIFF
--- a/.azure-pipelines/templates/code-quality-checks.yml
+++ b/.azure-pipelines/templates/code-quality-checks.yml
@@ -13,12 +13,12 @@ stages:
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
               sudo add-apt-repository --yes 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
               sudo apt-get update
-              sudo apt-get install --yes clang-format-7
+              sudo apt-get install --yes clang-format-14
             displayName: 'Install tooling'
           - bash: |
               set -ex
-              clang-format-7 --version
-              find . -type f -regex '.*\.\(c\|cpp\|h\|hpp\|hui\)' -exec clang-format-7 -i {} +
+              clang-format-14 --version
+              find . -type f -regex '.*\.\(c\|cpp\|h\|hpp\|hui\)' -exec clang-format-14 -i {} +
               git diff
               git diff --quiet
             displayName: 'Run clang-format'

--- a/.azure-pipelines/templates/code-quality-checks.yml
+++ b/.azure-pipelines/templates/code-quality-checks.yml
@@ -11,7 +11,7 @@ stages:
           - bash: |
               set -ex
               wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-              sudo add-apt-repository --yes 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main'
+              sudo add-apt-repository --yes 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
               sudo apt-get update
               sudo apt-get install --yes clang-format-7
             displayName: 'Install tooling'

--- a/.azure-pipelines/templates/code-quality-checks.yml
+++ b/.azure-pipelines/templates/code-quality-checks.yml
@@ -10,15 +10,13 @@ stages:
         steps:
           - bash: |
               set -ex
-              wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-              sudo add-apt-repository --yes 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main'
               sudo apt-get update
-              sudo apt-get install --yes clang-format-14
+              sudo apt-get install --yes clang-format-13
             displayName: 'Install tooling'
           - bash: |
               set -ex
-              clang-format-14 --version
-              find . -type f -regex '.*\.\(c\|cpp\|h\|hpp\|hui\)' -exec clang-format-14 -i {} +
+              clang-format-13 --version
+              find . -type f -regex '.*\.\(c\|cpp\|h\|hpp\|hui\)' -exec clang-format-13 -i {} +
               git diff
               git diff --quiet
             displayName: 'Run clang-format'

--- a/src/base/enumoptions.h
+++ b/src/base/enumoptions.h
@@ -97,9 +97,9 @@ template <class E> class EnumOptions : public EnumOptionsBase
     // Return whether specified option keyword is valid
     bool isValid(std::string_view keyword) const
     {
-        return std::find_if(options_.cbegin(), options_.cend(), [keyword](auto &option) {
-                   return DissolveSys::sameString(keyword, option.keyword());
-               }) != options_.end();
+        return std::find_if(options_.cbegin(), options_.cend(),
+                            [keyword](auto &option)
+                            { return DissolveSys::sameString(keyword, option.keyword()); }) != options_.end();
     }
 
     // Raise error, printing valid options
@@ -247,9 +247,9 @@ template <class E> class EnumOptions : public EnumOptionsBase
                     else
                         return Messenger::error(
                             "'{}' keyword '{}' requires {} {} {}, but {} {} provided.\n", name(), opt.keyword(),
-                            opt.minArgs().value() == opt.maxArgs().value()
-                                ? "exactly"
-                                : nArgsProvided < opt.minArgs().value() ? "at least" : "at most",
+                            opt.minArgs().value() == opt.maxArgs().value() ? "exactly"
+                            : nArgsProvided < opt.minArgs().value()        ? "at least"
+                                                                           : "at most",
                             nArgsProvided < opt.minArgs().value() ? opt.minArgs().value() : opt.maxArgs().value(),
                             opt.minArgs().value() == 1 ? "argument" : "arguments", nArgsProvided,
                             nArgsProvided == 1 ? "was" : "were");

--- a/src/base/sysfunc.cpp
+++ b/src/base/sysfunc.cpp
@@ -227,7 +227,8 @@ std::string DissolveSys::niceName(std::string_view original)
 {
     std::string s{original};
 
-    std::replace_if(s.begin(), s.end(), [](auto &c) { return " /\\#*$"sv.find(c) != std::string::npos; }, '_');
+    std::replace_if(
+        s.begin(), s.end(), [](auto &c) { return " /\\#*$"sv.find(c) != std::string::npos; }, '_');
 
     return s;
 }
@@ -349,9 +350,9 @@ std::vector<double> DissolveSys::splitStringToDoubles(std::string_view str, std:
 // Double any of the supplied characters in the string
 std::string DissolveSys::doubleChars(const std::string_view s, const std::string_view charsToDouble)
 {
-    std::string result(s.length() +
-                           std::count_if(s.begin(), s.end(),
-                                         [charsToDouble](const char c) { return charsToDouble.find(c) != std::string::npos; }),
+    std::string result(s.length() + std::count_if(s.begin(), s.end(),
+                                                  [charsToDouble](const char c)
+                                                  { return charsToDouble.find(c) != std::string::npos; }),
                        ' ');
     auto pos = 0;
     for (auto c : s)

--- a/src/base/sysfunc.h
+++ b/src/base/sysfunc.h
@@ -79,9 +79,11 @@ class DissolveSys
 
         // Iterate until we find an unused name
         auto suffix = 0;
-        while (std::find_if(objects.begin(), objects.end(), [nameFunction, &uniqueName](const auto &object) {
-                   return !nameFunction(object).empty() && DissolveSys::sameString(nameFunction(object), uniqueName);
-               }) != objects.end())
+        while (std::find_if(objects.begin(), objects.end(),
+                            [nameFunction, &uniqueName](const auto &object) {
+                                return !nameFunction(object).empty() &&
+                                       DissolveSys::sameString(nameFunction(object), uniqueName);
+                            }) != objects.end())
             uniqueName = fmt::format("{}{:02d}", base, ++suffix);
 
         return uniqueName;

--- a/src/classes/atomtypemix.cpp
+++ b/src/classes/atomtypemix.cpp
@@ -144,9 +144,9 @@ bool AtomTypeMix::contains(const std::shared_ptr<AtomType> &atomType) const
 // Check for presence of AtomType/Isotope pair
 bool AtomTypeMix::contains(const std::shared_ptr<AtomType> &atomType, Sears91::Isotope tope) const
 {
-    return std::find_if(types_.begin(), types_.end(), [&atomType, tope](const auto &typeData) {
-               return typeData.atomType() == atomType && typeData.hasIsotope(tope);
-           }) != types_.end();
+    return std::find_if(types_.begin(), types_.end(),
+                        [&atomType, tope](const auto &typeData)
+                        { return typeData.atomType() == atomType && typeData.hasIsotope(tope); }) != types_.end();
 }
 
 // Return number of AtomType/Isotopes

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -56,9 +56,9 @@ bool Configuration::containsSpecies(const Species *sp)
 // Return the total charge of the Configuration
 double Configuration::totalCharge(bool ppIncludeCoulomb) const
 {
-    return std::accumulate(speciesPopulations_.begin(), speciesPopulations_.end(), 0.0, [&](const auto &acc, auto &spPop) {
-        return acc + spPop.first->totalCharge(ppIncludeCoulomb) * spPop.second;
-    });
+    return std::accumulate(speciesPopulations_.begin(), speciesPopulations_.end(), 0.0,
+                           [&](const auto &acc, auto &spPop)
+                           { return acc + spPop.first->totalCharge(ppIncludeCoulomb) * spPop.second; });
 }
 
 // Return the total atomic mass present in the Configuration
@@ -150,7 +150,8 @@ std::shared_ptr<Molecule> Configuration::copyMolecule(AtomChangeToken &lock, con
 void Configuration::removeMolecules(const Species *sp)
 {
     molecules_.erase(std::remove_if(molecules_.begin(), molecules_.end(),
-                                    [&, sp](auto &mol) {
+                                    [&, sp](auto &mol)
+                                    {
                                         if (mol->species() == sp)
                                         {
                                             for (auto &i : mol->atoms())
@@ -169,7 +170,8 @@ void Configuration::removeMolecules(const Species *sp)
 void Configuration::removeMolecules(const std::vector<std::shared_ptr<Molecule>> &molecules)
 {
     molecules_.erase(std::remove_if(molecules_.begin(), molecules_.end(),
-                                    [&, molecules](const auto &mol) {
+                                    [&, molecules](const auto &mol)
+                                    {
                                         if (std::find(molecules.begin(), molecules.end(), mol) != molecules.end())
                                         {
                                             for (auto &i : mol->atoms())

--- a/src/classes/coredata.cpp
+++ b/src/classes/coredata.cpp
@@ -337,9 +337,9 @@ Configuration *CoreData::addConfiguration()
     auto &newConfiguration = configurations_.emplace_back(std::make_unique<Configuration>());
 
     // Create a suitable unique name
-    newConfiguration->setName(DissolveSys::uniqueName("NewConfiguration", configurations_, [&](const auto &cfg) {
-        return newConfiguration == cfg ? std::string() : cfg->name();
-    }));
+    newConfiguration->setName(DissolveSys::uniqueName("NewConfiguration", configurations_,
+                                                      [&](const auto &cfg)
+                                                      { return newConfiguration == cfg ? std::string() : cfg->name(); }));
 
     return newConfiguration.get();
 }

--- a/src/classes/distributor.cpp
+++ b/src/classes/distributor.cpp
@@ -177,9 +177,9 @@ bool Distributor::canHardLock(int cellIndex) const
     auto *cell = cellArray_.cell(cellIndex);
 
     // For the specified Cell to be hard lockable its neighbours must not be HardLocked
-    if (std::find_if(cellArray_.neighbours(*cell).begin(), cellArray_.neighbours(*cell).end(), [&](const auto &nbr) {
-            return cellLocks_[nbr.neighbour_.index()] == HardLocked;
-        }) != cellArray_.neighbours(*cell).end())
+    if (std::find_if(cellArray_.neighbours(*cell).begin(), cellArray_.neighbours(*cell).end(),
+                     [&](const auto &nbr)
+                     { return cellLocks_[nbr.neighbour_.index()] == HardLocked; }) != cellArray_.neighbours(*cell).end())
         return false;
 
     return true;

--- a/src/classes/kvector.cpp
+++ b/src/classes/kvector.cpp
@@ -71,9 +71,10 @@ void KVector::calculateIntensities(std::vector<BraggReflection> &reflections)
     auto halfSphereNorm = (hkl_.x == 0 ? 1 : 2);
     auto &braggReflection = reflections[braggReflectionIndex_];
     braggReflection.addKVectors(halfSphereNorm);
-    dissolve::for_each_pair(ParallelPolicies::par, 0, cosTerms_.size(), [&](auto i, auto j) {
-        braggReflection.addIntensity(i, j, (cosTerms_[i] * cosTerms_[j] + sinTerms_[i] * sinTerms_[j]) * halfSphereNorm);
-    });
+    dissolve::for_each_pair(
+        ParallelPolicies::par, 0, cosTerms_.size(),
+        [&](auto i, auto j)
+        { braggReflection.addIntensity(i, j, (cosTerms_[i] * cosTerms_[j] + sinTerms_[i] * sinTerms_[j]) * halfSphereNorm); });
 }
 
 // Return specified intensity

--- a/src/classes/masters.cpp
+++ b/src/classes/masters.cpp
@@ -15,18 +15,18 @@ SerialisedValue CoreData::Masters::serialise() const
 
 void CoreData::Masters::deserialise(SerialisedValue &node)
 {
-    Serialisable::toMap(node, "bonds", [this](const std::string &name, SerialisedValue &bond) {
-        bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond);
-    });
-    Serialisable::toMap(node, "angles", [this](const std::string &name, SerialisedValue &angle) {
-        angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle);
-    });
-    Serialisable::toMap(node, "torsions", [this](const std::string &name, SerialisedValue &torsion) {
-        torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion);
-    });
-    Serialisable::toMap(node, "impropers", [this](const std::string &name, SerialisedValue &improper) {
-        impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper);
-    });
+    Serialisable::toMap(node, "bonds",
+                        [this](const std::string &name, SerialisedValue &bond)
+                        { bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond); });
+    Serialisable::toMap(node, "angles",
+                        [this](const std::string &name, SerialisedValue &angle)
+                        { angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle); });
+    Serialisable::toMap(node, "torsions",
+                        [this](const std::string &name, SerialisedValue &torsion)
+                        { torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion); });
+    Serialisable::toMap(node, "impropers",
+                        [this](const std::string &name, SerialisedValue &improper)
+                        { impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper); });
     return;
 }
 

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -127,10 +127,12 @@ void Molecule::traverseLocal(const Box *box, ConstManipulationFunction action) c
 Vec3<double> Molecule::unFold(const Box *box)
 {
     Vec3<double> cog{0.0, 0.0, 0.0};
-    traverseLocal(box, [&cog](Atom *j, Vec3<double> rJ) {
-        j->setCoordinates(rJ);
-        cog += rJ;
-    });
+    traverseLocal(box,
+                  [&cog](Atom *j, Vec3<double> rJ)
+                  {
+                      j->setCoordinates(rJ);
+                      cog += rJ;
+                  });
     return cog / nAtoms();
 }
 

--- a/src/classes/neutronweights.cpp
+++ b/src/classes/neutronweights.cpp
@@ -119,7 +119,8 @@ void NeutronWeights::calculateWeightingMatrices()
 
     // Determine atomic concentration products, bound coherent products, and full scattering weights
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_.begin(), atomTypes_.end(),
-                            [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2) {
+                            [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2)
+                            {
                                 ci = atd1.fraction();
                                 bi = atd1.boundCoherent() * 0.1;
 
@@ -160,7 +161,8 @@ void NeutronWeights::calculateWeightingMatrices()
         intraFlag = false;
         dissolve::for_each_pair(
             ParallelPolicies::seq, atomTypes_.begin(), atomTypes_.end(),
-            [&](int i_, const AtomTypeData &atd1, int j_, const AtomTypeData &atd2) {
+            [&](int i_, const AtomTypeData &atd1, int j_, const AtomTypeData &atd2)
+            {
                 // Find this AtomType in our local AtomTypeMix
                 int typeI = atomTypes_.indexOf(atd1.atomType());
                 if (typeI == -1)
@@ -226,7 +228,8 @@ void NeutronWeights::calculateWeightingMatrices()
 
     // Normalise the boundWeights_ array, and multiply by atomic concentrations and Kronecker delta
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_.begin(), atomTypes_.end(),
-                            [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2) {
+                            [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2)
+                            {
                                 // Skip this pair if there are no such intramolecular interactions
                                 if (!globalFlag[{typeI, typeJ}])
                                     return;

--- a/src/classes/partialset.cpp
+++ b/src/classes/partialset.cpp
@@ -60,7 +60,8 @@ bool PartialSet::setUpPartials(const AtomTypeMix &atomTypeMix)
     // Set up array matrices for partials
     dissolve::for_each_pair(
         ParallelPolicies::par, atomTypeMix_.begin(), atomTypeMix_.end(),
-        [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2) {
+        [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2)
+        {
             partials_[{n, m}].setTag(fmt::format("{}-{}//Full", at1.atomTypeName(), at2.atomTypeName()));
             boundPartials_[{n, m}].setTag(fmt::format("{}-{}//Bound", at1.atomTypeName(), at2.atomTypeName()));
             unboundPartials_[{n, m}].setTag(fmt::format("{}-{}//Unbound", at1.atomTypeName(), at2.atomTypeName()));
@@ -88,11 +89,13 @@ void PartialSet::setUpHistograms(double rdfRange, double binWidth)
     boundHistograms_.initialise(nTypes, nTypes, true);
     unboundHistograms_.initialise(nTypes, nTypes, true);
 
-    dissolve::for_each_pair(ParallelPolicies::par, 0, nTypes, [&](int i, int j) {
-        fullHistograms_[{i, j}].initialise(0.0, rdfRange, binWidth);
-        boundHistograms_[{i, j}].initialise(0.0, rdfRange, binWidth);
-        unboundHistograms_[{i, j}].initialise(0.0, rdfRange, binWidth);
-    });
+    dissolve::for_each_pair(ParallelPolicies::par, 0, nTypes,
+                            [&](int i, int j)
+                            {
+                                fullHistograms_[{i, j}].initialise(0.0, rdfRange, binWidth);
+                                boundHistograms_[{i, j}].initialise(0.0, rdfRange, binWidth);
+                                unboundHistograms_[{i, j}].initialise(0.0, rdfRange, binWidth);
+                            });
 }
 
 // Reset partial arrays
@@ -108,12 +111,15 @@ void PartialSet::reset()
         }
 
     // Zero partials
-    dissolve::for_each_pair(ParallelPolicies::par, 0, atomTypeMix_.nItems(), [&](int i, int j) {
-        std::fill(partials_[{i, j}].values().begin(), partials_[{i, j}].values().end(), 0.0);
-        std::fill(boundPartials_[{i, j}].values().begin(), boundPartials_[{i, j}].values().end(), 0.0);
-        std::fill(unboundPartials_[{i, j}].values().begin(), unboundPartials_[{i, j}].values().end(), 0.0);
-        emptyBoundPartials_[{i, j}] = true;
-    });
+    dissolve::for_each_pair(
+        ParallelPolicies::par, 0, atomTypeMix_.nItems(),
+        [&](int i, int j)
+        {
+            std::fill(partials_[{i, j}].values().begin(), partials_[{i, j}].values().end(), 0.0);
+            std::fill(boundPartials_[{i, j}].values().begin(), boundPartials_[{i, j}].values().end(), 0.0);
+            std::fill(unboundPartials_[{i, j}].values().begin(), unboundPartials_[{i, j}].values().end(), 0.0);
+            emptyBoundPartials_[{i, j}] = true;
+        });
 
     // Zero totals
     std::fill(total_.values().begin(), total_.values().end(), 0.0);
@@ -181,7 +187,8 @@ void PartialSet::formTotals(bool applyConcentrationWeights)
 
     dissolve::for_each_pair(
         ParallelPolicies::seq, atomTypeMix_.begin(), atomTypeMix_.end(),
-        [&](int typeI, const AtomTypeData &at1, int typeJ, const AtomTypeData &at2) {
+        [&](int typeI, const AtomTypeData &at1, int typeJ, const AtomTypeData &at2)
+        {
             // Set weighting factor if requested
             auto factor = applyConcentrationWeights ? at1.fraction() * at2.fraction() * (typeI == typeJ ? 1.0 : 2.0) : 1.0;
 
@@ -220,7 +227,8 @@ bool PartialSet::save(std::string_view prefix, std::string_view tag, std::string
 
     // Write partials
     for_each_pair_early(atomTypeMix_.begin(), atomTypeMix_.end(),
-                        [&](int typeI, const AtomTypeData &at1, int typeJ, const AtomTypeData &at2) -> EarlyReturn<bool> {
+                        [&](int typeI, const AtomTypeData &at1, int typeJ, const AtomTypeData &at2) -> EarlyReturn<bool>
+                        {
                             // Open file and check that we're OK to proceed writing to it
                             std::string filename{
                                 fmt::format("{}-{}-{}-{}.{}", prefix, tag, at1.atomTypeName(), at2.atomTypeName(), suffix)};
@@ -265,7 +273,8 @@ bool PartialSet::save(std::string_view prefix, std::string_view tag, std::string
 void PartialSet::adjust(double delta)
 {
     dissolve::for_each_pair(ParallelPolicies::par, atomTypeMix_.begin(), atomTypeMix_.end(),
-                            [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2) {
+                            [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2)
+                            {
                                 partials_[{n, m}] += delta;
                                 boundPartials_[{n, m}] += delta;
                                 unboundPartials_[{n, m}] += delta;
@@ -280,7 +289,8 @@ void PartialSet::adjust(double delta)
 void PartialSet::formPartials(double boxVolume)
 {
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypeMix_.begin(), atomTypeMix_.end(),
-                            [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2) {
+                            [&](int n, const AtomTypeData &at1, int m, const AtomTypeData &at2)
+                            {
                                 // Calculate RDFs from histogram data
                                 calculateRDF(partials_[{n, m}], fullHistograms_[{n, m}], boxVolume, at1.population(),
                                              at2.population(), &at1 == &at2 ? 2.0 : 1.0);
@@ -388,7 +398,8 @@ void PartialSet::operator+=(const PartialSet &source)
     const auto &types = source.atomTypeMix();
     dissolve::for_each_pair(
         ParallelPolicies::seq, types.begin(), types.end(),
-        [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2) {
+        [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2)
+        {
             const auto atI = atd1.atomType();
             const auto atJ = atd2.atomType();
             int localI = atomTypeMix_.indexOf(atI);
@@ -424,11 +435,13 @@ void PartialSet::operator-=(const double delta) { adjust(-delta); }
 
 void PartialSet::operator*=(const double factor)
 {
-    dissolve::for_each_pair(ParallelPolicies::par, 0, atomTypeMix_.nItems(), [&](auto n, auto m) {
-        partials_[{n, m}] *= factor;
-        boundPartials_[{n, m}] *= factor;
-        unboundPartials_[{n, m}] *= factor;
-    });
+    dissolve::for_each_pair(ParallelPolicies::par, 0, atomTypeMix_.nItems(),
+                            [&](auto n, auto m)
+                            {
+                                partials_[{n, m}] *= factor;
+                                boundPartials_[{n, m}] *= factor;
+                                unboundPartials_[{n, m}] *= factor;
+                            });
 
     total_ *= factor;
     boundTotal_ *= factor;
@@ -592,29 +605,32 @@ bool PartialSet::serialise(LineParser &parser) const
     auto nTypes = atomTypeMix_.nItems();
 
     // Write individual Data1D
-    auto success = for_each_pair_early(0, nTypes, [&](int typeI, int typeJ) -> EarlyReturn<bool> {
-        const auto &part = partials_[{typeI, typeJ}];
-        const auto &bound = boundPartials_[{typeI, typeJ}];
-        const auto &unbound = unboundPartials_[{typeI, typeJ}];
-
-        // Write tag
-        if (!parser.writeLineF("'{}' '{}' '{}'\n", part.tag(), bound.tag(), unbound.tag()))
-            return false;
-
-        // Write axis size and errors flag
-        if (!parser.writeLineF("{} {} {} {}\n", part.xAxis().size(), DissolveSys::btoa(part.valuesHaveErrors()),
-                               DissolveSys::btoa(bound.valuesHaveErrors()), DissolveSys::btoa(unbound.valuesHaveErrors())))
-            return false;
-
-        for (auto i = 0; i < part.xAxis().size(); ++i)
+    auto success = for_each_pair_early(
+        0, nTypes,
+        [&](int typeI, int typeJ) -> EarlyReturn<bool>
         {
-            if (!parser.writeLineF("{} {} {} {}\n", part.xAxis(i), writeDataPoint(i, part), writeDataPoint(i, bound),
-                                   writeDataPoint(i, unbound)))
-                return false;
-        }
+            const auto &part = partials_[{typeI, typeJ}];
+            const auto &bound = boundPartials_[{typeI, typeJ}];
+            const auto &unbound = unboundPartials_[{typeI, typeJ}];
 
-        return EarlyReturn<bool>::Continue;
-    });
+            // Write tag
+            if (!parser.writeLineF("'{}' '{}' '{}'\n", part.tag(), bound.tag(), unbound.tag()))
+                return false;
+
+            // Write axis size and errors flag
+            if (!parser.writeLineF("{} {} {} {}\n", part.xAxis().size(), DissolveSys::btoa(part.valuesHaveErrors()),
+                                   DissolveSys::btoa(bound.valuesHaveErrors()), DissolveSys::btoa(unbound.valuesHaveErrors())))
+                return false;
+
+            for (auto i = 0; i < part.xAxis().size(); ++i)
+            {
+                if (!parser.writeLineF("{} {} {} {}\n", part.xAxis(i), writeDataPoint(i, part), writeDataPoint(i, bound),
+                                       writeDataPoint(i, unbound)))
+                    return false;
+            }
+
+            return EarlyReturn<bool>::Continue;
+        });
 
     if (!success.value_or(true))
         return false;

--- a/src/classes/partialsetaccumulator.cpp
+++ b/src/classes/partialsetaccumulator.cpp
@@ -23,39 +23,43 @@ void PartialSetAccumulator::operator+=(const PartialSet &source)
         total_.clear();
 
         // Copy tags (for retrieval and sanity checking purposes)
-        dissolve::for_each_pair(ParallelPolicies::par, 0, n, [&](auto i, auto j) {
-            partials_[{i, j}].setTag(source.partial(i, j).tag());
-            boundPartials_[{i, j}].setTag(source.boundPartial(i, j).tag());
-            unboundPartials_[{i, j}].setTag(source.unboundPartial(i, j).tag());
-        });
+        dissolve::for_each_pair(ParallelPolicies::par, 0, n,
+                                [&](auto i, auto j)
+                                {
+                                    partials_[{i, j}].setTag(source.partial(i, j).tag());
+                                    boundPartials_[{i, j}].setTag(source.boundPartial(i, j).tag());
+                                    unboundPartials_[{i, j}].setTag(source.unboundPartial(i, j).tag());
+                                });
         total_.setTag(source.total().tag());
     }
 
     assert(n == partials_.nRows());
 
     // Accumulate the data, ensuring tags are identical - if not, we really don't want to be blindly accumulating
-    dissolve::for_each_pair(ParallelPolicies::par, 0, n, [&](auto i, auto j) {
-        // Full partials
-        if (partials_[{i, j}].tag() != source.partial(i, j).tag())
-            throw(std::runtime_error(
-                fmt::format("Can't accumulate PartialSet data as the data tags are mismatched ('{}' vs '{}').\n",
-                            partials_[{i, j}].tag(), source.partial(i, j).tag())));
-        partials_[{i, j}] += source.partial(i, j);
+    dissolve::for_each_pair(ParallelPolicies::par, 0, n,
+                            [&](auto i, auto j)
+                            {
+                                // Full partials
+                                if (partials_[{i, j}].tag() != source.partial(i, j).tag())
+                                    throw(std::runtime_error(fmt::format(
+                                        "Can't accumulate PartialSet data as the data tags are mismatched ('{}' vs '{}').\n",
+                                        partials_[{i, j}].tag(), source.partial(i, j).tag())));
+                                partials_[{i, j}] += source.partial(i, j);
 
-        // Bound partials
-        if (boundPartials_[{i, j}].tag() != source.boundPartial(i, j).tag())
-            throw(std::runtime_error(
-                fmt::format("Can't accumulate PartialSet data as the data tags are mismatched ('{}' vs '{}').\n",
-                            boundPartials_[{i, j}].tag(), source.boundPartial(i, j).tag())));
-        boundPartials_[{i, j}] += source.boundPartial(i, j);
+                                // Bound partials
+                                if (boundPartials_[{i, j}].tag() != source.boundPartial(i, j).tag())
+                                    throw(std::runtime_error(fmt::format(
+                                        "Can't accumulate PartialSet data as the data tags are mismatched ('{}' vs '{}').\n",
+                                        boundPartials_[{i, j}].tag(), source.boundPartial(i, j).tag())));
+                                boundPartials_[{i, j}] += source.boundPartial(i, j);
 
-        // Unbound partials
-        if (unboundPartials_[{i, j}].tag() != source.unboundPartial(i, j).tag())
-            throw(std::runtime_error(
-                fmt::format("Can't accumulate PartialSet data as the data tags are mismatched ('{}' vs '{}').\n",
-                            unboundPartials_[{i, j}].tag(), source.unboundPartial(i, j).tag())));
-        unboundPartials_[{i, j}] += source.unboundPartial(i, j);
-    });
+                                // Unbound partials
+                                if (unboundPartials_[{i, j}].tag() != source.unboundPartial(i, j).tag())
+                                    throw(std::runtime_error(fmt::format(
+                                        "Can't accumulate PartialSet data as the data tags are mismatched ('{}' vs '{}').\n",
+                                        unboundPartials_[{i, j}].tag(), source.unboundPartial(i, j).tag())));
+                                unboundPartials_[{i, j}] += source.unboundPartial(i, j);
+                            });
 
     total_ += source.total();
 

--- a/src/classes/sitestack.cpp
+++ b/src/classes/sitestack.cpp
@@ -23,9 +23,8 @@ Vec3<double> SiteStack::centreOfGeometry(const Molecule &mol, const Box *box, co
 {
     const auto ref = mol.atom(indices.front())->r();
     return std::accumulate(std::next(indices.begin()), indices.end(), ref,
-                           [&ref, &mol, box](const auto &acc, const auto idx) {
-                               return acc + box->minimumImage(mol.atom(idx)->r(), ref);
-                           }) /
+                           [&ref, &mol, box](const auto &acc, const auto idx)
+                           { return acc + box->minimumImage(mol.atom(idx)->r(), ref); }) /
            indices.size();
 }
 
@@ -35,7 +34,8 @@ Vec3<double> SiteStack::centreOfMass(const Molecule &mol, const Box *box, const 
     auto mass = AtomicMass::mass(mol.atom(indices.front())->speciesAtom()->Z());
     const auto ref = mol.atom(indices.front())->r();
     auto sums = std::accumulate(std::next(indices.begin()), indices.end(), std::pair<Vec3<double>, double>(ref * mass, mass),
-                                [&ref, &mol, box](const auto &acc, const auto idx) {
+                                [&ref, &mol, box](const auto &acc, const auto idx)
+                                {
                                     auto mass = AtomicMass::mass(mol.atom(idx)->speciesAtom()->Z());
                                     return std::pair<Vec3<double>, double>(
                                         acc.first + box->minimumImage(mol.atom(idx)->r(), ref) * mass, acc.second + mass);

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -229,33 +229,41 @@ void Species::deserialise(SerialisedValue &node, CoreData &coreData)
     for (auto &tomlAtom : tomlAtoms)
         atoms_.emplace_back().deserialise(tomlAtom);
 
-    Serialisable::toVector(node, "bonds", [this, &coreData](SerialisedValue &bond) {
-        bonds_.emplace_back(&atoms_[bond["i"].as_integer() - 1], &atoms_[bond["j"].as_integer() - 1])
-            .deserialise(bond, coreData);
-    });
-    Serialisable::toVector(node, "angles", [this, &coreData](SerialisedValue &angle) {
-        angles_
-            .emplace_back(&atoms_[angle["i"].as_integer() - 1], &atoms_[angle["j"].as_integer() - 1],
-                          &atoms_[angle["k"].as_integer() - 1])
-            .deserialise(angle, coreData);
-    });
-    Serialisable::toVector(node, "impropers", [this, &coreData](SerialisedValue &improper) {
-        impropers_
-            .emplace_back(&atoms_[improper["i"].as_integer() - 1], &atoms_[improper["j"].as_integer() - 1],
-                          &atoms_[improper["k"].as_integer() - 1], &atoms_[improper["l"].as_integer() - 1])
-            .deserialise(improper, coreData);
-    });
-    Serialisable::toVector(node, "torsions", [this, &coreData](SerialisedValue &torsion) {
-        torsions_
-            .emplace_back(&atoms_[torsion["i"].as_integer() - 1], &atoms_[torsion["j"].as_integer() - 1],
-                          &atoms_[torsion["k"].as_integer() - 1], &atoms_[torsion["l"].as_integer() - 1])
-            .deserialise(torsion, coreData);
-    });
+    Serialisable::toVector(node, "bonds",
+                           [this, &coreData](SerialisedValue &bond) {
+                               bonds_.emplace_back(&atoms_[bond["i"].as_integer() - 1], &atoms_[bond["j"].as_integer() - 1])
+                                   .deserialise(bond, coreData);
+                           });
+    Serialisable::toVector(node, "angles",
+                           [this, &coreData](SerialisedValue &angle)
+                           {
+                               angles_
+                                   .emplace_back(&atoms_[angle["i"].as_integer() - 1], &atoms_[angle["j"].as_integer() - 1],
+                                                 &atoms_[angle["k"].as_integer() - 1])
+                                   .deserialise(angle, coreData);
+                           });
+    Serialisable::toVector(node, "impropers",
+                           [this, &coreData](SerialisedValue &improper)
+                           {
+                               impropers_
+                                   .emplace_back(
+                                       &atoms_[improper["i"].as_integer() - 1], &atoms_[improper["j"].as_integer() - 1],
+                                       &atoms_[improper["k"].as_integer() - 1], &atoms_[improper["l"].as_integer() - 1])
+                                   .deserialise(improper, coreData);
+                           });
+    Serialisable::toVector(node, "torsions",
+                           [this, &coreData](SerialisedValue &torsion)
+                           {
+                               torsions_
+                                   .emplace_back(&atoms_[torsion["i"].as_integer() - 1], &atoms_[torsion["j"].as_integer() - 1],
+                                                 &atoms_[torsion["k"].as_integer() - 1], &atoms_[torsion["l"].as_integer() - 1])
+                                   .deserialise(torsion, coreData);
+                           });
 
-    Serialisable::toVector(node, "isotopologues", [this, &coreData](SerialisedValue &iso) {
-        isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData);
-    });
-    Serialisable::toVector(node, "sites", [this, &coreData](SerialisedValue &site) {
-        sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site);
-    });
+    Serialisable::toVector(node, "isotopologues",
+                           [this, &coreData](SerialisedValue &iso)
+                           { isotopologues_.emplace_back(std::make_unique<Isotopologue>())->deserialise(iso, coreData); });
+    Serialisable::toVector(node, "sites",
+                           [this, &coreData](SerialisedValue &site)
+                           { sites_.emplace_back(std::make_unique<SpeciesSite>(this))->deserialise(site); });
 }

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -55,15 +55,17 @@ void Species::removeAtom(int index)
     impropers_.clear();
 
     // Detach & remove any bond terms that involve 'i'
-    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [i](auto &bond) {
-        if (bond.i() == i || bond.j() == i)
-        {
-            bond.detach();
-            return true;
-        }
-        else
-            return false;
-    });
+    auto it = std::remove_if(bonds_.begin(), bonds_.end(),
+                             [i](auto &bond)
+                             {
+                                 if (bond.i() == i || bond.j() == i)
+                                 {
+                                     bond.detach();
+                                     return true;
+                                 }
+                                 else
+                                     return false;
+                             });
     if (it != bonds_.end())
         bonds_.erase(it, bonds_.end());
 
@@ -84,23 +86,27 @@ void Species::removeAtoms(std::vector<int> indices)
     impropers_.clear();
 
     // Detach & remove any bond terms that involve any of the supplied atom
-    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [&indices](auto &bond) {
-        if (std::find_if(indices.begin(), indices.end(),
-                         [&bond](const auto i) { return (bond.i()->index() == i || bond.j()->index() == i); }) != indices.end())
-        {
-            bond.detach();
-            return true;
-        }
-        else
-            return false;
-    });
+    auto it = std::remove_if(bonds_.begin(), bonds_.end(),
+                             [&indices](auto &bond)
+                             {
+                                 if (std::find_if(indices.begin(), indices.end(),
+                                                  [&bond](const auto i) {
+                                                      return (bond.i()->index() == i || bond.j()->index() == i);
+                                                  }) != indices.end())
+                                 {
+                                     bond.detach();
+                                     return true;
+                                 }
+                                 else
+                                     return false;
+                             });
     if (it != bonds_.end())
         bonds_.erase(it, bonds_.end());
 
     // Now remove the atoms
-    auto atomIt = std::remove_if(atoms_.begin(), atoms_.end(), [&](const auto &i) {
-        return std::find(indices.begin(), indices.end(), i.index()) != indices.end();
-    });
+    auto atomIt =
+        std::remove_if(atoms_.begin(), atoms_.end(),
+                       [&](const auto &i) { return std::find(indices.begin(), indices.end(), i.index()) != indices.end(); });
     atoms_.erase(atomIt, atoms_.end());
     renumberAtoms();
 
@@ -303,9 +309,9 @@ int Species::simplifyAtomTypes()
 double Species::totalCharge(bool useAtomTypes) const
 {
     if (useAtomTypes)
-        return std::accumulate(atoms_.begin(), atoms_.end(), 0.0, [](const auto acc, const auto &i) {
-            return acc + (i.atomType() ? i.atomType()->charge() : 0.0);
-        });
+        return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,
+                               [](const auto acc, const auto &i)
+                               { return acc + (i.atomType() ? i.atomType()->charge() : 0.0); });
     else
         return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,
                                [](const auto acc, const auto &i) { return acc + i.charge(); });

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -133,10 +133,13 @@ void Species::removePeriodicBonds()
     if (box_->type() == Box::BoxType::NonPeriodic)
         return;
 
-    auto it = std::remove_if(bonds_.begin(), bonds_.end(), [&](const auto &b) {
-        // Check the literal vs the minimum image distance between the involved atoms 'i' and 'j'
-        return fabs(box_->minimumDistance(b.i()->r(), b.j()->r()) - (b.j()->r() - b.i()->r()).magnitude()) > 1.0e-3;
-    });
+    auto it = std::remove_if(bonds_.begin(), bonds_.end(),
+                             [&](const auto &b)
+                             {
+                                 // Check the literal vs the minimum image distance between the involved atoms 'i' and 'j'
+                                 return fabs(box_->minimumDistance(b.i()->r(), b.j()->r()) -
+                                             (b.j()->r() - b.i()->r()).magnitude()) > 1.0e-3;
+                             });
     if (it != bonds_.end())
         bonds_.erase(it, bonds_.end());
 }
@@ -187,13 +190,13 @@ void Species::updateIntramolecularTerms()
             }
         }
     }
-    auto atomsContains = [this](const auto *x) {
-        return std::find_if(atoms_.begin(), atoms_.end(), [&x](const auto &p) { return &p == x; }) != atoms_.end();
-    };
+    auto atomsContains = [this](const auto *x)
+    { return std::find_if(atoms_.begin(), atoms_.end(), [&x](const auto &p) { return &p == x; }) != atoms_.end(); };
 
     // Check existing angle terms for any that are invalid
     angles_.erase(std::remove_if(angles_.begin(), angles_.end(),
-                                 [this, &atomsContains](const auto &angle) {
+                                 [this, &atomsContains](const auto &angle)
+                                 {
                                      return ((!atomsContains(angle.i())) || (!atomsContains(angle.j())) ||
                                              (!atomsContains(angle.k()))) ||
                                             ((!hasBond(angle.i(), angle.j())) || (!hasBond(angle.j(), angle.k())));
@@ -202,7 +205,8 @@ void Species::updateIntramolecularTerms()
 
     // Remove torsions with invalid atoms or bonds
     torsions_.erase(std::remove_if(torsions_.begin(), torsions_.end(),
-                                   [this, &atomsContains](const auto &torsion) {
+                                   [this, &atomsContains](const auto &torsion)
+                                   {
                                        return ((!atomsContains(torsion.i())) || (!atomsContains(torsion.j())) ||
                                                (!atomsContains(torsion.k())) || (!atomsContains(torsion.l()))) ||
                                               ((!hasBond(torsion.i(), torsion.j())) || (!hasBond(torsion.j(), torsion.k())) ||
@@ -212,7 +216,8 @@ void Species::updateIntramolecularTerms()
 
     // Remove impropers with invalid atoms or bonds
     impropers_.erase(std::remove_if(impropers_.begin(), impropers_.end(),
-                                    [this, &atomsContains](const auto &improper) {
+                                    [this, &atomsContains](const auto &improper)
+                                    {
                                         return ((!atomsContains(improper.i())) || (!atomsContains(improper.j())) ||
                                                 (!atomsContains(improper.k())) || (!atomsContains(improper.l()))) ||
                                                ((!hasBond(improper.i(), improper.j())) ||
@@ -632,9 +637,9 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
         // Construct a name for the master term based on the atom types
         std::vector<std::string_view> names = {bond.i()->atomType()->name(), bond.j()->atomType()->name()};
         std::sort(names.begin(), names.end());
-        generateMasterTerm<MasterBond>(bond, joinStrings(names, "-"),
-                                       [&coreData](std::string_view name) { return coreData.getMasterBond(name); },
-                                       [&coreData](auto name) -> MasterBond & { return coreData.addMasterBond(name); });
+        generateMasterTerm<MasterBond>(
+            bond, joinStrings(names, "-"), [&coreData](std::string_view name) { return coreData.getMasterBond(name); },
+            [&coreData](auto name) -> MasterBond & { return coreData.addMasterBond(name); });
     }
 
     // Angles
@@ -646,17 +651,19 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
 
         // Construct a name for the master term based on the atom types
         if (angle.i()->atomType()->name() < angle.k()->atomType()->name())
-            generateMasterTerm<MasterAngle>(angle,
-                                            fmt::format("{}-{}-{}", angle.i()->atomType()->name(),
-                                                        angle.j()->atomType()->name(), angle.k()->atomType()->name()),
-                                            [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
-                                            [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
+            generateMasterTerm<MasterAngle>(
+                angle,
+                fmt::format("{}-{}-{}", angle.i()->atomType()->name(), angle.j()->atomType()->name(),
+                            angle.k()->atomType()->name()),
+                [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
+                [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
         else
-            generateMasterTerm<MasterAngle>(angle,
-                                            fmt::format("{}-{}-{}", angle.k()->atomType()->name(),
-                                                        angle.j()->atomType()->name(), angle.i()->atomType()->name()),
-                                            [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
-                                            [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
+            generateMasterTerm<MasterAngle>(
+                angle,
+                fmt::format("{}-{}-{}", angle.k()->atomType()->name(), angle.j()->atomType()->name(),
+                            angle.i()->atomType()->name()),
+                [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
+                [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
     }
 
     // Torsions

--- a/src/classes/species_site.cpp
+++ b/src/classes/species_site.cpp
@@ -50,9 +50,9 @@ std::string Species::uniqueSiteName(std::string_view base, const SpeciesSite *ex
 // Search for SpeciesSite by name
 const SpeciesSite *Species::findSite(std::string_view name, const SpeciesSite *exclude) const
 {
-    auto it = std::find_if(sites_.begin(), sites_.end(), [name, exclude](const auto &site) {
-        return ((site.get() != exclude) && (DissolveSys::sameString(name, site->name())));
-    });
+    auto it = std::find_if(sites_.begin(), sites_.end(),
+                           [name, exclude](const auto &site)
+                           { return ((site.get() != exclude) && (DissolveSys::sameString(name, site->name()))); });
     if (it != sites_.end())
         return (*it).get();
 
@@ -60,9 +60,9 @@ const SpeciesSite *Species::findSite(std::string_view name, const SpeciesSite *e
 }
 SpeciesSite *Species::findSite(std::string_view name, const SpeciesSite *exclude)
 {
-    auto it = std::find_if(sites_.begin(), sites_.end(), [name, exclude](const auto &site) {
-        return ((site.get() != exclude) && (DissolveSys::sameString(name, site->name())));
-    });
+    auto it = std::find_if(sites_.begin(), sites_.end(),
+                           [name, exclude](const auto &site)
+                           { return ((site.get() != exclude) && (DissolveSys::sameString(name, site->name()))); });
     if (it != sites_.end())
         return (*it).get();
 

--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -135,7 +135,8 @@ void XRayWeights::setUpMatrices()
 
     // Determine atomic concentration products and full pre-factor
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypeMix_.begin(), atomTypeMix_.end(),
-                            [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2) {
+                            [&](int typeI, const AtomTypeData &atd1, int typeJ, const AtomTypeData &atd2)
+                            {
                                 double ci = atd1.fraction();
                                 concentrations_.at(typeI) = ci;
 

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -123,13 +123,15 @@ void Forcefield::addParameters(std::string_view name, const std::vector<double> 
 // Create NETA definitions for all atom types from stored defs
 bool Forcefield::createNETADefinitions()
 {
-    auto nFailed = std::count_if(atomTypes_.begin(), atomTypes_.end(), [this](auto &atomType) {
-        auto success = atomType.createNETA(this);
-        if (!success)
-            Messenger::print("Failed to parse NETA definition '{}' for atom type '{}'.", atomType.neta().definitionString(),
-                             atomType.name());
-        return !success;
-    });
+    auto nFailed = std::count_if(atomTypes_.begin(), atomTypes_.end(),
+                                 [this](auto &atomType)
+                                 {
+                                     auto success = atomType.createNETA(this);
+                                     if (!success)
+                                         Messenger::print("Failed to parse NETA definition '{}' for atom type '{}'.",
+                                                          atomType.neta().definitionString(), atomType.name());
+                                     return !success;
+                                 });
 
     if (nFailed > 0)
         Messenger::error("Failed to create {} NETA {} for the forcefield '{}'.\n", nFailed,

--- a/src/data/ff/ff.h
+++ b/src/data/ff/ff.h
@@ -195,7 +195,7 @@ class Forcefield
 };
 
 template <class T, typename... Args>
-OptionalReferenceWrapper<const T> Forcefield::termMatch_(const std::vector<T> &container, Args &&... args)
+OptionalReferenceWrapper<const T> Forcefield::termMatch_(const std::vector<T> &container, Args &&...args)
 {
     auto it = std::find_if(container.begin(), container.end(),
                            [&](const T &item) { return item.isMatch(std::forward<Args>(args)...); });

--- a/src/data/ff/library.cpp
+++ b/src/data/ff/library.cpp
@@ -99,9 +99,9 @@ std::vector<std::shared_ptr<Forcefield>> &ForcefieldLibrary::forcefields()
 // Return named Forcefield, if it exists
 std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(std::string_view name)
 {
-    auto it = std::find_if(forcefields().begin(), forcefields().end(), [&name](const std::shared_ptr<Forcefield> &ff) {
-        return DissolveSys::sameString(ff->name(), name);
-    });
+    auto it =
+        std::find_if(forcefields().begin(), forcefields().end(),
+                     [&name](const std::shared_ptr<Forcefield> &ff) { return DissolveSys::sameString(ff->name(), name); });
     if (it == forcefields().end())
         return nullptr;
 

--- a/src/data/formfactors_wk1995.cpp
+++ b/src/data/formfactors_wk1995.cpp
@@ -1132,9 +1132,9 @@ OptionalReferenceWrapper<const FormFactorData> wk1995Data(Elements::Element Z, i
                                                                {0.550447, 3.581973, 14.357388, 96.064972, 0.052450},
                                                                3.005326}};
 
-    auto it = std::find_if(wk1995.cbegin(), wk1995.cend(), [&](const FormFactorData_WK1995 &data) {
-        return data.Z() == Z && data.formalCharge() == formalCharge;
-    });
+    auto it =
+        std::find_if(wk1995.cbegin(), wk1995.cend(),
+                     [&](const FormFactorData_WK1995 &data) { return data.Z() == Z && data.formalCharge() == formalCharge; });
     if (it == wk1995.end())
         return {};
     return *it;

--- a/src/data/sginfo/sghkl.c
+++ b/src/data/sginfo/sghkl.c
@@ -261,10 +261,10 @@ int IsSuppressed_hkl(const T_SgInfo *SgInfo, int Minh, int Mink, int Minl, int M
                     return (mate ? -(iList + 1) : iList + 1);
                 else /* if (hm == h) */
                     if (km < k)
-                    return (mate ? -(iList + 1) : iList + 1);
-                else if (km == k)
-                    if (lm < l)
                         return (mate ? -(iList + 1) : iList + 1);
+                    else if (km == k)
+                        if (lm < l)
+                            return (mate ? -(iList + 1) : iList + 1);
             }
         }
     }

--- a/src/data/sginfo/sginfo.h
+++ b/src/data/sginfo/sginfo.h
@@ -36,7 +36,8 @@ extern "C"
         int *TrVector;
     } T_LatticeInfo;
 
-    typedef union {
+    typedef union
+    {
         struct
         {
             int R[9], T[3];

--- a/src/data/spacegroups.cpp
+++ b/src/data/spacegroups.cpp
@@ -594,16 +594,19 @@ SpaceGroups::SpaceGroupId findByHermannMauginnSymbol(std::string_view hmSymbol, 
                                      return sg.hermannMauginnSymbol() == cleanedHMSymbol ||
                                             sg.condensedHermannMauginnSymbol() == cleanedHMSymbol;
                                  })
-                  : std::find_if(symbols_.begin(), symbols_.end(), [cleanedHMSymbol, code](const auto &sg) {
-                        if (sg.hermannMauginnSymbol().find(':') == std::string::npos)
-                            return (sg.hermannMauginnSymbol() == cleanedHMSymbol ||
-                                    sg.condensedHermannMauginnSymbol() == cleanedHMSymbol) &&
-                                   (code.empty() || sg.code() == code);
-                        else
-                            return (DissolveSys::beforeChar(sg.hermannMauginnSymbol(), ':') == cleanedHMSymbol ||
-                                    DissolveSys::beforeChar(sg.condensedHermannMauginnSymbol(), ':') == cleanedHMSymbol) &&
-                                   (code.empty() || sg.code() == code);
-                    });
+                  : std::find_if(symbols_.begin(), symbols_.end(),
+                                 [cleanedHMSymbol, code](const auto &sg)
+                                 {
+                                     if (sg.hermannMauginnSymbol().find(':') == std::string::npos)
+                                         return (sg.hermannMauginnSymbol() == cleanedHMSymbol ||
+                                                 sg.condensedHermannMauginnSymbol() == cleanedHMSymbol) &&
+                                                (code.empty() || sg.code() == code);
+                                     else
+                                         return (DissolveSys::beforeChar(sg.hermannMauginnSymbol(), ':') == cleanedHMSymbol ||
+                                                 DissolveSys::beforeChar(sg.condensedHermannMauginnSymbol(), ':') ==
+                                                     cleanedHMSymbol) &&
+                                                (code.empty() || sg.code() == code);
+                                 });
 
     return it == symbols_.end() ? SpaceGroupId::NoSpaceGroup : it->id();
 }
@@ -611,9 +614,9 @@ SpaceGroups::SpaceGroupId findByHermannMauginnSymbol(std::string_view hmSymbol, 
 // Find space group from supplied International Tables index and (optional) code
 SpaceGroups::SpaceGroupId findByInternationalTablesIndex(int itIndex, std::string_view code)
 {
-    auto it = std::find_if(symbols_.begin(), symbols_.end(), [itIndex, code](const auto &sg) {
-        return sg.internationalTableIndex() == itIndex && (code.empty() || sg.code() == code);
-    });
+    auto it = std::find_if(symbols_.begin(), symbols_.end(),
+                           [itIndex, code](const auto &sg)
+                           { return sg.internationalTableIndex() == itIndex && (code.empty() || sg.code() == code); });
     return it == symbols_.end() ? SpaceGroupId::NoSpaceGroup : it->id();
 }
 

--- a/src/genericitems/deserialisers.cpp
+++ b/src/genericitems/deserialisers.cpp
@@ -20,120 +20,142 @@
 GenericItemDeserialiser::GenericItemDeserialiser()
 {
     // PODs
-    registerDeserialiser<bool>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        std::any_cast<bool &>(a) = parser.argb(0);
-        return true;
-    });
-    registerDeserialiser<double>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        std::any_cast<double &>(a) = parser.argd(0);
-        return true;
-    });
-    registerDeserialiser<int>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        std::any_cast<int &>(a) = parser.argi(0);
-        return true;
-    });
+    registerDeserialiser<bool>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            std::any_cast<bool &>(a) = parser.argb(0);
+            return true;
+        });
+    registerDeserialiser<double>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            std::any_cast<double &>(a) = parser.argd(0);
+            return true;
+        });
+    registerDeserialiser<int>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            std::any_cast<int &>(a) = parser.argi(0);
+            return true;
+        });
 
     // Standard Classes / Containers
-    registerDeserialiser<std::streampos>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        // NOTE Can't implicit cast streampos into the arg for readArg(), so assume long long int for now.
-        long long int pos;
-        if (!parser.readArg(pos))
-            return false;
-        std::any_cast<std::streampos &>(a) = pos;
-        return true;
-    });
-    registerDeserialiser<std::string>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        std::any_cast<std::string &>(a) = parser.line();
-        return true;
-    });
-    registerDeserialiser<std::vector<double>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<std::vector<double> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        v.clear();
-        v.resize(parser.argi(0));
-        for (auto &n : v)
+    registerDeserialiser<std::streampos>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            // NOTE Can't implicit cast streampos into the arg for readArg(), so assume long long int for now.
+            long long int pos;
+            if (!parser.readArg(pos))
+                return false;
+            std::any_cast<std::streampos &>(a) = pos;
+            return true;
+        });
+    registerDeserialiser<std::string>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
         {
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-            n = parser.argd(0);
-        }
-        return true;
-    });
-    registerDeserialiser<std::vector<Vec3<double>>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<std::vector<Vec3<double>> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        v.clear();
-        v.resize(parser.argi(0));
-        for (auto &n : v)
+            std::any_cast<std::string &>(a) = parser.line();
+            return true;
+        });
+    registerDeserialiser<std::vector<double>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
         {
+            auto &v = std::any_cast<std::vector<double> &>(a);
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-            n = parser.arg3d(0);
-        }
-        return true;
-    });
+            v.clear();
+            v.resize(parser.argi(0));
+            for (auto &n : v)
+            {
+                if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                    return false;
+                n = parser.argd(0);
+            }
+            return true;
+        });
+    registerDeserialiser<std::vector<Vec3<double>>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            auto &v = std::any_cast<std::vector<Vec3<double>> &>(a);
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            v.clear();
+            v.resize(parser.argi(0));
+            for (auto &n : v)
+            {
+                if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                    return false;
+                n = parser.arg3d(0);
+            }
+            return true;
+        });
 
     // Custom Classes
-    registerDeserialiser<Array2D<char>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<Array2D<char> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        auto nRows = parser.argi(0), nColumns = parser.argi(1);
-        v.initialise(nRows, nColumns, parser.argb(2));
-        for (auto &n : v)
+    registerDeserialiser<Array2D<char>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
         {
+            auto &v = std::any_cast<Array2D<char> &>(a);
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-            n = (parser.argsv(0)[0] == 'T' || parser.argsv(0)[0] == 't');
-        }
-        return true;
-    });
-    registerDeserialiser<Array2D<double>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<Array2D<double> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        auto nRows = parser.argi(0), nColumns = parser.argi(1);
-        v.initialise(nRows, nColumns, parser.argb(2));
-        for (auto &n : v)
+            auto nRows = parser.argi(0), nColumns = parser.argi(1);
+            v.initialise(nRows, nColumns, parser.argb(2));
+            for (auto &n : v)
+            {
+                if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                    return false;
+                n = (parser.argsv(0)[0] == 'T' || parser.argsv(0)[0] == 't');
+            }
+            return true;
+        });
+    registerDeserialiser<Array2D<double>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
         {
+            auto &v = std::any_cast<Array2D<double> &>(a);
             if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-            n = parser.argd(0);
-        }
-        return true;
-    });
-    registerDeserialiser<Array2D<std::vector<double>>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<Array2D<std::vector<double>> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        auto nRows = parser.argi(0), nColumns = parser.argi(1);
-        v.initialise(nRows, nColumns, parser.argb(2));
-        for (auto &data : v)
-            if (!GenericItemDeserialiser::deserialise<std::vector<double>>(data, parser, coreData))
+            auto nRows = parser.argi(0), nColumns = parser.argi(1);
+            v.initialise(nRows, nColumns, parser.argb(2));
+            for (auto &n : v)
+            {
+                if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                    return false;
+                n = parser.argd(0);
+            }
+            return true;
+        });
+    registerDeserialiser<Array2D<std::vector<double>>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            auto &v = std::any_cast<Array2D<std::vector<double>> &>(a);
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-        return true;
-    });
-    registerDeserialiser<Array2D<Data1D>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<Array2D<Data1D> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        int nRows = parser.argi(0), nColumns = parser.argi(1);
-        v.initialise(nRows, nColumns, parser.argb(2));
-        for (auto &n : v)
-            if (!n.deserialise(parser))
+            auto nRows = parser.argi(0), nColumns = parser.argi(1);
+            v.initialise(nRows, nColumns, parser.argb(2));
+            for (auto &data : v)
+                if (!GenericItemDeserialiser::deserialise<std::vector<double>>(data, parser, coreData))
+                    return false;
+            return true;
+        });
+    registerDeserialiser<Array2D<Data1D>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            auto &v = std::any_cast<Array2D<Data1D> &>(a);
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
                 return false;
-        return true;
-    });
+            int nRows = parser.argi(0), nColumns = parser.argi(1);
+            v.initialise(nRows, nColumns, parser.argb(2));
+            for (auto &n : v)
+                if (!n.deserialise(parser))
+                    return false;
+            return true;
+        });
     registerDeserialiser<AtomTypeMix>(simpleDeserialiseCore<AtomTypeMix>);
     registerDeserialiser<Data1D>(simpleDeserialise<Data1D>);
     registerDeserialiser<Data2D>(simpleDeserialise<Data2D>);
@@ -146,20 +168,24 @@ GenericItemDeserialiser::GenericItemDeserialiser()
     registerDeserialiser<PartialSetAccumulator>(simpleDeserialise<PartialSetAccumulator>);
     registerDeserialiser<SampledDouble>(simpleDeserialise<SampledDouble>);
     registerDeserialiser<SampledVector>(simpleDeserialise<SampledVector>);
-    registerDeserialiser<Vec3<int>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<Vec3<int> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        v = parser.arg3i(0);
-        return true;
-    });
-    registerDeserialiser<Vec3<double>>([](std::any &a, LineParser &parser, const CoreData &coreData) {
-        auto &v = std::any_cast<Vec3<double> &>(a);
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        v = parser.arg3d(0);
-        return true;
-    });
+    registerDeserialiser<Vec3<int>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            auto &v = std::any_cast<Vec3<int> &>(a);
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            v = parser.arg3i(0);
+            return true;
+        });
+    registerDeserialiser<Vec3<double>>(
+        [](std::any &a, LineParser &parser, const CoreData &coreData)
+        {
+            auto &v = std::any_cast<Vec3<double> &>(a);
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return false;
+            v = parser.arg3d(0);
+            return true;
+        });
     registerDeserialiser<XRayWeights>(simpleDeserialiseCore<XRayWeights>);
 
     // Containers of Custom Classes

--- a/src/genericitems/searchers.cpp
+++ b/src/genericitems/searchers.cpp
@@ -17,15 +17,19 @@
 template <> GenericItemSearcher<const Data1D>::GenericItemSearcher()
 {
     // Custom Classes
-    registerSearcher<Array2D<Data1D>>([](const std::any &a, std::string_view dataName) {
-        auto &array = std::any_cast<const Array2D<Data1D> &>(a);
-        auto it = std::find_if(array.begin(), array.end(), [dataName](const auto &data) { return dataName == data.tag(); });
-        return it == array.end() ? OptionalReferenceWrapper<const Data1D>() : OptionalReferenceWrapper<const Data1D>(*it);
-    });
-    registerSearcher<PartialSet>([](const std::any &a, std::string_view dataName) {
-        auto &ps = std::any_cast<const PartialSet &>(a);
-        return ps.searchData1D(dataName);
-    });
+    registerSearcher<Array2D<Data1D>>(
+        [](const std::any &a, std::string_view dataName)
+        {
+            auto &array = std::any_cast<const Array2D<Data1D> &>(a);
+            auto it = std::find_if(array.begin(), array.end(), [dataName](const auto &data) { return dataName == data.tag(); });
+            return it == array.end() ? OptionalReferenceWrapper<const Data1D>() : OptionalReferenceWrapper<const Data1D>(*it);
+        });
+    registerSearcher<PartialSet>(
+        [](const std::any &a, std::string_view dataName)
+        {
+            auto &ps = std::any_cast<const PartialSet &>(a);
+            return ps.searchData1D(dataName);
+        });
 }
 
 /*
@@ -47,16 +51,20 @@ template <> GenericItemSearcher<const Data3D>::GenericItemSearcher() {}
 template <> GenericItemSearcher<const SampledData1D>::GenericItemSearcher()
 {
     // Custom Classes
-    registerSearcher<Array2D<SampledData1D>>([](const std::any &a, std::string_view dataName) {
-        auto &array = std::any_cast<const Array2D<SampledData1D> &>(a);
-        auto it = std::find_if(array.begin(), array.end(), [dataName](const auto &data) { return dataName == data.tag(); });
-        return it == array.end() ? OptionalReferenceWrapper<const SampledData1D>()
-                                 : OptionalReferenceWrapper<const SampledData1D>(*it);
-    });
-    registerSearcher<PartialSetAccumulator>([](const std::any &a, std::string_view dataName) {
-        auto &psa = std::any_cast<const PartialSetAccumulator &>(a);
-        return psa.searchSampledData1D(dataName);
-    });
+    registerSearcher<Array2D<SampledData1D>>(
+        [](const std::any &a, std::string_view dataName)
+        {
+            auto &array = std::any_cast<const Array2D<SampledData1D> &>(a);
+            auto it = std::find_if(array.begin(), array.end(), [dataName](const auto &data) { return dataName == data.tag(); });
+            return it == array.end() ? OptionalReferenceWrapper<const SampledData1D>()
+                                     : OptionalReferenceWrapper<const SampledData1D>(*it);
+        });
+    registerSearcher<PartialSetAccumulator>(
+        [](const std::any &a, std::string_view dataName)
+        {
+            auto &psa = std::any_cast<const PartialSetAccumulator &>(a);
+            return psa.searchSampledData1D(dataName);
+        });
 }
 
 /*

--- a/src/genericitems/serialisers.cpp
+++ b/src/genericitems/serialisers.cpp
@@ -19,75 +19,86 @@
 GenericItemSerialiser::GenericItemSerialiser()
 {
     // PODs
-    registerSerialiser<bool>([](const std::any &a, LineParser &parser) {
-        return parser.writeLineF("{}\n", DissolveSys::btoa(std::any_cast<bool>(a)));
-    });
-    registerSerialiser<double>(
-        [](const std::any &a, LineParser &parser) { return parser.writeLineF("{}\n", std::any_cast<double>(a)); });
-    registerSerialiser<int>(
-        [](const std::any &a, LineParser &parser) { return parser.writeLineF("{}\n", std::any_cast<int>(a)); });
+    registerSerialiser<bool>([](const std::any &a, LineParser &parser)
+                             { return parser.writeLineF("{}\n", DissolveSys::btoa(std::any_cast<bool>(a))); });
+    registerSerialiser<double>([](const std::any &a, LineParser &parser)
+                               { return parser.writeLineF("{}\n", std::any_cast<double>(a)); });
+    registerSerialiser<int>([](const std::any &a, LineParser &parser)
+                            { return parser.writeLineF("{}\n", std::any_cast<int>(a)); });
 
     // Standard Classes / Containers
-    registerSerialiser<std::string>(
-        [](const std::any &a, LineParser &parser) { return parser.writeLineF("{}\n", std::any_cast<std::string>(a)); });
-    registerSerialiser<std::streampos>(
-        [](const std::any &a, LineParser &parser) { return parser.writeLineF("{}\n", std::any_cast<std::streampos>(a)); });
-    registerSerialiser<std::vector<double>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const std::vector<double> &>(a);
-        if (!parser.writeLineF("{}\n", v.size()))
-            return false;
-        for (auto &n : v)
-            if (!parser.writeLineF("{}\n", n))
+    registerSerialiser<std::string>([](const std::any &a, LineParser &parser)
+                                    { return parser.writeLineF("{}\n", std::any_cast<std::string>(a)); });
+    registerSerialiser<std::streampos>([](const std::any &a, LineParser &parser)
+                                       { return parser.writeLineF("{}\n", std::any_cast<std::streampos>(a)); });
+    registerSerialiser<std::vector<double>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const std::vector<double> &>(a);
+            if (!parser.writeLineF("{}\n", v.size()))
                 return false;
-        return true;
-    });
-    registerSerialiser<std::vector<Vec3<double>>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const std::vector<Vec3<double>> &>(a);
-        if (!parser.writeLineF("{}\n", v.size()))
-            return false;
-        for (auto &n : v)
-            if (!parser.writeLineF("{} {} {}\n", n.x, n.y, n.z))
+            for (auto &n : v)
+                if (!parser.writeLineF("{}\n", n))
+                    return false;
+            return true;
+        });
+    registerSerialiser<std::vector<Vec3<double>>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const std::vector<Vec3<double>> &>(a);
+            if (!parser.writeLineF("{}\n", v.size()))
                 return false;
-        return true;
-    });
+            for (auto &n : v)
+                if (!parser.writeLineF("{} {} {}\n", n.x, n.y, n.z))
+                    return false;
+            return true;
+        });
 
     // Custom Classes / Containers
-    registerSerialiser<Array2D<char>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const Array2D<char> &>(a);
-        if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
-            return false;
-        for (auto &n : v)
-            if (!parser.writeLineF("{}\n", n ? 'T' : 'F'))
+    registerSerialiser<Array2D<char>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const Array2D<char> &>(a);
+            if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
                 return false;
-        return true;
-    });
-    registerSerialiser<Array2D<double>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const Array2D<double> &>(a);
-        if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
-            return false;
-        for (auto &n : v)
-            if (!parser.writeLineF("{}\n", n))
+            for (auto &n : v)
+                if (!parser.writeLineF("{}\n", n ? 'T' : 'F'))
+                    return false;
+            return true;
+        });
+    registerSerialiser<Array2D<double>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const Array2D<double> &>(a);
+            if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
                 return false;
-        return true;
-    });
-    registerSerialiser<Array2D<std::vector<double>>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const Array2D<std::vector<double>> &>(a);
-        if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
-            return false;
-        for (auto &data : v)
-            if (!GenericItemSerialiser::serialise<std::vector<double>>(data, parser))
+            for (auto &n : v)
+                if (!parser.writeLineF("{}\n", n))
+                    return false;
+            return true;
+        });
+    registerSerialiser<Array2D<std::vector<double>>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const Array2D<std::vector<double>> &>(a);
+            if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
                 return false;
-        return true;
-    });
-    registerSerialiser<Array2D<Data1D>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const Array2D<Data1D> &>(a);
-        if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
-            return false;
-        for (auto &n : v)
-            if (!n.serialise(parser))
+            for (auto &data : v)
+                if (!GenericItemSerialiser::serialise<std::vector<double>>(data, parser))
+                    return false;
+            return true;
+        });
+    registerSerialiser<Array2D<Data1D>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const Array2D<Data1D> &>(a);
+            if (!parser.writeLineF("{}  {}  {}\n", v.nRows(), v.nColumns(), DissolveSys::btoa(v.halved())))
                 return false;
-        return true;
-    });
+            for (auto &n : v)
+                if (!n.serialise(parser))
+                    return false;
+            return true;
+        });
     registerSerialiser<AtomTypeMix>(simpleSerialise<AtomTypeMix>);
     registerSerialiser<Data1D>(simpleSerialise<Data1D>);
     registerSerialiser<Data2D>(simpleSerialise<Data2D>);
@@ -100,10 +111,12 @@ GenericItemSerialiser::GenericItemSerialiser()
     registerSerialiser<PartialSetAccumulator>(simpleSerialise<PartialSetAccumulator>);
     registerSerialiser<SampledDouble>(simpleSerialise<SampledDouble>);
     registerSerialiser<SampledVector>(simpleSerialise<SampledVector>);
-    registerSerialiser<Vec3<int>>([](const std::any &a, LineParser &parser) {
-        const auto &v = std::any_cast<const Vec3<int> &>(a);
-        return parser.writeLineF("{}  {}  {}\n", v.x, v.y, v.z);
-    });
+    registerSerialiser<Vec3<int>>(
+        [](const std::any &a, LineParser &parser)
+        {
+            const auto &v = std::any_cast<const Vec3<int> &>(a);
+            return parser.writeLineF("{}  {}  {}\n", v.x, v.y, v.z);
+        });
     registerSerialiser<XRayWeights>(simpleSerialise<XRayWeights>);
 
     // Containers of Custom Classes

--- a/src/gui/addconfigurationdialog_funcs.cpp
+++ b/src/gui/addconfigurationdialog_funcs.cpp
@@ -90,9 +90,9 @@ bool AddConfigurationDialog::progressionAllowed(int index) const
     {
         // Must have at least one species, and not more than one periodic species
         auto selection = ui_.TargetSpeciesWidget->selection();
-        if (selection.size() == 0 || std::count_if(selection.begin(), selection.end(), [](const auto *sp) {
-                                         return sp->box()->type() != Box::BoxType::NonPeriodic;
-                                     }) > 1)
+        if (selection.size() == 0 ||
+            std::count_if(selection.begin(), selection.end(),
+                          [](const auto *sp) { return sp->box()->type() != Box::BoxType::NonPeriodic; }) > 1)
             return false;
     }
     else if (index == AddConfigurationDialog::BoxGeometryPage)

--- a/src/gui/addforcefieldtermsdialog_funcs.cpp
+++ b/src/gui/addforcefieldtermsdialog_funcs.cpp
@@ -19,10 +19,12 @@ AddForcefieldTermsDialog::AddForcefieldTermsDialog(QWidget *parent, Dissolve &di
 
     // Set model for atom type conflicts list
     ui_.AtomTypesConflictsList->setModel(&atomTypeModel_);
-    atomTypeModel_.setIconFunction([&](const auto &atomType) {
-        return QIcon(dissolve_.findAtomType(atomType->name()) ? ":/general/icons/general_warn.svg"
-                                                              : ":/general/icons/general_true.svg");
-    });
+    atomTypeModel_.setIconFunction(
+        [&](const auto &atomType)
+        {
+            return QIcon(dissolve_.findAtomType(atomType->name()) ? ":/general/icons/general_warn.svg"
+                                                                  : ":/general/icons/general_true.svg");
+        });
     connect(ui_.AtomTypesConflictsList->selectionModel(),
             SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
             SLOT(atomTypeConflictsSelectionChanged(const QItemSelection &, const QItemSelection &)));
@@ -30,22 +32,30 @@ AddForcefieldTermsDialog::AddForcefieldTermsDialog(QWidget *parent, Dissolve &di
             SLOT(atomTypeConflictsDataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)));
 
     // Set model and signals for the master terms tree
-    masterTermModel_.setBondIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterBond(name) ? ":/general/icons/general_warn.svg"
-                                                              : ":/general/icons/general_true.svg");
-    });
-    masterTermModel_.setAngleIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterAngle(name) ? ":/general/icons/general_warn.svg"
-                                                               : ":/general/icons/general_true.svg");
-    });
-    masterTermModel_.setTorsionIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterTorsion(name) ? ":/general/icons/general_warn.svg"
-                                                                 : ":/general/icons/general_true.svg");
-    });
-    masterTermModel_.setImproperIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterImproper(name) ? ":/general/icons/general_warn.svg"
+    masterTermModel_.setBondIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterBond(name) ? ":/general/icons/general_warn.svg"
                                                                   : ":/general/icons/general_true.svg");
-    });
+        });
+    masterTermModel_.setAngleIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterAngle(name) ? ":/general/icons/general_warn.svg"
+                                                                   : ":/general/icons/general_true.svg");
+        });
+    masterTermModel_.setTorsionIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterTorsion(name) ? ":/general/icons/general_warn.svg"
+                                                                     : ":/general/icons/general_true.svg");
+        });
+    masterTermModel_.setImproperIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterImproper(name) ? ":/general/icons/general_warn.svg"
+                                                                      : ":/general/icons/general_true.svg");
+        });
     ui_.MasterTermsTree->setModel(&masterTermModel_);
     connect(&masterTermModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
             SLOT(masterTermDataChanged(const QModelIndex &, const QModelIndex &)));

--- a/src/gui/copyspeciestermsdialog_funcs.cpp
+++ b/src/gui/copyspeciestermsdialog_funcs.cpp
@@ -70,20 +70,22 @@ void CopySpeciesTermsDialog::findTermsToCopy(std::vector<std::pair<Intra *, cons
 
         // Check for a suitable term in the target species
         auto js = targetTerm.atoms();
-        auto it = std::find_if(sourceTerms.begin(), sourceTerms.end(), [js](const auto &sourceTerm) {
-            // Assess atom types between the two terms, from both vector directions
-            auto n = 0;
-            auto sameForwards = true, sameBackwards = true;
-            for (const auto *i : sourceTerm.atoms())
-            {
-                if (sameForwards && i->atomType() != js[n]->atomType())
-                    sameForwards = false;
-                if (sameBackwards && i->atomType() != js[js.size() - n - 1]->atomType())
-                    sameBackwards = false;
-                ++n;
-            }
-            return sameForwards || sameBackwards;
-        });
+        auto it = std::find_if(sourceTerms.begin(), sourceTerms.end(),
+                               [js](const auto &sourceTerm)
+                               {
+                                   // Assess atom types between the two terms, from both vector directions
+                                   auto n = 0;
+                                   auto sameForwards = true, sameBackwards = true;
+                                   for (const auto *i : sourceTerm.atoms())
+                                   {
+                                       if (sameForwards && i->atomType() != js[n]->atomType())
+                                           sameForwards = false;
+                                       if (sameBackwards && i->atomType() != js[js.size() - n - 1]->atomType())
+                                           sameBackwards = false;
+                                       ++n;
+                                   }
+                                   return sameForwards || sameBackwards;
+                               });
         if (it != sourceTerms.end())
             termVector.emplace_back(&targetTerm, &(*it));
     }

--- a/src/gui/getmodulelayernamedialog_funcs.cpp
+++ b/src/gui/getmodulelayernamedialog_funcs.cpp
@@ -43,9 +43,11 @@ void GetModuleLayerNameDialog::on_NameEdit_textChanged(const QString text)
         nameValid = false;
     else
     {
-        nameValid = std::none_of(layers_.begin(), layers_.end(), [text, this](const auto &layer) {
-            return this->moduleLayer_ != layer.get() && DissolveSys::sameString(layer->name(), qPrintable(text));
-        });
+        nameValid = std::none_of(layers_.begin(), layers_.end(),
+                                 [text, this](const auto &layer) {
+                                     return this->moduleLayer_ != layer.get() &&
+                                            DissolveSys::sameString(layer->name(), qPrintable(text));
+                                 });
     }
 
     // Update indicator

--- a/src/gui/importcifdialog_funcs.cpp
+++ b/src/gui/importcifdialog_funcs.cpp
@@ -331,9 +331,9 @@ bool ImportCIFDialog::createStructuralSpecies()
                         r = box->fold(r);
 
                         // If this atom overlaps with another in the box, don't add it as it's a symmetry-related copy
-                        if (std::any_of(
-                                crystalSpecies_->atoms().begin(), crystalSpecies_->atoms().end(),
-                                [&r, box, tolerance](const auto &j) { return box->minimumDistance(r, j.r()) < tolerance; }))
+                        if (std::any_of(crystalSpecies_->atoms().begin(), crystalSpecies_->atoms().end(),
+                                        [&r, box, tolerance](const auto &j)
+                                        { return box->minimumDistance(r, j.r()) < tolerance; }))
                             continue;
 
                         // Create the new atom

--- a/src/gui/importspeciesdialog_funcs.cpp
+++ b/src/gui/importspeciesdialog_funcs.cpp
@@ -22,31 +22,41 @@ ImportSpeciesDialog::ImportSpeciesDialog(QWidget *parent, Dissolve &dissolve)
             SLOT(speciesSelectionChanged(const QItemSelection &, const QItemSelection &)));
 
     // Set model, signals, and lambdas for atom types list
-    atomTypesModel_.setIconFunction([&](const std::shared_ptr<AtomType> &atomType) {
-        return QIcon(dissolve_.findAtomType(atomType->name()) ? ":/general/icons/general_warn.svg"
-                                                              : ":/general/icons/general_true.svg");
-    });
+    atomTypesModel_.setIconFunction(
+        [&](const std::shared_ptr<AtomType> &atomType)
+        {
+            return QIcon(dissolve_.findAtomType(atomType->name()) ? ":/general/icons/general_warn.svg"
+                                                                  : ":/general/icons/general_true.svg");
+        });
     ui_.AtomTypesList->setModel(&atomTypesModel_);
     connect(ui_.AtomTypesList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
             SLOT(atomTypeSelectionChanged(const QItemSelection &, const QItemSelection &)));
 
     // Set model and signals for the master terms tree
-    masterTermModel_.setBondIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterBond(name) ? ":/general/icons/general_warn.svg"
-                                                              : ":/general/icons/general_true.svg");
-    });
-    masterTermModel_.setAngleIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterAngle(name) ? ":/general/icons/general_warn.svg"
-                                                               : ":/general/icons/general_true.svg");
-    });
-    masterTermModel_.setTorsionIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterTorsion(name) ? ":/general/icons/general_warn.svg"
-                                                                 : ":/general/icons/general_true.svg");
-    });
-    masterTermModel_.setImproperIconFunction([&](std::string_view name) {
-        return QIcon(dissolve_.coreData().getMasterImproper(name) ? ":/general/icons/general_warn.svg"
+    masterTermModel_.setBondIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterBond(name) ? ":/general/icons/general_warn.svg"
                                                                   : ":/general/icons/general_true.svg");
-    });
+        });
+    masterTermModel_.setAngleIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterAngle(name) ? ":/general/icons/general_warn.svg"
+                                                                   : ":/general/icons/general_true.svg");
+        });
+    masterTermModel_.setTorsionIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterTorsion(name) ? ":/general/icons/general_warn.svg"
+                                                                     : ":/general/icons/general_true.svg");
+        });
+    masterTermModel_.setImproperIconFunction(
+        [&](std::string_view name)
+        {
+            return QIcon(dissolve_.coreData().getMasterImproper(name) ? ":/general/icons/general_warn.svg"
+                                                                      : ":/general/icons/general_true.svg");
+        });
     ui_.MasterTermsTree->setModel(&masterTermModel_);
     connect(&masterTermModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
             SLOT(masterTermDataChanged(const QModelIndex &, const QModelIndex &)));

--- a/src/gui/keywordwidgets/isotopologueset_funcs.cpp
+++ b/src/gui/keywordwidgets/isotopologueset_funcs.cpp
@@ -127,9 +127,9 @@ void IsotopologueSetKeywordWidget::updateSummaryText()
     auto nNatural = 0;
     for (const auto &topes : keyword_->data().isotopologues())
         // Check if this is a completely "natural" specification
-        if (std::count_if(topes.mix().begin(), topes.mix().end(), [&topes](const auto &part) {
-                return part.isotopologue() == topes.species()->naturalIsotopologue();
-            }) == topes.nIsotopologues())
+        if (std::count_if(topes.mix().begin(), topes.mix().end(),
+                          [&topes](const auto &part)
+                          { return part.isotopologue() == topes.species()->naturalIsotopologue(); }) == topes.nIsotopologues())
         {
             text += fmt::format("{}{}[Natural]", text.empty() ? "" : ", ", topes.species()->name());
             ++nNatural;
@@ -141,9 +141,9 @@ void IsotopologueSetKeywordWidget::updateSummaryText()
                                     topes.mix().front().isotopologue()->name());
             else
                 text += fmt::format("{}{}[{}]", text.empty() ? "" : ", ", topes.species()->name(),
-                                    joinStrings(topes.mix(), ", ", [](const auto &part) {
-                                        return fmt::format("{}={}", part.isotopologue()->name(), part.weight());
-                                    }));
+                                    joinStrings(topes.mix(), ", ",
+                                                [](const auto &part)
+                                                { return fmt::format("{}={}", part.isotopologue()->name(), part.weight()); }));
         }
 
     setSummaryText(nNatural == keyword_->data().nSpecies() ? QString("<Default to Natural>") : QString::fromStdString(text));

--- a/src/gui/keywordwidgets/producers.h
+++ b/src/gui/keywordwidgets/producers.h
@@ -45,7 +45,8 @@ class KeywordWidgetProducer
     template <class K> void registerProducer(ProducerFunction function) { producers_[typeid(K)] = std::move(function); }
     template <class K, class W> void registerProducer()
     {
-        producers_[typeid(K *)] = [&](KeywordBase *keyword, const CoreData &coreData) {
+        producers_[typeid(K *)] = [&](KeywordBase *keyword, const CoreData &coreData)
+        {
             // Cast the base up to the full keyword
             auto *k = dynamic_cast<K *>(keyword);
             assert(k);

--- a/src/gui/keywordwidgets/speciessitevector_funcs.cpp
+++ b/src/gui/keywordwidgets/speciessitevector_funcs.cpp
@@ -71,7 +71,7 @@ void SpeciesSiteVectorKeywordWidget::updateSummaryText()
     if (keyword_->data().empty())
         setSummaryText("<None>");
     else
-        setSummaryText(QString::fromStdString(joinStrings(keyword_->data(), ", ", [](const auto &site) {
-            return fmt::format("{} ({})", site->name(), site->parent()->name());
-        })));
+        setSummaryText(QString::fromStdString(
+            joinStrings(keyword_->data(), ", ",
+                        [](const auto &site) { return fmt::format("{} ({})", site->name(), site->parent()->name()); })));
 }

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -28,9 +28,9 @@ void DissolveWindow::on_SpeciesCreateAtomicAction_triggered(bool checked)
     // Create the new Species, and add a single atom at {0,0,0}
     auto *newSpecies = dissolve_.addSpecies();
     newSpecies->addAtom(Z, Vec3<double>());
-    newSpecies->setName(DissolveSys::uniqueName(Elements::symbol(Z), dissolve().coreData().species(), [&](const auto &sp) {
-        return newSpecies == sp.get() ? std::string() : sp->name();
-    }));
+    newSpecies->setName(DissolveSys::uniqueName(Elements::symbol(Z), dissolve().coreData().species(),
+                                                [&](const auto &sp)
+                                                { return newSpecies == sp.get() ? std::string() : sp->name(); }));
 
     setModified();
     fullUpdate();

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -126,9 +126,9 @@ bool AtomTypeModel::setData(const QModelIndex &index, const QVariant &value, int
             case (0):
                 // Ensure uniqueness of name if we have a reference CoreData
                 if (coreData_)
-                    atomType->setName(DissolveSys::uniqueName(
-                        value.toString().toStdString(), coreData_->get().atomTypes(),
-                        [&atomType](const auto &at) { return atomType == at ? std::string() : at->name(); }));
+                    atomType->setName(DissolveSys::uniqueName(value.toString().toStdString(), coreData_->get().atomTypes(),
+                                                              [&atomType](const auto &at)
+                                                              { return atomType == at ? std::string() : at->name(); }));
                 else
                     atomType->setName(value.toString().toStdString());
                 break;

--- a/src/gui/models/moduleModel.cpp
+++ b/src/gui/models/moduleModel.cpp
@@ -10,9 +10,10 @@ void ModuleModel::setData(const std::vector<Module *> &modules)
     modules_ = modules;
     if (checkedItems_)
     {
-        auto it = std::remove_if(checkedItems_->get().begin(), checkedItems_->get().end(), [&](const auto *m) {
-            return std::find(modules_->get().begin(), modules_->get().end(), m) == modules_->get().end();
-        });
+        auto it =
+            std::remove_if(checkedItems_->get().begin(), checkedItems_->get().end(),
+                           [&](const auto *m)
+                           { return std::find(modules_->get().begin(), modules_->get().end(), m) == modules_->get().end(); });
         if (it != checkedItems_->get().end())
             checkedItems_->get().erase(it, checkedItems_->get().end());
     }

--- a/src/gui/sitewidget_funcs.cpp
+++ b/src/gui/sitewidget_funcs.cpp
@@ -82,8 +82,8 @@ void SiteWidget::updateStatusBar()
     if (sp)
     {
         auto selection = sp->selectedAtoms();
-        ui_.FormulaLabel->setText(
-            QString::fromStdString(EmpiricalFormula::formula(sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
+        ui_.FormulaLabel->setText(QString::fromStdString(EmpiricalFormula::formula(
+            sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
         ui_.SelectionLabel->setText(!selection.empty() ? QString::fromStdString(EmpiricalFormula::formula(
                                                              selection, [](const auto &i) { return i->Z(); }, true))
                                                        : "--");

--- a/src/gui/specieseditor_funcs.cpp
+++ b/src/gui/specieseditor_funcs.cpp
@@ -94,8 +94,8 @@ void SpeciesEditor::updateStatusBar()
 
     // Set / update empirical formula for the Species and its current atom selection
     auto selection = sp->selectedAtoms();
-    ui_.FormulaLabel->setText(
-        QString::fromStdString(EmpiricalFormula::formula(sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
+    ui_.FormulaLabel->setText(QString::fromStdString(EmpiricalFormula::formula(
+        sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
     ui_.SelectionLabel->setText(selection.empty() ? "--"
                                                   : QString::fromStdString(EmpiricalFormula::formula(
                                                         selection, [](const auto &i) { return i->Z(); }, true)));

--- a/src/gui/speciestab_isotopologues.cpp
+++ b/src/gui/speciestab_isotopologues.cpp
@@ -65,10 +65,10 @@ void SpeciesTab::on_IsotopologuesTree_customContextMenuRequested(const QPoint &p
 
         // Set a unique name for the new isotopologue
         auto newIso = isos_.data(newIndex, Qt::UserRole).value<Isotopologue *>();
-        isos_.setData(newIndex, QString::fromStdString(DissolveSys::uniqueName(
-                                    iso->name(), species_->isotopologues(), [newIso](const auto &oldIso) {
-                                        return newIso == oldIso.get() ? std::string() : oldIso->name();
-                                    })));
+        isos_.setData(newIndex,
+                      QString::fromStdString(DissolveSys::uniqueName(
+                          iso->name(), species_->isotopologues(),
+                          [newIso](const auto &oldIso) { return newIso == oldIso.get() ? std::string() : oldIso->name(); })));
 
         auto row = 0;
         for (const auto &[atomType, tope] : iso->isotopes())

--- a/src/gui/specieswidget_funcs.cpp
+++ b/src/gui/specieswidget_funcs.cpp
@@ -63,8 +63,8 @@ void SpeciesWidget::updateStatusBar()
     if (sp)
     {
         auto selection = sp->selectedAtoms();
-        ui_.FormulaLabel->setText(
-            QString::fromStdString(EmpiricalFormula::formula(sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
+        ui_.FormulaLabel->setText(QString::fromStdString(EmpiricalFormula::formula(
+            sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
         ui_.SelectionLabel->setText(!selection.empty() ? QString::fromStdString(EmpiricalFormula::formula(
                                                              selection, [](const auto &i) { return i->Z(); }, true))
                                                        : "--");

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -367,9 +367,11 @@ bool CIFImport::hasBondDistances() const { return !bondingPairs_.empty(); }
 // Return whether a bond distance is defined for the specified label pair
 std::optional<double> CIFImport::bondDistance(std::string_view labelI, std::string_view labelJ) const
 {
-    auto it = std::find_if(bondingPairs_.begin(), bondingPairs_.end(), [labelI, labelJ](const auto &bp) {
-        return (bp.labelI() == labelI && bp.labelJ() == labelJ) || (bp.labelI() == labelJ && bp.labelJ() == labelI);
-    });
+    auto it = std::find_if(bondingPairs_.begin(), bondingPairs_.end(),
+                           [labelI, labelJ](const auto &bp) {
+                               return (bp.labelI() == labelI && bp.labelJ() == labelJ) ||
+                                      (bp.labelI() == labelJ && bp.labelJ() == labelI);
+                           });
     if (it != bondingPairs_.end())
         return it->r();
     return std::nullopt;

--- a/src/keywords/atomtypevector.cpp
+++ b/src/keywords/atomtypevector.cpp
@@ -34,9 +34,9 @@ bool AtomTypeVectorKeyword::deserialise(LineParser &parser, int startArg, const 
     for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         // Do we recognise the AtomType?
-        auto it = std::find_if(coreData.atomTypes().begin(), coreData.atomTypes().end(), [&parser, n](const auto atomType) {
-            return DissolveSys::sameString(atomType->name(), parser.argsv(n));
-        });
+        auto it = std::find_if(coreData.atomTypes().begin(), coreData.atomTypes().end(),
+                               [&parser, n](const auto atomType)
+                               { return DissolveSys::sameString(atomType->name(), parser.argsv(n)); });
         if (it == coreData.atomTypes().end())
             return Messenger::error("Unrecognised AtomType '{}' given to '{}' keyword.\n", parser.argsv(n), name());
         auto atomType = *it;

--- a/src/keywords/modulevector.cpp
+++ b/src/keywords/modulevector.cpp
@@ -52,9 +52,9 @@ bool ModuleVectorKeyword::deserialise(LineParser &parser, int startArg, const Co
             return Messenger::error("No Module named '{}' exists.\n", parser.argsv(n));
 
         // Check the module's type if we can
-        if (!moduleTypes_.empty() && std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(), [module](const auto &s) {
-                                         return s == module->type();
-                                     }) == moduleTypes_.cend())
+        if (!moduleTypes_.empty() &&
+            std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(), [module](const auto &s) { return s == module->type(); }) ==
+                moduleTypes_.cend())
             return Messenger::error("Module '{}' is of type '{}', and is not relevant to keyword '{}' (allowed types = {}).\n",
                                     parser.argsv(n), module->type(), name(), joinStrings(moduleTypes_));
 

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -28,12 +28,14 @@ class KeywordStore
     ~KeywordStore()
     {
         // Remove keywords in this store from the global reference
-        auto it = std::remove_if(allKeywords_.begin(), allKeywords_.end(), [&](const auto *k) {
-            for (auto &[name, keyword] : keywords_)
-                if (k == keyword)
-                    return true;
-            return false;
-        });
+        auto it = std::remove_if(allKeywords_.begin(), allKeywords_.end(),
+                                 [&](const auto *k)
+                                 {
+                                     for (auto &[name, keyword] : keywords_)
+                                         if (k == keyword)
+                                             return true;
+                                     return false;
+                                 });
         allKeywords_.erase(it, allKeywords_.end());
     }
 
@@ -53,7 +55,7 @@ class KeywordStore
     public:
     // Add keyword (no group)
     template <class K, typename... Args>
-    KeywordBase *addKeyword(std::string_view name, std::string_view description, Args &&... args)
+    KeywordBase *addKeyword(std::string_view name, std::string_view description, Args &&...args)
     {
         // Check for keyword of this name already
         if (keywords_.find(name) != keywords_.end())
@@ -70,7 +72,7 @@ class KeywordStore
         return k;
     }
     // Add target keyword
-    template <class K, typename... Args> void addTarget(std::string_view name, std::string_view description, Args &&... args)
+    template <class K, typename... Args> void addTarget(std::string_view name, std::string_view description, Args &&...args)
     {
         auto *k = addKeyword<K>(name, description, args...);
 
@@ -78,7 +80,7 @@ class KeywordStore
     }
     // Add keyword (displaying in named group)
     template <class K, typename... Args>
-    KeywordBase *add(std::string_view displayGroup, std::string_view name, std::string_view description, Args &&... args)
+    KeywordBase *add(std::string_view displayGroup, std::string_view name, std::string_view description, Args &&...args)
     {
         auto *k = addKeyword<K>(name, description, args...);
 
@@ -94,13 +96,13 @@ class KeywordStore
     // Add keyword (displaying in named group) and capture in restart file
     template <class K, typename... Args>
     KeywordBase *addRestartable(std::string_view displayGroup, std::string_view name, std::string_view description,
-                                Args &&... args)
+                                Args &&...args)
     {
         return restartables_.emplace_back(add<K>(displayGroup, name, description, args...));
     }
     // Add deprecated keyword
     template <class K, typename... Args>
-    KeywordBase *addDeprecated(std::string_view name, std::string_view description, Args &&... args)
+    KeywordBase *addDeprecated(std::string_view name, std::string_view description, Args &&...args)
     {
         auto *k = addKeyword<K>(name, description, args...);
 

--- a/src/main/cli.cpp
+++ b/src/main/cli.cpp
@@ -21,13 +21,14 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
 
     // Basic Control
     app.add_option("-n,--iterations", nIterations_, "Number of iterations to run (default = 0)")->group("Basic Control");
-    app.add_flag_callback("-q,--quiet", []() { Messenger::setQuiet(true); },
-                          "Be quiet - don't output any messages whatsoever (output files are still written)")
+    app.add_flag_callback(
+           "-q,--quiet", []() { Messenger::setQuiet(true); },
+           "Be quiet - don't output any messages whatsoever (output files are still written)")
         ->group("Basic Control");
     app.add_option("--seed", randomSeed_, "Random number seed to use (otherwise determined by system time)")
         ->group("Basic Control");
-    app.add_flag_callback("-v,--verbose", []() { Messenger::setVerbose(true); },
-                          "Print lots of additional output, useful for debugging")
+    app.add_flag_callback(
+           "-v,--verbose", []() { Messenger::setVerbose(true); }, "Print lots of additional output, useful for debugging")
         ->group("Basic Control");
 
     // Input Files
@@ -57,8 +58,8 @@ int CLIOptions::parse(const int args, char **argv, bool isGUI, bool isParallel)
     // Add parallel-specific options
     if (isParallel)
     {
-        app.add_flag_callback("-a,--all", []() { Messenger::setMasterOnly(false); },
-                              "Write output from all processes, not just master")
+        app.add_flag_callback(
+               "-a,--all", []() { Messenger::setMasterOnly(false); }, "Write output from all processes, not just master")
             ->group("Parallel Code Options");
         app.add_option("--redirect", redirectionBasename_,
                        "Redirect output from individual processes to files based on the supplied name")

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -165,9 +165,9 @@ void Dissolve::deserialise(SerialisedValue &node)
         if (!mastersNode.is_uninitialized())
             coreData_.deserialiseMaster(mastersNode);
     }
-    Serialisable::toMap(node, "species", [this](const std::string &name, SerialisedValue &data) {
-        species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_);
-    });
+    Serialisable::toMap(node, "species",
+                        [this](const std::string &name, SerialisedValue &data)
+                        { species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_); });
 }
 
 // Load input from supplied file

--- a/src/main/pairpotentials.cpp
+++ b/src/main/pairpotentials.cpp
@@ -65,18 +65,23 @@ PairPotential *Dissolve::pairPotential(int n) { return pairPotentials_[n].get();
 // Return specified PairPotential (if defined)
 PairPotential *Dissolve::pairPotential(const std::shared_ptr<AtomType> &at1, const std::shared_ptr<AtomType> &at2) const
 {
-    auto it = std::find_if(pairPotentials_.begin(), pairPotentials_.end(), [at1, at2](const auto &pp) {
-        return (pp->atomTypeI() == at1 && pp->atomTypeJ() == at2) || (pp->atomTypeI() == at2 && pp->atomTypeJ() == at1);
-    });
+    auto it = std::find_if(pairPotentials_.begin(), pairPotentials_.end(),
+                           [at1, at2](const auto &pp) {
+                               return (pp->atomTypeI() == at1 && pp->atomTypeJ() == at2) ||
+                                      (pp->atomTypeI() == at2 && pp->atomTypeJ() == at1);
+                           });
     return it != pairPotentials_.end() ? it->get() : nullptr;
 }
 
 PairPotential *Dissolve::pairPotential(std::string_view at1, std::string_view at2) const
 {
-    auto it = std::find_if(pairPotentials_.begin(), pairPotentials_.end(), [at1, at2](const auto &pp) {
-        return (DissolveSys::sameString(pp->atomTypeNameI(), at1) && DissolveSys::sameString(pp->atomTypeNameJ(), at2)) ||
-               (DissolveSys::sameString(pp->atomTypeNameI(), at2) && DissolveSys::sameString(pp->atomTypeNameJ(), at1));
-    });
+    auto it = std::find_if(
+        pairPotentials_.begin(), pairPotentials_.end(),
+        [at1, at2](const auto &pp)
+        {
+            return (DissolveSys::sameString(pp->atomTypeNameI(), at1) && DissolveSys::sameString(pp->atomTypeNameJ(), at2)) ||
+                   (DissolveSys::sameString(pp->atomTypeNameI(), at2) && DissolveSys::sameString(pp->atomTypeNameJ(), at1));
+        });
     return it != pairPotentials_.end() ? it->get() : nullptr;
 }
 
@@ -93,7 +98,8 @@ bool Dissolve::regeneratePairPotentials()
     // Create a pair potential for each unique atom type pair
     auto success =
         for_each_pair_early(coreData_.atomTypes().begin(), coreData_.atomTypes().end(),
-                            [&](int typeI, const auto &at1, int typeJ, const auto &at2) -> EarlyReturn<bool> {
+                            [&](int typeI, const auto &at1, int typeJ, const auto &at2) -> EarlyReturn<bool>
+                            {
                                 Messenger::printVerbose("Adding new PairPotential for interaction between '{}' and '{}'...\n",
                                                         at1->name(), at2->name());
                                 auto *pot = addPairPotential(at1, at2);

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -33,7 +33,8 @@ bool Dissolve::prepare()
         usedAtomTypes.add(sp->atomTypes());
 
     atomTypes().erase(std::remove_if(atomTypes().begin(), atomTypes().end(),
-                                     [&](const auto &at) {
+                                     [&](const auto &at)
+                                     {
                                          if (usedAtomTypes.contains(at))
                                              return false;
                                          else
@@ -106,10 +107,14 @@ bool Dissolve::prepare()
                             DissolveSys::btoa(neutralConfigsWithSpeciesCharges));
 
     // -- Do all used Species have 95% non-zero atomic charges?
-    auto speciesHaveValidAtomicCharges = std::all_of(globalUsedSpecies.begin(), globalUsedSpecies.end(), [](const auto &sp) {
-        return (std::count_if(sp->atoms().begin(), sp->atoms().end(), [](const auto &i) { return fabs(i.charge()) > 1.0e-5; }) /
-                double(sp->nAtoms())) > 0.95;
-    });
+    auto speciesHaveValidAtomicCharges =
+        std::all_of(globalUsedSpecies.begin(), globalUsedSpecies.end(),
+                    [](const auto &sp)
+                    {
+                        return (std::count_if(sp->atoms().begin(), sp->atoms().end(),
+                                              [](const auto &i) { return fabs(i.charge()) > 1.0e-5; }) /
+                                double(sp->nAtoms())) > 0.95;
+                    });
     Messenger::printVerbose("Species atomic charge validity  : {}\n", DissolveSys::btoa(speciesHaveValidAtomicCharges));
     // -- Do all atom types have 95% non-zero charges
     auto atomTypesHaveValidAtomicCharges =

--- a/src/main/species.cpp
+++ b/src/main/species.cpp
@@ -124,9 +124,9 @@ Species *Dissolve::copySpecies(const Species *species)
 {
     // Create our new Species
     Species *newSpecies = addSpecies();
-    newSpecies->setName(DissolveSys::uniqueName(species->name(), coreData_.species(), [&](const auto &sp) {
-        return newSpecies == sp.get() ? std::string() : sp->name();
-    }));
+    newSpecies->setName(DissolveSys::uniqueName(species->name(), coreData_.species(),
+                                                [&](const auto &sp)
+                                                { return newSpecies == sp.get() ? std::string() : sp->name(); }));
 
     // Copy Box definition if one exists
     if (species->box()->type() != Box::BoxType::NonPeriodic)

--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -47,9 +47,8 @@ void convolve(Data1D &data, const Functions::Function1DWrapper function, bool va
         {
             // Inner loop over whole array
             std::transform(x.begin(), x.end(), newY.begin(), newY.begin(),
-                           [yn = yn, &function, norm, xCentre = xCentre](auto X, auto NewY) {
-                               return NewY + yn * function.y(X - xCentre) * norm;
-                           });
+                           [yn = yn, &function, norm, xCentre = xCentre](auto X, auto NewY)
+                           { return NewY + yn * function.y(X - xCentre) * norm; });
         }
     }
 

--- a/src/math/ft.cpp
+++ b/src/math/ft.cpp
@@ -59,15 +59,15 @@ bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double w
 
     // Perform Fourier sine transform, apply general and omega-dependent broadening, as well as window function
     dissolve::transform(ParallelPolicies::par, newX.begin(), newX.end(), newY.begin(),
-                        [normFactor, &product, &x, &windowFunction, &broadening](const auto omega) {
+                        [normFactor, &product, &x, &windowFunction, &broadening](const auto omega)
+                        {
                             double ft = 0.0;
 
                             if (omega > 0.0)
-                                ft = std::transform_reduce(product.begin(), product.end(), x.begin(), 0.0, std::plus(),
-                                                           [omega, &windowFunction, &broadening](const auto r, const auto x) {
-                                                               return r * sin(x * omega) * windowFunction.y(x, omega) *
-                                                                      broadening.yFT(x, omega);
-                                                           });
+                                ft = std::transform_reduce(
+                                    product.begin(), product.end(), x.begin(), 0.0, std::plus(),
+                                    [omega, &windowFunction, &broadening](const auto r, const auto x)
+                                    { return r * sin(x * omega) * windowFunction.y(x, omega) * broadening.yFT(x, omega); });
                             else
                                 ft = std::transform_reduce(product.begin(), product.end(), x.begin(), 0.0, std::plus(),
                                                            [omega, &windowFunction, &broadening](const auto r, const auto x) {

--- a/src/math/function1d.cpp
+++ b/src/math/function1d.cpp
@@ -62,7 +62,8 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
     {Function1D::Gaussian,
      {{"fwhm"},
       FunctionProperties::FourierTransform | FunctionProperties::Normalisation,
-      [](std::vector<double> p) {
+      [](std::vector<double> p)
+      {
           p.push_back(p[0] / (2.0 * sqrt(2.0 * log(2.0))));
           p.push_back(1.0 / p[1]);
           return p;
@@ -97,7 +98,8 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
     {Function1D::ScaledGaussian,
      {{"A", "fwhm"},
       FunctionProperties::FourierTransform | FunctionProperties::Normalisation,
-      [](std::vector<double> p) {
+      [](std::vector<double> p)
+      {
           p.push_back(p[1] / (2.0 * sqrt(2.0 * log(2.0))));
           p.push_back(1.0 / p[2]);
           return p;
@@ -131,7 +133,8 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
     {Function1D::OmegaDependentGaussian,
      {{"fwhm(x)"},
       FunctionProperties::FourierTransform | FunctionProperties::Normalisation,
-      [](std::vector<double> p) {
+      [](std::vector<double> p)
+      {
           p.push_back(p[0] / (2.0 * sqrt(2.0 * log(2.0))));
           p.push_back(1.0 / p[1]);
           return p;
@@ -141,17 +144,15 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
        * f(x) = exp ( - ---------------- )
        *            (   2 * (c*omega)**2 )
        */
-      [](double x, double omega, const std::vector<double> &p) {
-          return exp(-(x * x) / (2.0 * (p[1] * omega) * (p[1] * omega)));
-      },
+      [](double x, double omega, const std::vector<double> &p)
+      { return exp(-(x * x) / (2.0 * (p[1] * omega) * (p[1] * omega))); },
       /*
        *             (   x*x * (c*omega)**2 )
        * FT(x) = exp ( - ------------------ )
        *             (            2         )
        */
-      [](double x, double omega, const std::vector<double> &p) {
-          return exp(-(0.5 * x * x * (p[1] * omega) * (p[1] * omega)));
-      },
+      [](double x, double omega, const std::vector<double> &p)
+      { return exp(-(0.5 * x * x * (p[1] * omega) * (p[1] * omega))); },
       /*
        *                1
        * Norm = ------------------
@@ -172,7 +173,8 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
     {Function1D::GaussianC2,
      {{"fwhm", "fwhm(x)"},
       FunctionProperties::FourierTransform,
-      [](std::vector<double> p) {
+      [](std::vector<double> p)
+      {
           p.push_back(p[0] / (2.0 * sqrt(2.0 * log(2.0))));
           p.push_back(p[1] / (2.0 * sqrt(2.0 * log(2.0))));
           p.push_back(1.0 / p[2]);
@@ -184,17 +186,15 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
        * f(x) = exp ( - ---------------------- )
        *            (   2 * (c1 + c2*omega)**2 )
        */
-      [](double x, double omega, const std::vector<double> &p) {
-          return exp(-(x * x) / (2.0 * (p[2] + p[3] * omega) * (p[2] + p[3] * omega)));
-      },
+      [](double x, double omega, const std::vector<double> &p)
+      { return exp(-(x * x) / (2.0 * (p[2] + p[3] * omega) * (p[2] + p[3] * omega))); },
       /*
        *             (   x * x * (c1 + c2*omega)**2 )
        * FT(x) = exp ( - -------------------------- )
        *             (                2             )
        */
-      [](double x, double omega, const std::vector<double> &p) {
-          return exp(-(0.5 * x * x * (p[2] + p[3] * omega) * (p[2] + p[3] * omega)));
-      },
+      [](double x, double omega, const std::vector<double> &p)
+      { return exp(-(0.5 * x * x * (p[2] + p[3] * omega) * (p[2] + p[3] * omega))); },
       /*
        *                    1
        * Norm = --------------------------

--- a/src/math/gaussfit.cpp
+++ b/src/math/gaussfit.cpp
@@ -273,24 +273,27 @@ double GaussFit::sweepFitA(FunctionSpace::SpaceType space, double xMin, int samp
             generateApproximation(alphaSpace_);
 
             // Set up minimiser for the next batch
-            MonteCarloMinimiser gaussMinimiser([this]() {
-                double sose = 0.0;
-                double multiplier = 1.0;
-
-                // Loop over data points, add in our Gaussian contributions, and
-                double dy;
-                for (auto &&[x, y, refY] : zip(approximateData_.xAxis(), approximateData_.values(), referenceData_.values()))
+            MonteCarloMinimiser gaussMinimiser(
+                [this]()
                 {
-                    // Add in contributions from our Gaussians
-                    for (auto n = 0; n < A_.size(); ++n)
-                        y += functionValue(alphaSpace_, x, x_[n], A_[n], fwhm_[n]);
+                    double sose = 0.0;
+                    double multiplier = 1.0;
 
-                    dy = refY - y;
-                    sose += dy * dy;
-                }
+                    // Loop over data points, add in our Gaussian contributions, and
+                    double dy;
+                    for (auto &&[x, y, refY] :
+                         zip(approximateData_.xAxis(), approximateData_.values(), referenceData_.values()))
+                    {
+                        // Add in contributions from our Gaussians
+                        for (auto n = 0; n < A_.size(); ++n)
+                            y += functionValue(alphaSpace_, x, x_[n], A_[n], fwhm_[n]);
 
-                return sose * multiplier;
-            });
+                        dy = refY - y;
+                        sose += dy * dy;
+                    }
+
+                    return sose * multiplier;
+                });
 
             // Add Gaussian parameters as fitting targets
             for (auto n = 0; n < sampleSize; ++n)
@@ -353,26 +356,28 @@ double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, d
     updatePrecalculatedFunctions(alphaSpace_);
 
     // Perform Monte Carlo minimisation on the amplitudes
-    MonteCarloMinimiser gaussMinimiser([this]() {
-        auto sose = 0.0;
-
-        // Loop over data points and sum contributions from tabulated functions on to the current approximate data
-        double y, dy;
-        for (auto i = 0; i < approximateData_.nValues(); ++i)
+    MonteCarloMinimiser gaussMinimiser(
+        [this]()
         {
-            // Get approximate data x and y for this point
-            y = approximateData_.value(i);
+            auto sose = 0.0;
 
-            // Add in contributions from our Gaussians
-            for (auto n = 0; n < A_.size(); ++n)
-                y += functions_[{n, i}] * A_[n];
+            // Loop over data points and sum contributions from tabulated functions on to the current approximate data
+            double y, dy;
+            for (auto i = 0; i < approximateData_.nValues(); ++i)
+            {
+                // Get approximate data x and y for this point
+                y = approximateData_.value(i);
 
-            dy = referenceData_.value(i) - y;
-            sose += dy * dy;
-        }
+                // Add in contributions from our Gaussians
+                for (auto n = 0; n < A_.size(); ++n)
+                    y += functions_[{n, i}] * A_[n];
 
-        return sose;
-    });
+                dy = referenceData_.value(i) - y;
+                sose += dy * dy;
+            }
+
+            return sose;
+        });
 
     // Add the Gaussian amplitudes to the fitting pool - ignore any whose x centre is below rMin
     for (auto n = 0; n < nGaussians_; ++n)
@@ -421,26 +426,28 @@ double GaussFit::constructReciprocal(double rMin, double rMax, const std::vector
     updatePrecalculatedFunctions(alphaSpace_);
 
     // Perform Monte Carlo minimisation on the amplitudes
-    MonteCarloMinimiser gaussMinimiser([this]() {
-        auto sose = 0.0;
-
-        // Loop over data points and sum contributions from tabulated functions on to the current approximate data
-        double y, dy;
-        for (auto i = 0; i < approximateData_.nValues(); ++i)
+    MonteCarloMinimiser gaussMinimiser(
+        [this]()
         {
-            // Get approximate data x and y for this point
-            y = approximateData_.value(i);
+            auto sose = 0.0;
 
-            // Add in contributions from our Gaussians
-            for (auto n = 0; n < A_.size(); ++n)
-                y += functions_[{n, i}] * A_[n];
+            // Loop over data points and sum contributions from tabulated functions on to the current approximate data
+            double y, dy;
+            for (auto i = 0; i < approximateData_.nValues(); ++i)
+            {
+                // Get approximate data x and y for this point
+                y = approximateData_.value(i);
 
-            dy = referenceData_.value(i) - y;
-            sose += dy * dy;
-        }
+                // Add in contributions from our Gaussians
+                for (auto n = 0; n < A_.size(); ++n)
+                    y += functions_[{n, i}] * A_[n];
 
-        return sose;
-    });
+                dy = referenceData_.value(i) - y;
+                sose += dy * dy;
+            }
+
+            return sose;
+        });
 
     // Add the Gaussian amplitudes to the fitting pool - ignore any whose x centre is below rMin
     for (auto n = 0; n < nGaussians_; ++n)

--- a/src/math/poissonfit.cpp
+++ b/src/math/poissonfit.cpp
@@ -322,28 +322,30 @@ double PoissonFit::sweepFitC(FunctionSpace::SpaceType space, double xMin, int sa
             generateApproximation(space);
 
             // Set up minimiser for the next batch
-            MonteCarloMinimiser poissonMinimiser([this]() {
-                auto sose = 0.0;
-                auto multiplier = 1.0;
-
-                // Loop over data points, add in our Gaussian contributions, and
-                double x, y, dy;
-                for (auto i = 0; i < approximateData_.nValues(); ++i)
+            MonteCarloMinimiser poissonMinimiser(
+                [this]()
                 {
-                    // Get approximate data x and y for this point
-                    x = approximateData_.xAxis(i);
-                    y = approximateData_.value(i);
+                    auto sose = 0.0;
+                    auto multiplier = 1.0;
 
-                    // Add in contributions from our Gaussians
-                    for (auto n = 0; n < C_.size(); ++n)
-                        y += (alphaSpace_ == FunctionSpace::RealSpace ? C_[n] * poisson(x, n) : C_[n] * poissonFT(i, n));
+                    // Loop over data points, add in our Gaussian contributions, and
+                    double x, y, dy;
+                    for (auto i = 0; i < approximateData_.nValues(); ++i)
+                    {
+                        // Get approximate data x and y for this point
+                        x = approximateData_.xAxis(i);
+                        y = approximateData_.value(i);
 
-                    dy = referenceData_.value(i) - y;
-                    sose += dy * dy;
-                }
+                        // Add in contributions from our Gaussians
+                        for (auto n = 0; n < C_.size(); ++n)
+                            y += (alphaSpace_ == FunctionSpace::RealSpace ? C_[n] * poisson(x, n) : C_[n] * poissonFT(i, n));
 
-                return sose * multiplier;
-            });
+                        dy = referenceData_.value(i) - y;
+                        sose += dy * dy;
+                    }
+
+                    return sose * multiplier;
+                });
 
             alphaSpace_ = space;
 

--- a/src/module/groups.cpp
+++ b/src/module/groups.cpp
@@ -41,9 +41,9 @@ const std::vector<std::string> &ModuleGroups::allowedModuleTypes() const { retur
 ModuleGroup *ModuleGroups::addModule(Module *module, std::string_view groupName)
 {
     // Does the specified group exist?
-    auto moduleGroup = std::find_if(groups_.begin(), groups_.end(), [groupName](auto &moduleGroup) {
-        return DissolveSys::sameString(moduleGroup->name(), groupName);
-    });
+    auto moduleGroup =
+        std::find_if(groups_.begin(), groups_.end(),
+                     [groupName](auto &moduleGroup) { return DissolveSys::sameString(moduleGroup->name(), groupName); });
 
     if (moduleGroup == groups_.end())
     {

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -82,9 +82,9 @@ bool ModuleLayer::canRun(GenericList &processingModuleData) const
     if (runControlFlags_.isSet(ModuleLayer::RunControlFlag::SizeFactors))
     {
         // Check that Configurations have unmodified size factor
-        if (std::any_of(cfgs.begin(), cfgs.end(), [](const auto *cfg) {
-                return std::abs(cfg->appliedSizeFactor() - 1.0) > 2 * std::numeric_limits<double>::epsilon();
-            }))
+        if (std::any_of(cfgs.begin(), cfgs.end(),
+                        [](const auto *cfg)
+                        { return std::abs(cfg->appliedSizeFactor() - 1.0) > 2 * std::numeric_limits<double>::epsilon(); }))
         {
             Messenger::print("One or more configurations have an applied size factor, so the layer will not run.\n");
             return false;

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -37,9 +37,9 @@ bool AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Messenger::print("Accumulating data from module '{}'...\n", targetModule->name());
 
         // Is the target module / data type a valid combination?
-        auto targetModule_It = std::find_if(validTargets.begin(), validTargets.end(), [targetModule](const auto &target) {
-            return target.first == targetModule->type();
-        });
+        auto targetModule_It =
+            std::find_if(validTargets.begin(), validTargets.end(),
+                         [targetModule](const auto &target) { return target.first == targetModule->type(); });
         if (targetModule_It == validTargets.end())
             return Messenger::error("Module of type '{}' is not a valid target.\n", targetModule->type());
         auto dataName = targetModule_It->second[targetPartialSet_];

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -339,7 +339,8 @@ bool BraggModule::formReflectionFunctions(GenericList &moduleData, const Process
     int bin;
     auto &types = cfg->atomTypes();
     dissolve::for_each_pair(ParallelPolicies::seq, types.begin(), types.end(),
-                            [&](int typeI, auto &atd1, int typeJ, auto &atd2) {
+                            [&](int typeI, auto &atd1, int typeJ, auto &atd2)
+                            {
                                 // Retrieve partial container and make sure its tag is set
                                 auto &partial = braggPartials[{typeI, typeJ}];
                                 partial.setTag(fmt::format("{}-{}", atd1.atomTypeName(), atd2.atomTypeName()));

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -153,7 +153,8 @@ bool BraggModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         auto &types = targetConfiguration_->atomTypes();
         auto success = for_each_pair_early(
             types.begin(), types.end(),
-            [&](int i, const AtomTypeData &atd1, int j, const AtomTypeData &atd2) -> EarlyReturn<bool> {
+            [&](int i, const AtomTypeData &atd1, int j, const AtomTypeData &atd2) -> EarlyReturn<bool>
+            {
                 LineParser intensityParser(&procPool);
                 if (!intensityParser.openOutput(fmt::format("{}-{}-{}.txt", name_, atd1.atomTypeName(), atd2.atomTypeName())))
                     return false;

--- a/src/modules/checkspecies/process.cpp
+++ b/src/modules/checkspecies/process.cpp
@@ -79,12 +79,14 @@ bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool
     {
         Messenger::print("\nChecking bond parameters...\n");
         nBondsFailed =
-            std::accumulate(bondParameters_.begin(), bondParameters_.end(), 0, [&](const auto &acc, const auto &bond) {
-                auto &indices = std::get<0>(bond);
-                return acc + parametersDiffer<const SpeciesBond>("bond",
-                                                                 targetSpecies_->getBond(indices.at(0) - 1, indices.at(1) - 1),
-                                                                 indices, std::get<1>(bond), tolerance_);
-            });
+            std::accumulate(bondParameters_.begin(), bondParameters_.end(), 0,
+                            [&](const auto &acc, const auto &bond)
+                            {
+                                auto &indices = std::get<0>(bond);
+                                return acc + parametersDiffer<const SpeciesBond>(
+                                                 "bond", targetSpecies_->getBond(indices.at(0) - 1, indices.at(1) - 1), indices,
+                                                 std::get<1>(bond), tolerance_);
+                            });
     }
 
     // Check angle parameters
@@ -92,8 +94,10 @@ bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool
     if (!angleParameters_.empty())
     {
         Messenger::print("\nChecking angle parameters...\n");
-        nAnglesFailed =
-            std::accumulate(angleParameters_.begin(), angleParameters_.end(), 0, [&](const auto &acc, const auto &angle) {
+        nAnglesFailed = std::accumulate(
+            angleParameters_.begin(), angleParameters_.end(), 0,
+            [&](const auto &acc, const auto &angle)
+            {
                 auto &indices = std::get<0>(angle);
                 return acc + parametersDiffer<SpeciesAngle>(
                                  "angle", targetSpecies_->getAngle(indices.at(0) - 1, indices.at(1) - 1, indices.at(2) - 1),
@@ -106,14 +110,16 @@ bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool
     if (!torsionParameters_.empty())
     {
         Messenger::print("\nChecking torsion parameters...\n");
-        nTorsionsFailed =
-            std::accumulate(torsionParameters_.begin(), torsionParameters_.end(), 0, [&](const auto &acc, const auto &torsion) {
-                auto &indices = std::get<0>(torsion);
-                return acc + parametersDiffer<SpeciesTorsion>("torsion",
-                                                              targetSpecies_->getTorsion(indices.at(0) - 1, indices.at(1) - 1,
-                                                                                         indices.at(2) - 1, indices.at(3) - 1),
-                                                              indices, std::get<1>(torsion), tolerance_);
-            });
+        nTorsionsFailed = std::accumulate(torsionParameters_.begin(), torsionParameters_.end(), 0,
+                                          [&](const auto &acc, const auto &torsion)
+                                          {
+                                              auto &indices = std::get<0>(torsion);
+                                              return acc + parametersDiffer<SpeciesTorsion>(
+                                                               "torsion",
+                                                               targetSpecies_->getTorsion(indices.at(0) - 1, indices.at(1) - 1,
+                                                                                          indices.at(2) - 1, indices.at(3) - 1),
+                                                               indices, std::get<1>(torsion), tolerance_);
+                                          });
     }
 
     // Check improper parameters
@@ -121,15 +127,17 @@ bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool
     if (!improperParameters_.empty())
     {
         Messenger::print("\nChecking improper parameters...\n");
-        nImpropersFailed = std::accumulate(
-            improperParameters_.begin(), improperParameters_.end(), 0, [&](const auto &acc, const auto &improper) {
-                auto &indices = std::get<0>(improper);
-                return acc +
-                       parametersDiffer<SpeciesImproper>("improper",
-                                                         targetSpecies_->getImproper(indices.at(0) - 1, indices.at(1) - 1,
-                                                                                     indices.at(2) - 1, indices.at(3) - 1),
-                                                         indices, std::get<1>(improper), tolerance_);
-            });
+        nImpropersFailed =
+            std::accumulate(improperParameters_.begin(), improperParameters_.end(), 0,
+                            [&](const auto &acc, const auto &improper)
+                            {
+                                auto &indices = std::get<0>(improper);
+                                return acc + parametersDiffer<SpeciesImproper>(
+                                                 "improper",
+                                                 targetSpecies_->getImproper(indices.at(0) - 1, indices.at(1) - 1,
+                                                                             indices.at(2) - 1, indices.at(3) - 1),
+                                                 indices, std::get<1>(improper), tolerance_);
+                            });
     }
 
     return (nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0;

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -31,8 +31,9 @@ void ForcesModule::internalMoleculeForces(const ProcessPool &procPool, Configura
     // Molecule Force Operator
     auto combinableForcesInter = createCombinableForces(fInter);
     auto combinableForcesIntra = createCombinableForces(fIntra);
-    auto moleculeForceOperator = [&combinableForcesInter, &combinableForcesIntra, &kernel,
-                                  includePairPotentialTerms](const auto &mol) {
+    auto moleculeForceOperator =
+        [&combinableForcesInter, &combinableForcesIntra, &kernel, includePairPotentialTerms](const auto &mol)
+    {
         auto &fLocalInter = combinableForcesInter.local();
         auto &fLocalIntra = combinableForcesIntra.local();
 
@@ -58,7 +59,8 @@ void ForcesModule::internalMoleculeForces(const ProcessPool &procPool, Configura
         // Pair potential interactions between atoms
         if (includePairPotentialTerms)
             dissolve::for_each_pair(ParallelPolicies::seq, mol->atoms().begin(), mol->atoms().end(),
-                                    [&](int indexI, const auto &i, int indexJ, const auto &j) {
+                                    [&](int indexI, const auto &i, int indexJ, const auto &j)
+                                    {
                                         if (indexI == indexJ)
                                             return;
                                         auto scale = i->scaling(j);
@@ -115,7 +117,8 @@ void ForcesModule::pairPotentialForces(const ProcessPool &procPool, Configuratio
     auto [begin, end] = chop_range(0, cellArray.nCells(), stride, start);
 
     // algorithm parameters
-    auto unaryOp = [&combinableForces, &kernel, &cellArray, strategy](const int id) {
+    auto unaryOp = [&combinableForces, &kernel, &cellArray, strategy](const int id)
+    {
         auto *cellI = cellArray.cell(id);
         auto &fLocal = combinableForces.local();
         // This cell with itself
@@ -215,8 +218,9 @@ void ForcesModule::totalForces(const ProcessPool &procPool, const Species *sp, c
     const auto cutoffSq = potentialMap.range() * potentialMap.range();
 
     auto combinableForces = createCombinableForces(f);
-    auto pairwiseForceOperator = [&combinableForces, &potentialMap, cutoffSq, box](int indexI, const auto &i, int indexJ,
-                                                                                   const auto &j) {
+    auto pairwiseForceOperator =
+        [&combinableForces, &potentialMap, cutoffSq, box](int indexI, const auto &i, int indexJ, const auto &j)
+    {
         if (indexI == indexJ)
             return;
         auto scale = i.scaling(&j);

--- a/src/modules/rdf/functions.cpp
+++ b/src/modules/rdf/functions.cpp
@@ -46,7 +46,8 @@ bool RDFModule::calculateGRTestSerial(Configuration *cfg, PartialSet &partialSet
 
     dissolve::for_each_pair(
         ParallelPolicies::seq, cfg->atoms().begin(), cfg->atoms().end(),
-        [box, &partialSet](auto i, auto &ii, auto j, auto &jj) {
+        [box, &partialSet](auto i, auto &ii, auto j, auto &jj)
+        {
             if (&ii != &jj)
                 partialSet.fullHistogram(ii.localTypeIndex(), jj.localTypeIndex()).bin(box->minimumDistance(ii.r(), jj.r()));
         });
@@ -108,16 +109,18 @@ bool RDFModule::calculateGRSimple(const ProcessPool &procPool, Configuration *cf
         nPoints = partialSet.fullHistogram(typeI, typeI).nBins();
         PairIterator pairs(maxr[typeI]);
         auto [start, stop] = chop_range(pairs, pairs.end(), nChunks, offset);
-        std::for_each(start, stop, [box, bins, rbin, ri, nPoints, &histogram](auto it) {
-            auto [i, j] = it;
-            auto centre = ri[i];
-            auto other = ri[j];
-            if (i == j)
-                return;
-            bins[j] = box->minimumDistance(centre, other) * rbin;
-            if (bins[j] < nPoints)
-                ++histogram[bins[j]];
-        });
+        std::for_each(start, stop,
+                      [box, bins, rbin, ri, nPoints, &histogram](auto it)
+                      {
+                          auto [i, j] = it;
+                          auto centre = ri[i];
+                          auto other = ri[j];
+                          if (i == j)
+                              return;
+                          bins[j] = box->minimumDistance(centre, other) * rbin;
+                          if (bins[j] < nPoints)
+                              ++histogram[bins[j]];
+                      });
     }
 
     Messenger::printVerbose("Cross terms..\n");
@@ -174,16 +177,19 @@ bool RDFModule::calculateGRCells(const ProcessPool &procPool, Configuration *cfg
     auto nChunks = procPool.interleavedLoopStride(ProcessPool::PoolStrategy);
     auto [cStart, cEnd] = chop_range(0, comb.getNumCombinations(), nChunks, offset);
 
-    auto combinableHistograms = dissolve::CombinableValue<Array2D<Histogram1D>>([&partialSet]() {
-        Array2D<Histogram1D> histograms;
-        histograms.initialise(partialSet.nAtomTypes(), partialSet.nAtomTypes(), true);
-        for (auto i = 0; i < partialSet.nAtomTypes(); ++i)
-            for (auto j = i; j < partialSet.nAtomTypes(); ++j)
-                histograms[{i, j}] = partialSet.fullHistogram(i, j);
-        return histograms;
-    });
+    auto combinableHistograms = dissolve::CombinableValue<Array2D<Histogram1D>>(
+        [&partialSet]()
+        {
+            Array2D<Histogram1D> histograms;
+            histograms.initialise(partialSet.nAtomTypes(), partialSet.nAtomTypes(), true);
+            for (auto i = 0; i < partialSet.nAtomTypes(); ++i)
+                for (auto j = i; j < partialSet.nAtomTypes(); ++j)
+                    histograms[{i, j}] = partialSet.fullHistogram(i, j);
+            return histograms;
+        });
 
-    auto unaryOp = [&combinableHistograms, cfg, &comb, rdfRange](const auto idx) {
+    auto unaryOp = [&combinableHistograms, cfg, &comb, rdfRange](const auto idx)
+    {
         // auto &histograms = combinableHistograms.local().histograms_;
         auto &histograms = combinableHistograms.local();
         const auto *box = cfg->box();
@@ -229,16 +235,18 @@ bool RDFModule::calculateGRCells(const ProcessPool &procPool, Configuration *cfg
 
         // Add contributions between atoms in cellI
         PairIterator pairs(atomsI.size());
-        std::for_each(pairs.begin(), pairs.end(), [&atomsI, &partialSet](auto it) {
-            auto [idx, jdx] = it;
-            if (idx == jdx)
-                return;
-            auto &i = atomsI[idx];
-            auto &j = atomsI[jdx];
-            // No need to perform MIM since we're in the same cell
-            double distance = (i->r() - j->r()).magnitude();
-            partialSet.fullHistogram(i->localTypeIndex(), j->localTypeIndex()).bin(distance);
-        });
+        std::for_each(pairs.begin(), pairs.end(),
+                      [&atomsI, &partialSet](auto it)
+                      {
+                          auto [idx, jdx] = it;
+                          if (idx == jdx)
+                              return;
+                          auto &i = atomsI[idx];
+                          auto &j = atomsI[jdx];
+                          // No need to perform MIM since we're in the same cell
+                          double distance = (i->r() - j->r()).magnitude();
+                          partialSet.fullHistogram(i->localTypeIndex(), j->localTypeIndex()).bin(distance);
+                      });
     }
     return true;
 }
@@ -374,7 +382,8 @@ bool RDFModule::calculateGR(GenericList &processingData, const ProcessPool &proc
 
         dissolve::for_each_pair(
             ParallelPolicies::seq, atoms.begin(), atoms.end(),
-            [box, &cells, &originalgr](int index, auto &i, int jndex, auto &j) {
+            [box, &cells, &originalgr](int index, auto &i, int jndex, auto &j)
+            {
                 // Ignore atom on itself
                 if (index == jndex)
                     return;
@@ -394,24 +403,26 @@ bool RDFModule::calculateGR(GenericList &processingData, const ProcessPool &proc
 
     timer.start();
     Timer commsTimer(false);
-    auto success = for_each_pair_early(
-        0, originalgr.nAtomTypes(), [&originalgr, &procPool, &commsTimer, method](auto typeI, auto typeJ) -> EarlyReturn<bool> {
-            // Sum histogram data from all processes (except if using RDFModule::TestMethod, where all
-            // processes have all data already)
-            if (method != RDFModule::TestMethod)
-            {
-                if (!originalgr.fullHistogram(typeI, typeJ).allSum(procPool, commsTimer))
-                    return false;
-                if (!originalgr.boundHistogram(typeI, typeJ).allSum(procPool, commsTimer))
-                    return false;
-            }
+    auto success =
+        for_each_pair_early(0, originalgr.nAtomTypes(),
+                            [&originalgr, &procPool, &commsTimer, method](auto typeI, auto typeJ) -> EarlyReturn<bool>
+                            {
+                                // Sum histogram data from all processes (except if using RDFModule::TestMethod, where all
+                                // processes have all data already)
+                                if (method != RDFModule::TestMethod)
+                                {
+                                    if (!originalgr.fullHistogram(typeI, typeJ).allSum(procPool, commsTimer))
+                                        return false;
+                                    if (!originalgr.boundHistogram(typeI, typeJ).allSum(procPool, commsTimer))
+                                        return false;
+                                }
 
-            // Create unbound histogram from total and bound data
-            originalgr.unboundHistogram(typeI, typeJ) = originalgr.fullHistogram(typeI, typeJ);
-            originalgr.unboundHistogram(typeI, typeJ).add(originalgr.boundHistogram(typeI, typeJ), -1.0);
+                                // Create unbound histogram from total and bound data
+                                originalgr.unboundHistogram(typeI, typeJ) = originalgr.fullHistogram(typeI, typeJ);
+                                originalgr.unboundHistogram(typeI, typeJ).add(originalgr.boundHistogram(typeI, typeJ), -1.0);
 
-            return EarlyReturn<bool>::Continue;
-        });
+                                return EarlyReturn<bool>::Continue;
+                            });
     if (success.has_value() && !success.value())
         return false;
 
@@ -466,21 +477,20 @@ bool RDFModule::calculateUnweightedGR(const ProcessPool &procPool, Configuration
     // Broaden the bound partials according to the supplied PairBroadeningFunction
     auto &types = unweightedgr.atomTypeMix();
     dissolve::for_each_pair(ParallelPolicies::seq, types.begin(), types.end(),
-                            [&](int i, const AtomTypeData &typeI, int j, const AtomTypeData &typeJ) {
-                                Filters::convolve(unweightedgr.boundPartial(i, j), intraBroadening, true, true);
-                            });
+                            [&](int i, const AtomTypeData &typeI, int j, const AtomTypeData &typeJ)
+                            { Filters::convolve(unweightedgr.boundPartial(i, j), intraBroadening, true, true); });
 
     // Add broadened bound partials back in to full partials
     dissolve::for_each_pair(ParallelPolicies::seq, types.begin(), types.end(),
-                            [&](int i, const AtomTypeData &typeI, int j, const AtomTypeData &typeJ) {
-                                unweightedgr.partial(i, j) += unweightedgr.boundPartial(i, j);
-                            });
+                            [&](int i, const AtomTypeData &typeI, int j, const AtomTypeData &typeJ)
+                            { unweightedgr.partial(i, j) += unweightedgr.boundPartial(i, j); });
 
     // Apply smoothing if requested
     if (smoothing > 0)
     {
         dissolve::for_each_pair(ParallelPolicies::seq, types.begin(), types.end(),
-                                [&](int i, const AtomTypeData &typeI, int j, const AtomTypeData &typeJ) {
+                                [&](int i, const AtomTypeData &typeI, int j, const AtomTypeData &typeJ)
+                                {
                                     Filters::movingAverage(unweightedgr.partial(i, j), smoothing);
                                     Filters::movingAverage(unweightedgr.boundPartial(i, j), smoothing);
                                     Filters::movingAverage(unweightedgr.unboundPartial(i, j), smoothing);
@@ -530,9 +540,9 @@ bool RDFModule::sumUnweightedGR(GenericList &processingData, const ProcessPool &
     }
 
     // Calculate overall density of combined system
-    double rho0 = std::accumulate(configWeights.begin(), configWeights.end(), 0.0, [totalWeight](double acc, auto pair) {
-        return acc + pair.second / totalWeight / pair.first->atomicDensity().value();
-    });
+    double rho0 = std::accumulate(configWeights.begin(), configWeights.end(), 0.0,
+                                  [totalWeight](double acc, auto pair)
+                                  { return acc + pair.second / totalWeight / pair.first->atomicDensity().value(); });
     rho0 = 1.0 / rho0;
 
     // Sum Configurations into the PartialSet
@@ -569,7 +579,8 @@ bool RDFModule::testReferencePartials(PartialSet &setA, PartialSet &setB, double
 
     for_each_pair_early(
         atomTypes.begin(), atomTypes.end(),
-        [&](int n, const AtomTypeData &typeI, int m, const AtomTypeData &typeJ) -> EarlyReturn<bool> {
+        [&](int n, const AtomTypeData &typeI, int m, const AtomTypeData &typeJ) -> EarlyReturn<bool>
+        {
             // Full partial
             error = Error::percent(setA.partial(n, m), setB.partial(n, m));
             Messenger::print("Test reference full partial '{}-{}' has error of {:7.3f}% with calculated data and is "
@@ -664,7 +675,8 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
         auto &[data, format] = *sharedDataPointer.get();
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data.tag()};
-        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(
+            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments
@@ -695,7 +707,8 @@ bool RDFModule::testReferencePartials(const Data1DStore &testData, double testTh
         auto &[data, format] = *sharedDataPointer.get();
         // Grab the name, replace hyphens with '-', and parse the string into arguments
         std::string dataName{data.tag()};
-        std::replace_if(dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
+        std::replace_if(
+            dataName.begin(), dataName.end(), [](auto &c) { return c == '-'; }, ' ');
         parser.getArgsDelim(LineParser::Defaults, dataName);
 
         // Sanity check on number of arguments

--- a/src/modules/sq/functions.cpp
+++ b/src/modules/sq/functions.cpp
@@ -24,21 +24,24 @@ bool SQModule::calculateUnweightedSQ(const ProcessPool &procPool, const PartialS
     // Don't subtract 1.0 from the bound partials
     Timer timer;
     timer.start();
-    dissolve::for_each_pair(ParallelPolicies::par, 0, unweightedgr.nAtomTypes(), [&](int n, int m) {
-        // Total partial
-        unweightedsq.partial(n, m).copyArrays(unweightedgr.partial(n, m));
-        unweightedsq.partial(n, m) -= 1.0;
-        Fourier::sineFT(unweightedsq.partial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
+    dissolve::for_each_pair(
+        ParallelPolicies::par, 0, unweightedgr.nAtomTypes(),
+        [&](int n, int m)
+        {
+            // Total partial
+            unweightedsq.partial(n, m).copyArrays(unweightedgr.partial(n, m));
+            unweightedsq.partial(n, m) -= 1.0;
+            Fourier::sineFT(unweightedsq.partial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
 
-        // Bound partial
-        unweightedsq.boundPartial(n, m).copyArrays(unweightedgr.boundPartial(n, m));
-        Fourier::sineFT(unweightedsq.boundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
+            // Bound partial
+            unweightedsq.boundPartial(n, m).copyArrays(unweightedgr.boundPartial(n, m));
+            Fourier::sineFT(unweightedsq.boundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
 
-        // Unbound partial
-        unweightedsq.unboundPartial(n, m).copyArrays(unweightedgr.unboundPartial(n, m));
-        unweightedsq.unboundPartial(n, m) -= 1.0;
-        Fourier::sineFT(unweightedsq.unboundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
-    });
+            // Unbound partial
+            unweightedsq.unboundPartial(n, m).copyArrays(unweightedgr.unboundPartial(n, m));
+            unweightedsq.unboundPartial(n, m) -= 1.0;
+            Fourier::sineFT(unweightedsq.unboundPartial(n, m), 4.0 * PI * rho, qMin, qDelta, qMax, windowFunction, broadening);
+        });
 
     // Sum into total
     unweightedsq.formTotals(true);

--- a/src/modules/widgetproducer.h
+++ b/src/modules/widgetproducer.h
@@ -38,7 +38,8 @@ class ModuleWidgetProducer
     // Register producer for specific class
     template <class M, class W> void registerProducer()
     {
-        producers_[typeid(M)] = [](Module *module, Dissolve &dissolve) {
+        producers_[typeid(M)] = [](Module *module, Dissolve &dissolve)
+        {
             auto *derived = dynamic_cast<M *>(module);
             assert(derived);
             return new W(nullptr, derived, dissolve);

--- a/src/modules/xraysq/process.cpp
+++ b/src/modules/xraysq/process.cpp
@@ -193,7 +193,8 @@ bool XRaySQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     {
         auto result = for_each_pair_early(
             unweightedSQ.atomTypeMix().begin(), unweightedSQ.atomTypeMix().end(),
-            [&](int i, auto &at1, int j, auto &at2) -> EarlyReturn<bool> {
+            [&](int i, auto &at1, int j, auto &at2) -> EarlyReturn<bool>
+            {
                 if (i == j)
                 {
                     if (procPool.isMaster())

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -194,9 +194,9 @@ int NETAConnectionNode::score(const SpeciesAtom *i, std::vector<const SpeciesAto
         totalScore += jScore;
 
         // Track atoms matched in the neighbour branch
-        std::copy_if(jMatchPath.begin(), jMatchPath.end(), std::back_inserter(matchPath), [&matchPath](const auto *j) {
-            return std::find(matchPath.begin(), matchPath.end(), j) == matchPath.end();
-        });
+        std::copy_if(jMatchPath.begin(), jMatchPath.end(), std::back_inserter(matchPath),
+                     [&matchPath](const auto *j)
+                     { return std::find(matchPath.begin(), matchPath.end(), j) == matchPath.end(); });
     }
 
     return totalScore;

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -223,10 +223,10 @@ int NETARingNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &
                     totalAttemptedNodeMatches == forwardMatches.size() ? forwardMatches : backwardMatches;
 
                 // Store the ring information - total score and all matched atoms
-                matchedRings[&ring] = {
-                    std::accumulate(matchedRingAtoms.begin(), matchedRingAtoms.end(), 0,
-                                    [](const auto &acc, const auto &jInfo) { return acc + jInfo.second.first; }),
-                    {}};
+                matchedRings[&ring] = {std::accumulate(matchedRingAtoms.begin(), matchedRingAtoms.end(), 0,
+                                                       [](const auto &acc, const auto &jInfo)
+                                                       { return acc + jInfo.second.first; }),
+                                       {}};
                 auto &totalRingMatch = matchedRings[&ring].second;
                 for (auto &jInfo : matchedRingAtoms)
                 {
@@ -261,9 +261,9 @@ int NETARingNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &
         totalScore += ringScore;
 
         // Track atoms matched in the neighbour branch
-        std::copy_if(ringMatchPath.begin(), ringMatchPath.end(), std::back_inserter(matchPath), [&matchPath](const auto *j) {
-            return std::find(matchPath.begin(), matchPath.end(), j) == matchPath.end();
-        });
+        std::copy_if(ringMatchPath.begin(), ringMatchPath.end(), std::back_inserter(matchPath),
+                     [&matchPath](const auto *j)
+                     { return std::find(matchPath.begin(), matchPath.end(), j) == matchPath.end(); });
     }
 
     return totalScore;

--- a/src/procedure/nodes/coordinatesets.cpp
+++ b/src/procedure/nodes/coordinatesets.cpp
@@ -147,11 +147,13 @@ bool CoordinateSetsProcedureNode::execute(const ProcedureContext &procedureConte
 
     // Initialise random velocities
     std::vector<Vec3<double>> velocities(species_->nAtoms());
-    std::generate(velocities.begin(), velocities.end(), [&]() {
-        return Vec3<double>(exp(randomBuffer.random() - 0.5), exp(randomBuffer.random() - 0.5),
-                            exp(randomBuffer.random() - 0.5)) /
-               sqrt(TWOPI);
-    });
+    std::generate(velocities.begin(), velocities.end(),
+                  [&]()
+                  {
+                      return Vec3<double>(exp(randomBuffer.random() - 0.5), exp(randomBuffer.random() - 0.5),
+                                          exp(randomBuffer.random() - 0.5)) /
+                             sqrt(TWOPI);
+                  });
 
     // Grab current Species coordinates
     std::vector<Vec3<double>> r(species_->nAtoms());

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -40,7 +40,7 @@ class ProcedureNodeSequence
     // Append specified node to the sequence, or optionally insert at index
     void appendNode(NodeRef nodeToAdd, std::optional<int> insertAtIndex = std::nullopt);
     // Create new node
-    template <class N, typename... Args> std::shared_ptr<N> create(std::string_view name, Args &&... args)
+    template <class N, typename... Args> std::shared_ptr<N> create(std::string_view name, Args &&...args)
     {
         // Create the new node
         auto node = std::make_shared<N>(args...);

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -30,7 +30,7 @@ class Procedure
     // Clear all data
     void clear();
     // Create new node
-    template <class N, typename... Args> std::shared_ptr<N> createRootNode(std::string_view name, Args &&... args)
+    template <class N, typename... Args> std::shared_ptr<N> createRootNode(std::string_view name, Args &&...args)
     {
         return rootSequence_.create<N>(name, args...);
     }

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -95,9 +95,11 @@ template <typename... Args> class ZipIterator
     bool operator!=(ZipIterator<Args...> other)
     {
         return std::apply(
-            [&other](auto &a, auto &... as) {
+            [&other](auto &a, auto &...as)
+            {
                 return std::apply(
-                    [&a](auto &b, auto &... bs) {
+                    [&a](auto &b, auto &...bs)
+                    {
                         // Only test the first elements.  We have to make the
                         // assumption that all the containers are the same length,
                         // anyway and this saves us some tests and some code.
@@ -109,11 +111,11 @@ template <typename... Args> class ZipIterator
     }
     void operator++()
     {
-        std::apply([](auto &... item) { (item++, ...); }, source_);
+        std::apply([](auto &...item) { (item++, ...); }, source_);
     }
     auto operator*()
     {
-        return std::apply([](auto &... item) { return std::make_tuple(std::ref(*item)...); }, source_);
+        return std::apply([](auto &...item) { return std::make_tuple(std::ref(*item)...); }, source_);
     }
 
     private:
@@ -123,14 +125,14 @@ template <typename... Args> class ZipIterator
 template <typename... Args> class zip
 {
     public:
-    zip(Args &... args) : sources_(args...) {}
+    zip(Args &...args) : sources_(args...) {}
     auto begin()
     {
-        return ZipIterator(std::apply([](auto &... item) { return std::make_tuple(item.begin()...); }, sources_));
+        return ZipIterator(std::apply([](auto &...item) { return std::make_tuple(item.begin()...); }, sources_));
     }
     auto end()
     {
-        return ZipIterator(std::apply([](auto &... item) { return std::make_tuple(item.end()...); }, sources_));
+        return ZipIterator(std::apply([](auto &...item) { return std::make_tuple(item.end()...); }, sources_));
     }
 
     private:
@@ -218,20 +220,24 @@ template <typename ParallelPolicy, class Iter, class Lam>
 void for_each_pair(ParallelPolicy policy, Iter begin, Iter end, Lam lambda)
 {
     PairIterator start(end - begin), stop(end - begin, ((end - begin) * (end - begin + 1)) / 2);
-    for_each(policy, start, stop, [&lambda, &begin](const auto pair) {
-        auto &[i, j] = pair;
-        lambda(i, begin[i], j, begin[j]);
-    });
+    for_each(policy, start, stop,
+             [&lambda, &begin](const auto pair)
+             {
+                 auto &[i, j] = pair;
+                 lambda(i, begin[i], j, begin[j]);
+             });
 }
 
 // Perform an operation on every pair of elements in a range (begin <= i < end)
 template <typename ParallelPolicy, class Lam> void for_each_pair(ParallelPolicy policy, int begin, int end, Lam lambda)
 {
     PairIterator start(end), stop(end, end * (end + 1) / 2);
-    for_each(policy, start, stop, [&lambda](const auto pair) {
-        auto [i, j] = pair;
-        lambda(i, j);
-    });
+    for_each(policy, start, stop,
+             [&lambda](const auto pair)
+             {
+                 auto [i, j] = pair;
+                 lambda(i, j);
+             });
 }
 } // namespace dissolve
 

--- a/src/templates/combinable.h
+++ b/src/templates/combinable.h
@@ -24,9 +24,8 @@ template <class Container> class CombinableContainer
     }
     void finalize()
     {
-        auto combineOp = [this](const auto &localContainer) {
-            std::transform(parent_.begin(), parent_.end(), localContainer.begin(), parent_.begin(), std::plus<>{});
-        };
+        auto combineOp = [this](const auto &localContainer)
+        { std::transform(parent_.begin(), parent_.end(), localContainer.begin(), parent_.begin(), std::plus<>{}); };
         combinable_.combine_each(combineOp);
     }
 

--- a/unit/algorithms/sysFunc.cpp
+++ b/unit/algorithms/sysFunc.cpp
@@ -119,9 +119,9 @@ TEST(SysFunc, StringManipulation)
     auto &exc = names.emplace_back("IAmUnique01");
     EXPECT_FALSE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique01");
     EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique02");
-    EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [&](const auto &obj) {
-                    return &exc == &obj ? std::string() : obj.name;
-                }) == "IAmUnique01");
+    EXPECT_TRUE(
+        DissolveSys::uniqueName("IAmUnique", names, [&](const auto &obj) { return &exc == &obj ? std::string() : obj.name; }) ==
+        "IAmUnique01");
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR bumps the version of `clang-format` we use from `7` to `13`. `13` is not the most recent release, but it seems to be one which is consistently available across recent Linux distributions. In addition, version `7` is not available for Ubuntu 22.04 which will become the default version in pipelines over Azure and GitHub Actions soon.

There are, of course, some subtle formatting changes that this enforces within the code base, but at around ~1k lines it isn't _too_ bad.