### PR TITLE
1389 Regenerating Connectivity

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -168,6 +168,8 @@ class Species : public Serialisable
     void addMissingBonds(double tolerance = 1.1, bool preventMetallic = false);
     // Remove bonds crossing periodic boundaries
     void removePeriodicBonds();
+    // Remove all higher order intramolecular terms
+    void removeHigherOrderIntramolecularTerms();
     // Add missing higher order intramolecular terms from current bond connectivity, and prune any that are now invalid
     void updateIntramolecularTerms();
     // Add new SpeciesAngle definition

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -144,6 +144,16 @@ void Species::removePeriodicBonds()
         bonds_.erase(it, bonds_.end());
 }
 
+// Remove all higher order intramolecular terms
+void Species::removeHigherOrderIntramolecularTerms()
+{
+    angles_.clear();
+    torsions_.clear();
+    impropers_.clear();
+
+    ++version_;
+}
+
 // Add missing higher order intramolecular terms from current bond connectivity, and prune any that are now invalid
 void Species::updateIntramolecularTerms()
 {

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -277,6 +277,7 @@ void DissolveWindow::on_SpeciesRegenerateIntraFromConnectivityAction_triggered(b
     if (ret != QMessageBox::Yes)
         return;
 
+    species->removeHigherOrderIntramolecularTerms();
     species->updateIntramolecularTerms();
 
     setModified();


### PR DESCRIPTION
A PR to fix the Species->Regenerate Angles/Torsions from Connectivity option. This option is supposed to leave defines species bonds intact and delete all other intramolecular terms, then regenerate angles and torsions from the connectivity alone. However, all it did in reality was check through the current terms and make sure they were valid, adding any missing definitions.

This is not the intended behaviour, and is remedied in the present PR.

Closes #1389.