### PR TITLE
(Release Automation) Change release version to 0.9.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Dissolve's Logo](icon/logo.png)
 
-_Last Release: 0.9.11, Wednesday 30th November 2022_
+_Last Release: 0.9.12, Tuesday 20th December 2022_
 
 _Development Build::_ [![Build Status](https://dev.azure.com/DisorderedMaterials/Dissolve/_apis/build/status/Continuous%20Build?branchName=develop)](https://dev.azure.com/DisorderedMaterials/Dissolve/_build/latest?definitionId=9&branchName=develop)
 

--- a/web/config.toml
+++ b/web/config.toml
@@ -52,8 +52,8 @@ latexDashes = true
 # General Parameters
 [params]
 copyright = "Copyright (c) 2022 Team Dissolve and contributors. Built using Hugo/Docsy."
-releaseVersion = "0.9.11"
-releaseDate = "30th November 2022"
+releaseVersion = "0.9.12"
+releaseDate = "20th December 2022"
 devVersion = "1.0.0"
 github_repo = "https://github.com/disorderedmaterials/dissolve"
 github_subdir = "web"

--- a/web/static/include/old_releases.md
+++ b/web/static/include/old_releases.md
@@ -1,3 +1,4 @@
+- [Version 0.9.11, released 30 November 2022](https://github.com/disorderedmaterials/dissolve/releases/tag/0.9.11)
 - [Version 0.9.10, released 16 November 2022](https://github.com/disorderedmaterials/dissolve/releases/tag/0.9.10)
 - [Version 0.9.9, released 10 October 2022](https://github.com/disorderedmaterials/dissolve/releases/tag/0.9.9)
 - [Version 0.9.8, released 3 October 2022](https://github.com/disorderedmaterials/dissolve/releases/tag/0.9.8)


### PR DESCRIPTION
This is a spoofed automation PR for changing the released version of the code in web-visible locations.  It will be automated fully when the move to GitHub actions is complete.