### PR TITLE
EPSR sampling and range

### DIFF
--- a/examples/water/input.txt
+++ b/examples/water/input.txt
@@ -1,4 +1,4 @@
-# Input file written by Dissolve v1.0.0 at 09:47:55 on 16-02-2023.
+# Input file written by Dissolve v1.2.0 at 09:11:59 on 05-04-2023.
 
 #==============================================================================#
 #                                 Master Terms                                 #
@@ -144,9 +144,8 @@ Layer  'GR / Neutron S(Q)'
 
   Module  SQ  'SQ01'
     Frequency  1
-
     SourceGR  'GR01'
-    QBroadening  'OmegaDependentGaussian'  0.020000
+    Averaging  5
   EndModule
 
   Module  NeutronSQ  'H2O'
@@ -187,14 +186,15 @@ EndLayer
 
 Layer  'Refine (EPSR)'
   Frequency  5
-  Disabled
 
   Module  EPSR  'EPSR01'
     Frequency  1
     Target  'H2O'
     Target  'D2O'
     Target  'HDO'
-    EReq  6
+    EReq  3
+    ModifyPotential  5
+    Weighting  0.1
     ExpansionFunction  Poisson
     InpAFile  ''
     PCofFile  ''

--- a/src/math/gaussfit.cpp
+++ b/src/math/gaussfit.cpp
@@ -336,74 +336,8 @@ double GaussFit::sweepFitA(FunctionSpace::SpaceType space, double xMin, int samp
 double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, double sigmaQ, int nIterations,
                                      double initialStepSize, std::optional<int> degreeOfSmoothing)
 {
-    // Clear any existing data
-    x_.clear();
-    A_.clear();
-    fwhm_.clear();
-    nGaussians_ = nGaussians;
-    approximateData_.initialise(referenceData_);
-
-    double x, gDelta = rMax / nGaussians_;
-    for (auto n = 0; n < nGaussians_; ++n)
-    {
-        x = (n + 1) * gDelta;
-        x_.push_back(x);
-        A_.push_back(0.0);
-        fwhm_.push_back(sigmaQ);
-    }
-
-    // Update the tabulated functions
-    alphaSpace_ = FunctionSpace::ReciprocalSpace;
-    updatePrecalculatedFunctions(alphaSpace_);
-
-    // Perform Monte Carlo minimisation on the amplitudes
-    MonteCarloMinimiser gaussMinimiser(
-        [this]()
-        {
-            auto sose = 0.0;
-
-            // Loop over data points and sum contributions from tabulated functions on to the current approximate data
-            double y, dy;
-            for (auto i = 0; i < approximateData_.nValues(); ++i)
-            {
-                // Get approximate data x and y for this point
-                y = approximateData_.value(i);
-
-                // Add in contributions from our Gaussians
-                for (auto n = 0; n < A_.size(); ++n)
-                    y += functions_[{n, i}] * A_[n];
-
-                dy = referenceData_.value(i) - y;
-                sose += dy * dy;
-            }
-
-            return sose;
-        },
-        [degreeOfSmoothing](std::vector<double> &params)
-        {
-            if (degreeOfSmoothing)
-                Filters::movingAverage(params, *degreeOfSmoothing);
-        });
-
-    // Add the Gaussian amplitudes to the fitting pool - ignore any whose x centre is below rMin
-    for (auto n = 0; n < nGaussians_; ++n)
-    {
-        if (x_[n] < rMin)
-            continue;
-        gaussMinimiser.addTarget(&A_[n]);
-    }
-
-    // Optimise this set of Gaussians
-    gaussMinimiser.setMaxIterations(nIterations);
-    gaussMinimiser.setStepSize(initialStepSize);
-    gaussMinimiser.setSamplingFrequency(nIterations / 2.5);
-    currentError_ = gaussMinimiser.minimise();
-
-    // Regenerate approximation and calculate percentage error of fit
-    generateApproximation(FunctionSpace::ReciprocalSpace);
-    currentError_ = Error::percent(referenceData_, approximateData_);
-
-    return currentError_;
+    return constructReciprocal(rMin, rMax, std::vector<double>(nGaussians, 0.0), sigmaQ, nIterations, initialStepSize,
+                               degreeOfSmoothing);
 }
 
 // Construct function representation in reciprocal space using specified parameters as starting point
