### PR TITLE
Account for potentially big integers in Select node.

### DIFF
--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -143,10 +143,10 @@ int SelectProcedureNode::nSitesInStack() const { return sites_.size(); }
 double SelectProcedureNode::nAverageSites() const { return double(nCumulativeSites_) / nSelections_; }
 
 // Return the cumulative number of sites ever selected
-int SelectProcedureNode::nCumulativeSites() const { return nCumulativeSites_; }
+unsigned long int SelectProcedureNode::nCumulativeSites() const { return nCumulativeSites_; }
 
 // Return total number of sites available per selection
-int SelectProcedureNode::nAvailableSites() const { return double(nAvailableSites_) / nSelections_; }
+unsigned long int SelectProcedureNode::nAvailableSites() const { return double(nAvailableSites_) / nSelections_; }
 
 // Return current site
 const Site *SelectProcedureNode::currentSite() const

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -90,9 +90,9 @@ class SelectProcedureNode : public ProcedureNode
     // Number of selections made by the node
     int nSelections_;
     // Cumulative number of sites ever selected
-    int nCumulativeSites_;
+    unsigned long int nCumulativeSites_;
     // Total number of sites available per selection
-    int nAvailableSites_;
+    unsigned long int nAvailableSites_;
 
     public:
     // Selection Populations
@@ -108,9 +108,9 @@ class SelectProcedureNode : public ProcedureNode
     // Return the average number of sites selected
     double nAverageSites() const;
     // Return the cumulative number of sites ever selected
-    int nCumulativeSites() const;
+    unsigned long int nCumulativeSites() const;
     // Return total number of sites available per selection
-    int nAvailableSites() const;
+    unsigned long int nAvailableSites() const;
     // Return current site
     const Site *currentSite() const;
 


### PR DESCRIPTION
A small PR to change storage type for a couple of counters from `int` to `unsigned long int`, since an `int` is very easy to overflow when you're talking about squares of the number of molecules in a reasonably big simulation box.