### PR TITLE
1272 Isotopologue Ratio Setting

### DIFF
--- a/src/gui/delegates/exponentialspin_funcs.cpp
+++ b/src/gui/delegates/exponentialspin_funcs.cpp
@@ -42,6 +42,9 @@ void ExponentialSpinDelegate::setModelData(QWidget *editor, QAbstractItemModel *
 {
     auto *spinBox = static_cast<ExponentialSpin *>(editor);
 
+    // Update value from current text
+    spinBox->updateValueFromText();
+
     model->setData(index, spinBox->value(), Qt::EditRole);
 }
 

--- a/src/gui/delegates/integerspin_funcs.cpp
+++ b/src/gui/delegates/integerspin_funcs.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "gui/delegates/integerspin.hui"
+#include "gui/widgets/integerspin.hui"
 
 IntegerSpinDelegate::IntegerSpinDelegate(QObject *parent, int vmin, int vmax, int vstep) : QItemDelegate(parent)
 {
@@ -15,7 +16,7 @@ IntegerSpinDelegate::IntegerSpinDelegate(QObject *parent, int vmin, int vmax, in
 QWidget *IntegerSpinDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     // Create editor widget (in this case a QSpinBox) and set some properties
-    auto *editor = new QSpinBox(parent);
+    auto *editor = new IntegerSpin(parent);
     editor->setMinimum(min_);
     editor->setMaximum(max_);
     editor->setSingleStep(step_);
@@ -28,20 +29,19 @@ void IntegerSpinDelegate::setEditorData(QWidget *editor, const QModelIndex &inde
 {
     auto value = index.model()->data(index, Qt::EditRole).toInt();
 
-    auto *spinBox = static_cast<QSpinBox *>(editor);
+    auto *spinBox = static_cast<IntegerSpin *>(editor);
     spinBox->setValue(value);
 }
 
 // Get value from editing widget, and set back in model
 void IntegerSpinDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
 {
-    auto *spinBox = static_cast<QSpinBox *>(editor);
+    auto *spinBox = static_cast<IntegerSpin *>(editor);
 
-    // Make sure the value in the spinBox has been updated from the current text
-    spinBox->interpretText();
-    auto value = spinBox->value();
+    // Update value from current text
+    spinBox->updateValueFromText();
 
-    model->setData(index, value, Qt::EditRole);
+    model->setData(index, spinBox->value(), Qt::EditRole);
 }
 
 // Update widget geometry

--- a/src/gui/widgets/exponentialspin.hui
+++ b/src/gui/widgets/exponentialspin.hui
@@ -56,8 +56,9 @@ class ExponentialSpin : public QAbstractSpinBox
      * Signals / Slots
      */
     private slots:
-    void valueEditingFinished();
     void returnPressed();
+    public slots:
+    void updateValueFromText();
 
     signals:
     void valueChanged(double);
@@ -67,7 +68,9 @@ class ExponentialSpin : public QAbstractSpinBox
      * Reimplementations
      */
     public:
+    // Focus events
     void focusInEvent(QFocusEvent *e) override;
+    void focusOutEvent(QFocusEvent *e) override;
     // Step value by specified number of increments
     void stepBy(int steps) override;
     // Return whether stepping is currently available

--- a/src/gui/widgets/exponentialspin_funcs.cpp
+++ b/src/gui/widgets/exponentialspin_funcs.cpp
@@ -15,7 +15,7 @@ ExponentialSpin::ExponentialSpin(QWidget *parent) : QAbstractSpinBox(parent)
     setValue(value_.value());
     blockSignals(false);
 
-    connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(valueEditingFinished()));
+    connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(updateValueFromText()));
     connect(lineEdit(), SIGNAL(returnPressed()), this, SLOT(returnPressed()));
 }
 
@@ -94,8 +94,13 @@ void ExponentialSpin::setRange(double minValue, double maxValue)
  * Signals / Slots
  */
 
-// Line edit editing finished
-void ExponentialSpin::valueEditingFinished()
+void ExponentialSpin::returnPressed()
+{
+    lineEdit()->selectAll();
+    updateValueFromText();
+}
+
+void ExponentialSpin::updateValueFromText()
 {
     if (lineEdit()->text() == valueText_)
         return;
@@ -103,22 +108,18 @@ void ExponentialSpin::valueEditingFinished()
     setValue(lineEdit()->text().toDouble());
 }
 
-void ExponentialSpin::returnPressed()
-{
-    lineEdit()->selectAll();
-    valueEditingFinished();
-}
-
 /*
  * Reimplementations
  */
 
+// Focus events
 void ExponentialSpin::focusInEvent(QFocusEvent *event)
 {
     if (valueText_ == specialValueText())
         lineEdit()->setText(QString::fromStdString(value_.asString(exponentFormatThreshold_, nDecimals_)));
     QAbstractSpinBox::focusInEvent(event);
 }
+void ExponentialSpin::focusOutEvent(QFocusEvent *e) { updateValueFromText(); }
 
 // Step value by specified number of increments
 void ExponentialSpin::stepBy(int steps) { setValue(value_.value() + steps * stepSize_); }

--- a/src/gui/widgets/integerspin.hui
+++ b/src/gui/widgets/integerspin.hui
@@ -49,8 +49,9 @@ class IntegerSpin : public QAbstractSpinBox
      * Signals / Slots
      */
     private slots:
-    void valueEditingFinished();
     void returnPressed();
+    public slots:
+    void updateValueFromText();
 
     signals:
     void valueChanged(int);
@@ -61,6 +62,7 @@ class IntegerSpin : public QAbstractSpinBox
      */
     public:
     void focusInEvent(QFocusEvent *e) override;
+    void focusOutEvent(QFocusEvent *e) override;
     // Step value by specified number of increments
     void stepBy(int steps) override;
     // Return whether stepping is currently available

--- a/src/gui/widgets/integerspin_funcs.cpp
+++ b/src/gui/widgets/integerspin_funcs.cpp
@@ -14,7 +14,7 @@ IntegerSpin::IntegerSpin(QWidget *parent) : QAbstractSpinBox(parent)
     setValue(value_);
     blockSignals(false);
 
-    connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(valueEditingFinished()));
+    connect(lineEdit(), SIGNAL(editingFinished()), this, SLOT(updateValueFromText()));
     connect(lineEdit(), SIGNAL(returnPressed()), this, SLOT(returnPressed()));
 }
 
