### PR TITLE
added deprecated keyword for UseHalfCellWidth

### DIFF
--- a/src/modules/gr/gr.cpp
+++ b/src/modules/gr/gr.cpp
@@ -46,6 +46,11 @@ GRModule::GRModule() : Module("GR")
         internalTest_);
     keywords_.add<EnumOptionsKeyword<GRModule::PartialsMethod>>(
         "Method", "Calculation method for partial radial distribution functions", partialsMethod_, GRModule::partialsMethods());
+
+    // Deprecated
+    static bool deprecatedBool_{false};
+    keywords_.addDeprecated<BoolKeyword>(
+        "UseHalfCellRange", "Whether to use the maximal RDF range possible that avoids periodic images", deprecatedBool_);
 }
 
 // Return enum option info for NormalisationType


### PR DESCRIPTION
Change from release/1.0.1 added to develop that adds a deprecated value to useHalfCellRange in the module g(r), that was deleted when adding optional variables