### PR TITLE
1334 Ignored Enumerations

### DIFF
--- a/src/base/enumoptionsbase.h
+++ b/src/base/enumoptionsbase.h
@@ -25,10 +25,6 @@ class EnumOptionsBase
     virtual std::string keywordByIndex(int index) const = 0;
     // Return description for the nth keyword in the list
     virtual std::string descriptionByIndex(int index) const = 0;
-    // Return index of current option
-    virtual int index() const = 0;
-    // Set current option index
-    virtual void setIndex(int index) = 0;
 
     /*
      * Search

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -115,7 +115,7 @@ bool Configuration::initialiseContent(const ProcedureContext &procedureContext)
     // If an input file was specified, try to load it
     if (inputCoordinates_.hasFilename())
     {
-        if (DissolveSys::fileExists(inputCoordinates_))
+        if (DissolveSys::fileExists(inputCoordinates_.filename()))
         {
             Messenger::print("Loading initial coordinates from file '{}'...\n", inputCoordinates_.filename());
             if (!inputCoordinates_.importData(this, &procedureContext.processPool()))

--- a/src/gui/configurationtab_funcs.cpp
+++ b/src/gui/configurationtab_funcs.cpp
@@ -132,7 +132,7 @@ void ConfigurationTab::updateControls()
 
     // Input Coordinates
     ui_.CoordinatesFileEdit->setText(QString::fromStdString(std::string(configuration_->inputCoordinates().filename())));
-    ui_.CoordinatesFileFormatCombo->setCurrentIndex(configuration_->inputCoordinates().formats().index());
+    ui_.CoordinatesFileFormatCombo->setCurrentIndex(configuration_->inputCoordinates().formatIndex());
 
     // Size Factor
     ui_.RequestedSizeFactorSpin->setValue(configuration_->requestedSizeFactor());

--- a/src/gui/keywordwidgets/fileandformat_funcs.cpp
+++ b/src/gui/keywordwidgets/fileandformat_funcs.cpp
@@ -149,7 +149,7 @@ void FileAndFormatKeywordWidget::updateWidgetValues(const CoreData &coreData)
 
     // Update widgets
     ui_.FileEdit->setText(QString::fromStdString(std::string(fileAndFormat.filename())));
-    ui_.FormatCombo->setCurrentIndex(fileAndFormat.formats().index());
+    ui_.FormatCombo->setCurrentIndex(fileAndFormat.formatIndex());
     checkFileValidity();
 
     refreshing_ = false;
@@ -162,5 +162,5 @@ void FileAndFormatKeywordWidget::updateKeywordData()
     auto &fileAndFormat = keyword_->data();
 
     fileAndFormat.setFilename(qPrintable(ui_.FileEdit->text()));
-    fileAndFormat.formats().setIndex(ui_.FormatCombo->currentIndex());
+    fileAndFormat.setFormatByIndex(ui_.FormatCombo->currentIndex());
 }

--- a/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
+++ b/src/gui/keywordwidgets/nodevalueenumoptions_funcs.cpp
@@ -84,7 +84,7 @@ void NodeValueEnumOptionsKeywordWidget::updateValue(const Flags<DissolveSignals:
     refreshing_ = true;
 
     ui_.ValueEdit->setText(QString::fromStdString(keyword_->value().asString()));
-    ui_.OptionsCombo->setCurrentIndex(keyword_->baseOptions().index());
+    ui_.OptionsCombo->setCurrentIndex(keyword_->enumerationIndex());
 
     checkValueValidity();
 

--- a/src/gui/models/enumOptionsModel.cpp
+++ b/src/gui/models/enumOptionsModel.cpp
@@ -5,7 +5,7 @@
 #include "base/enumoptionsbase.h"
 
 // Set source AtomType data
-void EnumOptionsModel::setData(EnumOptionsBase &options)
+void EnumOptionsModel::setData(const EnumOptionsBase &options)
 {
     beginResetModel();
     enumOptions_ = options;

--- a/src/gui/models/enumOptionsModel.h
+++ b/src/gui/models/enumOptionsModel.h
@@ -17,11 +17,11 @@ class EnumOptionsModel : public QAbstractListModel
 
     private:
     // Source EnumOptions data
-    OptionalReferenceWrapper<EnumOptionsBase> enumOptions_;
+    OptionalReferenceWrapper<const EnumOptionsBase> enumOptions_;
 
     public:
     // Set source EnumOptions data
-    void setData(EnumOptionsBase &options);
+    void setData(const EnumOptionsBase &options);
 
     /*
      * QAbstractItemModel overrides

--- a/src/io/export/forces.cpp
+++ b/src/io/export/forces.cpp
@@ -11,10 +11,10 @@
 #include "data/atomicmasses.h"
 
 ForceExportFileFormat::ForceExportFileFormat(std::string_view filename, ForceExportFormat format)
-    : FileAndFormat(formats_, filename)
+    : FileAndFormat(formats_, filename, (int)format)
 {
     formats_ = EnumOptions<ForceExportFileFormat::ForceExportFormat>(
-        "ForceExportFileFormat", {{ForceExportFormat::Simple, "simple", "Simple Free-Formatted Forces"}}, format);
+        "ForceExportFileFormat", {{ForceExportFormat::Simple, "simple", "Simple Free-Formatted Forces"}});
 }
 
 /*
@@ -51,12 +51,14 @@ bool ForceExportFileFormat::exportData(const std::vector<Vec3<double>> &f)
 
     // Write data
     auto result = false;
-    if (formats_.enumeration() == ForceExportFormat::Simple)
-        result = exportSimple(parser, f);
-    else
+    switch (formats_.enumerationByIndex(*formatIndex_))
     {
-        Messenger::error("Unrecognised force format.\nKnown formats are:\n");
-        printAvailableFormats();
+        case (ForceExportFormat::Simple):
+            result = exportSimple(parser, f);
+            break;
+        default:
+            throw(std::runtime_error(
+                fmt::format("Forces format '{}' export has not been implemented.\n", formats_.keywordByIndex(*formatIndex_))));
     }
 
     return result;

--- a/src/io/export/pairpotential.cpp
+++ b/src/io/export/pairpotential.cpp
@@ -7,13 +7,11 @@
 #include "classes/pairpotential.h"
 
 PairPotentialExportFileFormat::PairPotentialExportFileFormat(std::string_view filename, PairPotentialExportFormat format)
-    : FileAndFormat(formats_, filename)
+    : FileAndFormat(formats_, filename, (int)format)
 {
     formats_ = EnumOptions<PairPotentialExportFileFormat::PairPotentialExportFormat>(
-        "PairPotentialExportFileFormat",
-        {{PairPotentialExportFormat::Block, "block", "Block Data"},
-         {PairPotentialExportFormat::DLPOLYTABLE, "table", "DL_POLY TABLE File"}},
-        format);
+        "PairPotentialExportFileFormat", {{PairPotentialExportFormat::Block, "block", "Block Data"},
+                                          {PairPotentialExportFormat::DLPOLYTABLE, "table", "DL_POLY TABLE File"}});
 }
 
 /*
@@ -107,14 +105,18 @@ bool PairPotentialExportFileFormat::exportData(PairPotential *pp)
 
     // Write data
     auto result = false;
-    if (formats_.enumeration() == PairPotentialExportFormat::Block)
-        result = exportBlock(parser, pp);
-    else if (formats_.enumeration() == PairPotentialExportFormat::DLPOLYTABLE)
-        result = exportDLPOLY(parser, pp);
-    else
+    switch (formats_.enumerationByIndex(*formatIndex_))
     {
-        Messenger::error("Unrecognised pair potential format.\nKnown formats are:\n");
-        printAvailableFormats();
+        case (PairPotentialExportFormat::Block):
+            result = exportBlock(parser, pp);
+            break;
+        case (PairPotentialExportFormat::DLPOLYTABLE):
+            result = exportDLPOLY(parser, pp);
+            break;
+        default:
+            throw(std::runtime_error(fmt::format("Pairpotential format '{}' export has not been implemented.\n",
+                                                 formats_.keywordByIndex(*formatIndex_))));
     }
+
     return result;
 }

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -13,25 +13,30 @@ class LineParser;
 class FileAndFormat
 {
     public:
-    FileAndFormat(EnumOptionsBase &formats, std::string_view filename = "");
+    FileAndFormat(EnumOptionsBase &formats, std::string_view filename = "", std::optional<int> formatIndex = {});
     FileAndFormat(const FileAndFormat &source) = default;
     virtual ~FileAndFormat() = default;
-    operator std::string_view() const;
 
     /*
-     * File and Format
+     * Format
      */
     protected:
     // Formats enum as the base object
     EnumOptionsBase &formats_;
