### PR TITLE
1246 Use optional numeric controls where appropriate

### DIFF
--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -47,12 +47,11 @@ EPSRModule::EPSRModule() : Module("EPSR")
     keywords_.add<DoubleKeyword>("PSigma1", "Width for Poisson functions in reciprocal space (N.B. this is psigma2 in EPSR)",
                                  pSigma1_, 0.001, 1.0);
     keywords_.add<DoubleKeyword>("PSigma2", "Width for Poisson functions in real space", pSigma2_, 0.001, 1.0);
-    keywords_.add<OptionalDoubleKeyword>(
-        "RMaxPT", "Radius at which potential truncation goes to zero", rMaxPT_, 0.0,
-        std::nullopt, 1.0, "Use Cuttoff Range");
-    keywords_.add<OptionalDoubleKeyword>(
-        "RMinPT", "Radius at which potential truncation begins (or Auto for 2 Angstroms under rmaxpt)", rMinPT_, 0.0,
-        std::nullopt, 1.0, "Auto");
+    keywords_.add<OptionalDoubleKeyword>("RMaxPT", "Radius at which potential truncation goes to zero", rMaxPT_, 0.0,
+                                         std::nullopt, 1.0, "Use Cuttoff Range");
+    keywords_.add<OptionalDoubleKeyword>("RMinPT",
+                                         "Radius at which potential truncation begins (or Auto for 2 Angstroms under rmaxpt)",
+                                         rMinPT_, 0.0, std::nullopt, 1.0, "Auto");
     keywords_.add<OptionalIntegerKeyword>("Smoothing",
                                           "Smoothing to apply to fluctuation coefficients before summation into potential",
                                           fluctuationSmoothing_, 0, std::nullopt, 1, "Off");

--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -6,6 +6,7 @@
 #include "keywords/data1dstore.h"
 #include "keywords/double.h"
 #include "keywords/modulevector.h"
+#include "keywords/optionaldouble.h"
 #include "keywords/optionalint.h"
 #include "keywords/stdstring.h"
 #include "keywords/vector_stringdouble.h"
@@ -46,11 +47,12 @@ EPSRModule::EPSRModule() : Module("EPSR")
     keywords_.add<DoubleKeyword>("PSigma1", "Width for Poisson functions in reciprocal space (N.B. this is psigma2 in EPSR)",
                                  pSigma1_, 0.001, 1.0);
     keywords_.add<DoubleKeyword>("PSigma2", "Width for Poisson functions in real space", pSigma2_, 0.001, 1.0);
-    keywords_.add<DoubleKeyword>("RMaxPT",
-                                 "Radius at which potential truncation goes to zero (-1.0 to use pair potential maximum range)",
-                                 rMaxPT_, -1.0);
-    keywords_.add<DoubleKeyword>(
-        "RMinPT", "Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)", rMinPT_, -1.0);
+    keywords_.add<OptionalDoubleKeyword>(
+        "RMaxPT", "Radius at which potential truncation goes to zero (-1.0 to use pair potential maximum range)", rMaxPT_, 0.0,
+        std::nullopt, -1.0, "");
+    keywords_.add<OptionalDoubleKeyword>(
+        "RMinPT", "Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)", rMinPT_, 0.0,
+        std::nullopt, -1.0, "");
     keywords_.add<OptionalIntegerKeyword>("Smoothing",
                                           "Smoothing to apply to fluctuation coefficients before summation into potential",
                                           fluctuationSmoothing_, 0, std::nullopt, 1, "Off");

--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -48,11 +48,11 @@ EPSRModule::EPSRModule() : Module("EPSR")
                                  pSigma1_, 0.001, 1.0);
     keywords_.add<DoubleKeyword>("PSigma2", "Width for Poisson functions in real space", pSigma2_, 0.001, 1.0);
     keywords_.add<OptionalDoubleKeyword>(
-        "RMaxPT", "Radius at which potential truncation goes to zero (-1.0 to use pair potential maximum range)", rMaxPT_, 0.0,
-        std::nullopt, -1.0, "");
+        "RMaxPT", "Radius at which potential truncation goes to zero", rMaxPT_, 0.0,
+        std::nullopt, 1.0, "Use Cuttoff Range");
     keywords_.add<OptionalDoubleKeyword>(
-        "RMinPT", "Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)", rMinPT_, 0.0,
-        std::nullopt, -1.0, "");
+        "RMinPT", "Radius at which potential truncation begins (or Auto for 2 Angstroms under rmaxpt)", rMinPT_, 0.0,
+        std::nullopt, 1.0, "Auto");
     keywords_.add<OptionalIntegerKeyword>("Smoothing",
                                           "Smoothing to apply to fluctuation coefficients before summation into potential",
                                           fluctuationSmoothing_, 0, std::nullopt, 1, "Off");

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -72,9 +72,9 @@ class EPSRModule : public Module
     // Width for Poisson functions in real space
     double pSigma2_{0.01};
     // Radius at which potential truncation goes to zero (-1.0 to use pair potential maximum range)
