### PR TITLE
1388 Edit Functional Forms

### DIFF
--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -83,7 +83,7 @@ Qt::ItemFlags SpeciesAngleModel::flags(const QModelIndex &index) const
 {
     if (index.column() <= DataType::IndexK)
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
-    if (index.column() > DataType::IndexK && angles_[index.row()].masterTerm())
+    if (index.column() > DataType::Form && angles_[index.row()].masterTerm())
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled;
 }

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -78,7 +78,7 @@ Qt::ItemFlags SpeciesBondModel::flags(const QModelIndex &index) const
 {
     if (index.column() <= DataType::IndexJ)
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
-    if (index.column() > DataType::IndexJ && bonds_[index.row()].masterTerm())
+    if (index.column() > DataType::Form && bonds_[index.row()].masterTerm())
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled;
 }

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -87,7 +87,7 @@ Qt::ItemFlags SpeciesImproperModel::flags(const QModelIndex &index) const
 {
     if (index.column() <= DataType::IndexL)
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
-    if (index.column() > DataType::IndexL && impropers_[index.row()].masterTerm())
+    if (index.column() > DataType::Form && impropers_[index.row()].masterTerm())
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled;
 }

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -97,7 +97,7 @@ Qt::ItemFlags SpeciesTorsionModel::flags(const QModelIndex &index) const
 {
     if (index.column() <= DataType::IndexL)
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
-    if (index.column() > DataType::IndexL && torsions_[index.row()].masterTerm())
+    if (index.column() > DataType::Form && torsions_[index.row()].masterTerm())
         return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     return Qt::ItemIsSelectable | Qt::ItemIsEditable | Qt::ItemIsEnabled;
 }


### PR DESCRIPTION
This PR addresses an issue with all intramolecular models whereby the form could not be edited if a master term was defined for the interaction.

Closes #1388.