### PR TITLE
1244 Restart File Renaming

### DIFF
--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -237,9 +237,6 @@ bool DissolveWindow::loadRestartFile(std::string_view restartFile)
     {
         Messenger::print("Restart file '{}' exists and will be loaded.\n", restartFile);
         loadSuccess = dissolve_.loadRestart(restartFile);
-
-        // Reset the restart filename to be the standard one
-        dissolve_.setRestartFilename(fmt::format("{}.restart", dissolve_.inputFilename()));
     }
     else
         Messenger::print("Restart file '{}' does not exist.\n", restartFile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,9 +111,6 @@ int main(int args, char **argv)
                 Messenger::ceaseRedirect();
                 return 1;
             }
-
-            // Reset the restart filename to be the standard one
-            dissolve.setRestartFilename(fmt::format("{}.restart", options.inputFile().value()));
         }
         else
             Messenger::print("Restart file '{}' does not exist.\n", restartFile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ int main(int args, char **argv)
     else
     {
         // We may have been provided the name of a restart file to read in...
-        std::string restartFile = options.restartFilename().value_or(fmt::format("{}.restart", options.inputFile().value()));
+        auto restartFile = options.restartFilename().value_or(fmt::format("{}.restart", options.inputFile().value()));
 
         if (DissolveSys::fileExists(restartFile))
         {

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -273,8 +273,6 @@ class Dissolve : public Serialisable
     void setInputFilename(std::string_view filename);
     // Return current input filename
     std::string_view inputFilename() const;
-    // Set restart filename
-    void setRestartFilename(std::string_view filename);
     // Return restart filename
     std::string_view restartFilename() const;
     // Return whether a restart filename has been set

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -691,9 +691,6 @@ void Dissolve::setInputFilename(std::string_view filename)
 // Return current input filename
 std::string_view Dissolve::inputFilename() const { return inputFilename_; }
 
-// Set restart filename
-void Dissolve::setRestartFilename(std::string_view filename) { restartFilename_ = filename; }
-
 // Return restart filename
 std::string_view Dissolve::restartFilename() const { return restartFilename_; }
 

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -686,6 +686,8 @@ void Dissolve::setInputFilename(std::string_view filename)
 {
     inputFilename_ = filename;
     coreData_.setInputFilename(filename);
+
+    restartFilename_ = fmt::format("{}.restart", inputFilename_);
 }
 
 // Return current input filename


### PR DESCRIPTION
This PR handles an issue where, once a simulation was saved under a new filename, the target restart filename was not updated to match.

Here we remove manual setting of restart filenames, and instead perform this automatically as and when the input filename is set.

Closes #1244.