### PR TITLE
1380 LigParGen Simplify AtomTypes Crash

### DIFF
--- a/src/gui/importligpargendialog_funcs.cpp
+++ b/src/gui/importligpargendialog_funcs.cpp
@@ -275,9 +275,10 @@ void ImportLigParGenDialog::on_ReduceToMasterTermsGroup_clicked(bool checked)
 // Attempt to manually apply our forcefield to the specified species
 bool ImportLigParGenDialog::applyForcefield(CoreData &coreData, Species *sp) const
 {
+    sp->clearAtomTypes();
+    sp->detachFromMasterTerms();
     coreData.clearAtomTypes();
     coreData.clearMasterTerms();
-    sp->clearAtomTypes();
 
     // Assign atomic charges from the original forcefield, based on the element/class atom types
     for (auto &&[i, classID] : zip(sp->atoms(), xyzClassIDs_))


### PR DESCRIPTION
A small PR to fix a nasty crash in the LigParGen import wizard when clicking the "Simplify AtomTypes" button.  It had nothing to do with simplifying the atom types, but rather was a case of bad data management.

Closes #1380.