### PR TITLE
1283 Deserialising XRayWeights

### DIFF
--- a/src/classes/xrayweights.cpp
+++ b/src/classes/xrayweights.cpp
@@ -267,7 +267,7 @@ bool XRayWeights::deserialise(LineParser &parser, const CoreData &coreData)
     clear();
 
     // Read form factor dataset to use
-    if (!parser.getArgsDelim())
+    if (parser.getArgsDelim() != LineParser::Success)
         return false;
     formFactors_ = XRayFormFactors::xRayFormFactorData().enumeration(parser.argsv(0));
 


### PR DESCRIPTION
One-liner to fix a problem with deserialisation of `XRayWeights`.

Closes #1281.