### PR TITLE
NETA Identifiers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ int main(int args, char **argv)
         else
             Messenger::print("Restart file '{}' does not exist.\n", restartFile);
     }
-    
+
     // If we're just checking the input and restart files, exit now
     if (!options.nIterations())
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,7 @@ int main(int args, char **argv)
         else
             Messenger::print("Restart file '{}' does not exist.\n", restartFile);
     }
-
+    
     // If we're just checking the input and restart files, exit now
     if (!options.nIterations())
     {

--- a/src/neta/CMakeLists.txt
+++ b/src/neta/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   connection.cpp
   geometry.cpp
   hydrogencount.cpp
+  matchedpath.cpp
   neta.cpp
   node.cpp
   or.cpp
@@ -44,6 +45,7 @@ add_library(
   connection.h
   geometry.h
   hydrogencount.h
+  matchedpath.h
   neta.h
   node.h
   or.h

--- a/src/neta/NETALexer.g4
+++ b/src/neta/NETALexer.g4
@@ -59,10 +59,11 @@ CharacterKeyword: '?';
 ConnectionKeyword: '-';
 GeometryKeyword: 'g' 'e' 'o' 'm' 'e' 't' 'r' 'y';
 HydrogenCountKeyword: 'n' 'h';
+IdKeyword: '#';
 RingKeyword: 'r' 'i' 'n' 'g';
 
 // Named Tokens
 Element: UCASELETTER LCASELETTER*;
 FFTypeName: TypeReference LETTER (LETTER | DIGIT | SYMBOL)*;
 FFTypeIndex: TypeReference Integer;
-Keyword: LCASELETTER+;
+Text: LCASELETTER+;

--- a/src/neta/NETAParser.g4
+++ b/src/neta/NETAParser.g4
@@ -32,7 +32,7 @@ options {
 neta: RootNodes=nodeSequence? EOF;
 
 // Node Sequence - Zero or more nodes, comma-separated
-nodeSequence:    (Nodes+=node|Modifiers+=modifier|Options+=option|Flags+=flag) (Comma (Nodes+=node|Modifiers+=modifier|Options+=option|Flags+=flag))*      #sequence
+nodeSequence:    (Nodes+=node|Modifiers+=modifier|Options+=option|Flags+=flag|Identifiers+=identifier) (Comma (Nodes+=node|Modifiers+=modifier|Options+=option|Flags+=flag|Identifiers+=identifier))*      #sequence
 | LHS=nodeSequence Or RHS=nodeSequence                                                                                                                     #orSequence
 ;
 
@@ -64,7 +64,7 @@ connectionNode: Not? ConnectionKeyword Targets=targetList OpenParenthesis Sequen
 ;
 
 // Geometry Node
-geometryNode: GeometryKeyword EqualityOperator geometry=Keyword;
+geometryNode: GeometryKeyword EqualityOperator geometry=Text;
 
 // Hydrogen Count Node
 hydrogenCountNode: HydrogenCountKeyword comparisonOperator Integer;
@@ -86,13 +86,17 @@ targetList: targets+=elementOrType
 ;
 
 // Contextual Modifiers (kwd op value)
-modifier: Keyword comparisonOperator value=Integer;
+modifier: Text comparisonOperator value=Integer;
 
 // Option (kwd op kwd, only accepting '=' and '!=')
-option: opt=Keyword comparisonOperator value=Keyword;
+option: opt=Text comparisonOperator value=Text;
 
 // Context Flags (kwd)
-flag: Keyword;
+flag: Text;
+
+// Identifying Name
+identifier: IdKeyword names+=Text
+| IdKeyword OpenSquareBracket names+=Text (Comma names+=Text)* CloseSquareBracket;
 
 // Comparison Operators
 comparisonOperator: SizeOperator

--- a/src/neta/NETAVisitor.h
+++ b/src/neta/NETAVisitor.h
@@ -38,8 +38,6 @@ class NETAVisitor : private NETAParserBaseVisitor
     private:
     // Nodes
     antlrcpp::Any visitNeta(NETAParser::NetaContext *context) override;
-    void setContextuals(std::vector<NETAParser::ModifierContext *> modifiers, std::vector<NETAParser::OptionContext *> options,
-                        std::vector<NETAParser::FlagContext *> flags);
     antlrcpp::Any visitOrSequence(NETAParser::OrSequenceContext *context) override;
     antlrcpp::Any visitSequence(NETAParser::SequenceContext *context) override;
     antlrcpp::Any visitRingSequence(NETAParser::RingSequenceContext *context) override;
@@ -58,4 +56,5 @@ class NETAVisitor : private NETAParserBaseVisitor
     void visitModifier(NETAParser::ModifierContext *context, NETANode *contextNode);
     void visitOption(NETAParser::OptionContext *context, NETANode *contextNode);
     void visitFlag(NETAParser::FlagContext *context, NETANode *contextNode);
+    void visitIdentifier(NETAParser::IdentifierContext *context, NETANode *contextNode);
 };

--- a/src/neta/bondcount.cpp
+++ b/src/neta/bondcount.cpp
@@ -25,7 +25,7 @@ void NETABondCountNode::set(ComparisonOperator op, int value)
  */
 
 // Evaluate the node and return its score
-int NETABondCountNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETABondCountNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     if (!value_)
         return NETANode::NoMatch;

--- a/src/neta/bondcount.h
+++ b/src/neta/bondcount.h
@@ -34,5 +34,5 @@ class NETABondCountNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/character.cpp
+++ b/src/neta/character.cpp
@@ -41,7 +41,7 @@ bool NETACharacterNode::addFFTypeTarget(const ForcefieldAtomType &ffType)
  */
 
 // Evaluate the node and return its score
-int NETACharacterNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETACharacterNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     // Check element
     if (std::find(allowedElements_.begin(), allowedElements_.end(), i->Z()) != allowedElements_.end() && !reverseLogic_)

--- a/src/neta/character.h
+++ b/src/neta/character.h
@@ -40,5 +40,5 @@ class NETACharacterNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -116,19 +116,17 @@ bool NETAConnectionNode::setFlag(std::string_view flag, bool state)
  */
 
 // Evaluate the node and return its score
-int NETAConnectionNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETAConnectionNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     // Get directly connected atoms about 'i', excluding any that have already been matched
-    std::map<const SpeciesAtom *, std::pair<int, std::vector<const SpeciesAtom *>>> neighbours;
+    std::map<const SpeciesAtom *, std::pair<int, NETAMatchedPath>> neighbours;
     for (const SpeciesBond &bond : i->bonds())
     {
         const auto *partner = bond.partner(i);
 
-        // Search for this species atom in the current match path
-        auto atomIt =
-            std::find_if(matchPath.begin(), matchPath.end(), [partner](const auto spAtom) { return spAtom == partner; });
-        if (atomIt == matchPath.end() || (atomIt == matchPath.begin() && allowRootMatch_))
-            neighbours.emplace(partner, std::pair<int, std::vector<const SpeciesAtom *>>(NETANode::NoMatch, matchPath));
+        // Search for this atom in the current match path
+        if (!matchPath.contains(partner) || (allowRootMatch_ && matchPath.isRoot(partner)))
+            neighbours.emplace(partner, std::pair<int, NETAMatchedPath>(NETANode::NoMatch, matchPath));
     }
 
     // Loop over neighbour atoms
@@ -194,9 +192,7 @@ int NETAConnectionNode::score(const SpeciesAtom *i, std::vector<const SpeciesAto
         totalScore += jScore;
 
         // Track atoms matched in the neighbour branch
-        std::copy_if(jMatchPath.begin(), jMatchPath.end(), std::back_inserter(matchPath),
-                     [&matchPath](const auto *j)
-                     { return std::find(matchPath.begin(), matchPath.end(), j) == matchPath.end(); });
+        matchPath.merge(jMatchPath);
     }
 
     return totalScore;

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -193,6 +193,10 @@ int NETAConnectionNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) 
 
         // Track atoms matched in the neighbour branch
         matchPath.merge(jMatchPath);
+
+        // Add identifiers to the match data
+        for (auto &id : identifiers())
+            matchPath.addIdentifier(nbr.first, id);
     }
 
     return totalScore;

