### PR TITLE
1398 Kernel Extension (#1398 pt 3)

### DIFF
--- a/benchmark/energy/energy_benchmark.cpp
+++ b/benchmark/energy/energy_benchmark.cpp
@@ -23,7 +23,7 @@ template <ProblemType problem, Population population> static void BM_CalculateEn
     auto energyKernel = createEnergyKernel(problemDef);
     auto &i = problemDef.cfg_->atom(0);
     for (auto _ : state)
-        energyKernel->pairPotentialEnergy(i);
+        energyKernel->totalEnergy(i);
 }
 
 template <ProblemType problem, Population population>
@@ -45,7 +45,7 @@ template <ProblemType problem, Population population> static void BM_CalculateEn
     const auto mol = problemDef.cfg_->molecules().front();
     for (auto _ : state)
     {
-        double molecularEnergy = energyKernel->pairPotentialEnergy(*mol, false, ProcessPool::PoolStrategy);
+        double molecularEnergy = energyKernel->totalEnergy(*mol, ProcessPool::PoolStrategy).total();
         benchmark::DoNotOptimize(molecularEnergy);
     }
 }

--- a/benchmark/forces/forces_benchmark.cpp
+++ b/benchmark/forces/forces_benchmark.cpp
@@ -62,7 +62,7 @@ static void BM_CalculateForces_TotalIntraMolecular(benchmark::State &state)
     std::vector<Vec3<double>> forces(cfg->nAtoms());
     auto forceKernel = createForceKernel(problemDef);
     for (auto _ : state)
-        forceKernel->totalIntramolecularForces(forces, true, ProcessPool::PoolStrategy);
+        forceKernel->totalForces(forces, forces, ProcessPool::PoolStrategy, ForceKernel::ExcludePairPotential);
 }
 
 template <ProblemType problem, Population population> static void BM_CalculateForces_TotalSpecies(benchmark::State &state)
@@ -83,7 +83,7 @@ template <ProblemType problem, Population population> static void BM_CalculateFo
     std::vector<Vec3<double>> forces(cfg->nAtoms());
     auto forceKernel = createForceKernel(problemDef);
     for (auto _ : state)
-        forceKernel->totalPairPotentialForces(forces, ProcessPool::PoolStrategy);
+        forceKernel->totalForces(forces, forces, ProcessPool::PoolStrategy, ForceKernel::ExcludeGeometry);
 }
 
 template <ProblemType problem, Population population> static void BM_CalculateForces_TotalForces(benchmark::State &state)

--- a/src/kernels/energy.cpp
+++ b/src/kernels/energy.cpp
@@ -260,6 +260,10 @@ double EnergyKernel::pairPotentialEnergy(const Molecule &mol, bool includeIntraM
     return totalEnergy;
 }
 