@@ -415,7 +349,6 @@ double GaussFit::constructReciprocal(double rMin, double rMax, const std::vector
     x_.clear();
     fwhm_.clear();
     nGaussians_ = A_.size();
-    approximateData_.initialise(referenceData_);
     double x, gDelta = rMax / nGaussians_;
     for (auto n = 0; n < nGaussians_; ++n)
     {
@@ -427,6 +360,9 @@ double GaussFit::constructReciprocal(double rMin, double rMax, const std::vector
     // Update the tabulated functions
     alphaSpace_ = FunctionSpace::ReciprocalSpace;
     updatePrecalculatedFunctions(alphaSpace_);
+
+    // Clear the approximate data
+    approximateData_.initialise(referenceData_);
 
     // Perform Monte Carlo minimisation on the amplitudes
     MonteCarloMinimiser gaussMinimiser(

--- a/src/math/gaussfit.cpp
+++ b/src/math/gaussfit.cpp
@@ -333,7 +333,7 @@ double GaussFit::sweepFitA(FunctionSpace::SpaceType space, double xMin, int samp
 
 // Construct function representation in reciprocal space, spacing Gaussians out evenly in real space up to rMax
 double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, double sigmaQ, int nIterations,
-                                     double initialStepSize, bool reFitAtEnd)
+                                     double initialStepSize)
 {
     // Clear any existing data
     x_.clear();
@@ -392,10 +392,6 @@ double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, d
     gaussMinimiser.setStepSize(initialStepSize);
     currentError_ = gaussMinimiser.minimise();
 
-    // Perform a final grouped refit of the amplitudes
-    if (reFitAtEnd)
-        sweepFitA(FunctionSpace::ReciprocalSpace, rMin);
-
     // Regenerate approximation and calculate percentage error of fit
     generateApproximation(FunctionSpace::ReciprocalSpace);
     currentError_ = Error::percent(referenceData_, approximateData_);
@@ -405,7 +401,7 @@ double GaussFit::constructReciprocal(double rMin, double rMax, int nGaussians, d
 
 // Construct function representation in reciprocal space using specified parameters as starting point
 double GaussFit::constructReciprocal(double rMin, double rMax, const std::vector<double> &A, double sigmaQ, int nIterations,
-                                     double initialStepSize, bool reFitAtEnd)
+                                     double initialStepSize)
 {
     // Create the fitting functions
     A_ = A;
@@ -461,10 +457,6 @@ double GaussFit::constructReciprocal(double rMin, double rMax, const std::vector
     gaussMinimiser.setMaxIterations(nIterations);
     gaussMinimiser.setStepSize(initialStepSize);
     currentError_ = gaussMinimiser.minimise();
-
-    // Perform a final grouped refit of the amplitudes
-    if (reFitAtEnd)
-        sweepFitA(FunctionSpace::ReciprocalSpace, rMin);
 
     // Regenerate approximation and calculate percentage error of fit
     generateApproximation(FunctionSpace::ReciprocalSpace);

--- a/src/math/gaussfit.h
+++ b/src/math/gaussfit.h
@@ -90,8 +90,9 @@ class GaussFit
     public:
     // Construct function representation in reciprocal space, spacing Gaussians out evenly in real space up to rMax
     double constructReciprocal(double rMin, double rMax, int nGaussians, double sigmaQ = 0.02, int nIterations = 1000,
-                               double initialStepSize = 0.01);
+                               double initialStepSize = 0.01, std::optional<int> degreeOfSmoothing = {});
     // Construct function representation in reciprocal space using specified parameters as starting point
     double constructReciprocal(double rMin, double rMax, const std::vector<double> &A, double sigmaQ = 0.02,
-                               int nIterations = 1000, double initialStepSize = 0.01);
+                               int nIterations = 1000, double initialStepSize = 0.01,
+                               std::optional<int> degreeOfSmoothing = {});
 };

--- a/src/math/gaussfit.h
+++ b/src/math/gaussfit.h
@@ -90,8 +90,8 @@ class GaussFit
     public:
     // Construct function representation in reciprocal space, spacing Gaussians out evenly in real space up to rMax
     double constructReciprocal(double rMin, double rMax, int nGaussians, double sigmaQ = 0.02, int nIterations = 1000,
-                               double initialStepSize = 0.01, bool reFitAtEnd = false);
+                               double initialStepSize = 0.01);
     // Construct function representation in reciprocal space using specified parameters as starting point
     double constructReciprocal(double rMin, double rMax, const std::vector<double> &A, double sigmaQ = 0.02,
-                               int nIterations = 1000, double initialStepSize = 0.01, bool reFitAtEnd = false);
+                               int nIterations = 1000, double initialStepSize = 0.01);
 };