--- a/src/neta/connection.h
+++ b/src/neta/connection.h
@@ -86,5 +86,5 @@ class NETAConnectionNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/geometry.cpp
+++ b/src/neta/geometry.cpp
@@ -26,7 +26,7 @@ void NETAGeometryNode::set(ComparisonOperator op, SpeciesAtom::AtomGeometry geom
  */
 
 // Evaluate the node and return its score
-int NETAGeometryNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETAGeometryNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     auto result = i->isGeometry(geometry_);
 

--- a/src/neta/geometry.h
+++ b/src/neta/geometry.h
@@ -34,5 +34,5 @@ class NETAGeometryNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/hydrogencount.cpp
+++ b/src/neta/hydrogencount.cpp
@@ -26,7 +26,7 @@ void NETAHydrogenCountNode::set(ComparisonOperator op, int value)
  */
 
 // Evaluate the node and return its score
-int NETAHydrogenCountNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETAHydrogenCountNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     if (!value_)
         return NETANode::NoMatch;

--- a/src/neta/hydrogencount.h
+++ b/src/neta/hydrogencount.h
@@ -34,5 +34,5 @@ class NETAHydrogenCountNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/matchedpath.cpp
+++ b/src/neta/matchedpath.cpp
@@ -36,3 +36,6 @@ void NETAMatchedPath::merge(const NETAMatchedPath &other)
         for (auto &i : atoms)
             identifiers_[key].insert(i);
 }
