### PR TITLE
1295 Nix Cache Tidying

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -19,6 +19,18 @@ runs:
     with:
       target: ${{ inputs.target }}
 
+  - name: Cache Nix Store
+    uses: actions/cache@v3
+    id: nix-cache
+    with:
+      path: /tmp/nixcache
+      key: ${{ runner.os }}-nix-cache
+
+  - name: Import Nix Store Cache
+    if: "steps.nix-cache.outputs.cache-hit == 'true'"
+    shell: bash
+    run: nix-store --import < /tmp/nixcache
+
   - name: Build
     shell: bash
     run: |
@@ -50,10 +62,15 @@ runs:
     run: |
       set -ex
       # Remove the built dissolve derivations / img from the nix store to save space and leave just the other core build deps
-      for a in `nix path-info --all | grep dissolve`
-      do
-        nix --extra-experimental-features nix-command store delete --ignore-liveness $a
-      done
+      # Need to do this via sudo so we can use --ignore-liveness
+      nixStoreCmd=`which nix-store`
+      targets=`nix path-info --all | grep dissolve`
+      echo "for a in \"$targets\"; do $nixStoreCmd -q --referrers-closure \$a | xargs $nixStoreCmd --delete --ignore-liveness $b; done" | sudo bash
+
+  - name: Export Nix Store Cache
+    if: ${{ inputs.cacheOnly == 'true' }}
+    shell: bash
+    run: nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nixcache
 
   - name: Upload Package Artifacts
     if: ${{ inputs.cacheOnly == 'false' }}

--- a/.github/workflows/get-nix/action.yml
+++ b/.github/workflows/get-nix/action.yml
@@ -9,25 +9,9 @@ runs:
   using: "composite"
   steps:
 
-  - name: Cache Nix Store
-    uses: actions/cache@v3
-    id: nix-cache
-    with:
-      path: /tmp/nixcache
-      key: ${{ runner.os }}-nix-cache
-
   - name: Install Nix
     uses: cachix/install-nix-action@v15
     with:
       nix_path: nixpkgs=channel:nixos-unstable
       extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
 
-  - name: Import Nix Store Cache
-    if: "steps.nix-cache.outputs.cache-hit == 'true'"
-    shell: bash
-    run: nix-store --import < /tmp/nixcache
-
-  - name: Export Nix Store Cache
-    if: "steps.nix-cache.outputs.cache-hit != 'true'"
-    shell: bash
-    run: nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nixcache


### PR DESCRIPTION
This PR addresses an issue introduced in #1303 which used some "clever" commands to remove the build dissolve derivation and image from the nix store before storing the cache.  However, while this worked on a local machine it did not in the CI since local tests were made using a single-user install of nix (CI was multi-user).

Works towards #1295.