--- a/src/math/mc.h
+++ b/src/math/mc.h
@@ -11,9 +11,10 @@
 class MonteCarloMinimiser
 {
     using MinimiserCostFunction = std::function<double()>;
+    using MinimiserSamplingFunction = std::function<void(std::vector<double> &)>;
 
     public:
-    explicit MonteCarloMinimiser(MinimiserCostFunction costFunction);
+    explicit MonteCarloMinimiser(MinimiserCostFunction costFunction, MinimiserSamplingFunction samplingFunction = {});
 
     private:
     // Maximum number of iterations to perform
@@ -24,6 +25,10 @@ class MonteCarloMinimiser
     double targetAcceptanceRatio_{0.33};
     // Pointer to cost function
     MinimiserCostFunction costFunction_;
+    // Frequency at which sampling function will be called
+    int samplingFrequency_{0};
+    // Pointer to periodic sampling function
+    MinimiserSamplingFunction samplingFunction_;
     // Pointers to double values to be fit
     std::vector<double *> targets_;
 
@@ -42,6 +47,8 @@ class MonteCarloMinimiser
     double stepSize() const;
     // Target acceptance ratio
     void setTargetAcceptanceRatio(double ratio);
+    // Set sampling frequency
+    void setSamplingFrequency(int frequency);
     // Add fit target
     void addTarget(double *var);
     // Minimise target parameters

--- a/src/math/poissonfit.cpp
+++ b/src/math/poissonfit.cpp
@@ -388,7 +388,7 @@ double PoissonFit::sweepFitC(FunctionSpace::SpaceType space, double xMin, int sa
 // Construct suitable representation using given number of Poissons spaced evenly in real space up to rMax (those below rMin
 // will be zeroed)
 double PoissonFit::constructReciprocal(double rMin, double rMax, int nPoissons, double sigmaQ, double sigmaR, int nIterations,
-                                       double initialStepSize, bool reFitAtEnd)
+                                       double initialStepSize)
 {
     // Clear any existing data
     nPoissons_ = nPoissons;
@@ -425,10 +425,6 @@ double PoissonFit::constructReciprocal(double rMin, double rMax, int nPoissons, 
     poissonMinimiser.setStepSize(initialStepSize);
     currentError_ = poissonMinimiser.minimise();
 
-    // Perform a final grouped refit of the amplitudes
-    if (reFitAtEnd)
-        sweepFitC(FunctionSpace::ReciprocalSpace, rMin);
-
     // Regenerate approximation and calculate percentage error of fit
     generateApproximation(FunctionSpace::ReciprocalSpace);
     currentError_ = Error::percent(referenceData_, approximateData_, true);
@@ -438,7 +434,7 @@ double PoissonFit::constructReciprocal(double rMin, double rMax, int nPoissons, 
 
 // Construct suitable reciprocal-space representation using provided coefficients as a starting point
 double PoissonFit::constructReciprocal(double rMin, double rMax, const std::vector<double> &coefficients, double sigmaQ,
-                                       double sigmaR, int nIterations, double initialStepSize, bool reFitAtEnd)
+                                       double sigmaR, int nIterations, double initialStepSize)
 {
     // Set up data
     nPoissons_ = coefficients.size();
@@ -472,10 +468,6 @@ double PoissonFit::constructReciprocal(double rMin, double rMax, const std::vect
     poissonMinimiser.setMaxIterations(nIterations);
     poissonMinimiser.setStepSize(initialStepSize);
     currentError_ = poissonMinimiser.minimise();
-
-    // Perform a final grouped refit of the amplitudes
-    if (reFitAtEnd)
-        sweepFitC(FunctionSpace::ReciprocalSpace, rMin);
 
     // Regenerate approximation and calculate percentage error of fit
     generateApproximation(FunctionSpace::ReciprocalSpace);

--- a/src/math/poissonfit.h
+++ b/src/math/poissonfit.h
@@ -105,8 +105,10 @@ class PoissonFit
     // Construct suitable reciprocal-space representation using given number of Poissons spaced evenly in real space up to
     // rMax (those below rMin will be ignored)
     double constructReciprocal(double rMin, double rMax, int nPoissons, double sigmaQ = 0.02, double sigmaR = 0.08,
-                               int nIterations = 1000, double initialStepSize = 0.01);
+                               int nIterations = 1000, double initialStepSize = 0.01,
+                               std::optional<int> degreeOfSmoothing = {});
     // Construct suitable reciprocal-space representation using provided coefficients as a starting point
     double constructReciprocal(double rMin, double rMax, const std::vector<double> &coefficients, double sigmaQ = 0.02,
-                               double sigmaR = 0.08, int nIterations = 1000, double initialStepSize = 0.01);
+                               double sigmaR = 0.08, int nIterations = 1000, double initialStepSize = 0.01,
+                               std::optional<int> degreeOfSmoothing = {});
 };

--- a/src/math/poissonfit.h
+++ b/src/math/poissonfit.h
@@ -105,9 +105,8 @@ class PoissonFit
     // Construct suitable reciprocal-space representation using given number of Poissons spaced evenly in real space up to
     // rMax (those below rMin will be ignored)
     double constructReciprocal(double rMin, double rMax, int nPoissons, double sigmaQ = 0.02, double sigmaR = 0.08,
-                               int nIterations = 1000, double initialStepSize = 0.01, bool reFitAtEnd = false);
+                               int nIterations = 1000, double initialStepSize = 0.01);
     // Construct suitable reciprocal-space representation using provided coefficients as a starting point
     double constructReciprocal(double rMin, double rMax, const std::vector<double> &coefficients, double sigmaQ = 0.02,
-                               double sigmaR = 0.08, int nIterations = 1000, double initialStepSize = 0.01,
-                               bool reFitAtEnd = false);
+                               double sigmaR = 0.08, int nIterations = 1000, double initialStepSize = 0.01);
 };

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -248,8 +248,9 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Get difference data container and form the difference between the reference and calculated data
         auto &differenceData = dissolve.processingModuleData().realise<Data1D>(fmt::format("Difference//{}", module->name()),
                                                                                name(), GenericItem::InRestartFileFlag);
