### PR TITLE
Resist Conan 2.0

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -41,7 +41,7 @@ runs:
   - name: Install Python Dependencies
     shell: bash
     run: |
-      pip3 install --user aqtinstall conan
+      pip3 install --user aqtinstall conan==1.58.0
 
   - name: Retrieve Qt Cache
     id: cache-qt

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -33,7 +33,7 @@ runs:
 
   - name: Install Python Dependencies
     shell: bash
-    run: pip3 install --user aqtinstall conan
+    run: pip3 install --user aqtinstall conan==1.58.0
 
   #
   # Retrieve Qt cache (or install it)

--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,7 @@
               ccls
               cmake-format
               cmake-language-server
-              conan
+              conan-1.58.0
               distcc
               gdb
               openmpi


### PR DESCRIPTION
This PR locks us to `conan` v1.58.0 until issues with v2 are resolved (see #1332).