### PR TITLE
1387 Lost interaction parameters

### DIFF
--- a/src/classes/interactionpotential.h
+++ b/src/classes/interactionpotential.h
@@ -35,13 +35,10 @@ template <class Functions> class InteractionPotential
     void setForm(typename Functions::Form form)
     {
         form_ = form;
-        // Set parameters vector to correct size
-        while (parameters_.size() != Functions::forms().minArgs(form_).value_or(0))
-            if (parameters_.size() < Functions::forms().minArgs(form_).value_or(0))
-                parameters_.push_back(0.0);
 
-            else
-                parameters_.pop_back();
+        // Resize parameter vector if necessary
+        if (!Functions::forms().validNArgs(form_, parameters_.size()))
+            parameters_.resize(Functions::forms().minArgs(form_).value_or(0), 0.0);
     }
     // Return functional form of interaction
     typename Functions::Form form() const { return form_; }


### PR DESCRIPTION
This PR addresses an issue when the functional form of an interaction potential is changed to one with a variable number of parameters (e.g. `CosN` or `CosNC`) and only the minimum number of parameters are retained, rather than the _N_ that are defined.  The solution tidies up the code quite nicely actually!

Closes #1387.