-    double rMaxPT_{-1.0};
+    std::optional<double> rMaxPT_{-1.0};
     // Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)
-    double rMinPT_{-1.0};
+    std::optional<double> rMinPT_{-1.0};
     // Degree of smoothing to apply to fluctuation coefficients before summation into potential
     std::optional<int> fluctuationSmoothing_;
     // Whether to save difference function and fit

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -72,9 +72,9 @@ class EPSRModule : public Module
     // Width for Poisson functions in real space
     double pSigma2_{0.01};
     // Radius at which potential truncation goes to zero (-1.0 to use pair potential maximum range)
-    std::optional<double> rMaxPT_{-1.0};
+    std::optional<double> rMaxPT_;
     // Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)
-    std::optional<double> rMinPT_{-1.0};
+    std::optional<double> rMinPT_;
     // Degree of smoothing to apply to fluctuation coefficients before summation into potential
     std::optional<int> fluctuationSmoothing_;
     // Whether to save difference function and fit

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -126,8 +126,8 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i,
     const auto mcoeff = 200;
 
     // Calculate some values if they were not provided
-    auto rmaxpt = rMaxPT_ < 0.0 ? dissolve.pairPotentialRange() : rMaxPT_;
-    auto rminpt = rMinPT_ < 0.0 ? rmaxpt - 2.0 : rMinPT_;
+    auto rmaxpt = rMaxPT_.value() < 0.0 ? dissolve.pairPotentialRange() : rMaxPT_.value();
+    auto rminpt = rMinPT_.value() < 0.0 ? rmaxpt - 2.0 : rMinPT_.value();
     nCoeffP_ = nCoeffP_ <= 0 ? std::min(int(10.0 * rmaxpt + 0.0001), mcoeff) : nCoeffP_;
 
     // Get coefficients array

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -126,8 +126,8 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i,
     const auto mcoeff = 200;
 
     // Calculate some values if they were not provided
-    auto rmaxpt = rMaxPT_.value() < 0.0 ? dissolve.pairPotentialRange() : rMaxPT_.value();
-    auto rminpt = rMinPT_.value() < 0.0 ? rmaxpt - 2.0 : rMinPT_.value();
+    auto rmaxpt = rMaxPT_ ? rMaxPT_.value() : dissolve.pairPotentialRange();
+    auto rminpt = rMinPT_ ? rMinPT_.value() : rmaxpt - 2.0;
     nCoeffP_ = nCoeffP_ <= 0 ? std::min(int(10.0 * rmaxpt + 0.0001), mcoeff) : nCoeffP_;
 
     // Get coefficients array

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -286,8 +286,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             GaussFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError =
-                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01, false);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01, false);
             else
             {
                 if (fitCoefficients.size() != ncoeffp)
@@ -312,8 +311,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             PoissonFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations,
-                                                              0.1, false);
+                fitError =
+                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.1, false);
             else
             {
                 if (fitCoefficients.size() != ncoeffp)
@@ -321,8 +320,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     Messenger::warn("Number of terms ({}) in existing FitCoefficients array for target '{}' does "
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), ncoeffp);
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_,
-                                                                  nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.01);
                 }
                 else
                     fitError =

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -285,8 +285,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             GaussFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), gSigma1_, nIterations,
-                                                              0.01, false);
+                fitError =
+                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), gSigma1_, nIterations, 0.01, false);
             else
             {
                 if (fitCoefficients.size() != nCoeffP_)
@@ -294,12 +294,10 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     Messenger::warn("Number of terms ({}) in existing FitCoefficients array for target '{}' does "
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), nCoeffP_.value());
-                    fitError =
-                        coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), gSigma1_, nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), gSigma1_, nIterations, 0.01);
                 }
                 else
