### PR TITLE
1333 Silent Fails on Load

### DIFF
--- a/src/gui/menu_file.cpp
+++ b/src/gui/menu_file.cpp
@@ -148,6 +148,8 @@ void DissolveWindow::on_FileOpenAction_triggered(bool checked)
         return;
 
     loadInputFile(qPrintable(inputFile), true);
+
+    fullUpdate();
 }
 
 void DissolveWindow::recentFileSelected()


### PR DESCRIPTION
A fabulous PR to actually update the GUI after selecting a file to load via the `File->Open...` menu item.

Class.

Closes #1333.