+    // Index of current format
+    std::optional<int> formatIndex_;
 
     public:
     // Return formats enum as the base object
-    EnumOptionsBase &formats();
+    const EnumOptionsBase &formats() const;
+    // Set current format by index
+    void setFormatByIndex(int index);
+    // Return current format index
+    int formatIndex() const;
     // Return current format keyword
-    std::string format() const;
+    std::string formatKeyword() const;
     // Return current format description
-    std::string description() const;
+    std::string formatDescription() const;
     // Print available formats
     void printAvailableFormats() const;
 

--- a/src/io/import/data2d.cpp
+++ b/src/io/import/data2d.cpp
@@ -7,10 +7,11 @@
 #include "keywords/vec3double.h"
 
 Data2DImportFileFormat::Data2DImportFileFormat(std::string_view filename, Data2DImportFileFormat::Data2DImportFormat format)
-    : FileAndFormat(formats_, filename)
+    : FileAndFormat(formats_, filename, (int)format)
 {
     formats_ = EnumOptions<Data2DImportFileFormat::Data2DImportFormat>(
-        "Data2DImportFileFormat", {{Data2DImportFormat::Cartesian, "cartesian", "Cartesian X,Y,f(X,Y) data"}}, format);
+        "Data2DImportFileFormat", {{Data2DImportFormat::Cartesian, "cartesian", "Cartesian X,Y,f(X,Y) data"}});
+
     setUpKeywords();
 }
 