+
+// Add identifier for specified atom
+void NETAMatchedPath::addIdentifier(const SpeciesAtom *i, std::string id) { identifiers_[id].insert(i); }

--- a/src/neta/matchedpath.cpp
+++ b/src/neta/matchedpath.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "neta/matchedpath.h"
+#include "classes/speciesatom.h"
+#include <algorithm>
+
+// Return path of matched atoms
+const std::vector<const SpeciesAtom *> &NETAMatchedPath::path() const { return path_; }
+
+// Return identified atoms (if any) in path
+const std::map<std::string, std::set<const SpeciesAtom *>> &NETAMatchedPath::identifiers() const { return identifiers_; }
+
+/*
+ * Path Management
+ */
+
+// Append atom to path
+void NETAMatchedPath::append(const SpeciesAtom *i) { path_.push_back(i); }
+
+// Return whether the path contains the specified atom
+bool NETAMatchedPath::contains(const SpeciesAtom *i) const { return std::find(path_.begin(), path_.end(), i) != path_.end(); }
+
+// Return whether the specified atom is the root atom in the path
+bool NETAMatchedPath::isRoot(const SpeciesAtom *i) const { return !path_.empty() && (path_.front() == i); }
+
+// Merge supplied path into this one, appending new atoms and copying any relevant identifiers
+void NETAMatchedPath::merge(const NETAMatchedPath &other)
+{
+    // Copy new, unique atoms to our path
+    std::copy_if(other.path_.begin(), other.path_.end(), std::back_inserter(path_),
+                 [&](const auto *j) { return std::find(path_.begin(), path_.end(), j) == path_.end(); });
+
+    // Copy any identifiers
+    for (auto &&[key, atoms] : other.identifiers_)
+        for (auto &i : atoms)
+            identifiers_[key].insert(i);
+}

--- a/src/neta/matchedpath.h
+++ b/src/neta/matchedpath.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+// Forward Declarations
+class SpeciesAtom;
+
+// NETA Matched Path
+class NETAMatchedPath
+{
+    private:
+    // Path of matched atoms
+    std::vector<const SpeciesAtom *> path_;
+    // Identified atoms (if any) in path
+    std::map<std::string, std::set<const SpeciesAtom *>> identifiers_;
+
+    public:
+    // Return path of matched atoms
+    const std::vector<const SpeciesAtom *> &path() const;
+    // Return identified atoms (if any) in path
+    const std::map<std::string, std::set<const SpeciesAtom *>> &identifiers() const;
+
+    /*
+     * Path Management
+     */
+    public:
+    // Append atom to path
+    void append(const SpeciesAtom *i);
+    // Return whether the path contains the specified atom
+    bool contains(const SpeciesAtom *i) const;
+    // Return whether the specified atom is the root atom in the path
+    bool isRoot(const SpeciesAtom *i) const;
+    // Merge supplied path into this one, appending new atoms and copying any relevant identifiers
+    void merge(const NETAMatchedPath &other);
+};

