### PR TITLE
1271 React to coordinate edits

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -122,6 +122,8 @@ class Species : public Serialisable
     void clearAtomTypes();
     // Simplify atom types, merging together those with identical parameters
     int simplifyAtomTypes();
+    // Set charge of specified atom
+    void setAtomCharge(SpeciesAtom *i, double q);
     // Return total charge of species from local/atomtype atomic charges
     double totalCharge(bool useAtomTypes) const;
     // Apply random noise to atoms

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -305,6 +305,16 @@ int Species::simplifyAtomTypes()
     return nModified;
 }
 
+// Set charge of specified atom
+void Species::setAtomCharge(SpeciesAtom *i, double q)
+{
+    assert(i);
+
+    i->setCharge(q);
+
+    ++version_;
+}
+
 // Return total charge of species from local/atomtype atomic charges
 double Species::totalCharge(bool useAtomTypes) const
 {

--- a/src/classes/species_isotopologues.cpp
+++ b/src/classes/species_isotopologues.cpp
@@ -3,7 +3,6 @@
 
 #include "base/sysfunc.h"
 #include "classes/species.h"
-#include <cstring>
 
 // Update current Isotopologues
 void Species::updateIsotopologues(OptionalReferenceWrapper<const std::vector<std::shared_ptr<AtomType>>> atomTypes)

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -82,7 +82,7 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
 {
     if (role != Qt::EditRole)
         return false;
-    SpeciesAtom &item = species_.atom(index.row());
+    auto &item = species_.atom(index.row());
     switch (index.column())
     {
         case 0:
@@ -101,8 +101,12 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
         case 2:
         case 3:
         case 4:
-            item.setCoordinate(index.column() - 2, value.toDouble());
-            break;
+        {
+            auto newR = item.r();
+            newR.set(index.column() - 2, value.toDouble());
+            species_.setAtomCoordinates(&item, newR);
+        }
+        break;
         case 5:
             item.setCharge(value.toDouble());
     }

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -108,7 +108,8 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
         }
         break;
         case 5:
-            item.setCharge(value.toDouble());
+            species_.setAtomCharge(&item, value.toDouble());
+            break;
     }
     emit dataChanged(index, index);
     return true;


### PR DESCRIPTION
This PR addresses an issue where the chemical model displayed in the `SpeciesTab` does not get updated if any of the atomic coordinates of the species are edited. This was due to the coordinates of the `SpeciesAtom` being set directly by the table model, rather than proceeding through the parent `Species` (so that the internal `version_` counter could be updated, and which affects updates to the rendered model).

The same is also done for setting atom charges (for when we finally display labels on atoms).

Closes #1271.