### PR TITLE
Update CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -176,7 +176,7 @@
             "name": "SCARF",
             "displayName": "SCARF build",
             "description": "Best setup for SCARF",
-	    "inherits" : ["parallel-Release"]
+	    "inherits" : ["MPI-Release"]
         }
     ]
 }


### PR DESCRIPTION
The SCARF preset called the MPI build by its old name.  This wouldn't be an issue, since we don't really use the SCARF build, but `cmake` automatically fails if any of the presets are misconfigured.