### PR TITLE
1355 RDF/CN Layer Crash

### DIFF
--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -319,10 +319,6 @@ void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
     auto *calcRDFModule = ModuleRegistry::create("SiteRDF", newLayer);
     calcRDFModule->keywords().set("Configuration", firstCfg);
 
-    // Add a CalculateCN module
-    auto *module = ModuleRegistry::create("CalculateCN", newLayer);
-    module->keywords().set("SourceRDF", calcRDFModule);
-
     // Run set-up stages for modules
     newLayer->setUpAll(dissolve_, dissolve_.worldPool());
 


### PR DESCRIPTION
This PR removes some old code relating to the now-removed `CalculateCN` module.  The GUI still tried to create a module of this type, and which caused an unhandled exception (handled by Qt in the form of an immediate crash).

To be added in to v1.0.1.

Closes #1355.