### PR TITLE
Global Potentials (#1398 pt 4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ set(BASIC_LINK_LIBS
     main
     classes
     kernels
+    potentials
     module
     moduleregistry
     io

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   configuration_box.cpp
   configuration_contents.cpp
   configuration_io.cpp
+  configuration_potentials.cpp
   configuration_sites.cpp
   configuration_upkeep.cpp
   coredata.cpp

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -13,6 +13,7 @@
 #include "classes/sitestack.h"
 #include "genericitems/list.h"
 #include "io/import/coordinates.h"
+#include "kernels/potentials/base.h"
 #include "math/data1d.h"
 #include "math/histogram1d.h"
 #include "math/interpolator.h"
@@ -20,9 +21,8 @@
 #include "procedure/procedure.h"
 #include "templates/vector3.h"
 #include <deque>
-#include <memory>
-
 #include <map>
+#include <memory>
 #include <vector>
 
 // Forward Declarations
@@ -204,6 +204,19 @@ class Configuration : public Serialisable
     const CellArray &cells() const;
     // Scale Box, Cells, and Molecule geometric centres according to current size factor
     void applySizeFactor(const ProcessPool &procPool, const PotentialMap &potentialMap);
+
+    /*
+     * External Potentials
+     */
+    private:
+    // Defined global potentials
+    std::vector<std::unique_ptr<ExternalPotential>> globalPotentials_;
+
+    public:
+    // Add global potential
+    void addGlobalPotential(std::unique_ptr<ExternalPotential> potential);
+    // Return vector of defined global potentials
+    const std::vector<std::unique_ptr<ExternalPotential>> &globalPotentials() const;
 
     /*
      * Upkeep

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -249,8 +249,7 @@ class Configuration : public Serialisable
     // Write through specified LineParser
     bool serialise(LineParser &parser) const;
     // Read from specified LineParser
-    bool deserialise(LineParser &parser, const std::vector<std::unique_ptr<Species>> &availableSpecies,
-                     double pairPotentialRange);
+    bool deserialise(LineParser &parser, const CoreData &coreData, double pairPotentialRange, bool hasPotentials);
     // Express as a tree node
     SerialisedValue serialise() const override;
 };

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -17,6 +17,7 @@ void Configuration::empty()
     atomTypes_.clear();
     appliedSizeFactor_ = 1.0;
     speciesPopulations_.clear();
+    globalPotentials_.clear();
 
     ++contentsVersion_;
 }

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -61,6 +61,17 @@ bool Configuration::serialise(LineParser &parser) const
             return false;
     }
 
+    // If there are no defined external potentials we are done
+    if (globalPotentials_.empty())
+        return true;
+
+    // Write global potentials
+    if (!parser.writeLineF("{}  # nGlobalPotentials\n", globalPotentials_.size()))
+        return false;
+    for (auto &pot : globalPotentials_)
+        if (!pot->serialise(parser, ""))
+            return false;
+
     return true;
 }
 

--- a/src/classes/configuration_potentials.cpp
+++ b/src/classes/configuration_potentials.cpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "classes/configuration.h"
+#include "kernels/potentials/base.h"
+
+// Add global potential
+void Configuration::addGlobalPotential(std::unique_ptr<ExternalPotential> potential)
+{
+    globalPotentials_.emplace_back(std::move(potential));
+}
+
+// Return vector of defined global potentials
+const std::vector<std::unique_ptr<ExternalPotential>> &Configuration::globalPotentials() const { return globalPotentials_; }

--- a/src/kernels/CMakeLists.txt
+++ b/src/kernels/CMakeLists.txt
@@ -2,11 +2,13 @@ add_library(
   kernels
   base.cpp
   energy.cpp
+  externalPotentials.cpp
   force.cpp
   geometry.cpp
   producer.cpp
   base.h
   energy.h
+  externalPotentials.h
   force.h
   geometry.h
   producer.h

--- a/src/kernels/CMakeLists.txt
+++ b/src/kernels/CMakeLists.txt
@@ -14,3 +14,5 @@ add_library(
 
 target_include_directories(kernels PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(kernels PUBLIC base ${THREADING_LINK_LIBS})
+
+add_subdirectory(potentials)

--- a/src/kernels/energy.h
+++ b/src/kernels/energy.h
@@ -46,6 +46,7 @@ class EnergyKernel : public GeometryKernel
 {
     private:
     friend class KernelProducer;
+    friend class ExternalPotentialsEnergyKernel;
     EnergyKernel(const Configuration *cfg, const ProcessPool &procPool, const PotentialMap &potentialMap,
                  std::optional<double> energyCutoff = {});
 

--- a/src/kernels/externalPotentials.cpp
+++ b/src/kernels/externalPotentials.cpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "kernels/externalPotentials.h"
+#include "classes/configuration.h"
+#include <numeric>
+
+ExternalPotentialsEnergyKernel::ExternalPotentialsEnergyKernel(const Configuration *cfg, const ProcessPool &procPool,
+                                                               const PotentialMap &potentialMap,
+                                                               std::optional<double> energyCutoff)
+    : EnergyKernel(cfg, procPool, potentialMap, energyCutoff), globalPotentials_(cfg->globalPotentials())
+{
+}
+
+/*
+ * Extended Terms
+ */
+
+// Return external energy of supplied atom
+double ExternalPotentialsEnergyKernel::extendedEnergy(const Atom &i) const
+{
+    return std::accumulate(globalPotentials_.begin(), globalPotentials_.end(), 0.0,
+                           [&](const auto acc, const auto &pot) { return acc + pot->energy(i, box_); });
+}
+
+// Return external energy of supplied molecule
+double ExternalPotentialsEnergyKernel::extendedEnergy(const Molecule &mol) const
+{
+    return std::accumulate(globalPotentials_.begin(), globalPotentials_.end(), 0.0,
+                           [&](const auto outerAcc, const auto &pot)
+                           {
+                               return outerAcc + std::accumulate(mol.atoms().begin(), mol.atoms().end(), 0.0,
+                                                                 [&](const auto innerAcc, const auto &i)
+                                                                 { return innerAcc + pot->energy(*i, box_); });
+                           });
+}

--- a/src/kernels/externalPotentials.h
+++ b/src/kernels/externalPotentials.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "kernels/energy.h"
+
+// Forward Declarations
+class ExternalPotential;
+
+// Energy Kernel with External Potentials
+class ExternalPotentialsEnergyKernel : public EnergyKernel
+{
+    private:
+    friend class KernelProducer;
+    ExternalPotentialsEnergyKernel(const Configuration *cfg, const ProcessPool &procPool, const PotentialMap &potentialMap,
+                                   std::optional<double> energyCutoff = {});
+
+    public:
+    ~ExternalPotentialsEnergyKernel() = default;
+
+    /*
+     * Source External Potentials
+     */
+    private:
+    // Global potentials acting on all atoms
+    const std::vector<std::unique_ptr<ExternalPotential>> &globalPotentials_;
+
+    /*
+     * Extended Terms
+     */
+    private:
+    // Return extended energy of supplied atom
+    double extendedEnergy(const Atom &i) const override;
+    // Return extended energy of supplied molecule
+    double extendedEnergy(const Molecule &mol) const override;
+};

--- a/src/kernels/externalPotentials.h
+++ b/src/kernels/externalPotentials.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "kernels/energy.h"
+#include "kernels/force.h"
 
 // Forward Declarations
 class ExternalPotential;
@@ -34,4 +35,30 @@ class ExternalPotentialsEnergyKernel : public EnergyKernel
     double extendedEnergy(const Atom &i) const override;
     // Return extended energy of supplied molecule
     double extendedEnergy(const Molecule &mol) const override;
+};
+
+// Force Kernel with External Potentials
+class ExternalPotentialsForceKernel : public ForceKernel
+{
+    private:
+    friend class KernelProducer;
+    ExternalPotentialsForceKernel(const Configuration *cfg, const ProcessPool &procPool, const PotentialMap &potentialMap,
+                                  std::optional<double> energyCutoff = {});
+
+    public:
+    ~ExternalPotentialsForceKernel() = default;
+
+    /*
+     * Source External Potentials
+     */
+    private:
+    // Global potentials acting on all atoms
+    const std::vector<std::unique_ptr<ExternalPotential>> &globalPotentials_;
+
+    /*
+     * Extended Terms
+     */
+    private:
+    // Calculate extended forces on supplied molecule
+    void extendedForces(const Molecule &mol, ForceVector &f) const override;
 };

