### PR TITLE
Add bundling to cache

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -46,7 +46,6 @@ runs:
       cp -v result packages/${{ inputs.target }}-${{ env.dissolveVersion }}.sif
 
   - name: Bundle Executable
-    if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
       set -ex


### PR DESCRIPTION
This PR adds the nix bundling step into the cache workflow, since this also requires download of a rather large amount of data (and causes timeouts because the nix servers are being mashed by GitHub).