### PR TITLE
1295 Continuous and Release

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,0 +1,99 @@
+name: Continuous
+
+on:
+  pull_request:
+    branches:
+    - '*'
+    paths-ignore:
+    - '.github/workflows/cache.yml'
+    - '.github/workflows/pr.yml'
+    - '.github/workflows/release.yml'
+    - '.github/workflows/web.yml'
+    - 'web/**'
+    - 'README.md'
+
+env:
+  pythonVersion: 3.9
+  qtVersion: 6.2.2
+  nixVersion: 2.4
+  nixOSVersion: 22.11
+
+jobs:
+
+  QC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Quality Control
+      uses: "./.github/workflows/qc"
+
+  Build:
+    needs: QC
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
+      - name: Set Short Hash
+        uses: "./.github/workflows/set-short-hash"
+      - name: "Build (${{ matrix.os }})"
+        uses: "./.github/workflows/build"
+
+  BuildLinux:
+    needs: QC
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ dissolve, dissolve-gui ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Acquire Code Version
+      uses: "./.github/workflows/get-version"
+    - name: Set Short Hash
+      uses: "./.github/workflows/set-short-hash"
+    - name: "Build, Test, Package (Linux, ${{ matrix.target }})"
+      uses: "./.github/workflows/build"
+      with:
+        target: ${{ matrix.target }}
+
+  Package:
+    needs: [ Build, BuildLinux ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
+      - name: "Package (${{ matrix.os }})"
+        uses: "./.github/workflows/package"
+
+  Publish:
+    needs: Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
+      - name: Set Short Hash
+        uses: "./.github/workflows/set-short-hash"
+      - name: Publish
+        uses: "./.github/workflows/publish"
+        with:
+          isRelease: false
+          publish: true
+        env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -1,9 +1,9 @@
 name: Continuous
 
 on:
-  pull_request:
+  push:
     branches:
-    - '*'
+    - 'develop'
     paths-ignore:
     - '.github/workflows/cache.yml'
     - '.github/workflows/pr.yml'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - '*'
     paths-ignore:
+    - '.github/workflows/cache.yml'
     - '.github/workflows/continuous.yml'
     - '.github/workflows/release.yml'
     - '.github/workflows/web.yml'

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -54,7 +54,7 @@ runs:
     run: |
       echo "Release tag will be: latest"
       singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      ${SINGULARITY_ROOT}/bin/singularity push packages/GudPy-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
+      ${SINGULARITY_ROOT}/bin/singularity push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
 
   - name: Publish on Harbor (Continuous)
     if: ${{ inputs.publish == 'true' && inputs.isRelease == 'false' }}
@@ -62,4 +62,4 @@ runs:
     run: |
       echo "Release tag will be: continuous"
       singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      ${SINGULARITY_ROOT}/bin/singularity push packages/GudPy-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous
+      ${SINGULARITY_ROOT}/bin/singularity push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Release
+
+on:
+  pull_request:
+    branches:
+    - 'release/*'
+    paths-ignore:
+    - '.github/workflows/cache.yml'
+    - '.github/workflows/pr.yml'
+    - '.github/workflows/release.yml'
+    - '.github/workflows/web.yml'
+    - 'web/**'
+    - 'README.md'
+
+env:
+  pythonVersion: 3.9
+  qtVersion: 6.2.2
+  nixVersion: 2.4
+  nixOSVersion: 22.11
+
+jobs:
+
+  QC:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Quality Control
+      uses: "./.github/workflows/qc"
+
+  Build:
+    needs: QC
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
+      - name: Set Short Hash
+        uses: "./.github/workflows/set-short-hash"
+      - name: "Build (${{ matrix.os }})"
+        uses: "./.github/workflows/build"
+
+  BuildLinux:
+    needs: QC
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [ dissolve, dissolve-gui ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Acquire Code Version
+      uses: "./.github/workflows/get-version"
+    - name: Set Short Hash
+      uses: "./.github/workflows/set-short-hash"
+    - name: "Build, Test, Package (Linux, ${{ matrix.target }})"
+      uses: "./.github/workflows/build"
+      with:
+        target: ${{ matrix.target }}
+
+  Package:
+    needs: [ Build, BuildLinux ]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
+      - name: "Package (${{ matrix.os }})"
+        uses: "./.github/workflows/package"
+
+  Publish:
+    needs: Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Acquire Code Version
+        uses: "./.github/workflows/get-version"
+      - name: Set Short Hash
+        uses: "./.github/workflows/set-short-hash"
+      - name: Publish
+        uses: "./.github/workflows/publish"
+        with:
+          isRelease: true
+          publish: ${{ ! endsWith(github.ref, 'pre') }}
+        env:
+          HARBOR_USER: ${{ secrets.HARBOR_USER }}
+          HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}


### PR DESCRIPTION
Add release and continuous pipelines to CI, including publishing action to deliver assets to GitHub and Harbor.

Tested as much as possible given the PR context.

Works towards #1295.