### PR TITLE
Update release info correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,8 +86,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Setup
         uses: "./.github/workflows/setup"
       - name: Set Short Hash
@@ -104,3 +102,4 @@ jobs:
         uses: "./.github/workflows/update-release-info"
         with:
           createPR: ${{ ! endsWith(github.ref, 'pre') }}
+          releaseVersion: ${{ env.dissolveVersion }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,6 @@ jobs:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}
       - name: Update Version Information
+        uses: "./.github/workflows/update-release-info"
         with:
           createPR: ${{ ! endsWith(github.ref, 'pre') }}
-        uses: "./.github/workflows/update-release-info"

--- a/.github/workflows/update-release-info/action.yml
+++ b/.github/workflows/update-release-info/action.yml
@@ -11,10 +11,17 @@ inputs:
   createPR:
     type: boolean
     default: true
+  releaseVersion:
+    type: string
 
 runs:
   using: "composite"
   steps:
+
+  - name: Checkout Develop
+    uses: actions/checkout@v3
+    with:
+      ref: develop
 
   - name: Get Release Information
     shell: bash
@@ -77,10 +84,10 @@ runs:
     shell: bash
     run: |
       # Set release version to ours
-      ./changeversion release -s ${{ env.dissolveVersion }}
+      ./changeversion release -s ${{ inputs.releaseVersion }}
 
       # Copy the old releases data, excluding the most recent (HIGHEST)
-      grep -v "Version ${{ env.dissolveVersion }}" ${{ inputs.oldReleasesFile }}.new > ${{ inputs.oldReleasesFile }}
+      grep -v "Version ${{ inputs.releaseVersion }}" ${{ inputs.oldReleasesFile }}.new > ${{ inputs.oldReleasesFile }}
 
       cat ${{ inputs.oldReleasesFile }}
 
@@ -98,6 +105,6 @@ runs:
         web/main.toml
       commit-message: Update release version info.
       delete-branch: true
-      branch: automation/update-current-release-to-${{ env.dissolveVersion }}
-      title: Update website release info (v${{ env.dissolveVersion }})
+      branch: automation/update-current-release-to-${{ inputs.releaseVersion }}
+      title: Update website release info (v${{ inputs.releaseVersion }})
       reviewers: trisyoungs


### PR DESCRIPTION
[annoyed swearing deleted from this text]

This PR fixes, hopefully, yet another issue with the CI, this time related to the updating of the release version on the website. Basically, only pushes to `develop` enact an update of the frontpage on www.projectdissolve.com. This is probably the best behaviour to have, but relies on the release version information being updated in `develop` as and when `release.yml` completes. This turned out not to work, since the changes can already be present in the release branch itself. Hence, no update to `develop` when trying to set the version.

Here it is *probably* fixed, but we won't know for sure until release 1.1 gets fired off.