### PR TITLE
1358 FileAndFormat Reading

### DIFF
--- a/src/classes/data1dstore.cpp
+++ b/src/classes/data1dstore.cpp
@@ -18,7 +18,7 @@ bool Data1DStore::addData(std::string_view dataName, LineParser &parser, int sta
     data.setTag(dataName);
 
     // Read the file / format
-    if (!format.read(parser, startArg, endKeyword, coreData))
+    if (format.read(parser, startArg, endKeyword, coreData) != FileAndFormat::ReadResult::Success)
         return false;
 
     // Load the data

--- a/src/classes/data2dstore.cpp
+++ b/src/classes/data2dstore.cpp
@@ -18,7 +18,7 @@ bool Data2DStore::addData(std::string_view dataName, LineParser &parser, int sta
     data.setTag(dataName);
 
     // Read the file / format
-    if (!format.read(parser, startArg, endKeyword, coreData))
+    if (format.read(parser, startArg, endKeyword, coreData) != FileAndFormat::ReadResult::Success)
         return false;
 
     // Load the data

--- a/src/classes/data3dstore.cpp
+++ b/src/classes/data3dstore.cpp
@@ -18,7 +18,7 @@ bool Data3DStore::addData(std::string_view dataName, LineParser &parser, int sta
     data.setTag(dataName);
 
     // Read the file / format
-    if (!format.read(parser, startArg, endKeyword, coreData))
+    if (format.read(parser, startArg, endKeyword, coreData) != FileAndFormat::ReadResult::Success)
         return false;
 
     // Load the data

--- a/src/classes/valuestore.cpp
+++ b/src/classes/valuestore.cpp
@@ -18,7 +18,7 @@ bool ValueStore::addData(std::string_view dataName, LineParser &parser, int star
     tag = dataName;
 
     // Read the file / format
-    if (!format.read(parser, startArg, endKeyword, coreData))
+    if (format.read(parser, startArg, endKeyword, coreData) != FileAndFormat::ReadResult::Success)
         return false;
 
     // Load the data

--- a/src/io/fileandformat.h
+++ b/src/io/fileandformat.h
@@ -79,8 +79,17 @@ class FileAndFormat
      * Read / Write
      */
     public:
+    // Read result
+    enum class ReadResult
+    {
+        UnrecognisedFormat,
+        FileNotFound,
+        UnrecognisedOption,
+        GeneralReadError,
+        Success
+    };
     // Read format / filename from specified parser
-    bool read(LineParser &parser, int startArg, std::string_view endKeyword, const CoreData &coreData);
+    ReadResult read(LineParser &parser, int startArg, std::string_view endKeyword, const CoreData &coreData);
     // Write format / filename to specified parser
     bool writeFilenameAndFormat(LineParser &parser, std::string_view prefix) const;
     // Write options and end block

--- a/src/keywords/fileandformat.cpp
+++ b/src/keywords/fileandformat.cpp
@@ -35,8 +35,11 @@ std::optional<int> FileAndFormatKeyword::maxArguments() const { return 2; }
 // Deserialise from supplied LineParser, starting at given argument offset
 bool FileAndFormatKeyword::deserialise(LineParser &parser, int startArg, const CoreData &coreData)
 {
-    if (!data_.read(parser, startArg, endKeyword_, coreData))
-        Messenger::warn("Failed to read file/format for '{}'.\n", name());
+    auto result = data_.read(parser, startArg, endKeyword_, coreData);
+
+    // Fail on hard errors
+    if (result == FileAndFormat::ReadResult::UnrecognisedFormat || result == FileAndFormat::ReadResult::UnrecognisedOption)
+        return Messenger::error("Failed to read file/format for '{}'.\n", name());
 
     return true;
 }

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -61,10 +61,10 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 }
                 break;
             case (ConfigurationBlock::InputCoordinatesKeyword):
-                if (!cfg->inputCoordinates().read(parser, 1,
-                                                  fmt::format("End{}", ConfigurationBlock::keywords().keyword(
-                                                                           ConfigurationBlock::InputCoordinatesKeyword)),
-                                                  dissolve->coreData()))
+                if (cfg->inputCoordinates().read(parser, 1,
+                                                 fmt::format("End{}", ConfigurationBlock::keywords().keyword(
+                                                                          ConfigurationBlock::InputCoordinatesKeyword)),
+                                                 dissolve->coreData()) != FileAndFormat::ReadResult::Success)
                 {
                     Messenger::error("Failed to set input coordinates file / format.\n");
                     error = true;


### PR DESCRIPTION
This PR addresses #1358, making the reading of `FileAndFormat` data easier to warn/fail on errors as appropriate, rather than just throwing a warning no matter how bad the error and allowing Dissolve to carry on.

Closes #1358.