### PR TITLE
1386 FileAndFormat keyword locations

### DIFF
--- a/src/modules/export_coordinates/exportcoords.cpp
+++ b/src/modules/export_coordinates/exportcoords.cpp
@@ -10,7 +10,7 @@ ExportCoordinatesModule::ExportCoordinatesModule() : Module(ModuleTypes::ExportC
 {
     keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
-    keywords_.setOrganisation("File");
+    keywords_.setOrganisation("Options", "File");
     keywords_.add<FileAndFormatKeyword>("Format", "File / format for coordinates", coordinatesFormat_, "EndFormat");
     keywords_.add<BoolKeyword>("TagWithIteration", "Whether to tag (suffix) the filename with the current iteration index",
                                tagWithIteration_);

--- a/src/modules/export_pairpotentials/exportpp.cpp
+++ b/src/modules/export_pairpotentials/exportpp.cpp
@@ -6,7 +6,7 @@
 
 ExportPairPotentialsModule::ExportPairPotentialsModule() : Module(ModuleTypes::ExportPairPotentials)
 {
-    keywords_.setOrganisation("File");
+    keywords_.setOrganisation("Options", "File");
     keywords_.add<FileAndFormatKeyword>("Format", "Basename and format in which to write potentials", pairPotentialFormat_,
                                         "EndFormat");
 }

--- a/src/modules/export_trajectory/exporttraj.cpp
+++ b/src/modules/export_trajectory/exporttraj.cpp
@@ -9,6 +9,6 @@ ExportTrajectoryModule::ExportTrajectoryModule() : Module(ModuleTypes::ExportTra
 {
     keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
-    keywords_.setOrganisation("File");
+    keywords_.setOrganisation("Options", "File");
     keywords_.add<FileAndFormatKeyword>("Format", "File / format for trajectory", trajectoryFormat_, "EndFormat");
 }

--- a/src/modules/import_trajectory/importtraj.cpp
+++ b/src/modules/import_trajectory/importtraj.cpp
@@ -9,6 +9,6 @@ ImportTrajectoryModule::ImportTrajectoryModule() : Module(ModuleTypes::ImportTra
 {
     keywords_.addTarget<ConfigurationKeyword>("Configuration", "Set target configuration for the module", targetConfiguration_);
 
-    keywords_.setOrganisation("File");
+    keywords_.setOrganisation("Options", "File");
     keywords_.add<FileAndFormatKeyword>("Format", "File / format for trajectory", trajectoryFormat_, "EndFormat");
 }


### PR DESCRIPTION
Small PR to put `FileAndFormat` keywords in the import and export modules into the standard "Options" group, rather than a separate one of their own.

Closes #1386.