-        differenceData = originalReferenceData;
-        Interpolator::addInterpolated(weightedSQ.total(), differenceData, -1.0);
+        differenceData = weightedSQ.total();
+        differenceData *= -1.0;
+        Interpolator::addInterpolated(originalReferenceData, differenceData);
 
         // Calculate r-factor over fit range and store
         auto tempRefData = originalReferenceData;
@@ -269,9 +270,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         auto &deltaFQFit = dissolve.processingModuleData().realise<Data1D>(fmt::format("DeltaFQFit//{}", module->name()), name_,
                                                                            GenericItem::InRestartFileFlag);
 
-        // Copy the original difference data and trim to the allowed range
+        // Copy the original difference data and "invert" it
         deltaFQ = differenceData;
-        Filters::trim(deltaFQ, qMin_, qMax_);
         deltaFQ *= -1.0;
 
         // Fit a function expansion to the deltaFQ - if the coefficient arrays already exist then re-fit starting from those.

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -311,8 +311,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             PoissonFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError =
-                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.1);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.1,
+                                                              fluctuationSmoothing_);
             else
             {
                 if (fitCoefficients.size() != ncoeffp)
@@ -320,24 +320,16 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     Messenger::warn("Number of terms ({}) in existing FitCoefficients array for target '{}' does "
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), ncoeffp);
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.01,
+                                                                  fluctuationSmoothing_);
                 }
                 else
