### PR TITLE
Module constructor throwing

### DIFF
--- a/src/modules/angle/angle.cpp
+++ b/src/modules/angle/angle.cpp
@@ -24,119 +24,110 @@
 
 AngleModule::AngleModule() : Module("Angle"), analyser_(ProcedureNode::AnalysisContext)
 {
-    try
-    {
-        // Select: Site 'A'
-        selectA_ = analyser_.createRootNode<SelectProcedureNode>("A");
-        auto &forEachA = selectA_->branch()->get();
+    // Select: Site 'A'
+    selectA_ = analyser_.createRootNode<SelectProcedureNode>("A");
+    auto &forEachA = selectA_->branch()->get();
 
-        // -- Select: Site 'B'
-        selectB_ = forEachA.create<SelectProcedureNode>("B");
-        auto &forEachB = selectB_->branch()->get();
+    // -- Select: Site 'B'
+    selectB_ = forEachA.create<SelectProcedureNode>("B");
+    auto &forEachB = selectB_->branch()->get();
 
-        // -- -- Calculate: 'rAB'
-        auto calcAB = forEachB.create<CalculateDistanceProcedureNode>("rAB", selectA_, selectB_);
+    // -- -- Calculate: 'rAB'
+    auto calcAB = forEachB.create<CalculateDistanceProcedureNode>("rAB", selectA_, selectB_);
 
-        // -- -- Collect1D:  'RDF(AB)'
-        collectAB_ = forEachB.create<Collect1DProcedureNode>({}, calcAB, ProcedureNode::AnalysisContext, rangeAB_.x, rangeAB_.y,
-                                                             rangeAB_.z);
+    // -- -- Collect1D:  'RDF(AB)'
+    collectAB_ =
+        forEachB.create<Collect1DProcedureNode>({}, calcAB, ProcedureNode::AnalysisContext, rangeAB_.x, rangeAB_.y, rangeAB_.z);
 
-        // -- -- Select: Site 'C'
-        selectC_ = forEachB.create<SelectProcedureNode>("C");
-        auto &forEachC = selectC_->branch()->get();
+    // -- -- Select: Site 'C'
+    selectC_ = forEachB.create<SelectProcedureNode>("C");
+    auto &forEachC = selectC_->branch()->get();
 
-        // -- -- -- Calculate: 'rBC'
-        auto calcBC = forEachC.create<CalculateDistanceProcedureNode>({}, selectB_, selectC_);
+    // -- -- -- Calculate: 'rBC'
+    auto calcBC = forEachC.create<CalculateDistanceProcedureNode>({}, selectB_, selectC_);
 
-        // -- -- -- Calculate: 'aABC'
-        calculateAngle_ = forEachC.create<CalculateAngleProcedureNode>({}, selectA_, selectB_, selectC_);
-        calculateAngle_->keywords().set("Symmetric", symmetric_);
+    // -- -- -- Calculate: 'aABC'
+    calculateAngle_ = forEachC.create<CalculateAngleProcedureNode>({}, selectA_, selectB_, selectC_);
+    calculateAngle_->keywords().set("Symmetric", symmetric_);
 
-        // -- -- -- Collect1D:  'RDF(BC)'
-        collectBC_ = forEachC.create<Collect1DProcedureNode>({}, calcBC, ProcedureNode::AnalysisContext, rangeBC_.x, rangeBC_.y,
-                                                             rangeBC_.z);
+    // -- -- -- Collect1D:  'RDF(BC)'
+    collectBC_ =
+        forEachC.create<Collect1DProcedureNode>({}, calcBC, ProcedureNode::AnalysisContext, rangeBC_.x, rangeBC_.y, rangeBC_.z);
 
-        // -- -- -- Collect1D:  'ANGLE(ABC)'
-        collectABC_ = forEachC.create<Collect1DProcedureNode>({}, calculateAngle_, ProcedureNode::AnalysisContext,
-                                                              angleRange_.x, angleRange_.y, angleRange_.z);
+    // -- -- -- Collect1D:  'ANGLE(ABC)'
+    collectABC_ = forEachC.create<Collect1DProcedureNode>({}, calculateAngle_, ProcedureNode::AnalysisContext, angleRange_.x,
+                                                          angleRange_.y, angleRange_.z);
 
-        // -- -- -- Collect2D:  'DAngle (A-B)-C'
-        collectDAngleAB_ =
-            forEachC.create<Collect2DProcedureNode>({}, calcAB, calculateAngle_, ProcedureNode::AnalysisContext, rangeAB_.x,
-                                                    rangeAB_.y, rangeAB_.z, angleRange_.x, angleRange_.y, angleRange_.z);
+    // -- -- -- Collect2D:  'DAngle (A-B)-C'
+    collectDAngleAB_ =
+        forEachC.create<Collect2DProcedureNode>({}, calcAB, calculateAngle_, ProcedureNode::AnalysisContext, rangeAB_.x,
+                                                rangeAB_.y, rangeAB_.z, angleRange_.x, angleRange_.y, angleRange_.z);
 
-        // -- -- -- Collect2D:  'DAngle A-(B-C)'
-        collectDAngleBC_ =
-            forEachC.create<Collect2DProcedureNode>({}, calcBC, calculateAngle_, ProcedureNode::AnalysisContext, rangeBC_.x,
-                                                    rangeBC_.y, rangeBC_.z, angleRange_.x, angleRange_.y, angleRange_.z);
+    // -- -- -- Collect2D:  'DAngle A-(B-C)'
+    collectDAngleBC_ =
+        forEachC.create<Collect2DProcedureNode>({}, calcBC, calculateAngle_, ProcedureNode::AnalysisContext, rangeBC_.x,
+                                                rangeBC_.y, rangeBC_.z, angleRange_.x, angleRange_.y, angleRange_.z);
 
-        // -- -- -- Collect3D:  'rAB vs rBC vs aABC'
-        collectDDA_ = forEachC.create<Collect3DProcedureNode>(
-            {}, calcAB, calcBC, calculateAngle_, ProcedureNode::AnalysisContext, rangeAB_.x, rangeAB_.y, rangeAB_.z, rangeBC_.x,
-            rangeBC_.y, rangeBC_.z, angleRange_.x, angleRange_.y, angleRange_.z);
+    // -- -- -- Collect3D:  'rAB vs rBC vs aABC'
+    collectDDA_ = forEachC.create<Collect3DProcedureNode>({}, calcAB, calcBC, calculateAngle_, ProcedureNode::AnalysisContext,
+                                                          rangeAB_.x, rangeAB_.y, rangeAB_.z, rangeBC_.x, rangeBC_.y,
+                                                          rangeBC_.z, angleRange_.x, angleRange_.y, angleRange_.z);
 
-        // Process1D: 'RDF(AB)'
-        processAB_ = analyser_.createRootNode<Process1DProcedureNode>("RDF(AB)", collectAB_);
-        processAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
-        processAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-        auto &rdfABNormalisation = processAB_->branch()->get();
-        rdfABNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
-        rdfABNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
-                                                                              ConstNodeVector<SelectProcedureNode>({selectB_}));
-        rdfABNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
+    // Process1D: 'RDF(AB)'
+    processAB_ = analyser_.createRootNode<Process1DProcedureNode>("RDF(AB)", collectAB_);
+    processAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
+    processAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+    auto &rdfABNormalisation = processAB_->branch()->get();
+    rdfABNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({},
+                                                                           ConstNodeVector<SelectProcedureNode>({selectA_}));
+    rdfABNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>({selectB_}));
+    rdfABNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
-        // Process1D: 'RDF(BC)'
-        processBC_ = analyser_.createRootNode<Process1DProcedureNode>("RDF(BC)", collectBC_);
-        processBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
-        processBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-        auto &rdfBCNormalisation = processBC_->branch()->get();
-        rdfBCNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
-        rdfBCNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
-                                                                              ConstNodeVector<SelectProcedureNode>({selectC_}));
-        rdfBCNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
+    // Process1D: 'RDF(BC)'
+    processBC_ = analyser_.createRootNode<Process1DProcedureNode>("RDF(BC)", collectBC_);
+    processBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
+    processBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+    auto &rdfBCNormalisation = processBC_->branch()->get();
+    rdfBCNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
+        {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
+    rdfBCNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>({selectC_}));
+    rdfBCNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
-        // Process1D: 'ANGLE(ABC)'
-        processAngle_ = analyser_.createRootNode<Process1DProcedureNode>("Angle(ABC)", collectABC_);
-        processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
-        processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
-        auto &angleNormalisation = processAngle_->branch()->get();
-        angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
-        angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
+    // Process1D: 'ANGLE(ABC)'
+    processAngle_ = analyser_.createRootNode<Process1DProcedureNode>("Angle(ABC)", collectABC_);
+    processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
+    processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
+    auto &angleNormalisation = processAngle_->branch()->get();
+    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+    angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
 