--- a/src/neta/matchedpath.h
+++ b/src/neta/matchedpath.h
@@ -38,4 +38,6 @@ class NETAMatchedPath
     bool isRoot(const SpeciesAtom *i) const;
     // Merge supplied path into this one, appending new atoms and copying any relevant identifiers
     void merge(const NETAMatchedPath &other);
+    // Add identifier for specified atom
+    void addIdentifier(const SpeciesAtom *i, std::string id);
 };

--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -153,7 +153,7 @@ bool NETADefinition::isValid() const { return valid_; }
 // Return score of supplied atom for this definition
 int NETADefinition::score(const SpeciesAtom *i) const
 {
-    std::vector<const SpeciesAtom *> matchPath;
+    NETAMatchedPath matchPath;
     return rootNode_->score(i, matchPath);
 }
 
@@ -161,9 +161,9 @@ int NETADefinition::score(const SpeciesAtom *i) const
 bool NETADefinition::matches(const SpeciesAtom *i) const { return score(i) != NETANode::NoMatch; }
 
 // Return the path of matched atoms, including the target atom, if the definition matches
-std::vector<const SpeciesAtom *> NETADefinition::matchedPath(const SpeciesAtom *i) const
+NETAMatchedPath NETADefinition::matchedPath(const SpeciesAtom *i) const
 {
-    std::vector<const SpeciesAtom *> matchPath;
+    NETAMatchedPath matchPath;
     if (rootNode_->score(i, matchPath) == NETANode::NoMatch)
         return {};
 

--- a/src/neta/neta.h
+++ b/src/neta/neta.h
@@ -5,6 +5,7 @@
 
 #include "base/enumoptions.h"
 #include "neta/connection.h"
+#include "neta/matchedpath.h"
 
 // Forward Declarations
 class Forcefield;
@@ -54,5 +55,5 @@ class NETADefinition
     // Return whether the supplied atom matches the definition
     bool matches(const SpeciesAtom *i) const;
     // Return the path of matched atoms, including the target atom, if the definition matches
-    std::vector<const SpeciesAtom *> matchedPath(const SpeciesAtom *i) const;
+    NETAMatchedPath matchedPath(const SpeciesAtom *i) const;
 };

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -167,12 +167,11 @@ bool NETANode::compareValues(int lhsValue, ComparisonOperator op, int rhsValue)
  */
 
 // Evaluate the provided sequence and return a score
-int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const SpeciesAtom *i,
-                            std::vector<const SpeciesAtom *> &matchPath)
+int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const SpeciesAtom *i, NETAMatchedPath &matchPath)
 {
     auto totalScore = 0;
     auto newMatchPath = matchPath;
-    newMatchPath.push_back(i);
+    newMatchPath.append(i);
 
     // Loop over nodes in sequence
     for (const auto &node : sequence)
@@ -195,7 +194,7 @@ int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const Specie
 void NETANode::setReverseLogic() { reverseLogic_ = true; }
 
 // Evaluate the node and return its score
-int NETANode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETANode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     auto branchScore = sequenceScore(nodes_, i, matchPath);
 

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -198,5 +198,10 @@ int NETANode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     auto branchScore = sequenceScore(nodes_, i, matchPath);
 
+    // Add local identifiers to the match data
+    if (branchScore != NETANode::NoMatch && !reverseLogic_)
+        for (auto &id : identifiers())
+            matchPath.addIdentifier(i, id);
+
     return reverseLogic_ ? (branchScore == NETANode::NoMatch ? 1 : NETANode::NoMatch) : branchScore;
 }

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -107,6 +107,25 @@ bool NETANode::isValidFlag(std::string_view s) const { return false; }
 bool NETANode::setFlag(std::string_view flag, bool state) { return false; }
 
 /*
+ * Identifier Names
+ */
+
+// Add identifier to this node, returning if it is already in use
+bool NETANode::addIdentifier(std::string_view s)
+{
+    auto it = std::find(identifiers_.begin(), identifiers_.end(), s);
+    if (it != identifiers_.end())
+        return false;
+
+    identifiers_.emplace_back(s);
+
+    return true;
+}
+
+// Return identifying names associated to this node
+const std::vector<std::string> &NETANode::identifiers() const { return identifiers_; }
+
+/*
  * Value Comparison
  */
 

