### PR TITLE
Push Main Website

### DIFF
--- a/.github/workflows/website/action.yml
+++ b/.github/workflows/website/action.yml
@@ -96,21 +96,21 @@ runs:
         cd ../../
       done
 
-  - name: 'SSH Deploy to Server (Release)'
+  - name: 'SSH Deploy to Server (Release) (Docs only)'
     if: ${{ inputs.deploy == 'true' && inputs.continuous == 'false' }}
     shell: bash
     run: |
       echo "${SERVER_ID}" > ./serverId
       echo "${SERVER_KEY}" > ./serverKey
       chmod 0600 ./serverKey ./serverId
-      rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public/ ${SERVER_IP}:${SERVER_MAIN_DIR}
       rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public-docs/ ${SERVER_IP}:${SERVER_DOCS_DIR}
 
-  - name: 'SSH Deploy to Server (Continuous, docs only)'
+  - name: 'SSH Deploy to Server (Continuous)'
     if: ${{ inputs.deploy == 'true' && inputs.continuous == 'true' }}
     shell: bash
     run: |
       echo "${SERVER_ID}" > ./serverId
       echo "${SERVER_KEY}" > ./serverKey
       chmod 0600 ./serverKey ./serverId
+      rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public/ ${SERVER_IP}:${SERVER_MAIN_DIR}
       rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public-docs/ ${SERVER_IP}:${SERVER_DOCS_DIR}/continuous


### PR DESCRIPTION
This PR switches the logic of when to push the main website frontpage content from `release` branches to the `develop` (continuous) branch.  Up-to-date version release info is contained in the latter rather than the former, so this makes more sense.