-        // Process2D: 'DAngle (A-B)-C'
-        processDAngleAB_ = analyser_.createRootNode<Process2DProcedureNode>("DAngle((A-B)-C)", collectDAngleAB_);
-        processDAngleAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
-        processDAngleAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-        processDAngleAB_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
-        auto &dAngleABNormalisation = processDAngleAB_->branch()->get();
-        dAngleABNormalisationExpression_ = dAngleABNormalisation.create<OperateExpressionProcedureNode>(
-            {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
-        dAngleABNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectA_, selectC_}));
-        dAngleABNormalisation.create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectB_}));
-        dAngleABNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
+    // Process2D: 'DAngle (A-B)-C'
+    processDAngleAB_ = analyser_.createRootNode<Process2DProcedureNode>("DAngle((A-B)-C)", collectDAngleAB_);
+    processDAngleAB_->keywords().set("LabelValue", std::string("g\\sub{AB}(r)"));
+    processDAngleAB_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+    processDAngleAB_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
+    auto &dAngleABNormalisation = processDAngleAB_->branch()->get();
+    dAngleABNormalisationExpression_ = dAngleABNormalisation.create<OperateExpressionProcedureNode>(
+        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleABNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
+        {}, ConstNodeVector<SelectProcedureNode>({selectA_, selectC_}));
+    dAngleABNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
+                                                                             ConstNodeVector<SelectProcedureNode>({selectB_}));
+    dAngleABNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
-        // Process2D: 'DAngle A-(B-C)'
-        processDAngleBC_ = analyser_.createRootNode<Process2DProcedureNode>("DAngle(A-(B-C))", collectDAngleBC_);
-        processDAngleBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
-        processDAngleBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-        processDAngleBC_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
-        auto &dAngleBCNormalisation = processDAngleBC_->branch()->get();
-        dAngleBCNormalisationExpression_ = dAngleBCNormalisation.create<OperateExpressionProcedureNode>(
-            {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
-        dAngleBCNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
-        dAngleBCNormalisation.create<OperateNumberDensityNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectC_}));
-        dAngleBCNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
-    }
-    catch (...)
-    {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
-    }
+    // Process2D: 'DAngle A-(B-C)'
+    processDAngleBC_ = analyser_.createRootNode<Process2DProcedureNode>("DAngle(A-(B-C))", collectDAngleBC_);
+    processDAngleBC_->keywords().set("LabelValue", std::string("g\\sub{BC}(r)"));
+    processDAngleBC_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+    processDAngleBC_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
+    auto &dAngleBCNormalisation = processDAngleBC_->branch()->get();
+    dAngleBCNormalisationExpression_ = dAngleBCNormalisation.create<OperateExpressionProcedureNode>(
+        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleBCNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
+        {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
+    dAngleBCNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
+                                                                             ConstNodeVector<SelectProcedureNode>({selectC_}));
+    dAngleBCNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
     /*
      * Keywords

--- a/src/modules/axisangle/axisangle.cpp
+++ b/src/modules/axisangle/axisangle.cpp
@@ -22,79 +22,70 @@
 
 AxisAngleModule::AxisAngleModule() : Module("AxisAngle"), analyser_(ProcedureNode::AnalysisContext)
 {
-    try
-    {
-        // Select: Site 'A'
-        selectA_ = analyser_.createRootNode<SelectProcedureNode>("A", std::vector<const SpeciesSite *>{},
-                                                                 ProcedureNode::NodeContext::AnalysisContext, true);
-        auto &forEachA = selectA_->branch()->get();
+    // Select: Site 'A'
+    selectA_ = analyser_.createRootNode<SelectProcedureNode>("A", std::vector<const SpeciesSite *>{},
+                                                             ProcedureNode::NodeContext::AnalysisContext, true);
+    auto &forEachA = selectA_->branch()->get();
 
-        // -- Select: Site 'B'
-        selectB_ = forEachA.create<SelectProcedureNode>("B", std::vector<const SpeciesSite *>{},
-                                                        ProcedureNode::NodeContext::AnalysisContext, true);
-        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
-        auto &forEachB = selectB_->branch()->get();
+    // -- Select: Site 'B'
+    selectB_ = forEachA.create<SelectProcedureNode>("B", std::vector<const SpeciesSite *>{},
+                                                    ProcedureNode::NodeContext::AnalysisContext, true);
+    selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
+    auto &forEachB = selectB_->branch()->get();
 
-        // -- -- Calculate: 'rAB'
-        auto calcDistance = forEachB.create<CalculateDistanceProcedureNode>({}, selectA_, selectB_);
+    // -- -- Calculate: 'rAB'
+    auto calcDistance = forEachB.create<CalculateDistanceProcedureNode>({}, selectA_, selectB_);
 
-        // -- -- Calculate: 'axisAngle'
-        calculateAxisAngle_ =
-            forEachB.create<CalculateAxisAngleProcedureNode>({}, selectA_, OrientedSite::XAxis, selectB_, OrientedSite::XAxis);
-        calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
+    // -- -- Calculate: 'axisAngle'
+    calculateAxisAngle_ =
+        forEachB.create<CalculateAxisAngleProcedureNode>({}, selectA_, OrientedSite::XAxis, selectB_, OrientedSite::XAxis);
+    calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
 
-        // -- -- Collect2D:  'rAB vs axisAngle)'
-        collectDAngle_ = forEachB.create<Collect2DProcedureNode>(
-            {}, calcDistance, calculateAxisAngle_, ProcedureNode::AnalysisContext, distanceRange_.x, distanceRange_.y,
-            distanceRange_.z, angleRange_.x, angleRange_.y, angleRange_.z);
-        auto &subCollection = collectDAngle_->branch()->get();
+    // -- -- Collect2D:  'rAB vs axisAngle)'
+    collectDAngle_ = forEachB.create<Collect2DProcedureNode>({}, calcDistance, calculateAxisAngle_,
+                                                             ProcedureNode::AnalysisContext, distanceRange_.x, distanceRange_.y,
+                                                             distanceRange_.z, angleRange_.x, angleRange_.y, angleRange_.z);
+    auto &subCollection = collectDAngle_->branch()->get();
 
-        // -- -- -- Collect1D:  'RDF(AB)'
-        collectDistance_ = subCollection.create<Collect1DProcedureNode>({}, calcDistance, ProcedureNode::AnalysisContext,
-                                                                        distanceRange_.x, distanceRange_.y, distanceRange_.z);
+    // -- -- -- Collect1D:  'RDF(AB)'
+    collectDistance_ = subCollection.create<Collect1DProcedureNode>({}, calcDistance, ProcedureNode::AnalysisContext,
+                                                                    distanceRange_.x, distanceRange_.y, distanceRange_.z);
 
-        // -- -- -- Collect1D:  'ANGLE(axis-axis)'
-        collectAngle_ = subCollection.create<Collect1DProcedureNode>({}, calculateAxisAngle_, ProcedureNode::AnalysisContext,
-                                                                     angleRange_.x, angleRange_.y, angleRange_.z);
+    // -- -- -- Collect1D:  'ANGLE(axis-axis)'
+    collectAngle_ = subCollection.create<Collect1DProcedureNode>({}, calculateAxisAngle_, ProcedureNode::AnalysisContext,
+                                                                 angleRange_.x, angleRange_.y, angleRange_.z);
 
-        // Process1D: 'RDF(AB)'
-        processDistance_ =
-            analyser_.createRootNode<Process1DProcedureNode>("RDF(AB)", collectDistance_, ProcedureNode::OperateContext);
-        processDistance_->keywords().set("LabelValue", std::string("g(r)"));
-        processDistance_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+    // Process1D: 'RDF(AB)'
+    processDistance_ =
+        analyser_.createRootNode<Process1DProcedureNode>("RDF(AB)", collectDistance_, ProcedureNode::OperateContext);
+    processDistance_->keywords().set("LabelValue", std::string("g(r)"));
+    processDistance_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
 
-        auto &rdfNormalisation = processDistance_->branch()->get();
-        rdfNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({},
-                                                                             ConstNodeVector<SelectProcedureNode>{selectA_});
-        rdfNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>{selectB_});
-        rdfNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
+    auto &rdfNormalisation = processDistance_->branch()->get();
+    rdfNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>{selectA_});
+    rdfNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>{selectB_});
+    rdfNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
-        // Process1D: 'ANGLE(axis)'
-        processAngle_ = analyser_.createRootNode<Process1DProcedureNode>("AxisAngle(AB)", collectAngle_);
-        processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
-        processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
-        auto &angleNormalisation = processAngle_->branch()->get();
-        angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
-        angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
+    // Process1D: 'ANGLE(axis)'
+    processAngle_ = analyser_.createRootNode<Process1DProcedureNode>("AxisAngle(AB)", collectAngle_);
+    processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
+    processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
+    auto &angleNormalisation = processAngle_->branch()->get();
+    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+    angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
 
-        // Process2D: 'DAngle'
-        processDAngle_ = analyser_.createRootNode<Process2DProcedureNode>("DAxisAngle", collectDAngle_);
-        processDAngle_->keywords().set("LabelX", std::string("\\it{r}, \\symbol{Angstrom}"));
-        processDAngle_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
-        processDAngle_->keywords().set("LabelValue", std::string("g(r)"));
-        auto &dAngleNormalisation = processDAngle_->branch()->get();
-        dAngleNormalisationExpression_ = dAngleNormalisation.create<OperateExpressionProcedureNode>(
-            {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
-        dAngleNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
-        dAngleNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
-                                                                               ConstNodeVector<SelectProcedureNode>{selectB_});
-        dAngleNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
-    }
-    catch (...)
-    {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
-    }
+    // Process2D: 'DAngle'
+    processDAngle_ = analyser_.createRootNode<Process2DProcedureNode>("DAxisAngle", collectDAngle_);
+    processDAngle_->keywords().set("LabelX", std::string("\\it{r}, \\symbol{Angstrom}"));
+    processDAngle_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
+    processDAngle_->keywords().set("LabelValue", std::string("g(r)"));
+    auto &dAngleNormalisation = processDAngle_->branch()->get();
+    dAngleNormalisationExpression_ = dAngleNormalisation.create<OperateExpressionProcedureNode>(
+        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({},
+                                                                            ConstNodeVector<SelectProcedureNode>({selectA_}));
+    dAngleNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>{selectB_});
+    dAngleNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
     /*
      * Keywords

--- a/src/modules/registry.cpp
+++ b/src/modules/registry.cpp
@@ -82,8 +82,7 @@ Module *ModuleRegistry::produce(std::string moduleType) const
 {
     auto it = producers_.find(moduleType);
     if (it == producers_.end())
-        throw(std::runtime_error(fmt::format(
-            "A producer has not been registered for module type '{}', so a new instance cannot be created.\n", moduleType)));
+        return {};
 
     return (it->second.first)();
 }
@@ -120,8 +119,10 @@ const std::map<std::string, std::vector<ModuleRegistry::ModuleInfoData>> &Module
 std::unique_ptr<Module> ModuleRegistry::create(std::string_view moduleType)
 {
     auto m = std::unique_ptr<Module>(instance().produce(std::string(moduleType)));
-    m->setName(DissolveSys::uniqueName(m->type(), Module::instances(),
-                                       [&](const auto &inst) { return inst == m.get() ? std::string() : inst->name(); }));
+
+    if (m)
+        m->setName(DissolveSys::uniqueName(m->type(), Module::instances(),
+                                           [&](const auto &inst) { return inst == m.get() ? std::string() : inst->name(); }));
     return m;
 }
 

--- a/src/modules/siterdf/siterdf.cpp
+++ b/src/modules/siterdf/siterdf.cpp
@@ -21,50 +21,41 @@
 
 SiteRDFModule::SiteRDFModule() : Module("SiteRDF"), analyser_(ProcedureNode::AnalysisContext)
 {
-    try
-    {
-        // Select: Site 'A'
-        selectA_ = analyser_.createRootNode<SelectProcedureNode>("A");
-        auto &forEachA = selectA_->branch()->get();
+    // Select: Site 'A'
+    selectA_ = analyser_.createRootNode<SelectProcedureNode>("A");
+    auto &forEachA = selectA_->branch()->get();
 
-        // -- Select: Site 'B'
-        selectB_ = forEachA.create<SelectProcedureNode>("B");
-        selectB_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectA_});
-        selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
-        auto &forEachB = selectB_->branch()->get();
+    // -- Select: Site 'B'
+    selectB_ = forEachA.create<SelectProcedureNode>("B");
+    selectB_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectA_});
+    selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectA_});
+    auto &forEachB = selectB_->branch()->get();
 
-        // -- -- Calculate: 'rAB'
-        auto calcDistance = forEachB.create<CalculateDistanceProcedureNode>({}, selectA_, selectB_);
+    // -- -- Calculate: 'rAB'
+    auto calcDistance = forEachB.create<CalculateDistanceProcedureNode>({}, selectA_, selectB_);
 
-        // -- -- Collect1D: 'RDF'
-        collectDistance_ = forEachB.create<Collect1DProcedureNode>("Histo-AB", calcDistance);
+    // -- -- Collect1D: 'RDF'
+    collectDistance_ = forEachB.create<Collect1DProcedureNode>("Histo-AB", calcDistance);
 
-        // Process1D: RDF
-        processDistance_ = analyser_.createRootNode<Process1DProcedureNode>("RDF", collectDistance_);
-        processDistance_->keywords().set("LabelValue", std::string("g(r)"));
-        processDistance_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
-        // -- Normalisation Branch
-        auto &rdfNormalisation = processDistance_->branch()->get();
-        rdfNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({},
-                                                                             ConstNodeVector<SelectProcedureNode>({selectA_}));
-        rdfNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
-                                                                            ConstNodeVector<SelectProcedureNode>({selectB_}));
-        rdfNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
+    // Process1D: RDF
+    processDistance_ = analyser_.createRootNode<Process1DProcedureNode>("RDF", collectDistance_);
+    processDistance_->keywords().set("LabelValue", std::string("g(r)"));
+    processDistance_->keywords().set("LabelX", std::string("r, \\symbol{Angstrom}"));
+    // -- Normalisation Branch
+    auto &rdfNormalisation = processDistance_->branch()->get();
+    rdfNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>({selectA_}));
+    rdfNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>({selectB_}));
+    rdfNormalisation.create<OperateSphericalShellNormaliseProcedureNode>({});
 
-        // Process1D: CN
-        processCN_ = analyser_.createRootNode<Process1DProcedureNode>("HistogramNorm", collectDistance_);
-        processCN_->keywords().set("Instantaneous", true);
-        auto &cnNormalisation = processCN_->branch()->get();
-        cnNormaliser_ = cnNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
-            {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
+    // Process1D: CN
+    processCN_ = analyser_.createRootNode<Process1DProcedureNode>("HistogramNorm", collectDistance_);
+    processCN_->keywords().set("Instantaneous", true);
+    auto &cnNormalisation = processCN_->branch()->get();
+    cnNormaliser_ = cnNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
+        {}, ConstNodeVector<SelectProcedureNode>({selectA_}));
 
-        // Sum1D
-        sumCN_ = analyser_.createRootNode<Sum1DProcedureNode>("CN", processCN_);
-    }
-    catch (...)
-    {
-        Messenger::error("Failed to create analysis procedure for module '{}'\n", name_);
-    }
+    // Sum1D
+    sumCN_ = analyser_.createRootNode<Sum1DProcedureNode>("CN", processCN_);
 
     /*
      * Keywords


### PR DESCRIPTION
### Not for inclusion in v1.0 release

This PR stops us hiding information from exceptions caught from module constructors. If a module constructor fails during setup this is a developer or code problem rather than something warranting a user-facing error message. The previous implementation would catch problems (e.g. passing the wrong object type when setting a keyword) and result in a silent fail of `Module type 'MyModuleName' not recognised` which hides the real problem.

Here we remove `try`/`catch` blocks from module constructors which used them as well as the input file reading in order to expose any real issues arising.