--- a/src/neta/node.h
+++ b/src/neta/node.h
@@ -121,6 +121,19 @@ class NETANode
     virtual bool setFlag(std::string_view flag, bool state);
 
     /*
+     * Identifier Names
+     */
+    private:
+    // Identifying names associated to this node
+    std::vector<std::string> identifiers_;
+
+    public:
+    // Add identifier to this node, returning if it is already in use
+    virtual bool addIdentifier(std::string_view s);
+    // Return identifying names associated to this node
+    const std::vector<std::string> &identifiers() const;
+
+    /*
      * Value Comparison
      */
     public:

--- a/src/neta/node.h
+++ b/src/neta/node.h
@@ -5,6 +5,7 @@
 
 #include "base/enumoptions.h"
 #include "data/elements.h"
+#include "neta/matchedpath.h"
 #include <memory>
 #include <vector>
 
@@ -149,12 +150,11 @@ class NETANode
 
     protected:
     // Evaluate the provided sequence and return a score
-    static int sequenceScore(const NETANode::NETASequence &sequence, const SpeciesAtom *i,
-                             std::vector<const SpeciesAtom *> &matchPath);
+    static int sequenceScore(const NETANode::NETASequence &sequence, const SpeciesAtom *i, NETAMatchedPath &matchPath);
 
     public:
     // Set node to use reverse logic
     void setReverseLogic();
     // Evaluate the node and return its score
-    virtual int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const;
+    virtual int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const;
 };

