### PR TITLE
1268 two element overload

### DIFF
--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -678,8 +678,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
                                     // Add in fluctuation coefficients
                                     auto [begin, end] = fluctuationCoefficients[{i, j}];
-				    std::transform(potCoeff.begin(), potCoeff.end(), begin, potCoeff.begin(),
-						   [this](auto pot, auto fluct) { return pot + weighting_ * fluct; });
+                                    std::transform(potCoeff.begin(), potCoeff.end(), begin, potCoeff.begin(),
+                                                   [this](auto pot, auto fluct) { return pot + weighting_ * fluct; });
 
                                     // Set first term to zero (following EPSR)
                                     potCoeff[0] = 0.0;

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -652,8 +652,9 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     weight *= 0.5;
 
                 // Store fluctuation coefficients ready for addition to potential coefficients later on.
-                for (auto n = 0; n < nCoeffP_; ++n)
-                    fluctuationCoefficients[{i, j, n}] += weight * feedback_ * fitCoefficients[n];
+                auto [begin, end] = fluctuationCoefficients[{i, j}];
+                std::transform(fitCoefficients.begin(), fitCoefficients.end(), begin, begin,
+                               [weight, this](auto coeff, auto result) { return result + weight * feedback_ * coeff; });
             });
 
         // Increase dataIndex
@@ -676,8 +677,9 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                                         std::fill(potCoeff.begin(), potCoeff.end(), 0.0);
 
                                     // Add in fluctuation coefficients
-                                    for (auto n = 0; n < nCoeffP_; ++n)
-                                        potCoeff[n] += weighting_ * fluctuationCoefficients[{i, j, n}];
+                                    auto [begin, end] = fluctuationCoefficients[{i, j}];
+				    std::transform(potCoeff.begin(), potCoeff.end(), begin, potCoeff.begin(),
+						   [this](auto pot, auto fluct) { return pot + weighting_ * fluct; });
 
                                     // Set first term to zero (following EPSR)
                                     potCoeff[0] = 0.0;

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -105,7 +105,7 @@ template <class A> class Array3D
         return array_[sliceOffsets_[x] + y * nZ_ + z];
     }
     // Return array range for a given x and y value
-    std::pair<typename std::vector<A>::iterator , typename std::vector<A>::iterator> operator[](std::tuple<int, int> index)
+    std::pair<typename std::vector<A>::iterator, typename std::vector<A>::iterator> operator[](std::tuple<int, int> index)
     {
         auto [x, y] = index;
         auto begin = array_.begin() + sliceOffsets_[x] + y * nZ_;
@@ -113,7 +113,8 @@ template <class A> class Array3D
         return {begin, end};
     }
     // Return array range for a given x and y value
-    std::pair<typename std::vector<A>::const_iterator , typename std::vector<A>::const_iterator> operator[](std::tuple<int, int> index) const
+    std::pair<typename std::vector<A>::const_iterator, typename std::vector<A>::const_iterator>
+    operator[](std::tuple<int, int> index) const
     {
         auto [x, y] = index;
         auto begin = array_.begin() + sliceOffsets_[x] + y * nZ_;

--- a/src/templates/array3d.h
+++ b/src/templates/array3d.h
@@ -104,6 +104,22 @@ template <class A> class Array3D
 
         return array_[sliceOffsets_[x] + y * nZ_ + z];
     }
+    // Return array range for a given x and y value
+    std::pair<typename std::vector<A>::iterator , typename std::vector<A>::iterator> operator[](std::tuple<int, int> index)
+    {
+        auto [x, y] = index;
+        auto begin = array_.begin() + sliceOffsets_[x] + y * nZ_;
+        auto end = array_.begin() + sliceOffsets_[x] + (y + 1) * nZ_;
+        return {begin, end};
+    }
+    // Return array range for a given x and y value
+    std::pair<typename std::vector<A>::const_iterator , typename std::vector<A>::const_iterator> operator[](std::tuple<int, int> index) const
+    {
+        auto [x, y] = index;
+        auto begin = array_.begin() + sliceOffsets_[x] + y * nZ_;
+        auto end = array_.begin() + sliceOffsets_[x] + (y + 1) * nZ_;
+        return {begin, end};
+    }
     // Return address of specified element
     A *ptr(int x, int y, int z)
     {


### PR DESCRIPTION
This adds the ability to access an entire row of the Array3D by providing only the `x` and `y` coordinates.  The result is returned as a pair of iterators.  The official way to do this is via `std::ranges::subrange`, but that isn't available until C++20, so we'll use the pair of iterators for now.  I've also updated the two lines in the EPSR process that inspired the original issue.

This closes the #1268.