@@ -51,15 +52,20 @@ bool Data2DImportFileFormat::importData(Data2D &data, const ProcessPool *procPoo
 // Import Data2D using supplied parser and current format
 bool Data2DImportFileFormat::importData(LineParser &parser, Data2D &data)
 {
+    // Check the format
+    if (!formatIndex_)
+        return Messenger::error("No format set for Data2DImportFileFormat so can't import.\n");
+
     // Import the data
     auto result = false;
-    switch (formats_.enumeration())
+    switch (formats_.enumerationByIndex(*formatIndex_))
     {
         case (Data2DImportFormat::Cartesian):
             result = importCartesian(parser, data);
             break;
         default:
-            throw(std::runtime_error(fmt::format("Data2D format '{}' import has not been implemented.\n", formats_.keyword())));
+            throw(std::runtime_error(
+                fmt::format("Data2D format '{}' import has not been implemented.\n", formats_.keywordByIndex(*formatIndex_))));
     }
 
     return result;

--- a/src/io/import/data3d.cpp
+++ b/src/io/import/data3d.cpp
@@ -6,10 +6,11 @@
 #include "base/sysfunc.h"
 
 Data3DImportFileFormat::Data3DImportFileFormat(std::string_view filename, Data3DImportFileFormat::Data3DImportFormat format)
-    : FileAndFormat(formats_, filename)
+    : FileAndFormat(formats_, filename, (int)format)
 {
     formats_ = EnumOptions<Data3DImportFileFormat::Data3DImportFormat>(
-        "Data3DImportFileFormat", {{Data3DImportFormat::Cartesian, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}}, format);
+        "Data3DImportFileFormat", {{Data3DImportFormat::Cartesian, "cartesian", "Cartesian X,Y,Z,f(x,y,z) data"}});
+
     setUpKeywords();
 }
 
@@ -43,12 +44,17 @@ bool Data3DImportFileFormat::importData(Data3D &data, const ProcessPool *procPoo
 // Import Data3D using supplied parser and current format
 bool Data3DImportFileFormat::importData(LineParser &parser, Data3D &data)
 {
+    // Check the format
+    if (!formatIndex_)
+        return Messenger::error("No format set for Data3DImportFileFormat so can't import.\n");
+
     // Import the data
     auto result = false;
-    switch (formats_.enumeration())
+    switch (formats_.enumerationByIndex(*formatIndex_))
     {
         default:
-            throw(std::runtime_error(fmt::format("Data3D format '{}' import has not been implemented.\n", formats_.keyword())));
+            throw(std::runtime_error(
+                fmt::format("Data3D format '{}' import has not been implemented.\n", formats_.keywordByIndex(*formatIndex_))));
     }
 
     return result;

--- a/src/keywords/nodevalueenumoptions.h
+++ b/src/keywords/nodevalueenumoptions.h
@@ -21,7 +21,7 @@ class NodeValueEnumOptionsBaseKeyword : public KeywordBase
      * Data
      */
     protected:
-    // Reference to  EnumBaseOptions
+    // Reference to EnumBaseOptions
     EnumOptionsBase &baseOptions_;
 
     public:

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -71,7 +71,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                     break;
                 }
                 Messenger::printVerbose("Initial coordinates will be loaded from file '{}' ({})\n",
-                                        cfg->inputCoordinates().filename(), cfg->inputCoordinates().format());
+                                        cfg->inputCoordinates().filename(), cfg->inputCoordinates().formatKeyword());
                 break;
             case (ConfigurationBlock::SizeFactorKeyword):
                 cfg->setRequestedSizeFactor(parser.argd(1));

--- a/src/modules/export_coordinates/process.cpp
+++ b/src/modules/export_coordinates/process.cpp
@@ -24,8 +24,8 @@ bool ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &pro
     // Only the pool master saves the data
     if (procPool.isMaster())
     {
-        Messenger::print("Export: Writing coordinates file ({}) for Configuration '{}'...\n", coordinatesFormat_.description(),
-                         targetConfiguration_->name());
+        Messenger::print("Export: Writing coordinates file ({}) for Configuration '{}'...\n",
+                         coordinatesFormat_.formatDescription(), targetConfiguration_->name());
 
         if (!coordinatesFormat_.exportData(targetConfiguration_))
         {

--- a/src/modules/export_pairpotentials/process.cpp
+++ b/src/modules/export_pairpotentials/process.cpp
@@ -23,8 +23,8 @@ bool ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &
 
         for (auto &pp : dissolve.pairPotentials())
         {
-            Messenger::print("Export: Writing pair potential file ({}) for {}-{}...\n", pairPotentialFormat_.description(),
-                             pp->atomTypeNameI(), pp->atomTypeNameJ());
+            Messenger::print("Export: Writing pair potential file ({}) for {}-{}...\n",
+                             pairPotentialFormat_.formatDescription(), pp->atomTypeNameI(), pp->atomTypeNameJ());
 
             // Generate filename
             pairPotentialFormat_.setFilename(fmt::format("{}-{}-{}.pp", rootPPName, pp->atomTypeNameI(), pp->atomTypeNameJ()));

--- a/src/modules/export_trajectory/process.cpp
+++ b/src/modules/export_trajectory/process.cpp
@@ -22,8 +22,8 @@ bool ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
     // Only the pool master saves the data
     if (procPool.isMaster())
     {
-        Messenger::print("Export: Appending trajectory file ({}) for Configuration '{}'...\n", trajectoryFormat_.description(),
-                         targetConfiguration_->name());
+        Messenger::print("Export: Appending trajectory file ({}) for Configuration '{}'...\n",
+                         trajectoryFormat_.formatDescription(), targetConfiguration_->name());
 
         if (!trajectoryFormat_.exportData(targetConfiguration_))
         {


### PR DESCRIPTION
This PR fixes an issue with EnumOptions attached to keywords, specifically `NodeValueEnumOptionsKeyword`. While everything works fine from the CLI, displaying and editing the enum via `NodeValueEnumOptionsKeywordWidget` in the GUI fails to display or change the enum value. The underlying cause of this was the fact that the current enumeration was stored in both the keyword as part of its `data_` as well as the `EnumOptions` object used in the keyword widget.

To clarify things, storage of the current enum within `EnumOptions` has been removed, making it a pure read-only utility class for manipulating enums and their associated keywords. The major side effect of this is the partial refactoring of `FileAndFormat` which depended heavily on the now-removed enum storage.

Closes #1334.