-                    fitError =
-                        coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, nIterations,
+                                                                  0.01, fluctuationSmoothing_);
             }
 
             // Store the new fit coefficients
             fitCoefficients = coeffMinimiser.C();
-
-            // Smooth coefficients?
-            if (fluctuationSmoothing_)
-            {
-                Filters::movingAverage(fitCoefficients, *fluctuationSmoothing_);
-
-                // Need to pass the smoothed parameters back into the minimiser so we generate the matching approximation
-                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, pSigma1_, pSigma2_, 0, 0.01);
-            }
 
             deltaFQFit = coeffMinimiser.approximation();
         }

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -273,6 +273,9 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Copy the original difference data and "invert" it
         deltaFQ = differenceData;
         deltaFQ *= -1.0;
+        for (auto &&[x, y] : zip(deltaFQ.xAxis(), deltaFQ.values()))
+            if (x < qMin_ || x > qMax_)
+                y = 0.0;
 
         // Fit a function expansion to the deltaFQ - if the coefficient arrays already exist then re-fit starting from those.
         auto [fitCoefficients, status] = dissolve.processingModuleData().realiseIf<std::vector<double>>(

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -312,7 +312,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
             if (status == GenericItem::ItemStatus::Created)
                 fitError =
-                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.1, false);
+                    coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, pSigma1_, pSigma2_, nIterations, 0.1);
             else
             {
                 if (fitCoefficients.size() != ncoeffp)

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -286,7 +286,7 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             GaussFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01, false);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01);
             else
             {
                 if (fitCoefficients.size() != ncoeffp)

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -286,7 +286,8 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             GaussFit coeffMinimiser(deltaFQ);
 
             if (status == GenericItem::ItemStatus::Created)
-                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01);
+                fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01,
+                                                              fluctuationSmoothing_);
             else
             {
                 if (fitCoefficients.size() != ncoeffp)
@@ -294,10 +295,12 @@ bool EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     Messenger::warn("Number of terms ({}) in existing FitCoefficients array for target '{}' does "
                                     "not match the current number ({}), so will fit from scratch.\n",
                                     fitCoefficients.size(), module->name(), ncoeffp);
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, ncoeffp, gSigma1_, nIterations, 0.01,
+                                                                  fluctuationSmoothing_);
                 }
                 else
-                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, gSigma1_, nIterations, 0.01);
+                    fitError = coeffMinimiser.constructReciprocal(0.0, rmaxpt, fitCoefficients, gSigma1_, nIterations, 0.01,
+                                                                  fluctuationSmoothing_);
             }
 
             // Store the new fit coefficients


### PR DESCRIPTION
This PR addresses two issues with the EPSR module:
1) Coefficient smoothing is now performed periodically during the Monte Carlo parameter minimisation - this is more in-line with the original EPSR and promotes consistency between what is fitted and what is used.
2) Potential generation was imperfect since we mistakenly set up the function coefficients according to the QMin value rather than the "zero limit".  This appears to be the cause of low-Q drift / separation observed in some simulations.