### PR TITLE
Cache Workflow

### DIFF
--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -3,6 +3,9 @@ name: Build
 inputs:
   target:
     default: "dissolve"
+  cacheOnly:
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -13,11 +16,16 @@ runs:
     uses: "./.github/workflows/build/linux"
     with:
       target: ${{ inputs.target }}
+      cacheOnly: ${{ inputs.cacheOnly }}
 
   - name: Build (OSX)
     if: runner.os == 'MacOS'
     uses: "./.github/workflows/build/osx"
+    with:
+      cacheOnly: ${{ inputs.cacheOnly }}
 
   - name: Build (Windows)
     if: runner.os == 'Windows'
     uses: "./.github/workflows/build/windows"
+    with:
+      cacheOnly: ${{ inputs.cacheOnly }}

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -5,6 +5,9 @@ inputs:
     default: ""
   target:
     default: "dissolve"
+  cacheOnly:
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -16,6 +19,7 @@ runs:
       target: ${{ inputs.target }}
 
   - name: Build
+    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       set -ex
@@ -25,6 +29,7 @@ runs:
       nix build --json .#${{ inputs.target }} > archive.json
 
   - name: Bundle
+    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       set -ex
@@ -37,6 +42,7 @@ runs:
       cp -v ${{ inputs.target }} build/${{ inputs.target }}-${{ env.dissolveVersion }}
 
   - name: Upload Raw Build Artifacts
+    if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v3
     with:
       name: linux-build-artifacts-${{ inputs.target }}

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -5,10 +5,17 @@ inputs:
     default: true
   extraCMakeFlags:
     default: ""
+  cacheOnly:
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
   steps:
+
+  #
+  # Setup / Install Dependencies
+  #
 
   - name: Setup Python
     uses: actions/setup-python@v4
@@ -16,6 +23,7 @@ runs:
       python-version: ${{ env.pythonVersion }}
 
   - name: Install Homebrew Dependencies
+    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       set -ex
@@ -23,6 +31,7 @@ runs:
       brew install ftgl ninja
 
   - name: Acquire ANTLR Java
+    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       set -ex
@@ -47,7 +56,12 @@ runs:
       export PATH="$(python3 -m site --user-base)/bin:$PATH"
       aqt install-qt --outputdir ${{ runner.temp }}/qt mac desktop ${{ env.qtVersion }}
 
+  #
+  # Main Build
+  #
+
   - name: Build
+    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       set -ex
@@ -71,6 +85,7 @@ runs:
       conan install .. -g deploy
 
   - name: Upload Raw Build Artifacts
+    if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v3
     with:
       name: osx-build-artifacts

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -9,6 +9,9 @@ inputs:
     default: https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.gz
   ftglRepo:
     default: https://github.com/frankheckenbach/ftgl.git
+  cacheOnly:
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -141,6 +144,7 @@ runs:
       conan profile update settings.compiler.version=17 default
 
   - name: Build
+    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       # Setup environment
@@ -165,6 +169,7 @@ runs:
       conan install .. -g deploy
 
   - name: Upload Raw Build Artifacts
+    if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v3
     with:
       name: windows-build-artifacts

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,31 @@
+name: Generate Caches
+
+on:
+  workflow_dispatch:
+
+env:
+  pythonVersion: 3.9
+  qtVersion: 6.2.2
+  nixVersion: 2.4
+  nixOSVersion: 22.11
+
+jobs:
+
+  Cache:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        target: [dissolve-gui]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: "Build (Cache Only) (${{ matrix.os }})"
+        uses: "./.github/workflows/build"
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_TOKEN }}
+        with:
+          target: ${{ matrix.target }}
+          cacheOnly: true
+

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/checkout@v3
       - name: "Build (Cache Only) (${{ matrix.os }})"
         uses: "./.github/workflows/build"
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_TOKEN }}
         with:
           target: ${{ matrix.target }}
           cacheOnly: true

--- a/.github/workflows/get-nix/action.yml
+++ b/.github/workflows/get-nix/action.yml
@@ -29,7 +29,7 @@ runs:
         !/nix/var/nix/gc.lock
         !/nix/var/nix/db/big-lock
         !/nix/var/nix/db/reserved
-      key: ${{ runner.os }}-${{ inputs.target }}-cache
+      key: ${{ runner.os }}-nix-cache
 
   - uses: cachix/install-nix-action@v15
     with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,8 +43,6 @@ jobs:
         uses: "./.github/workflows/set-short-hash"
       - name: "Build (${{ matrix.os }})"
         uses: "./.github/workflows/build"
-        env:
-          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_TOKEN }}
         with:
           target: ${{ matrix.target }}
 


### PR DESCRIPTION
This PR adds a "Generate Cache" workflow which can be manually run on the `develop` branch in order to create caches that can be accessed by any future workflow, from any branch. Of course, this is one of those PRs that can't be realistically tested until it gets merged in to `develop`!

@rprospero - A question on the GitHub Action caches generated for nix: The `get-nix` action is called for each distinct `$target`, but the actual value of that variable doesn't seem to influence what happens in the action, just the final name of the resulting cache.  Is the cache the same regardless of CLI/GUI/threading/MPI etc. build, and can we reduce the number of caches we need to just one for all nix builds?