### PR TITLE
No Fluctuation Smoothing

### DIFF
--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -76,7 +76,7 @@ class EPSRModule : public Module
     // Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)
     double rMinPT_{-1.0};
     // Degree of smoothing to apply to fluctuation coefficients before summation into potential
-    std::optional<int> fluctuationSmoothing_{1};
+    std::optional<int> fluctuationSmoothing_;
     // Whether to save difference function and fit
     bool saveDifferenceFunctions_{false};
     // Whether to save empirical potentials


### PR DESCRIPTION
A one-liner PR to turn off fluctuation smoothing in EPSR, which seems to cause more harm than good!