### PR TITLE
Add(Pair) No Overlaps

### DIFF
--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -109,8 +109,9 @@ bool AddProcedureNode::prepare(const ProcedureContext &procedureContext)
     if (positioningType_ == AddProcedureNode::PositioningType::Region && !region_)
         return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
     else if (positioningType_ != AddProcedureNode::PositioningType::Region && region_)
-        Messenger::warn("A region has been specified ({}) but the positioningType_ type is set to '{}'\n", region_->name(),
-                        AddProcedureNode::positioningTypes().keyword(positioningType_));
+        Messenger::warn(
+            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
+            region_->name(), AddProcedureNode::positioningTypes().keyword(positioningType_));
 
     // Check scalable axes definitions
     if (!scaleA_ && !scaleB_ && !scaleC_)

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -117,6 +117,12 @@ bool AddProcedureNode::prepare(const ProcedureContext &procedureContext)
     if (!scaleA_ && !scaleB_ && !scaleC_)
         return Messenger::error("Must have at least one scalable box axis!\n");
 
+    // If the positioning type is 'Central', don't allow more than one molecule to be added
+    if (positioningType_ == AddProcedureNode::PositioningType::Central && population_.asInteger() > 1)
+        return Messenger::error(
+            "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
+            population_.asInteger());
+
     return true;
 }
 

--- a/src/procedure/nodes/addpair.cpp
+++ b/src/procedure/nodes/addpair.cpp
@@ -96,8 +96,9 @@ bool AddPairProcedureNode::prepare(const ProcedureContext &procedureContext)
     if (positioningType_ == AddPairProcedureNode::PositioningType::Region && !region_)
         return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
     else if (positioningType_ != AddPairProcedureNode::PositioningType::Region && region_)
-        Messenger::warn("A region has been specified ({}) but the positioningType_ type is set to '{}'\n", region_->name(),
-                        AddPairProcedureNode::positioningTypes().keyword(positioningType_));
+        Messenger::warn(
+            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
+            region_->name(), AddPairProcedureNode::positioningTypes().keyword(positioningType_));
 
     // Can't set box
     if (boxAction_ == AddPairProcedureNode::BoxActionStyle::Set)
@@ -110,6 +111,12 @@ bool AddPairProcedureNode::prepare(const ProcedureContext &procedureContext)
     // Check scalable axes definitions
     if (!scaleA_ && !scaleB_ && !scaleC_)
         return Messenger::error("Must have at least one scalable box axis!\n");
+
+    // If the positioning type is 'Central', don't allow more than one molecule to be added
+    if (positioningType_ == AddPairProcedureNode::PositioningType::Central && population_.asInteger() > 1)
+        return Messenger::error(
+            "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
+            population_.asInteger());
 
     return true;
 }


### PR DESCRIPTION
This PR addresses a bug discovered while toying around with a test system, and prevents multiple copies of the same molecule being `Add`ed (or `AddPair`ed) into a box if the requested positioning type for the molecule is for it to be centered in the box. This prevents a nasty crash!