@@ -88,8 +88,13 @@ void IntegerSpin::setRange(int minValue, int maxValue)
  * Signals / Slots
  */
 
-// Line edit editing finished
-void IntegerSpin::valueEditingFinished()
+void IntegerSpin::returnPressed()
+{
+    lineEdit()->selectAll();
+    updateValueFromText();
+}
+
+void IntegerSpin::updateValueFromText()
 {
     if (lineEdit()->text() == valueText_)
         return;
@@ -97,22 +102,18 @@ void IntegerSpin::valueEditingFinished()
     setValue(lineEdit()->text().toInt());
 }
 
-void IntegerSpin::returnPressed()
-{
-    lineEdit()->selectAll();
-    valueEditingFinished();
-}
-
 /*
  * Reimplementations
  */
 
+// Focus events
 void IntegerSpin::focusInEvent(QFocusEvent *event)
 {
     if (valueText_ == specialValueText())
         lineEdit()->setText(QString::number(value_));
     QAbstractSpinBox::focusInEvent(event);
 }
+void IntegerSpin::focusOutEvent(QFocusEvent *e) { updateValueFromText(); }
 
 // Step value by specified number of increments
 void IntegerSpin::stepBy(int steps) { setValue(value_ + steps * stepSize_); }


### PR DESCRIPTION
This PR should close #1272, and addresses an issue with both `ExponentialSpinDelegate` and `IntegerSpinDelegate` whereby the method override which sets the actual data refers to the current `value()` of the underlying editor widget. If the text in that editor has been changed but has not been (literally) `Enter`ed, then the `value()` is still whatever it was previously. It is not clear exactly why this behaviour exists since our widget catches both `returnPressed()` and `editingFinished()`, the latter triggering after loss of focus.

The solution is to manually ensure that the value of the spinbox is updated in the delegate's `setModelData()` function.

Closes #1272.