-                    fitError =
-                        coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, gSigma1_, nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, gSigma1_, nIterations, 0.01);
             }
 
             // Store the new fit coefficients
@@ -313,8 +311,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             PoissonFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), pSigma1_, pSigma2_,
-                                                              nIterations, 0.1, false);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), pSigma1_, pSigma2_, nIterations,
+                                                              0.1, false);
             else
             {
                 if (fitCoefficients.size() != nCoeffP_)
@@ -326,8 +324,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                                                                   nIterations, 0.01);
                 }
                 else
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_,
-                                                                  nIterations, 0.01);
+                    fitError =
+                        coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, nIterations, 0.01);
             }
 
             // Store the new fit coefficients
@@ -339,8 +337,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                 Filters::movingAverage(fitCoefficients, *fluctuationSmoothing_);
 
                 // Need to pass the smoothed parameters back into the minimiser so we generate the matching approximation
-                fitError =
-                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
             }
 
             deltaFQFit = coeffMinimiser.approximation();
@@ -727,8 +724,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         auto sigma1 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma1_ : gSigma1_;
         auto sigma2 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma2_ : gSigma2_;
 
-        if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho, nCoeffP_, rminpt, rmaxpt, sigma1,
-                                         sigma2))
+        if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho, nCoeffP_, rminpt, rmaxpt, sigma1, sigma2))
             return false;
     }
     else

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -87,14 +87,14 @@ bool EPSRModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Ke
         // Set up the additional potentials - reconstruct them from the current coefficients
         if (expansionFunction_ == EPSRModule::GaussianExpansionFunction)
         {
-            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rMinPT_.value(), rMaxPT_.value(),
-                                             gSigma1_, gSigma2_))
+            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rMinPT_.value(),
+                                             rMaxPT_.value(), gSigma1_, gSigma2_))
                 return false;
         }
         else
         {
-            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rMinPT_.value(), rMaxPT_.value(),
-                                             pSigma1_, pSigma2_))
+            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rMinPT_.value(),
+                                             rMaxPT_.value(), pSigma1_, pSigma2_))
                 return false;
         }
     }
@@ -287,8 +287,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             GaussFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError =
-                    coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), gSigma1_, nIterations, 0.01, false);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), gSigma1_, nIterations,
+                                                              0.01, false);
             else
             {
                 if (fitCoefficients.size() != nCoeffP_)
@@ -296,10 +296,12 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     Messenger::warn("Number of terms ({}) in existing FitCoefficients array for target '{}' does "
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), nCoeffP_.value());
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), gSigma1_, nIterations, 0.01);
+                    fitError =
+                        coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), gSigma1_, nIterations, 0.01);
                 }
                 else
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, gSigma1_, nIterations, 0.01);
+                    fitError =
+                        coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, gSigma1_, nIterations, 0.01);
             }
 
             // Store the new fit coefficients
@@ -313,8 +315,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             PoissonFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), pSigma1_, pSigma2_, nIterations,
-                                                              0.1, false);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), pSigma1_, pSigma2_,
+                                                              nIterations, 0.1, false);
             else
             {
                 if (fitCoefficients.size() != nCoeffP_)
@@ -339,7 +341,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                 Filters::movingAverage(fitCoefficients, *fluctuationSmoothing_);
 
                 // Need to pass the smoothed parameters back into the minimiser so we generate the matching approximation
-                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
+                fitError =
+                    coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
             }
 
             deltaFQFit = coeffMinimiser.approximation();
@@ -726,7 +729,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         auto sigma1 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma1_ : gSigma1_;
         auto sigma2 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma2_ : gSigma2_;
 
-        if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho, nCoeffP_, rMinPT_.value(), rMaxPT_.value(), sigma1, sigma2))
+        if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho, nCoeffP_, rMinPT_.value(), rMaxPT_.value(), sigma1,
+                                         sigma2))
             return false;
     }
     else

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -85,16 +85,18 @@ bool EPSRModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Ke
             return Messenger::error("[SETUP {}] Failed to read in potential coefficients from EPSR pcof file.\n", name_);
 
         // Set up the additional potentials - reconstruct them from the current coefficients
