### PR TITLE
Move official Qt version to 6.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,6 @@ on:
     - 'web/**'
     - 'README.md'
 
-env:
-  pythonVersion: 3.9
-  qtVersion: 6.4.2
-  nixVersion: 2.4
-  nixOSVersion: 22.11
-
 jobs:
 
   QC:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   pythonVersion: 3.9
-  qtVersion: 6.2.2
+  qtVersion: 6.4.2
   nixVersion: 2.4
   nixOSVersion: 22.11
 

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 3.9
   qtVersion:
     type: string
-    default: 6.2.2
+    default: 6.4.2
   nixVersion:
     type: string
     default: 2.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ if(WIN32)
   # Add defines for Windows systems - NOMINMAX to prevent conflicts with std::min() and std::max() - NOGDI to prevent conflicts arising from
   # Windows defining ERROR as a global macro (used in ANTLR4)
   add_definitions(-DNOMINMAX -DNOGDI)
+  # Needed for Qt 6.4
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /PERMISSIVE")
 endif(WIN32)
 
 # -- Unix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if(WIN32)
   # Windows defining ERROR as a global macro (used in ANTLR4)
   add_definitions(-DNOMINMAX -DNOGDI)
   # Needed for Qt 6.4
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /PERMISSIVE")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 endif(WIN32)
 
 # -- Unix

--- a/flake.lock
+++ b/flake.lock
@@ -160,6 +160,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1680334310,
+        "narHash": "sha256-ISWz16oGxBhF7wqAxefMPwFag6SlsA9up8muV79V9ck=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "884e3b68be02ff9d61a042bc9bd9dd2a358f95da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "outdated": {
       "locked": {
         "lastModified": 1655034179,
@@ -176,6 +192,24 @@
         "type": "github"
       }
     },
+    "qt-idaaas": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5"
+      },
+      "locked": {
+        "lastModified": 1680528871,
+        "narHash": "sha256-DPb7Z638N94c/4/cXzSx8BdxnxTPFj+QxA7tWIVaBZ4=",
+        "owner": "disorderedmaterials",
+        "repo": "qt-idaaas",
+        "rev": "3fb484d010b4efa7aa591e914cb990ba8704ba46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "disorderedmaterials",
+        "repo": "qt-idaaas",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "bundlers": "bundlers",
@@ -183,6 +217,7 @@
         "nixGL-src": "nixGL-src",
         "nixpkgs": "nixpkgs_4",
         "outdated": "outdated",
+        "qt-idaaas": "qt-idaaas",
         "weggli": "weggli"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,7 @@
               ccls
               cmake-format
               cmake-language-server
-              conan-1.58.0
+              conan
               distcc
               gdb
               openmpi

--- a/nix/qt/patches/qtbase-tzdir.patch
+++ b/nix/qt/patches/qtbase-tzdir.patch
@@ -2,7 +2,7 @@ diff -git a/src/corelib/time/qtimezoneprivate_tz.cpp b/src/corelib/time/qtimezon
 index 627a4a81..a5f50acc 100644
 --- a/src/corelib/time/qtimezoneprivate_tz.cpp
 +++ b/src/corelib/time/qtimezoneprivate_tz.cpp
-@@ -84,9 +84,11 @@
+@@ -56,9 +56,11 @@
  // Parse zone.tab table, assume lists all installed zones, if not will need to read directories
  static QTzTimeZoneHash loadTzTimeZones()
  {
@@ -16,17 +16,17 @@ index 627a4a81..a5f50acc 100644
  
      QFile tzif(path);
      if (!tzif.open(QIODevice::ReadOnly))
-@@ -761,18 +764,22 @@
+@@ -729,18 +729,22 @@
          if (!tzif.open(QIODevice::ReadOnly))
              return ret;
      } else {
 -        // Open named tz, try modern path first, if fails try legacy path
--        tzif.setFileName(QLatin1String("/usr/share/zoneinfo/") + QString::fromLocal8Bit(ianaId));
+-        tzif.setFileName("/usr/share/zoneinfo/"_L1 + QString::fromLocal8Bit(ianaId));
 +        // Try TZDIR first, in case we're running on NixOS
 +        tzif.setFileName(QFile::decodeName(qgetenv("TZDIR")) + QStringLiteral("/") + QString::fromLocal8Bit(ianaId));
          if (!tzif.open(QIODevice::ReadOnly)) {
--            tzif.setFileName(QLatin1String("/usr/lib/zoneinfo/") + QString::fromLocal8Bit(ianaId));
-+            tzif.setFileName(QLatin1String("/usr/share/zoneinfo/") + QString::fromLocal8Bit(ianaId));
+-            tzif.setFileName("/usr/lib/zoneinfo/"_L1 + QString::fromLocal8Bit(ianaId));
++            tzif.setFileName("/usr/share/zoneinfo/"_L1 + QString::fromLocal8Bit(ianaId));
              if (!tzif.open(QIODevice::ReadOnly)) {
                  // ianaId may be a POSIX rule, taken from $TZ or /etc/TZ
                  auto check = validatePosixRule(ianaId);

--- a/nix/qt/srcs.nix
+++ b/nix/qt/srcs.nix
@@ -1,8 +1,8 @@
 { fetchurl, mirror,  }:
 
 let
-  minor = "6.3";
-  patch = "${minor}.0";
+  minor = "6.4";
+  patch = "${minor}.2";
 
 in {
   qt3d = {
@@ -37,7 +37,7 @@ in {
     src = fetchurl {
       url =
         "${mirror}/official_releases/qt/${minor}/${patch}/submodules/qtbase-everywhere-src-${patch}.tar.xz";
-      sha256 = "uGWq5DNX95KzsKFiiZ2b9qE5OlXE5eTt5TFrFXsaD5k=";
+      sha256 = "qIvGztuzSHikmmIrqnnKznjPutT5X9vTZW3bIccFUl0=";
       name = "qtbase-everywhere-src-${patch}.tar.xz";
     };
   };
@@ -244,7 +244,7 @@ in {
     src = fetchurl {
       url =
         "${mirror}/official_releases/qt/${minor}/${patch}/submodules/qtsvg-everywhere-src-${patch}.tar.xz";
-      sha256 = "MWRQTX4/ZAQ5MII1c5sRJgWrX8nMUXygso+fuTqNsOM=";
+      sha256 = "t0avPLF5NiHY7X6uONmtWhVUHcJ0IDEGnyrj/odZAxQ=";
       name = "qtsvg-everywhere-src-${patch}.tar.xz";
     };
   };


### PR DESCRIPTION
This delegates building the custom qt to the qt-idaaas repo.  This will both help with caching and also make it easier to upgrade Qt versions.  At the moment, this moves us to Qt 6.4, which enables certain QML features that we will want (e.g. TreeView support).