### PR TITLE
1432 AvgMol Export

### DIFF
--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -342,8 +342,6 @@ class Species : public Serialisable
     public:
     // Load Species information from XYZ file
     bool loadFromXYZ(std::string_view filename);
-    // Load Species from file
-    bool load(std::string_view filename);
 
     /*
      * Read / Write

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -337,13 +337,6 @@ class Species : public Serialisable
     void centreAtOrigin();
 
     /*
-     * File Input / Output
-     */
-    public:
-    // Load Species information from XYZ file
-    bool loadFromXYZ(std::string_view filename);
-
-    /*
      * Read / Write
      */
     public:

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -9,49 +9,7 @@
 #include "data/elements.h"
 #include "data/ff/library.h"
 #include "data/isotopes.h"
-#include "templates/algorithms.h"
 #include <string>
-
-// Load Species information from XYZ file
-bool Species::loadFromXYZ(std::string_view filename)
-{
-    Messenger::print("Loading XYZ data from file '{}'\n", filename);
-
-    // Open the specified file...
-    LineParser parser;
-    parser.openInput(filename);
-    if (!parser.isFileGoodForReading())
-    {
-        Messenger::error("Couldn't open XYZ file '{}'.\n", filename);
-        return false;
-    }
-
-    // Clear any existing data
-    clear();
-
-    // Simple format - first line is number of atoms, next line is title, then follow atoms/coordinates, one atom per line
-    parser.getArgsDelim(LineParser::Defaults);
-    auto nAtoms = parser.argi(0);
-    parser.readNextLine(LineParser::Defaults);
-    name_ = parser.line();
-    int success;
-    for (auto n = 0; n < nAtoms; ++n)
-    {
-        success = parser.getArgsDelim(LineParser::Defaults);
-        if (success != 0)
-        {
-            parser.closeFiles();
-            Messenger::error("Couldn't read Atom {} from file '{}'\n", n + 1, filename);
-            return false;
-        }
-        auto Z = Elements::element(parser.argsv(0));
-        addAtom(Z, parser.arg3d(1), parser.hasArg(4) ? parser.argd(4) : 0.0);
-    }
-
-    Messenger::print("Successfully loaded XYZ data from file '{}'.\n", filename);
-    parser.closeFiles();
-    return true;
-}
 
 /*
  * Read / Write

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -12,20 +12,6 @@
 #include "templates/algorithms.h"
 #include <string>
 
-// Load Species from file
-bool Species::load(std::string_view filename)
-{
-    // Grab extension from filename
-    std::string_view ext = DissolveSys::afterLastChar(filename, '.');
-
-    if (DissolveSys::sameString(ext, "xyz"))
-        return loadFromXYZ(filename);
-    else
-        Messenger::print("Can't load species - unknown extension for file '{}'.\n", filename);
-
-    return false;
-}
-
 // Load Species information from XYZ file
 bool Species::loadFromXYZ(std::string_view filename)
 {

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -13,6 +13,7 @@
 #include "gui/selectelementdialog.h"
 #include "gui/selectspeciesdialog.h"
 #include "gui/speciestab.h"
+#include "io/import/species.h"
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QMessageBox>
@@ -107,7 +108,12 @@ void DissolveWindow::on_SpeciesImportFromXYZAction_triggered(bool checked)
 
     // Add new species, load from the xyz, and create intramolecular terms
     auto *sp = dissolve_.addSpecies();
-    sp->loadFromXYZ(qPrintable(xyzFile));
+    SpeciesImportFileFormat importer(qPrintable(xyzFile));
+    if (!importer.importData(sp))
+    {
+        dissolve_.removeSpecies(sp);
+        return;
+    }
     sp->addMissingBonds();
 
     // Offer the species up for editing before finalising

--- a/src/io/export/CMakeLists.txt
+++ b/src/io/export/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
   data3d.cpp
   forces.cpp
   pairpotential.cpp
+  species.cpp
   trajectory.cpp
   values.cpp
   coordinates.h
@@ -14,6 +15,7 @@ add_library(
   data3d.h
   forces.h
   pairpotential.h
+  species.h
   trajectory.h
   values.h
 )

--- a/src/io/export/species.cpp
+++ b/src/io/export/species.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "io/export/species.h"
+#include "base/lineparser.h"
+#include "base/sysfunc.h"
+#include "classes/atomtype.h"
+#include "classes/species.h"
+#include "data/atomicmasses.h"
+
+SpeciesExportFileFormat::SpeciesExportFileFormat(std::string_view filename, SpeciesExportFormat format)
+    : FileAndFormat(formats_, filename, (int)format)
+{
+    formats_ = EnumOptions<SpeciesExportFileFormat::SpeciesExportFormat>(
+        "SpeciesExportFileFormat", {{SpeciesExportFormat::XYZ, "xyz", "Simple XYZ Speciess"},
+                                    {SpeciesExportFormat::DLPOLY, "dlpoly", "DL_POLY CONFIG File"}});
+}
+
+/*
+ * Export Functions
+ */
+
+// Export coordinates as XYZ
+bool SpeciesExportFileFormat::exportXYZ(LineParser &parser, const Species *sp)
+{
+    // Export number of atoms and title
+    if (!parser.writeLineF("{}\n", sp->nAtoms()))
+        return false;
+    if (!parser.writeLineF("{}\n", sp->name()))
+        return false;
+
+    // Export Atoms
+    for (const auto &i : sp->atoms())
+        if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}\n", Elements::symbol(i.Z()), i.r().x, i.r().y, i.r().z))
+            return false;
+
+    return true;
+}
+
+// Export coordinates using current filename and format
+bool SpeciesExportFileFormat::exportData(const Species *sp)
+{
+    // Check the format
+    if (!formatIndex_)
+        return Messenger::error("No format set for SpeciesExportFileFormat so can't export.\n");
+
+    // Open the file
+    LineParser parser;
+    if (!parser.openOutput(filename_))
+    {
+        parser.closeFiles();
+        return false;
+    }
+
+    // Write data
+    auto result = false;
+    switch (formats_.enumerationByIndex(*formatIndex_))
+    {
+        case (SpeciesExportFormat::XYZ):
+            result = exportXYZ(parser, sp);
+            break;
+        default:
+            throw(std::runtime_error(
+                fmt::format("Species format '{}' export has not been implemented.\n", formats_.keywordByIndex(*formatIndex_))));
+    }
+
+    return result;
+}