+        auto rmaxpt = rMaxPT_ ? rMaxPT_.value() : dissolve.pairPotentialRange();
+        auto rminpt = rMinPT_ ? rMinPT_.value() : rmaxpt - 2.0;
         if (expansionFunction_ == EPSRModule::GaussianExpansionFunction)
         {
-            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rMinPT_.value(),
-                                             rMaxPT_.value(), gSigma1_, gSigma2_))
+            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rminpt, rmaxpt,
+                                             gSigma1_, gSigma2_))
                 return false;
         }
         else
         {
-            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rMinPT_.value(),
-                                             rMaxPT_.value(), pSigma1_, pSigma2_))
+            if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho.value_or(0.1), nCoeffP_, rminpt, rmaxpt,
+                                             pSigma1_, pSigma2_))
                 return false;
         }
     }
@@ -124,12 +126,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     const auto mcoeff = 200;
 
     // Calculate some values if they were not provided
-    if (rMaxPT_.value_or(0.0) < 0.0)
-        rMaxPT_.value() = dissolve.pairPotentialRange();
-    if (rMinPT_.value_or(0.0) < 0.0)
-        rMinPT_.value() = rMaxPT_.value() - 2.0;
-    if (!nCoeffP_)
-        nCoeffP_ = std::min(int(10.0 * rMaxPT_.value() + 0.0001), mcoeff);
+    auto rmaxpt = rMaxPT_ ? rMaxPT_.value() : dissolve.pairPotentialRange();
+    auto rminpt = rMinPT_ ? rMinPT_.value() : rmaxpt - 2.0;
 
     // Print option summary
     Messenger::print("EPSR: Feedback factor is {}.\n", feedback_);
@@ -287,7 +285,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             GaussFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), gSigma1_, nIterations,
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), gSigma1_, nIterations,
                                                               0.01, false);
             else
             {
@@ -297,11 +295,11 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), nCoeffP_.value());
                     fitError =
-                        coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), gSigma1_, nIterations, 0.01);
+                        coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), gSigma1_, nIterations, 0.01);
                 }
                 else
                     fitError =
-                        coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, gSigma1_, nIterations, 0.01);
+                        coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, gSigma1_, nIterations, 0.01);
             }
 
             // Store the new fit coefficients
@@ -315,7 +313,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             PoissonFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), pSigma1_, pSigma2_,
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), pSigma1_, pSigma2_,
                                                               nIterations, 0.1, false);
             else
             {
@@ -324,11 +322,11 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     Messenger::warn("Number of terms ({}) in existing FitCoefficients array for target '{}' does "
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), nCoeffP_.value());
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), nCoeffP_.value(), pSigma1_, pSigma2_,
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, nCoeffP_.value(), pSigma1_, pSigma2_,
                                                                   nIterations, 0.01);
                 }
                 else
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, pSigma1_, pSigma2_,
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_,
                                                                   nIterations, 0.01);
             }
 
@@ -342,7 +340,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
                 // Need to pass the smoothed parameters back into the minimiser so we generate the matching approximation
                 fitError =
-                    coeffMinimiser.constructReciprocal(0.0, rMaxPT_.value(), fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
+                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
             }
 
             deltaFQFit = coeffMinimiser.approximation();
@@ -729,7 +727,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         auto sigma1 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma1_ : gSigma1_;
         auto sigma2 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma2_ : gSigma2_;
 
-        if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho, nCoeffP_, rMinPT_.value(), rMaxPT_.value(), sigma1,
+        if (!generateEmpiricalPotentials(dissolve, expansionFunction_, rho, nCoeffP_, rminpt, rmaxpt, sigma1,
                                          sigma2))
             return false;
     }

--- a/src/modules/gr/gr.cpp
+++ b/src/modules/gr/gr.cpp
@@ -8,6 +8,7 @@
 #include "keywords/function1d.h"
 #include "keywords/integer.h"
 #include "keywords/module.h"
+#include "keywords/optionaldouble.h"
 #include "keywords/optionalint.h"
 
 GRModule::GRModule() : Module("GR")
@@ -17,8 +18,8 @@ GRModule::GRModule() : Module("GR")
 
     keywords_.setOrganisation("Options", "Range");
     keywords_.add<DoubleKeyword>("BinWidth", "Bin width (spacing in r) to use", binWidth_, 1.0e-3);
