### PR TITLE
Fix layer menu again

### DIFF
--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -336,12 +336,12 @@ void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked
 
     auto firstCfg = dissolve_.configurations().empty() ? nullptr : dissolve_.configurations().front().get();
 
-    // Add the CalculateAvgMol module
-    auto *module = ModuleRegistry::create("CalculateAvgMol", newLayer);
+    // Add the AvgMol module
+    auto *module = ModuleRegistry::create("AvgMol", newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    // Add a CalculateSDF module
-    module = ModuleRegistry::create("CalculateSDF", newLayer);
+    // Add an SDF module
+    module = ModuleRegistry::create("SDF", newLayer);
     module->keywords().set("Configuration", firstCfg);
 
     // Run set-up stages for modules

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -53,7 +53,7 @@ bool AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateAngle experienced problems with its analysis.\n");
+        return Messenger::error("Angle experienced problems with its analysis.\n");
 
     return true;
 }

--- a/src/modules/axisangle/process.cpp
+++ b/src/modules/axisangle/process.cpp
@@ -33,7 +33,7 @@ bool AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateAxisAngle experienced problems with its analysis.\n");
+        return Messenger::error("AxisAngle experienced problems with its analysis.\n");
 
     return true;
 }


### PR DESCRIPTION
Another quick PR to address a hard crash caused by using the wrong module names in the Layer menu items. Also fixes a couple of uses of the old module names in error messages.