--- a/src/neta/or.cpp
+++ b/src/neta/or.cpp
@@ -18,7 +18,7 @@ void NETAOrNode::setAlternativeNodes(NETASequence nodes) { altNodes_ = std::move
  */
 
 // Evaluate the node and return its score
-int NETAOrNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETAOrNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     auto score = sequenceScore(nodes_, i, matchPath);
     if (score != NETANode::NoMatch)

--- a/src/neta/or.h
+++ b/src/neta/or.h
@@ -38,5 +38,5 @@ class NETAOrNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -131,7 +131,6 @@ int NETARingNode::score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
     // Loop over rings
     for (const auto &ring : rings)
     {
-        ring.print();
         // Check through atoms in the ring in the order specified
         for (auto ringAtomIt = ring.atoms().begin(); ringAtomIt != ring.atoms().end(); ++ringAtomIt)
         {

--- a/src/neta/ring.h
+++ b/src/neta/ring.h
@@ -57,5 +57,5 @@ class NETARingNode : public NETANode
 
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/src/neta/ringatom.cpp
+++ b/src/neta/ringatom.cpp
@@ -79,7 +79,7 @@ bool NETARingAtomNode::validRepeatCount(int value) const { return compareValues(
  */
 
 // Return whether we match the specified atom
-int NETARingAtomNode::matches(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const
+int NETARingAtomNode::matches(const SpeciesAtom *i, NETAMatchedPath &matchPath) const
 {
     // Evaluate the atom against our elements
     int atomScore = NETANode::NoMatch;
@@ -101,20 +101,19 @@ int NETARingAtomNode::matches(const SpeciesAtom *i, std::vector<const SpeciesAto
         return reverseLogic_ ? 1 : NETANode::NoMatch;
 
     // Process branch definition via the base class, using an empty path
-    std::vector<const SpeciesAtom *> emptyPath;
-    auto branchScore = NETANode::sequenceScore(nodes_, i, emptyPath);
+    NETAMatchedPath newPath;
+    auto branchScore = NETANode::sequenceScore(nodes_, i, newPath);
     if (branchScore == NETANode::NoMatch)
         return reverseLogic_ ? 1 : NETANode::NoMatch;
 
     // Track atoms matched in the neighbour branch
-    std::copy_if(emptyPath.begin(), emptyPath.end(), std::back_inserter(matchPath),
-                 [&matchPath](const auto *j) { return std::find(matchPath.begin(), matchPath.end(), j) == matchPath.end(); });
+    matchPath.merge(newPath);
 
     return reverseLogic_ ? NETANode::NoMatch : (atomScore + branchScore);
 }
 
 // Evaluate the node and return its score
-int NETARingAtomNode::score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &availableAtoms) const
+int NETARingAtomNode::score(const SpeciesAtom *i, NETAMatchedPath &availableAtoms) const
 {
     throw(std::runtime_error("NETARingAtomNode was called via its score() function, but this should never be done.\n"));
 }

--- a/src/neta/ringatom.cpp
+++ b/src/neta/ringatom.cpp
@@ -109,6 +109,10 @@ int NETARingAtomNode::matches(const SpeciesAtom *i, NETAMatchedPath &matchPath) 
     // Track atoms matched in the neighbour branch
     matchPath.merge(newPath);
 
+    // Add identifiers to the match data
+    for (auto &id : identifiers())
+        matchPath.addIdentifier(i, id);
+
     return reverseLogic_ ? NETANode::NoMatch : (atomScore + branchScore);
 }
 

--- a/src/neta/ringatom.h
+++ b/src/neta/ringatom.h
@@ -65,7 +65,7 @@ class NETARingAtomNode : public NETANode
      */
     public:
     // Return whether we match the specified atom
-    int matches(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const;
+    int matches(const SpeciesAtom *i, NETAMatchedPath &matchPath) const;
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, std::vector<const SpeciesAtom *> &matchPath) const override;
+    int score(const SpeciesAtom *i, NETAMatchedPath &matchPath) const override;
 };

--- a/unit/classes/neta.cpp
+++ b/unit/classes/neta.cpp
@@ -427,10 +427,11 @@ TEST_F(NETATest, IdentifierMatching)
     NETADefinition neta;
 
     // Methanol identifying cog at the oxygen, x on the carbon, and y on the hydroxyl hydrogen
-    EXPECT_TRUE(neta.create("?O,-C(#x),-H(-O(root),#y)"));
+    EXPECT_TRUE(neta.create("?O,#cog,-C(#x),-H(-O(root),#y)"));
     auto matchedPath = testNETAMatchPath("Carbon and hydroxyl", methanol_, neta, 4, {0, 4, 5});
     for (auto &&[key, ids] : matchedPath.identifiers())
         fmt::print("ID '{}' : {}\n", key, joinStrings(ids, " ", [](const auto *i) { return i->index(); }));
+    testIdentifiers(matchedPath, "cog", {4});
     testIdentifiers(matchedPath, "x", {0});
     testIdentifiers(matchedPath, "y", {5});
 

--- a/unit/classes/neta.cpp
+++ b/unit/classes/neta.cpp
@@ -131,11 +131,12 @@ class NETATest : public ::testing::Test
         fmt::print("Path Test: {}, atom {}...\n", title, targetAtomIndex);
         fmt::print("-- Species '{}', expected matched atom path : {}\n", sp.name(), matchingIndices);
 
-        auto path = neta.matchedPath(&sp.atom(targetAtomIndex));
-        fmt::print("-- Actual matched atom path : {}\n", joinStrings(path, " ", [](const auto *i) { return i->index(); }));
-        EXPECT_EQ(path.size(), matchingIndices.size());
+        auto matchedPath = neta.matchedPath(&sp.atom(targetAtomIndex));
+        fmt::print("-- Actual matched atom path : {}\n",
+                   joinStrings(matchedPath.path(), " ", [](const auto *i) { return i->index(); }));
+        EXPECT_EQ(matchedPath.path().size(), matchingIndices.size());
 
-        for (auto *i : path)
+        for (auto *i : matchedPath.path())
             EXPECT_TRUE(std::find(matchingIndices.begin(), matchingIndices.end(), i->index()) != matchingIndices.end());
     }
 };


### PR DESCRIPTION
This PR provides additional functionality to the NETA typing, allowing text identifiers to be assigned to atoms as they are matched. This contextual information can then be used to infer axis systems, for example, in other workflows in the code.