--- a/src/io/export/species.h
+++ b/src/io/export/species.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "io/fileandformat.h"
+
+// Forward Declarations
+class Species;
+
+// Species Export Formats
+class SpeciesExportFileFormat : public FileAndFormat
+{
+    public:
+    // Available coordinate formats
+    enum class SpeciesExportFormat
+    {
+        XYZ,
+        DLPOLY
+    };
+    SpeciesExportFileFormat(std::string_view filename = "", SpeciesExportFormat format = SpeciesExportFormat::XYZ);
+    ~SpeciesExportFileFormat() override = default;
+
+    /*
+     * Formats
+     */
+    private:
+    // Format enum options
+    EnumOptions<SpeciesExportFileFormat::SpeciesExportFormat> formats_;
+
+    /*
+     * Filename / Basename
+     */
+    public:
+    // Return whether the file must exist
+    bool fileMustExist() const override { return false; }
+
+    /*
+     * Export Functions
+     */
+    private:
+    // Export species as XYZ
+    bool exportXYZ(LineParser &parser, const Species *sp);
+
+    public:
+    // Export species using current filename and format
+    bool exportData(const Species *sp);
+};

--- a/src/io/import/CMakeLists.txt
+++ b/src/io/import/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(
   forces_dlpoly.cpp
   forces_moscito.cpp
   forces_simple.cpp
+  species.cpp
+  species_xyz.cpp
   trajectory.cpp
   trajectory_dlpoly.cpp
   values.cpp
@@ -53,6 +55,7 @@ add_library(
   data2d.h
   data3d.h
   forces.h
+  species.h
   trajectory.h
   values.h
   CIFImportErrorListeners.cpp

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -69,7 +69,7 @@ bool CoordinateImportFileFormat::importData(LineParser &parser, std::vector<Vec3
 {
     // Check the format
     if (!formatIndex_)
-        return Messenger::error("No format set for TrajectoryImportFileFormat so can't import.\n");
+        return Messenger::error("No format set for ConfigurationImportFileFormat so can't import.\n");
 
     // Import the data
     auto result = false;

--- a/src/io/import/species.cpp
+++ b/src/io/import/species.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "io/import/species.h"
+#include "base/lineparser.h"
+#include "base/processpool.h"
+#include "base/sysfunc.h"
+#include "classes/species.h"
+#include "templates/algorithms.h"
+
+SpeciesImportFileFormat::SpeciesImportFileFormat(std::string_view filename, SpeciesImportFileFormat::SpeciesImportFormat format)
+    : FileAndFormat(formats_, filename, (int)format)
+{
+    formats_ = EnumOptions<SpeciesImportFileFormat::SpeciesImportFormat>("SpeciesImportFileFormat",
+                                                                         {{SpeciesImportFormat::XYZ, "xyz", "Simple XYZ"}});
+
+    setUpKeywords();
+}
+
+/*
+ * Keyword Options
+ */
+
+// Set up keywords for the format
+void SpeciesImportFileFormat::setUpKeywords() {}
+
+/*
+ * Import Functions
+ */
+
+// Import coordinates direct to configuration using current filename and format
+bool SpeciesImportFileFormat::importData(Species *sp, const ProcessPool *procPool)
+{
+    // Open file and check that we're OK to proceed importing from it
+    LineParser parser(procPool);
+    if ((!parser.openInput(filename_)) || (!parser.isFileGoodForReading()))
+        return Messenger::error("Couldn't open file '{}' for loading coordinates data.\n", filename_);
+
+    // Import the data
+    auto result = false;
+    try
+    {
+        result = importData(parser, sp);
+        parser.closeFiles();
+    }
+    catch (...)
+    {
+        return Messenger::error("Failed to import species data ({}) from file '{}'.\n", formats_.keywordByIndex(*formatIndex_),
+                                filename_);
+    }
+
+    return result;
+}
+
+// Import coordinates direct to configuration using supplied parser and current format
+bool SpeciesImportFileFormat::importData(LineParser &parser, Species *sp)
+{
+    // Check the format
+    if (!formatIndex_)
+        return Messenger::error("No format set for SpeciesImportFileFormat so can't import.\n");
+
+    // Import the data
+    auto result = false;
+    switch (formats_.enumerationByIndex(*formatIndex_))
+    {
+        case (SpeciesImportFormat::XYZ):
+            result = importXYZ(parser, sp);
+            break;
+        default:
+            throw(std::runtime_error(
+                fmt::format("Species format '{}' import has not been implemented.\n", formats_.keywordByIndex(*formatIndex_))));
+    }
+
+    return result;
+}

--- a/src/io/import/species.h
+++ b/src/io/import/species.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "io/fileandformat.h"
+
+// Forward Declarations
+class ProcessPool;
+
+// Species Import Formats
+class SpeciesImportFileFormat : public FileAndFormat
+{
+    public:
+    // Species Import Formats
+    enum class SpeciesImportFormat
+    {
+        XYZ
+    };
+    explicit SpeciesImportFileFormat(std::string_view filename = "", SpeciesImportFormat format = SpeciesImportFormat::XYZ);
+    ~SpeciesImportFileFormat() override = default;
+
+    /*
+     * Keyword Options
+     */
+    private:
+    // Set up keywords for the format
+    void setUpKeywords();
+
+    /*
+     * Formats
+     */
+    private:
+    // Format enum options
+    EnumOptions<SpeciesImportFileFormat::SpeciesImportFormat> formats_;
+
+    /*
+     * Filename / Basename
+     */
+    public:
+    // Return whether the file must exist
+    bool fileMustExist() const override { return true; }
+
+    /*
+     * Import Functions
+     */
+    private:
+    // Import xyz coordinates through specified parser
+    bool importXYZ(LineParser &parser, Species *sp);
+
+    public:
+    // Import coordinates direct to configuration using current filename and format
+    bool importData(Species *sp, const ProcessPool *procPool = nullptr);
+    // Import coordinates using supplied parser and current format
+    bool importData(LineParser &parser, std::vector<Vec3<double>> &r);
+    // Import coordinates direct to configuration using supplied parser and current format
+    bool importData(LineParser &parser, Species *sp);
+};

--- a/src/io/import/species_xyz.cpp
+++ b/src/io/import/species_xyz.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "base/lineparser.h"
+#include "classes/species.h"
+#include "io/import/species.h"
+
+// Import xyz coordinates through specified parser
+bool SpeciesImportFileFormat::importXYZ(LineParser &parser, Species *sp)
+{
+    Messenger::print(" --> Importing species coordinates in xyz format...\n");
+
+    // Read natoms
+    if (parser.getArgsDelim() != LineParser::Success)
+        return false;
+    auto nAtoms = parser.argi(0);
+
+    // Skip title
+    if (parser.skipLines(1) != LineParser::Success)
+        return false;
+
+    Messenger::print(" --> Expecting coordinates for {} atoms.\n", nAtoms);
+    sp->clear();
+    for (auto n = 0; n < nAtoms; ++n)
+    {
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+        {
+            parser.closeFiles();
+            Messenger::error("Couldn't read atom {} from file '{}'\n", n + 1, parser.inputFilename());
+            return false;
+        }
+        auto Z = Elements::element(parser.argsv(0));
+        sp->addAtom(Z, parser.arg3d(1), parser.hasArg(4) ? parser.argd(4) : 0.0);
+    }
+
+    return true;
+}

--- a/src/modules/avgmol/avgmol.cpp
+++ b/src/modules/avgmol/avgmol.cpp
@@ -2,7 +2,9 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "modules/avgmol/avgmol.h"
+#include "keywords/bool.h"
 #include "keywords/configuration.h"
+#include "keywords/fileandformat.h"
 #include "keywords/speciessite.h"
 
 AvgMolModule::AvgMolModule() : Module(ModuleTypes::AvgMol)
@@ -13,6 +15,10 @@ AvgMolModule::AvgMolModule() : Module(ModuleTypes::AvgMol)
     keywords_
         .add<SpeciesSiteKeyword>("Site", "Target site about which to calculate average species geometry", targetSite_, true)
         ->setEditSignals(KeywordBase::ReloadExternalData);
+
+    keywords_.setOrganisation("Export");
+    keywords_.add<FileAndFormatKeyword>("ExportCoordinates", "Whether to save average coordinates to disk",
+                                        exportFileAndFormat_, "EndExportCoordinates");
 
     targetSpecies_ = nullptr;
 }

--- a/src/modules/avgmol/avgmol.h
+++ b/src/modules/avgmol/avgmol.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "classes/species.h"
+#include "io/export/species.h"
 #include "math/sampledvector.h"
 #include "module/module.h"
 
@@ -22,6 +23,8 @@ class AvgMolModule : public Module
     Configuration *targetConfiguration_{nullptr};
     // Target site
     const SpeciesSite *targetSite_{nullptr};
+    // Whether to save average coordinates to disk
+    SpeciesExportFileFormat exportFileAndFormat_;
     // Species targeted by module (derived from selected site)
     const Species *targetSpecies_{nullptr};
     // Local Species representing average of targeted Species

--- a/src/modules/avgmol/process.cpp
+++ b/src/modules/avgmol/process.cpp
@@ -68,6 +68,13 @@ bool AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (sp != targetSpecies_)
         return Messenger::error("Internal error - target site parent is not the same as the target species.\n");
 
+    Messenger::print("AvgMol: Target site (species) is {} ({}).\n", targetSite_->name(), targetSpecies_->name());
+    if (exportFileAndFormat_.hasFilename())
+        Messenger::print("AvgMol: Coordinates will be exported to '{}' ({}).\n", exportFileAndFormat_.filename(),
+                         exportFileAndFormat_.formatDescription());
+
+    Messenger::print("\n");
+
     // Update arrays
     updateArrays(dissolve);
 
@@ -107,6 +114,13 @@ bool AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     }
 
     updateSpecies(sampledX, sampledY, sampledZ);
+
+    // Export data?
+    if (exportFileAndFormat_.hasFilename())
+    {
+        if (!exportFileAndFormat_.exportData(&averageSpecies_))
+            return false;
+    }
 
     return true;
 }

--- a/web/docs/userguide/modules/analysis/avgmol/_index.md
+++ b/web/docs/userguide/modules/analysis/avgmol/_index.md
@@ -24,3 +24,9 @@ Results of the average molecule calculation can be used as a display reference i
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
 |`Site`|`Site`|--|{{< required-label >}}Target site about which to calculate the average species geometry. Must be an oriented site.|
+
+## Export
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`ExportCoordinates`|[`SpeciesExportFileFormat`]({{< ref speciesformat >}})|--|File and format to export average species coordinates to.|

--- a/web/docs/userguide/reference/fileandformat/speciesformat.md
+++ b/web/docs/userguide/reference/fileandformat/speciesformat.md
@@ -1,0 +1,11 @@
+---
+title: Species
+description: Species import/export
+---
+
+## Known Formats
+
+|Keyword|Import|Export|Description|
+|:-----:|:----:|:----:|-----------|
+|`xyz`|&check;|&check;|XMol-style xyz coordinates. Line 1 contains the number of atoms, N. Line 2 contains a title string. The next N lines contain "element  rx  ry  rz". |
+


### PR DESCRIPTION
This PR adds in specific `FileAndFormat`-based import and export for `Species`, moving the existing code for importing from xyz from the `Species` class itself.

The payoff is to add a new option to the `AvgMol` module to allow the average molecule to be exported.

Closes #1432.