--- a/src/kernels/force.h
+++ b/src/kernels/force.h
@@ -27,6 +27,7 @@ class ForceKernel : public GeometryKernel
 {
     private:
     friend class KernelProducer;
+    friend class ExternalPotentialsForceKernel;
     ForceKernel(const Configuration *cfg, const ProcessPool &procPool, const PotentialMap &potentialMap,
                 std::optional<double> energyCutoff = {});
     ForceKernel(const Box *box, const ProcessPool &procPool, const PotentialMap &potentialMap,

--- a/src/kernels/potentials/CMakeLists.txt
+++ b/src/kernels/potentials/CMakeLists.txt
@@ -1,8 +1,10 @@
 add_library(
   potentials
   base.cpp
+  spherical.cpp
   base.h
+  spherical.h
 )
 
-target_include_directories(potentials PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(potentials PRIVATE ${PROJECT_SOURCE_DIR}/src ${CONAN_INCLUDE_DIRS})
 

--- a/src/kernels/potentials/CMakeLists.txt
+++ b/src/kernels/potentials/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(
+  potentials
+  base.cpp
+  base.h
+)
+
+target_include_directories(potentials PRIVATE ${PROJECT_SOURCE_DIR}/src)
+

--- a/src/kernels/potentials/CMakeLists.txt
+++ b/src/kernels/potentials/CMakeLists.txt
@@ -2,11 +2,11 @@ add_library(
   potentials
   base.cpp
   producer.cpp
-  spherical.cpp
+  simple.cpp
   types.cpp
   base.h
   producer.h
-  spherical.h
+  simple.h
   types.h
 )
 

--- a/src/kernels/potentials/CMakeLists.txt
+++ b/src/kernels/potentials/CMakeLists.txt
@@ -1,10 +1,13 @@
 add_library(
   potentials
   base.cpp
+  producer.cpp
   spherical.cpp
+  types.cpp
   base.h
+  producer.h
   spherical.h
+  types.h
 )
 
 target_include_directories(potentials PRIVATE ${PROJECT_SOURCE_DIR}/src ${CONAN_INCLUDE_DIRS})
-

--- a/src/kernels/potentials/base.cpp
+++ b/src/kernels/potentials/base.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "kernels/potentials/base.h"
+
+AdditionalPotential::AdditionalPotential() {}
+
+/*
+ * Keywords
+ */
+
+// Return keywords for this potential
+KeywordStore &ExternalPotential::keywords() { return keywords_; }
+const KeywordStore &ExternalPotential::keywords() const { return keywords_; }
+
+/*
+ * Potential Calculation
+ */
+
+// Calculate energy on specified atom
+double ExternalPotential::energy(const Atom &i, const Box *box) const { return 0.0; }
+
+// Calculate force on specified atom, summing in to supplied vector
+void ExternalPotential::force(const Atom &i, const Box *box, Vec3<double> &f) const {}
+
+/*
+ * Read / Write
+ */
+
+// Read data from specified LineParser
+bool AdditionalPotential::deserialise(LineParser &parser, const CoreData &coreData) {}
+
+// Write data to specified LineParser
+bool AdditionalPotential::serialise(LineParser &parser, std::string_view prefix) const {}

--- a/src/kernels/potentials/base.cpp
+++ b/src/kernels/potentials/base.cpp
@@ -3,7 +3,7 @@
 
 #include "kernels/potentials/base.h"
 
-AdditionalPotential::AdditionalPotential() {}
+ExternalPotential::ExternalPotential(ExternalPotentialTypes::ExternalPotentialType type) : type_(type) {}
 
 /*
  * Keywords
@@ -28,7 +28,50 @@ void ExternalPotential::force(const Atom &i, const Box *box, Vec3<double> &f) co
  */
 
 // Read data from specified LineParser
-bool AdditionalPotential::deserialise(LineParser &parser, const CoreData &coreData) {}
+bool ExternalPotential::deserialise(LineParser &parser, const CoreData &coreData)
+{
+    // Read until we encounter the ending keyword (derived from the potential type), or we fail for some reason
+    while (!parser.eofOrBlank())
+    {
+        // Read and parse the next line
+        if (parser.getArgsDelim() != LineParser::Success)
+            return false;
+
+        // Is this the end of the block?
+        if (DissolveSys::sameString(parser.argsv(0), fmt::format("End{}", ExternalPotentialTypes::keyword(type_))))
+            return true;
+
+        // Try to parse this line as a keyword
+        KeywordBase::ParseResult result = keywords_.deserialise(parser, coreData);
+        if (result == KeywordBase::ParseResult::Unrecognised)
+            return Messenger::error("Unrecognised keyword '{}' found while parsing {} additional potential.\n", parser.argsv(0),
+                                    ExternalPotentialTypes::keyword(type_));
+        else if (result == KeywordBase::ParseResult::Deprecated)
+            Messenger::warn("The '{}' keyword is deprecated and will be removed in a future version.\n", parser.argsv(0));
+        else if (result == KeywordBase::ParseResult::Failed)
+            return Messenger::error("Failed to parse keyword '{}'.\n", parser.argsv(0));
+    }
+
+    return true;
+}
 
 // Write data to specified LineParser
-bool AdditionalPotential::serialise(LineParser &parser, std::string_view prefix) const {}
+bool ExternalPotential::serialise(LineParser &parser, std::string_view prefix) const
+{
+    // Block Start
+    if (!parser.writeLineF("{}{}\n", prefix, ExternalPotentialTypes::keyword(type_)))
+        return false;
+
+    // Create new prefix
+    std::string newPrefix = fmt::format("  {}", prefix);
+
+    // Write keywords
+    if (!keywords_.serialise(parser, newPrefix, true))
+        return false;
+
+    // Block End
+    if (!parser.writeLineF("{}End{}\n", prefix, ExternalPotentialTypes::keyword(type_)))
+        return false;
+
+    return true;
+}

--- a/src/kernels/potentials/base.h
+++ b/src/kernels/potentials/base.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "keywords/store.h"
+
+// Forward Declarations
+class Atom;
+class Box;
+class LineParser;
+
+// Extended Potential Base Class
+class ExternalPotential
+{
+    public:
+    AdditionalPotential();
+    ~AdditionalPotential() = default;
+
+    /*
+     * Keywords
+     */
+    protected:
+    // Keywords for the potential
+    KeywordStore keywords_;
+
+    public:
+    // Return keywords for this potential
+    KeywordStore &keywords();
+    const KeywordStore &keywords() const;
+
+    /*
+     * Potential Calculation
+     */
+    public:
+    // Calculate energy on specified atom
+    virtual double energy(const Atom &i, const Box *box) const;
+    // Calculate force on specified atom, summing in to supplied vector
+    virtual void force(const Atom &i, const Box *box, Vec3<double> &f) const;
+
+    /*
+     * Read / Write
+     */
+    public:
+    // Read data from specified LineParser
+    bool deserialise(LineParser &parser, const CoreData &coreData);
+    // Write data to specified LineParser
+    bool serialise(LineParser &parser, std::string_view prefix) const;
+};

--- a/src/kernels/potentials/base.h
+++ b/src/kernels/potentials/base.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "kernels/potentials/types.h"
 #include "keywords/store.h"
 
 // Forward Declarations
@@ -14,8 +15,15 @@ class LineParser;
 class ExternalPotential
 {
     public:
-    AdditionalPotential();
-    ~AdditionalPotential() = default;
+    explicit ExternalPotential(ExternalPotentialTypes::ExternalPotentialType type);
+    ~ExternalPotential() = default;
+
+    /*
+     * Type
+     */
+    protected:
+    // Additional potential type
+    ExternalPotentialTypes::ExternalPotentialType type_;
 
     /*
      * Keywords

--- a/src/kernels/potentials/producer.cpp
+++ b/src/kernels/potentials/producer.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "kernels/potentials/producer.h"
+#include "kernels/potentials/spherical.h"
+
+// External Potential Producer
+namespace ExternalPotentialProducer
+{
+// Create an external potential of the specified type
+std::unique_ptr<ExternalPotential> create(ExternalPotentialTypes::ExternalPotentialType type)
+{
+    switch (type)
+    {
+        case (ExternalPotentialTypes::ExternalPotentialType::Spherical):
+            return std::make_unique<SphericalPotential>();
+        default:
+            throw(std::runtime_error(fmt::format("Creation of external potential type '%s' not implemented.\n",
+                                                 ExternalPotentialTypes::keyword(type))));
+    }
+}
+}; // namespace ExternalPotentialProducer

--- a/src/kernels/potentials/producer.cpp
+++ b/src/kernels/potentials/producer.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "kernels/potentials/producer.h"
-#include "kernels/potentials/spherical.h"
+#include "kernels/potentials/simple.h"
 
 // External Potential Producer
 namespace ExternalPotentialProducer
@@ -13,7 +13,7 @@ std::unique_ptr<ExternalPotential> create(ExternalPotentialTypes::ExternalPotent
     switch (type)
     {
         case (ExternalPotentialTypes::ExternalPotentialType::Spherical):
-            return std::make_unique<SphericalPotential>();
+            return std::make_unique<SimplePotential>();
         default:
             throw(std::runtime_error(fmt::format("Creation of external potential type '%s' not implemented.\n",
                                                  ExternalPotentialTypes::keyword(type))));

--- a/src/kernels/potentials/producer.h
+++ b/src/kernels/potentials/producer.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "kernels/potentials/types.h"
+#include <memory>
+
+// Forward Declarations
+class ExternalPotential;
+
+// External Potential Producer
+namespace ExternalPotentialProducer
+{
+// Create an external potential of the specified type
+std::unique_ptr<ExternalPotential> create(ExternalPotentialTypes::ExternalPotentialType type);
+}; // namespace ExternalPotentialProducer

--- a/src/kernels/potentials/simple.h
+++ b/src/kernels/potentials/simple.h
@@ -6,8 +6,8 @@
 #include "classes/interactionpotential.h"
 #include "kernels/potentials/base.h"
 
-// SphericalPotential functional forms
-class SphericalPotentialFunctions
+// SimplePotential functional forms
+class SimplePotentialFunctions
 {
     public:
     enum class Form
@@ -24,12 +24,12 @@ class SphericalPotentialFunctions
     static std::optional<int> parameterIndex(Form form, std::string_view name);
 };
 
-// Spherical Potential
-class SphericalPotential : public ExternalPotential
+// Simple Potential
+class SimplePotential : public ExternalPotential
 {
     public:
-    SphericalPotential();
-    ~SphericalPotential() = default;
+    SimplePotential();
+    ~SimplePotential() = default;
 
     /*
      * Definition
@@ -37,7 +37,7 @@ class SphericalPotential : public ExternalPotential
 
     private:
     // Potential form
-    InteractionPotential<SphericalPotentialFunctions> interactionPotential_;
+    InteractionPotential<SimplePotentialFunctions> interactionPotential_;
     // Coordinate origin of external potential
     Vec3<double> origin_;
 

--- a/src/kernels/potentials/spherical.cpp
+++ b/src/kernels/potentials/spherical.cpp
@@ -4,6 +4,7 @@
 #include "kernels/potentials/spherical.h"
 #include "classes/atom.h"
 #include "classes/box.h"
+#include "keywords/interactionpotential.h"
 #include "keywords/vec3double.h"
 
 // Return enum options for SphericalPotentialFunctions
@@ -39,9 +40,12 @@ std::optional<int> SphericalPotentialFunctions::parameterIndex(Form form, std::s
 }
 
 SphericalPotential::SphericalPotential()
-    : interactionPotential_(SphericalPotentialFunctions::Form::Harmonic), AdditionalPotential()
+    : interactionPotential_(SphericalPotentialFunctions::Form::Harmonic),
+      ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Spherical)
 {
     keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
+    keywords_.add<InteractionPotentialKeyword<SphericalPotentialFunctions>>(
+        "Form", "Functional form and parameters for the potential", interactionPotential_);
 }
 
 /*

--- a/src/kernels/potentials/spherical.cpp
+++ b/src/kernels/potentials/spherical.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "kernels/potentials/spherical.h"
+#include "classes/atom.h"
+#include "classes/box.h"
+#include "keywords/vec3double.h"
+
+// Return enum options for SphericalPotentialFunctions
+EnumOptions<SphericalPotentialFunctions::Form> SphericalPotentialFunctions::forms()
+{
+    return EnumOptions<SphericalPotentialFunctions::Form>("SphericalPotentialFunction",
+                                                          {{SphericalPotentialFunctions::Form::Harmonic, "Harmonic", 1}});
+}
+
+// Return parameters for specified form
+const std::vector<std::string> &SphericalPotentialFunctions::parameters(Form form)
+{
+    static std::map<SphericalPotentialFunctions::Form, std::vector<std::string>> params_ = {
+        {SphericalPotentialFunctions::Form::Harmonic, {"k"}}};
+    return params_[form];
+}
+
+// Return nth parameter for the given form
+std::string SphericalPotentialFunctions::parameter(Form form, int n)
+{
+    return (n < 0 || n >= parameters(form).size()) ? "" : parameters(form)[n];
+}
+
+// Return index of parameter in the given form
+std::optional<int> SphericalPotentialFunctions::parameterIndex(Form form, std::string_view name)
+{
+    auto it = std::find_if(parameters(form).begin(), parameters(form).end(),
+                           [name](const auto &param) { return DissolveSys::sameString(name, param); });
+    if (it == parameters(form).end())
+        return {};
+
+    return it - parameters(form).begin();
+}
+
+SphericalPotential::SphericalPotential()
+    : interactionPotential_(SphericalPotentialFunctions::Form::Harmonic), AdditionalPotential()
+{
+    keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
+}
+
+/*
+ * Potential Calculation
+ */
+
+// Calculate energy on specified atom
+double SphericalPotential::energy(const Atom &i, const Box *box) const
+{
+    switch (interactionPotential_.form())
+    {
+        case (SphericalPotentialFunctions::Form::Harmonic):
+            return 0.5 * interactionPotential_.parameters()[0] * box->minimumDistanceSquared(i.r(), origin_);
+        default:
+            throw(
+                std::runtime_error(fmt::format("Requested functional form of SphericalPotential has not been implemented.\n")));
+    }
+}
+
+// Calculate force on specified atom, summing in to supplied vector
+void SphericalPotential::force(const Atom &i, const Box *box, Vec3<double> &f) const
+{
+    // Get normalised vector and distance
+    auto vecji = box->minimumVector(i.r(), origin_);
+    auto r = vecji.magAndNormalise();
+
+    // Calculate final force multiplier
+    auto forceMultiplier = 0.0;
+    switch (interactionPotential_.form())
+    {
+        case (SphericalPotentialFunctions::Form::Harmonic):
+            forceMultiplier = -interactionPotential_.parameters()[0] * r;
+            break;
+        default:
+            throw(
+                std::runtime_error(fmt::format("Requested functional form of SphericalPotential has not been implemented.\n")));
+    }
+
+    // Sum in forces on the atom
+    f -= vecji * forceMultiplier;
+}

--- a/src/kernels/potentials/spherical.h
+++ b/src/kernels/potentials/spherical.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/interactionpotential.h"
+#include "kernels/potentials/base.h"
+
+// SphericalPotential functional forms
+class SphericalPotentialFunctions
+{
+    public:
+    enum class Form
+    {
+        Harmonic /* Harmonic well potential */
+    };
+    // Return enum options for form
+    static EnumOptions<Form> forms();
+    // Return parameters for specified form
+    static const std::vector<std::string> &parameters(Form form);
+    // Return nth parameter for the given form
+    static std::string parameter(Form form, int n);
+    // Return index of parameter in the given form
+    static std::optional<int> parameterIndex(Form form, std::string_view name);
+};
+
+// Spherical Potential
+class SphericalPotential : public ExternalPotential
+{
+    public:
+    SphericalPotential();
+    ~SphericalPotential() = default;
+
+    /*
+     * Definition
+     */
+
+    private:
+    // Potential form
+    InteractionPotential<SphericalPotentialFunctions> interactionPotential_;
+    // Coordinate origin of external potential
+    Vec3<double> origin_;
+
+    /*
+     * Potential Calculation
+     */
+    public:
+    // Calculate energy on specified atom
+    double energy(const Atom &i, const Box *box) const override;
+    // Calculate force on specified atom, summing in to supplied vector
+    void force(const Atom &i, const Box *box, Vec3<double> &f) const override;
+};

--- a/src/kernels/potentials/types.cpp
+++ b/src/kernels/potentials/types.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "kernels/potentials/types.h"
+
+// External Potential Types
+namespace ExternalPotentialTypes
+{
+// External Potential Types
+EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Spherical, "Spherical"}});
+
+// Return whether the supplied external potential type is valid
+std::optional<ExternalPotentialType> isType(std::string_view name)
+{
+    if (types_.isValid(name))
+        return types_.enumeration(name);
+    return {};
+}
+
+// Return whether the supplied external potential type is valid
+std::string keyword(ExternalPotentialType type) { return types_.keyword(type); }
+}; // namespace ExternalPotentialTypes

--- a/src/kernels/potentials/types.h
+++ b/src/kernels/potentials/types.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/enumoptions.h"
+#include <optional>
+
+// External Potential Types
+namespace ExternalPotentialTypes
+{
+// External Potential Types
+enum class ExternalPotentialType
+{
+    Spherical
+};
+// Return whether the supplied external potential type is valid
+std::optional<ExternalPotentialType> isType(std::string_view name);
+// Return whether the supplied external potential type is valid
+std::string keyword(ExternalPotentialType type);
+}; // namespace ExternalPotentialTypes

--- a/src/kernels/producer.cpp
+++ b/src/kernels/producer.cpp
@@ -2,14 +2,19 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "kernels/producer.h"
+#include "classes/configuration.h"
 #include "kernels/energy.h"
+#include "kernels/externalPotentials.h"
 #include "kernels/force.h"
 
 // Create energy kernel for specified configuration
 std::unique_ptr<EnergyKernel> KernelProducer::energyKernel(const Configuration *cfg, const ProcessPool &procPool,
                                                            const PotentialMap &potentialMap, std::optional<double> energyCutoff)
 {
-    return std::unique_ptr<EnergyKernel>(new EnergyKernel(cfg, procPool, potentialMap, energyCutoff));
+    if (!cfg->globalPotentials().empty())
+        return std::unique_ptr<EnergyKernel>(new ExternalPotentialsEnergyKernel(cfg, procPool, potentialMap, energyCutoff));
+    else
+        return std::unique_ptr<EnergyKernel>(new EnergyKernel(cfg, procPool, potentialMap, energyCutoff));
 }
 
 // Create force kernel for specified configuration

--- a/src/kernels/producer.cpp
+++ b/src/kernels/producer.cpp
@@ -21,7 +21,10 @@ std::unique_ptr<EnergyKernel> KernelProducer::energyKernel(const Configuration *
 std::unique_ptr<ForceKernel> KernelProducer::forceKernel(const Configuration *cfg, const ProcessPool &procPool,
                                                          const PotentialMap &potentialMap, std::optional<double> energyCutoff)
 {
-    return std::unique_ptr<ForceKernel>(new ForceKernel(cfg, procPool, potentialMap, energyCutoff));
+    if (!cfg->globalPotentials().empty())
+        return std::unique_ptr<ForceKernel>(new ExternalPotentialsForceKernel(cfg, procPool, potentialMap, energyCutoff));
+    else
+        return std::unique_ptr<ForceKernel>(new ForceKernel(cfg, procPool, potentialMap, energyCutoff));
 }
 
 // Create force kernel using the specified Box

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -475,7 +475,7 @@ bool Dissolve::loadRestart(std::string_view filename)
             processingModuleData_.deserialise(parser, coreData_, parser.args(1), parser.args(2), parser.argi(3),
                                               parser.hasArg(4) ? parser.argi(4) : 0);
         }
-        else if (DissolveSys::sameString(parser.argsv(0), "Configuration"))
+        else if (DissolveSys::startsWith(parser.argsv(0), "Configuration"))
         {
             // Let the user know what we are doing
             Messenger::print("Reading Configuration '{}'...\n", parser.argsv(1));
@@ -488,7 +488,8 @@ bool Dissolve::loadRestart(std::string_view filename)
                 error = true;
                 break;
             }
-            else if (!cfg->deserialise(parser, species(), pairPotentialRange_))
+            else if (!cfg->deserialise(parser, coreData_, pairPotentialRange_,
+                                       DissolveSys::sameString(parser.argsv(0), "ConfigurationWithPotentials")))
                 error = true;
         }
         else if (DissolveSys::sameString(parser.argsv(0), "Timing"))

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -657,7 +657,8 @@ bool Dissolve::saveRestart(std::string_view filename)
     // Configurations
     for (const auto &cfg : configurations())
     {
-        if (!parser.writeLineF("Configuration  '{}'\n", cfg->name()))
+        if (!parser.writeLineF("{}  '{}'\n", cfg->globalPotentials().empty() ? "Configuration" : "ConfigurationWithPotentials",
+                               cfg->name()))
             return false;
         if (!cfg->serialise(parser))
             return false;


### PR DESCRIPTION
This PR adds in the basic classes and infrastructure for external potentials to be defined and utilised in a simulation. New kernels for energy and force are added to suit.

At present only a single external potential - a spherical harmonic type - has been added to illustrate the mechanisms, but which actually represents one of the most important external potentials we need moving forward.

The general mechanism for the use of this kind of potential is worth outlining:
- These `ExternalPotential`s are local to specific `Configuration` objects
- `ExternalPotential`s are to be created by suitable `ProcedureNode`s within the `Configuration`s generator
- `ExternalPotential`s are (de)serialised in the restart file rather than the input file, since they are objects owned by `Configuration`s.
- This PR only defines "global" potentials, with atom-specific potentials to come in the following PR. The underlying `ExternalPotential`s are identical, with the only difference in operation being the atom(s) that they are associated to.

With regard to storing the potential definitions as part of the `Configuration`, this would be a breaking change. To circumvent that, there are now two detectable types of `Configuration` in the restart file - the original standard one now coexists with `ConfigurationWithPotentials` which is expected to have potential definitions following the `Atom` section. Of course, when we move to TOML...

Example files illustrating the idea are attached (run with `dissolve-gui global.txt --restart=global.restart.txt`). Note that there is currently no mechanism to create / edit the potentials from within the GUI. This will trickle in with other PRs.
[global.txt](https://github.com/disorderedmaterials/dissolve/files/11295544/global.txt)
[global.restart.txt](https://github.com/disorderedmaterials/dissolve/files/11295554/global.restart.txt)

Works towards #1398.
Closes #1399.