+/*
+ * Totals
+ */
+
 // Return total interatomic PairPotential energy of the world
 double EnergyKernel::totalPairPotentialEnergy(bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const
 {
@@ -289,4 +293,34 @@ double EnergyKernel::totalPairPotentialEnergy(bool includeIntraMolecular, Proces
                                               });
 
     return totalEnergy;
+}
+
+// Return total interatomic PairPotential energy from summation of molecules
+double EnergyKernel::totalMoleculePairPotentialEnergy(bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const
+{
+    assert(molecules_);
+    auto &mols = molecules_->get();
+    auto molecularEnergy = 0.0;
+    for (const auto &mol : mols)
+        molecularEnergy += pairPotentialEnergy(*mol, includeIntraMolecular, ProcessPool::subDivisionStrategy(strategy));
+
+    // In the typical case where there is more than one molecule, our sum will contain double the intermolecular
+    // pairpotential energy, and zero intramolecular energy
+    if (mols.size() > 1)
+        molecularEnergy *= 0.5;
+
+    return molecularEnergy;
+}
+
+// Return total energy of supplied atom with the world
+EnergyResult EnergyKernel::totalEnergy(const Atom &i) const { return {pairPotentialEnergy(i), totalGeometryEnergy(i), 0.0}; }
+
+// Return total energy of supplied molecule with the world
+EnergyResult EnergyKernel::totalEnergy(const Molecule &mol, ProcessPool::DivisionStrategy strategy,
+                                       Flags<EnergyCalculationFlags> flags) const
+{
+    return {flags.isSet(ExcludePairPotential)
+                ? 0.0
+                : pairPotentialEnergy(mol, !flags.isSet(ExcludeIntraMolecularPairPotential), strategy),
+            flags.isSet(ExcludeGeometry) ? 0.0 : totalGeometryEnergy(mol), 0.0};
 }

--- a/src/kernels/energy.cpp
+++ b/src/kernels/energy.cpp
@@ -261,6 +261,16 @@ double EnergyKernel::pairPotentialEnergy(const Molecule &mol, bool includeIntraM
 }
 
 /*
+ * Extended Terms
+ */
+
+// Return energy of supplied atom from ad hoc extended terms
+double EnergyKernel::extendedEnergy(const Atom &i) const { return 0.0; }
+
+// Return energy of supplied molecule from ad hoc extended terms
+double EnergyKernel::extendedEnergy(const Molecule &mol) const { return 0.0; }
+
+/*
  * Totals
  */
 
@@ -313,7 +323,10 @@ double EnergyKernel::totalMoleculePairPotentialEnergy(bool includeIntraMolecular
 }
 
 // Return total energy of supplied atom with the world
-EnergyResult EnergyKernel::totalEnergy(const Atom &i) const { return {pairPotentialEnergy(i), totalGeometryEnergy(i), 0.0}; }
+EnergyResult EnergyKernel::totalEnergy(const Atom &i) const
+{
+    return {pairPotentialEnergy(i), totalGeometryEnergy(i), extendedEnergy(i)};
+}
 
 // Return total energy of supplied molecule with the world
 EnergyResult EnergyKernel::totalEnergy(const Molecule &mol, ProcessPool::DivisionStrategy strategy,
@@ -322,5 +335,6 @@ EnergyResult EnergyKernel::totalEnergy(const Molecule &mol, ProcessPool::Divisio
     return {flags.isSet(ExcludePairPotential)
                 ? 0.0
                 : pairPotentialEnergy(mol, !flags.isSet(ExcludeIntraMolecularPairPotential), strategy),
-            flags.isSet(ExcludeGeometry) ? 0.0 : totalGeometryEnergy(mol), 0.0};
+            flags.isSet(ExcludeGeometry) ? 0.0 : totalGeometryEnergy(mol),
+            flags.isSet(ExcludeExtended) ? 0.0 : extendedEnergy(mol)};
 }

--- a/src/kernels/energy.h
+++ b/src/kernels/energy.h
@@ -75,6 +75,15 @@ class EnergyKernel : public GeometryKernel
     double pairPotentialEnergy(const Molecule &mol, bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const;
 
     /*
+     * Extended Terms
+     */
+    private:
+    // Return energy of supplied atom from ad hoc extended terms
+    virtual double extendedEnergy(const Atom &i) const;
+    // Return energy of supplied molecule from ad hoc extended terms
+    virtual double extendedEnergy(const Molecule &mol) const;
+
+    /*
      * Totals
      */
     public:

--- a/src/kernels/energy.h
+++ b/src/kernels/energy.h
@@ -5,6 +5,7 @@
 
 #include "base/processpool.h"
 #include "kernels/geometry.h"
+#include "templates/flags.h"
 #include <memory>
 #include <optional>
 
@@ -20,6 +21,25 @@ class SpeciesBond;
 class SpeciesAngle;
 class SpeciesImproper;
 class SpeciesTorsion;
+
+// Energy Result
+class EnergyResult
+{
+    public:
+    EnergyResult(double pp = 0.0, double geom = 0.0, double ext = 0.0)
+        : total_(pp + geom + ext), pairPotential_(pp), geometry_(geom), extended_(ext){};
+
+    private:
+    // Components
+    double total_, pairPotential_, geometry_, extended_;
+
+    public:
+    double total() const { return total_; };
+    double pairPotential() const { return pairPotential_; };
+    double geometry() const { return geometry_; };
+    double extended() const { return extended_; };
+    double totalUnbound() const { return pairPotential_ + extended_; }
+};
 
 // Standard Energy Kernel, inheriting GeometryKernel
 class EnergyKernel : public GeometryKernel
@@ -49,12 +69,32 @@ class EnergyKernel : public GeometryKernel
     double cellEnergy(const Cell &cell, bool includeIntraMolecular) const;
     // Return PairPotential energy between two cells
     double cellToCellEnergy(const Cell &cell, const Cell &otherCell, bool applyMim, bool includeIntraMolecular) const;
-
-    public:
     // Return PairPotential energy of atom with world
     double pairPotentialEnergy(const Atom &i) const;
     // Return PairPotential energy of Molecule with world
     double pairPotentialEnergy(const Molecule &mol, bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const;
+
+    /*
+     * Totals
+     */
+    public:
+    // Energy calculation flags
+    enum EnergyCalculationFlags
+    {
+        ExcludePairPotential,
+        ExcludeGeometry,
+        ExcludeExtended,
+        ExcludeIntraMolecularPairPotential
+    };
+
+    public:
     // Return total interatomic PairPotential energy of the world
     double totalPairPotentialEnergy(bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const;
+    // Return total interatomic PairPotential energy from summation of molecules
+    double totalMoleculePairPotentialEnergy(bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const;
+    // Return total energy of supplied atom with the world
+    EnergyResult totalEnergy(const Atom &i) const;
+    // Return total energy of supplied molecule with the world
+    EnergyResult totalEnergy(const Molecule &mol, ProcessPool::DivisionStrategy strategy,
+                             Flags<EnergyCalculationFlags> flags = {}) const;
 };

--- a/src/kernels/geometry.cpp
+++ b/src/kernels/geometry.cpp
@@ -401,23 +401,23 @@ double GeometryKernel::totalGeometryEnergy(const Molecule &mol) const
 }
 
 // Calculate total forces within the specified molecule arising from geometry terms
-void GeometryKernel::totalGeometryForces(Molecule *mol, ForceVector &f) const
+void GeometryKernel::totalGeometryForces(const Molecule &mol, ForceVector &f) const
 {
     // Loop over bonds
-    for (const auto &bond : mol->species()->bonds())
-        bondForces(bond, *mol->atom(bond.indexI()), *mol->atom(bond.indexJ()), f);
+    for (const auto &bond : mol.species()->bonds())
+        bondForces(bond, *mol.atom(bond.indexI()), *mol.atom(bond.indexJ()), f);
 
     // Loop over angles
-    for (const auto &angle : mol->species()->angles())
-        angleForces(angle, *mol->atom(angle.indexI()), *mol->atom(angle.indexJ()), *mol->atom(angle.indexK()), f);
+    for (const auto &angle : mol.species()->angles())
+        angleForces(angle, *mol.atom(angle.indexI()), *mol.atom(angle.indexJ()), *mol.atom(angle.indexK()), f);
 
     // Loop over torsions
-    for (const auto &torsion : mol->species()->torsions())
-        torsionForces(torsion, *mol->atom(torsion.indexI()), *mol->atom(torsion.indexJ()), *mol->atom(torsion.indexK()),
-                      *mol->atom(torsion.indexL()), f);
+    for (const auto &torsion : mol.species()->torsions())
+        torsionForces(torsion, *mol.atom(torsion.indexI()), *mol.atom(torsion.indexJ()), *mol.atom(torsion.indexK()),
+                      *mol.atom(torsion.indexL()), f);
 
     // Loop over impropers
-    for (const auto &imp : mol->species()->impropers())
-        improperForces(imp, *mol->atom(imp.indexI()), *mol->atom(imp.indexJ()), *mol->atom(imp.indexK()),
-                       *mol->atom(imp.indexL()), f);
+    for (const auto &imp : mol.species()->impropers())
+        improperForces(imp, *mol.atom(imp.indexI()), *mol.atom(imp.indexJ()), *mol.atom(imp.indexK()), *mol.atom(imp.indexL()),
+                       f);
 }

--- a/src/kernels/geometry.h
+++ b/src/kernels/geometry.h
@@ -119,5 +119,5 @@ class GeometryKernel : public KernelBase
      */
     public:
     // Calculate total forces within the specified molecule arising from geometry terms
-    void totalGeometryForces(Molecule *mol, ForceVector &f) const;
+    void totalGeometryForces(const Molecule &mol, ForceVector &f) const;
 };

--- a/src/modules/atomshake/process.cpp
+++ b/src/modules/atomshake/process.cpp
@@ -49,6 +49,7 @@ bool AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     bool accept;
     double currentEnergy, currentIntraEnergy, newEnergy, newIntraEnergy, delta, totalDelta = 0.0;
     Vec3<double> rDelta;
+    EnergyResult er;
 
     Timer timer;
     while (distributor.cycle())
@@ -84,8 +85,9 @@ bool AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             for (const auto &i : mol->atoms())
             {
                 // Calculate reference energies for the Atom
-                currentEnergy = kernel->pairPotentialEnergy(*i);
-                currentIntraEnergy = kernel->totalGeometryEnergy(*i) * termScale;
+                er = kernel->totalEnergy(*i);
+                currentEnergy = er.totalUnbound();
+                currentIntraEnergy = er.geometry() * termScale;
 
                 // Loop over number of shakes per Atom
                 for (shake = 0; shake < nShakesPerAtom_; ++shake)
@@ -99,8 +101,9 @@ bool AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                     targetConfiguration_->updateCellLocation(i);
 
                     // Calculate new energy
-                    newEnergy = kernel->pairPotentialEnergy(*i);
-                    newIntraEnergy = kernel->totalGeometryEnergy(*i) * termScale;
+                    er = kernel->totalEnergy(*i);
+                    newEnergy = er.totalUnbound();
+                    newIntraEnergy = er.geometry() * termScale;
 
                     // Trial the transformed Atom position
                     delta = (newEnergy + newIntraEnergy) - (currentEnergy + currentIntraEnergy);

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -224,13 +224,7 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Calculate total interatomic energy from molecules
         Timer moleculeTimer;
         auto kernel = KernelProducer::energyKernel(targetConfiguration_, procPool, dissolve.potentialMap(), cutoff);
-        auto molecularEnergy = 0.0;
-        for (const auto &mol : targetConfiguration_->molecules())
-            molecularEnergy += kernel->pairPotentialEnergy(*mol, false, ProcessPool::subDivisionStrategy(strategy));
-        // In the typical case where there is more than one molecule, our sum will contain double the intermolecular
-        // pairpotential energy, and zero intramolecular energy
-        if (targetConfiguration_->nMolecules() > 1)
-            molecularEnergy *= 0.5;
+        auto molecularEnergy = kernel->totalMoleculePairPotentialEnergy(false, ProcessPool::subDivisionStrategy(strategy));
         molecularEnergy += correctSelfEnergy;
         moleculeTimer.stop();
 

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -311,7 +311,7 @@ bool ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Timer interTimer;
 
             interTimer.start();
-            kernel->totalPairPotentialForces(fInterCheck, ProcessPool::PoolStrategy);
+            kernel->totalForces(fInterCheck, fInterCheck, ProcessPool::PoolStrategy, ForceKernel::ExcludeGeometry);
             if (!procPool.allSum(fInterCheck))
                 return false;
             interTimer.stop();
@@ -326,7 +326,8 @@ bool ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             Timer intraTimer;
 
             intraTimer.start();
-            kernel->totalIntramolecularForces(fIntraCheck, false, ProcessPool::PoolStrategy);
+            kernel->totalForces(fIntraCheck, fIntraCheck, ProcessPool::PoolStrategy,
+                                {ForceKernel::ExcludePairPotential, ForceKernel::ExcludeIntraMolecularPairPotential});
             if (!procPool.allSum(fIntraCheck))
                 return false;
             intraTimer.stop();

--- a/src/modules/intrashake/process.cpp
+++ b/src/modules/intrashake/process.cpp
@@ -124,9 +124,12 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             // Set current atom targets in ChangeStore (whole molecule)
             changeStore.add(mol);
 
-            // Calculate reference pairpotential energy for Molecule
+            // Calculate reference non-geometry energy for Molecule
             ppEnergy =
-                termEnergyOnly_ ? 0.0 : kernel->pairPotentialEnergy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
+                termEnergyOnly_
+                    ? 0.0
+                    : kernel->totalEnergy(*mol, ProcessPool::subDivisionStrategy(strategy), EnergyKernel::ExcludeGeometry)
+                          .total();
 
             // Loop over defined bonds
             if (adjustBonds_)
@@ -158,9 +161,11 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         targetConfiguration_->updateCellLocation(bond.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_
-                                          ? 0.0
-                                          : kernel->pairPotentialEnergy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
+                        newPPEnergy = termEnergyOnly_ ? 0.0
+                                                      : kernel
+                                                            ->totalEnergy(*mol, ProcessPool::subDivisionStrategy(strategy),
+                                                                          EnergyKernel::ExcludeGeometry)
+                                                            .total();
                         newIntraEnergy = bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
 
                         // Trial the transformed Molecule
@@ -216,9 +221,11 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         targetConfiguration_->updateCellLocation(angle.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_
-                                          ? 0.0
-                                          : kernel->pairPotentialEnergy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
+                        newPPEnergy = termEnergyOnly_ ? 0.0
+                                                      : kernel
+                                                            ->totalEnergy(*mol, ProcessPool::subDivisionStrategy(strategy),
+                                                                          EnergyKernel::ExcludeGeometry)
+                                                            .total();
                         newIntraEnergy =
                             angle.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->angleEnergy(angle, *i, *j, *k);
 
@@ -279,9 +286,11 @@ bool IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                         targetConfiguration_->updateCellLocation(torsion.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_
-                                          ? 0.0
-                                          : kernel->pairPotentialEnergy(*mol, true, ProcessPool::subDivisionStrategy(strategy));
+                        newPPEnergy = termEnergyOnly_ ? 0.0
+                                                      : kernel
+                                                            ->totalEnergy(*mol, ProcessPool::subDivisionStrategy(strategy),
+                                                                          EnergyKernel::ExcludeGeometry)
+                                                            .total();
                         newIntraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
 
                         // Trial the transformed Molecule

--- a/src/modules/molshake/process.cpp
+++ b/src/modules/molshake/process.cpp
@@ -108,8 +108,11 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             // Set current atom targets in ChangeStore (whole Molecule)
             changeStore.add(mol);
 
-            // Calculate reference pair potential energy for Molecule, excluding intramolecular contributions
-            currentEnergy = kernel->pairPotentialEnergy(*mol, false, ProcessPool::subDivisionStrategy(strategy));
+            // Calculate reference pair potential energy for Molecule, excluding all intramolecular contributions
+            currentEnergy = kernel
+                                ->totalEnergy(*mol, ProcessPool::subDivisionStrategy(strategy),
+                                              {EnergyKernel::ExcludeGeometry, EnergyKernel::ExcludeIntraMolecularPairPotential})
+                                .total();
 
             // Loop over number of shakes per atom
             for (shake = 0; shake < nShakesPerMolecule_; ++shake)
@@ -152,7 +155,10 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                 targetConfiguration_->updateCellLocation(mol);
 
                 // Calculate new energy
-                newEnergy = kernel->pairPotentialEnergy(*mol, false, ProcessPool::subDivisionStrategy(strategy));
+                newEnergy = kernel
+                                ->totalEnergy(*mol, ProcessPool::subDivisionStrategy(strategy),
+                                              {EnergyKernel::ExcludeGeometry, EnergyKernel::ExcludeIntraMolecularPairPotential})
+                                .total();
 
                 // Trial the transformed atom position
                 delta = newEnergy - currentEnergy;

--- a/unit/classes/cells.cpp
+++ b/unit/classes/cells.cpp
@@ -96,7 +96,7 @@ TEST(CellsTest, Basic)
         EXPECT_NEAR(refEnergy, kernel->totalPairPotentialEnergy(false, ProcessPool::PoolStrategy), 1.0e-4);
 
         // Calculate atomic energy from the Ar
-        EXPECT_NEAR(refEnergy, kernel->pairPotentialEnergy(cfg->atom(0)), 1.0e-4);
+        EXPECT_NEAR(refEnergy, kernel->totalEnergy(cfg->atom(0)).total(), 1.0e-4);
     }
 }
 

--- a/unit/ff/forcesModule.cpp
+++ b/unit/ff/forcesModule.cpp
@@ -64,7 +64,7 @@ TEST(ForcesModuleTest, Unbound)
     std::vector<Vec3<double>> fReference(cfg->nAtoms());
     ASSERT_TRUE(importer.importData(fReference));
 
-    // Calculate full forces
+    // Calculate pair potential forces
     std::vector<Vec3<double>> fCalculated(cfg->nAtoms());
     ForcesModule::totalForces(dissolve.worldPool(), cfg.get(), dissolve.potentialMap(),
                               ForcesModule::ForceCalculationType::PairPotentialOnly, fCalculated, fCalculated);


### PR DESCRIPTION
Having attempted to introduce energy and force calculation for arbitrary external potentials, it became clear that a bit more refactoring of the existing `EnergyKernel` and `ForceKernel` classes from which all other kernels will derive was necessary.

Briefly, the two kernels now funnel requests for total energy/force calculation through a single function in order to ensure that the external potential cannot be "missed" by calling one of the (previously) subordinate functions, e.g. for pair potential terms alone.  This clears up a lot of ambiguity, and makes the whole process clean and controllable through a `Flags<T>` based argument.

Stub virtuals for external energy / force factors are also added.