### PR TITLE
1359 CoordinateSet Explosions

### DIFF
--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -85,5 +85,6 @@ class ForcesModule : public Module
                             std::vector<Vec3<double>> &f);
     // Calculate total forces within the specified Species using the supplied reference coordinates
     static void totalForces(const ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap,
-                            const std::vector<Vec3<double>> &r, std::vector<Vec3<double>> &f);
+                            const std::vector<Vec3<double>> &r, std::vector<Vec3<double>> &fInter,
+                            std::vector<Vec3<double>> &fIntra);
 };

--- a/src/modules/md/functions.cpp
+++ b/src/modules/md/functions.cpp
@@ -30,14 +30,15 @@ int MDModule::capForces(double maxForce, std::vector<Vec3<double>> &fInter, std:
 }
 
 // Determine timestep to use
-std::optional<double> MDModule::determineTimeStep(const std::vector<Vec3<double>> &fInter,
-                                                  const std::vector<Vec3<double>> &fIntra) const
+std::optional<double> MDModule::determineTimeStep(TimestepType timestepType, double requestedTimeStep,
+                                                  const std::vector<Vec3<double>> &fInter,
+                                                  const std::vector<Vec3<double>> &fIntra)
 {
-    if (timestepType_ == TimestepType::Fixed)
-        return fixedTimestep_;
+    if (timestepType == TimestepType::Fixed)
+        return requestedTimeStep;
 
     // Simple variable timestep
-    if (timestepType_ == TimestepType::Variable)
+    if (timestepType == TimestepType::Variable)
     {
         auto absFMax = 0.0;
         for (auto &&[inter, intra] : zip(fInter, fIntra))
@@ -53,9 +54,9 @@ std::optional<double> MDModule::determineTimeStep(const std::vector<Vec3<double>
             ->absMax();
 
     auto deltaT = 100.0 / absFMaxInter;
-    if (deltaT < (fixedTimestep_ / 100.0))
+    if (deltaT < (requestedTimeStep / 100.0))
         return {};
-    return deltaT > fixedTimestep_ ? fixedTimestep_ : deltaT;
+    return deltaT > requestedTimeStep ? requestedTimeStep : deltaT;
 }
 
 // Evolve Species coordinates, returning new coordinates

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -66,10 +66,11 @@ class MDModule : public Module
      */
     private:
     // Cap forces in Configuration
-    int capForces(double maxForceSq, std::vector<Vec3<double>> &fInter, std::vector<Vec3<double>> &fIntra);
+    static int capForces(double maxForceSq, std::vector<Vec3<double>> &fInter, std::vector<Vec3<double>> &fIntra);
     // Determine timestep to use
-    std::optional<double> determineTimeStep(const std::vector<Vec3<double>> &fInter,
-                                            const std::vector<Vec3<double>> &fIntra) const;
+    static std::optional<double> determineTimeStep(TimestepType timestepType, double requestedTimeStep,
+                                                   const std::vector<Vec3<double>> &fInter,
+                                                   const std::vector<Vec3<double>> &fIntra);
 
     public:
     // Evolve Species coordinates, returning new coordinates

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -75,7 +75,7 @@ class MDModule : public Module
     public:
     // Evolve Species coordinates, returning new coordinates
     static std::vector<Vec3<double>> evolve(const ProcessPool &procPool, const PotentialMap &potentialMap, const Species *sp,
-                                            double temperature, int nSteps, double deltaT,
+                                            double temperature, int nSteps, double maxDeltaT,
                                             const std::vector<Vec3<double>> &rInit, std::vector<Vec3<double>> &velocities);
 
     /*

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -219,8 +219,8 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         std::transform(fInter.begin(), fInter.end(), fInter.begin(), [](auto f) { return f * 100.0; });
         std::transform(fIntra.begin(), fIntra.end(), fIntra.begin(), [](auto f) { return f * 100.0; });
 
-        // If the strategy is Auto100 do a quick check on the timestep now
-        if (timestepType_ == TimestepType::Automatic && !determineTimeStep(fInter, fIntra))
+        // Check for suitable timestep
+        if (!determineTimeStep(timestepType_, fixedTimestep_, fInter, fIntra))
         {
             Messenger::print("Forces are currently too high for MD to proceed. Skipping this run.\n");
             return true;
@@ -232,7 +232,7 @@ bool MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     for (step = 1; step <= nSteps_; ++step)
     {
         // Get timestep
-        auto optDT = determineTimeStep(fInter, fIntra);
+        auto optDT = determineTimeStep(timestepType_, fixedTimestep_, fInter, fIntra);
         if (!optDT)
         {
             Messenger::warn("A reasonable timestep could not be determined. Stopping evolution.\n");


### PR DESCRIPTION
Here we fix an occasional bug arising from the use of `CoordinateSet`s where the source `Species` geometry was not minimised (enough) in the first place, and so application of molecular dynamics with a fixed timestep occasionally caused an explosion / segfault.

The solution is to apply the pre-existing automatic timestep algorithm when performing MD on species.

Closes #1359.