-    keywords_.add<DoubleKeyword>("Range", "Maximum r to calculate g(r) out to, unless UseHalfCellRange is true",
-                                 requestedRange_, 1.0);
+    keywords_.add<OptionalDoubleKeyword>("Range", "Maximum r to calculate g(r) out to, unless UseHalfCellRange is true",
+                                         requestedRange_, 0.0, std::nullopt, 1.0, "");
     keywords_.add<BoolKeyword>("UseHalfCellRange", "Whether to use the maximal RDF range possible that avoids periodic images",
                                useHalfCellRange_);
 

--- a/src/modules/gr/gr.cpp
+++ b/src/modules/gr/gr.cpp
@@ -18,10 +18,8 @@ GRModule::GRModule() : Module("GR")
 
     keywords_.setOrganisation("Options", "Range");
     keywords_.add<DoubleKeyword>("BinWidth", "Bin width (spacing in r) to use", binWidth_, 1.0e-3);
-    keywords_.add<OptionalDoubleKeyword>("Range", "Maximum r to calculate g(r) out to, unless UseHalfCellRange is true",
-                                         requestedRange_, 0.0, std::nullopt, 1.0, "");
-    keywords_.add<BoolKeyword>("UseHalfCellRange", "Whether to use the maximal RDF range possible that avoids periodic images",
-                               useHalfCellRange_);
+    keywords_.add<OptionalDoubleKeyword>("Range", "Maximum r to calculate g(r) out to", requestedRange_, 0.0, std::nullopt, 1.0,
+                                         "Use Half Cell Range");
 
     keywords_.setOrganisation("Options", "Averaging & Smoothing");
     keywords_.add<OptionalIntegerKeyword>("Averaging", "Number of historical partial sets to combine into final partials",

--- a/src/modules/gr/gr.h
+++ b/src/modules/gr/gr.h
@@ -55,7 +55,7 @@ class GRModule : public Module
     // Calculation method for partials
     GRModule::PartialsMethod partialsMethod_{GRModule::AutoMethod};
     // Maximum r to calculate g(r) out to, unless UseHalfCellRange is true
-    double requestedRange_{15.0};
+    std::optional<double> requestedRange_;
     // Whether to save partials and total functions to disk
     bool save_{false};
     // Whether to save original (unbroadened) partials and total functions to disk

--- a/src/modules/gr/gr.h
+++ b/src/modules/gr/gr.h
@@ -60,8 +60,6 @@ class GRModule : public Module
     bool save_{false};
     // Whether to save original (unbroadened) partials and total functions to disk
     bool saveOriginal_{false};
-    // Whether to use the maximal RDF range possible that avoids periodic images
-    bool useHalfCellRange_{true};
 
     /*
      * Functions

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -22,7 +22,7 @@ bool GRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         return Messenger::error("No configuration targets set for module '{}'.\n", name());
 
     // Print argument/parameter summary
-    if (useHalfCellRange_)
+    if (!requestedRange_)
         Messenger::print("RDF: Partials will be calculated up to the half-cell range limit.\n");
     else
         Messenger::print("RDF: Partials will be calculated out to {} Angstroms.\n", requestedRange_.value());
@@ -54,7 +54,7 @@ bool GRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     {
         // Check RDF range
         double rdfRange = cfg->box()->inscribedSphereRadius();
-        if (useHalfCellRange_)
+        if (!requestedRange_)
             Messenger::print("Maximal cutoff used for Configuration '{}' ({} Angstroms).\n", cfg->niceName(), rdfRange);
         else
         {

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -25,7 +25,7 @@ bool GRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (useHalfCellRange_)
         Messenger::print("RDF: Partials will be calculated up to the half-cell range limit.\n");
     else
-        Messenger::print("RDF: Partials will be calculated out to {} Angstroms.\n", requestedRange_);
+        Messenger::print("RDF: Partials will be calculated out to {} Angstroms.\n", requestedRange_.value());
     Messenger::print("RDF: Bin-width to use is {} Angstroms.\n", binWidth_);
     if (averagingLength_)
         Messenger::print("RDF: Partials will be averaged over {} sets (scheme = {}).\n", averagingLength_.value(),
@@ -58,11 +58,11 @@ bool GRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Messenger::print("Maximal cutoff used for Configuration '{}' ({} Angstroms).\n", cfg->niceName(), rdfRange);
         else
         {
-            if (requestedRange_ > rdfRange)
+            if (requestedRange_.value_or(0.0) > rdfRange)
                 return Messenger::error("Specified RDF range of {} Angstroms is out of range for Configuration "
                                         "'{}' (max = {} Angstroms).\n",
-                                        requestedRange_, cfg->niceName(), rdfRange);
-            rdfRange = requestedRange_;
+                                        requestedRange_.value(), cfg->niceName(), rdfRange);
+            rdfRange = requestedRange_.value();
             Messenger::print("Cutoff for Configuration '{}' is {} Angstroms.\n", cfg->niceName(), rdfRange);
         }
 

--- a/src/modules/md/md.cpp
+++ b/src/modules/md/md.cpp
@@ -32,11 +32,11 @@ MDModule::MDModule() : Module("MD")
 
     keywords_.setOrganisation("Options", "Output");
     keywords_.add<OptionalIntegerKeyword>("EnergyFrequency", "Frequency at which to calculate total system energy",
-                                          energyFrequency_, 0, std::nullopt, 10, "Off");
+                                          energyFrequency_, 0, std::nullopt, 5, "Off");
     keywords_.add<OptionalIntegerKeyword>("OutputFrequency", "Frequency at which to output step information", outputFrequency_,
                                           0, std::nullopt, 5, "Off");
     keywords_.add<OptionalIntegerKeyword>("TrajectoryFrequency", "Write frequency for trajectory file", trajectoryFrequency_, 0,
-                                          std::nullopt, 0, "Off");
+                                          std::nullopt, 5, "Off");
 
     keywords_.setOrganisation("Advanced");
     keywords_.add<BoolKeyword>("CapForces", "Control whether atomic forces are capped every step", capForces_);

--- a/src/modules/md/md.cpp
+++ b/src/modules/md/md.cpp
@@ -7,6 +7,7 @@
 #include "keywords/double.h"
 #include "keywords/integer.h"
 #include "keywords/optionaldouble.h"
+#include "keywords/optionalint.h"
 #include "keywords/speciesvector.h"
 
 MDModule::MDModule() : Module("MD")
@@ -30,12 +31,12 @@ MDModule::MDModule() : Module("MD")
                                onlyWhenEnergyStable_);
 
     keywords_.setOrganisation("Options", "Output");
-    keywords_.add<IntegerKeyword>("EnergyFrequency", "Frequency at which to calculate total system energy (or 0 to inhibit)",
-                                  energyFrequency_, 0);
-    keywords_.add<IntegerKeyword>("OutputFrequency", "Frequency at which to output step information (or 0 to inhibit)",
-                                  outputFrequency_, 0);
-    keywords_.add<IntegerKeyword>("TrajectoryFrequency", "Write frequency for trajectory file (or 0 to inhibit)",
-                                  trajectoryFrequency_, 0);
+    keywords_.add<OptionalIntegerKeyword>("EnergyFrequency", "Frequency at which to calculate total system energy",
+                                          energyFrequency_, 0, std::nullopt, 10, "Off");
+    keywords_.add<OptionalIntegerKeyword>("OutputFrequency", "Frequency at which to output step information", outputFrequency_,
+                                          0, std::nullopt, 5, "Off");
+    keywords_.add<OptionalIntegerKeyword>("TrajectoryFrequency", "Write frequency for trajectory file", trajectoryFrequency_, 0,
+                                          std::nullopt, 0, "Off");
 
     keywords_.setOrganisation("Advanced");
     keywords_.add<BoolKeyword>("CapForces", "Control whether atomic forces are capped every step", capForces_);

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -45,7 +45,7 @@ class MDModule : public Module
     // Fixed timestep (ps) to use in MD simulation
     double fixedTimestep_{5.0e-4};
     // Frequency at which to calculate total system energy
-    std::optional<int> energyFrequency_{10};
+    std::optional<int> energyFrequency_;
     // Whether to restrict force calculation to intramolecular contributions only
     bool intramolecularForcesOnly_{false};
     // Number of steps to perform
@@ -53,13 +53,13 @@ class MDModule : public Module
     // Only run MD when target Configuration energies are stable
     bool onlyWhenEnergyStable_{true};
     // Frequency at which to output step information
-    std::optional<int> outputFrequency_{5};
+    std::optional<int> outputFrequency_;
     // Whether random velocities should always be assigned before beginning MD simulation
     bool randomVelocities_{false};
     // Species to restrict calculation to
     std::vector<const Species *> restrictToSpecies_;
     // Write frequency for trajectory file
-    std::optional<int> trajectoryFrequency_{0};
+    std::optional<int> trajectoryFrequency_;
 
     /*
      * Functions

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -44,22 +44,22 @@ class MDModule : public Module
     TimestepType timestepType_{TimestepType::Automatic};
     // Fixed timestep (ps) to use in MD simulation
     double fixedTimestep_{5.0e-4};
-    // Frequency at which to calculate total system energy (or 0 to inhibit)
-    int energyFrequency_{10};
+    // Frequency at which to calculate total system energy
+    std::optional<int> energyFrequency_;
     // Whether to restrict force calculation to intramolecular contributions only
     bool intramolecularForcesOnly_{false};
     // Number of steps to perform
     int nSteps_{50};
     // Only run MD when target Configuration energies are stable
     bool onlyWhenEnergyStable_{true};
-    // Frequency at which to output step information (or 0 to inhibit)
-    int outputFrequency_{5};
+    // Frequency at which to output step information
+    std::optional<int> outputFrequency_;
     // Whether random velocities should always be assigned before beginning MD simulation
     bool randomVelocities_{false};
     // Species to restrict calculation to
     std::vector<const Species *> restrictToSpecies_;
-    // Write frequency for trajectory file (or 0 to inhibit)
-    int trajectoryFrequency_{0};
+    // Write frequency for trajectory file
+    std::optional<int> trajectoryFrequency_;
 
     /*
      * Functions

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -45,7 +45,7 @@ class MDModule : public Module
     // Fixed timestep (ps) to use in MD simulation
     double fixedTimestep_{5.0e-4};
     // Frequency at which to calculate total system energy
-    std::optional<int> energyFrequency_;
+    std::optional<int> energyFrequency_{10};
     // Whether to restrict force calculation to intramolecular contributions only
     bool intramolecularForcesOnly_{false};
     // Number of steps to perform
@@ -53,13 +53,13 @@ class MDModule : public Module
     // Only run MD when target Configuration energies are stable
     bool onlyWhenEnergyStable_{true};
     // Frequency at which to output step information
-    std::optional<int> outputFrequency_;
+    std::optional<int> outputFrequency_{5};
     // Whether random velocities should always be assigned before beginning MD simulation
     bool randomVelocities_{false};
     // Species to restrict calculation to
     std::vector<const Species *> restrictToSpecies_;
     // Write frequency for trajectory file
-    std::optional<int> trajectoryFrequency_;
+    std::optional<int> trajectoryFrequency_{0};
 
     /*
      * Functions

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -307,10 +307,10 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         ke *= 0.01;
 
         // Write step summary?
-        if ((step == 1) || (step % outputFrequency_.value_or(0) == 0))
+        if (outputFrequency_ && (step == 1 || (step % outputFrequency_.value() == 0)))
         {
             // Include total energy term?
-            if ((energyFrequency_.value_or(0) > 0) && (step % energyFrequency_.value_or(0) == 0))
+            if (energyFrequency_ && (step % energyFrequency_.value() == 0))
             {
                 peInter = EnergyModule::interAtomicEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
                 peIntra = EnergyModule::intraMolecularEnergy(procPool, targetConfiguration_, dissolve.potentialMap());
@@ -323,7 +323,7 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         }
 
         // Save trajectory frame
-        if (trajectoryFrequency_.value_or(0) > 0 && (step % trajectoryFrequency_.value_or(0) == 0))
+        if (trajectoryFrequency_ && (step % trajectoryFrequency_.value() == 0))
         {
             if (procPool.isMaster())
             {
@@ -332,7 +332,7 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
                 // Construct and write header
                 std::string header = fmt::format("Step {} of {}, T = {:10.3e}, ke = {:10.3e}", step, nSteps_, tInstant, ke);
-                if ((energyFrequency_.value_or(0) > 0) && (step % energyFrequency_.value_or(0) == 0))
+                if (energyFrequency_ && (step % energyFrequency_.value() == 0))
                     header += fmt::format(", inter = {:10.3e}, intra = {:10.3e}, tot = {:10.3e}", peInter, peIntra,
                                           ke + peInter + peIntra);
                 if (!trajParser.writeLine(header))


### PR DESCRIPTION
Closes #1246 
The OptionalIntegerKeyword and OptionalDoubleKeywords can be used in more places:

 RDFModule, "Cutoff" keyword (eliminates "UseHalfCellWidth" bool)
 EPSRModule, potential limits
 MDModule, energy, output, and trajectory frequencies