### PR TITLE
Module Bits

### DIFF
--- a/src/modules/calculate_angle/gui/calculateanglewidget_funcs.cpp
+++ b/src/modules/calculate_angle/gui/calculateanglewidget_funcs.cpp
@@ -121,25 +121,25 @@ void CalculateAngleModuleWidget::setGraphDataTargets(CalculateAngleModule *modul
         return;
 
     // Calculated A...B RDF
-    auto rdfAB = rdfABGraph_->createRenderable<RenderableData1D>(
-        fmt::format("{}//Process1D//RDF(AB)", module_->name(), cfg->niceName()), "A...B g(r)");
+    auto rdfAB =
+        rdfABGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(AB)", module_->name()), "A...B g(r)");
     rdfAB->setColour(StockColours::BlueStockColour);
 
     // Calculated B...C RDF
-    auto rdfBC = rdfBCGraph_->createRenderable<RenderableData1D>(
-        fmt::format("{}//Process1D//RDF(BC)", module_->name(), cfg->niceName()), "B...C g(r)");
+    auto rdfBC =
+        rdfBCGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(BC)", module_->name()), "B...C g(r)");
     rdfBC->setColour(StockColours::BlueStockColour);
 
     // Calculated angle histogram
-    auto angle = angleGraph_->createRenderable<RenderableData1D>(
-        fmt::format("{}//Process1D//Angle(ABC)", module_->name(), cfg->niceName()), "A-B...C Angle");
+    auto angle = angleGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//Angle(ABC)", module_->name()),
+                                                                 "A-B...C Angle");
     angle->setColour(StockColours::RedStockColour);
 
     // Calculated (A-B)-C distance-angle map
-    dAngleABGraph_->createRenderable<RenderableData2D>(
-        fmt::format("{}//Process2D//DAngle((A-B)-C)", module_->name(), cfg->niceName()), "A-B vs A-B-C");
+    dAngleABGraph_->createRenderable<RenderableData2D>(fmt::format("{}//Process2D//DAngle((A-B)-C)", module_->name()),
+                                                       "A-B vs A-B-C");
 
     // Calculated A-(B-C) distance-angle map
-    dAngleBCGraph_->createRenderable<RenderableData2D>(
-        fmt::format("{}//Process2D//DAngle(A-(B-C))", module_->name(), cfg->niceName()), "B-C vs A-B-C");
+    dAngleBCGraph_->createRenderable<RenderableData2D>(fmt::format("{}//Process2D//DAngle(A-(B-C))", module_->name()),
+                                                       "B-C vs A-B-C");
 }

--- a/src/modules/calculate_axisangle/gui/calculateaxisanglewidget_funcs.cpp
+++ b/src/modules/calculate_axisangle/gui/calculateaxisanglewidget_funcs.cpp
@@ -69,23 +69,20 @@ void CalculateAxisAngleModuleWidget::updateControls(const Flags<ModuleWidget::Up
     {
         // Calculated A...B RDF
         if (rdfGraph_->renderables().empty())
-            rdfGraph_
-                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(AB)", module_->name(), cfg->niceName()),
-                                                     "A...B g(r)")
+            rdfGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF(AB)", module_->name()), "A...B g(r)")
                 ->setColour(StockColours::BlueStockColour);
 
         // Calculated angle histogram
         if (angleGraph_->renderables().empty())
             angleGraph_
-                ->createRenderable<RenderableData1D>(
-                    fmt::format("{}//Process1D//AxisAngle(AB)", module_->name(), cfg->niceName()), "Axis Angle")
+                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//AxisAngle(AB)", module_->name()), "Axis Angle")
                 ->setColour(StockColours::RedStockColour);
 
         // Calculated distance-angle map
         if (dAngleGraph_->renderables().empty())
         {
-            auto x = dAngleGraph_->createRenderable<RenderableData2D>(
-                fmt::format("{}//Process2D//DAxisAngle", module_->name(), cfg->niceName()), "A...B vs Axis Angle");
+            auto x = dAngleGraph_->createRenderable<RenderableData2D>(fmt::format("{}//Process2D//DAxisAngle", module_->name()),
+                                                                      "A...B vs Axis Angle");
             x->colour().setStyle(ColourDefinition::HSVGradientStyle);
         }
     }

--- a/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
+++ b/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
@@ -34,16 +34,16 @@ void CalculateRDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFl
     // Update CN labels
     auto rangeAOn = module_->isRangeEnabled(0);
     ui_.RegionAResultFrame->setText(
-        rangeAOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//A", module_->name(), SampledDouble())
+        rangeAOn ? dissolve_.processingModuleData().valueOr("Sum1D//CN//A", module_->name(), SampledDouble())
                  : SampledDouble());
     auto rangeBOn = module_->isRangeEnabled(1);
     ui_.RegionBResultFrame->setText(
-        rangeBOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//B", module_->name(), SampledDouble())
+        rangeBOn ? dissolve_.processingModuleData().valueOr("Sum1D//CN//B", module_->name(), SampledDouble())
                  : SampledDouble());
     ui_.RegionBResultFrame->setEnabled(rangeBOn);
     auto rangeCOn = module_->isRangeEnabled(2);
     ui_.RegionCResultFrame->setText(
-        rangeCOn ? dissolve_.processingModuleData().valueOr("Analyser//Sum1D//CN//C", module_->name(), SampledDouble())
+        rangeCOn ? dissolve_.processingModuleData().valueOr("Sum1D//CN//C", module_->name(), SampledDouble())
                  : SampledDouble());
     ui_.RegionCResultFrame->setEnabled(rangeCOn);
 

--- a/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
+++ b/src/modules/calculate_rdf/gui/calculaterdfwidget_funcs.cpp
@@ -55,7 +55,7 @@ void CalculateRDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFl
         auto *cfg = module_->keywords().getConfiguration("Configuration");
         if (cfg)
             rdfGraph_
-                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF", module_->name(), cfg->niceName()),
+                ->createRenderable<RenderableData1D>(fmt::format("{}//Process1D//RDF", module_->name()),
                                                      fmt::format("RDF//{}", cfg->niceName()), cfg->niceName())
                 ->setColour(StockColours::BlueStockColour);
     }


### PR DESCRIPTION
Here we fix a an issue with the display of calculated coordination numbers in the GUI, related to the wrong names being used for the target values.

It also removes some additional redundant arguments to various calls to `fmt::format`, left over from when analysis modules could target multiple configurations (which was a looooong time ago....)