### PR TITLE
1419 Region from Expression

### DIFF
--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -232,6 +232,13 @@ Vec3<double> Box::getReal(Vec3<double> r) const
     return r;
 }
 
+// Return specified real coordinates converted to fractional coordinates
+Vec3<double> Box::getFractional(Vec3<double> r) const
+{
+    toFractional(r);
+    return r;
+}
+
 /*
  * Geometry
  */

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -103,6 +103,8 @@ class Box : public Serialisable
     Vec3<double> getReal(Vec3<double> r) const;
     // Convert specified real-space coordinates to fractional coordinates
     inline virtual void toFractional(Vec3<double> &r) const = 0;
+    // Return specified real coordinates converted to fractional coordinates
+    Vec3<double> getFractional(Vec3<double> r) const;
 
     /*
      * Minimum Image Calculation

--- a/src/expression/ExpressionErrorListeners.h
+++ b/src/expression/ExpressionErrorListeners.h
@@ -15,7 +15,21 @@ namespace ExpressionExceptions
 class ExpressionSyntaxException : public std::exception
 {
     public:
-    ExpressionSyntaxException(std::string_view message = "Undefined Expression Syntax Exception") : message_{message} {}
+    explicit ExpressionSyntaxException(std::string_view message = "Undefined Expression Syntax Exception") : message_{message} {}
+
+    private:
+    // Error message
+    std::string message_;
+
+    public:
+    const char *what() const noexcept override { return message_.c_str(); }
+};
+
+// Expression Semantic Exception
+class ExpressionSemanticException : public std::exception
+{
+    public:
+    explicit ExpressionSemanticException(std::string_view message = "Undefined Expression Semantic Exception") : message_{message} {}
 
     private:
     // Error message
@@ -29,7 +43,7 @@ class ExpressionSyntaxException : public std::exception
 class ExpressionInternalErrorException : public std::exception
 {
     public:
-    ExpressionInternalErrorException(std::string_view message = "Expression internal error.") : message_{message} {}
+    explicit ExpressionInternalErrorException(std::string_view message = "Expression internal error.") : message_{message} {}
 
     private:
     // Error message

--- a/src/expression/ExpressionErrorListeners.h
+++ b/src/expression/ExpressionErrorListeners.h
@@ -15,7 +15,9 @@ namespace ExpressionExceptions
 class ExpressionSyntaxException : public std::exception
 {
     public:
-    explicit ExpressionSyntaxException(std::string_view message = "Undefined Expression Syntax Exception") : message_{message} {}
+    explicit ExpressionSyntaxException(std::string_view message = "Undefined Expression Syntax Exception") : message_{message}
+    {
+    }
 
     private:
     // Error message
@@ -29,7 +31,10 @@ class ExpressionSyntaxException : public std::exception
 class ExpressionSemanticException : public std::exception
 {
     public:
-    explicit ExpressionSemanticException(std::string_view message = "Undefined Expression Semantic Exception") : message_{message} {}
+    explicit ExpressionSemanticException(std::string_view message = "Undefined Expression Semantic Exception")
+        : message_{message}
+    {
+    }
 
     private:
     // Error message

--- a/src/expression/ExpressionVisitor.cpp
+++ b/src/expression/ExpressionVisitor.cpp
@@ -159,7 +159,7 @@ antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext
     {
         // Do we have any external variables available?
         if (!externalVariables_)
-            throw(ExpressionExceptions::ExpressionSyntaxException(fmt::format(
+            throw(ExpressionExceptions::ExpressionSemanticException(fmt::format(
                 "Variable '{}' does not exist in this context (there are no variables defined).\n", ctx->Name()->getText())));
 
         // Does the named variable exist?
@@ -167,7 +167,7 @@ antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext
         it = std::find_if(extVars.begin(), extVars.end(),
                           [ctx](auto var) { return DissolveSys::sameString(var->name(), ctx->Name()->getText()); });
         if (it == extVars.end())
-            throw(ExpressionExceptions::ExpressionSyntaxException(
+            throw(ExpressionExceptions::ExpressionSemanticException(
                 fmt::format("Variable '{}' does not exist in this context.\n", ctx->Name()->getText())));
     }
 

--- a/src/expression/ExpressionVisitor.h
+++ b/src/expression/ExpressionVisitor.h
@@ -17,7 +17,8 @@ class ExpressionVisitor : ExpressionParserBaseVisitor
     private:
     // Target Expression
     Expression *expression_;
-    // External variables available to this expression
+    // Variables available to this expression
+    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> localVariables_;
     OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> externalVariables_;
     // Context stack
     std::vector<std::shared_ptr<ExpressionNode>> contextStack_;
@@ -29,6 +30,7 @@ class ExpressionVisitor : ExpressionParserBaseVisitor
     public:
     // Construct description within supplied object, from given tree
     void create(Expression &expr, ExpressionParser::ExpressionContext *tree,
+                const std::vector<std::shared_ptr<ExpressionVariable>> &localVariables,
                 OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> externalVariables);
 
     /*

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -106,7 +106,7 @@ bool Expression::create(std::string_view expressionString,
     {
         visitor.create(*this, tree, localVariables_, externalVariables);
     }
-    catch (ExpressionExceptions::ExpressionSyntaxException &ex)
+    catch (std::exception &ex)
     {
         fmt::print(ex.what());
         clearNodes();

--- a/src/expression/expression.h
+++ b/src/expression/expression.h
@@ -24,8 +24,12 @@ class Expression
     private:
     // Root node for the expression
     std::shared_ptr<ExpressionNode> rootNode_;
+    // Local expression variables
+    std::vector<std::shared_ptr<ExpressionVariable>> localVariables_;
 
     public:
+    // Add local variable
+    std::shared_ptr<ExpressionVariable> addLocalVariable(std::string_view name);
     // Clear node data
     void clearNodes();
     // Return whether current expression is valid (contains at least one node)

--- a/src/expression/function.cpp
+++ b/src/expression/function.cpp
@@ -115,6 +115,9 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
         case (TwoPiFunction):
             result = 2.0 * M_PI;
             break;
+        default:
+            throw(std::runtime_error(
+                fmt::format("Expression function '{}' has not been implemented.\n", internalFunctions().keyword(function_))));
     }
 
     return result;

--- a/src/expression/function.cpp
+++ b/src/expression/function.cpp
@@ -19,6 +19,8 @@ EnumOptions<ExpressionFunctionNode::InternalFunction> ExpressionFunctionNode::in
                                                                                       {SqrtFunction, "sqrt", 1},
                                                                                       {PiFunction, "pi"},
                                                                                       {TanFunction, "tan", 1},
+                                                                                      {ToDegreesFunction, "toDeg", 1},
+                                                                                      {ToRadiansFunction, "toRad", 1},
                                                                                       {TwoPiFunction, "twopi"}});
 }
 
@@ -72,16 +74,16 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
                 result = fabs(args[0].asDouble());
             break;
         case (ACosFunction):
-            result = acos(args[0].asDouble()) * DEGRAD;
+            result = acos(args[0].asDouble());
             break;
         case (ASinFunction):
-            result = asin(args[0].asDouble()) * DEGRAD;
+            result = asin(args[0].asDouble());
             break;
         case (ATanFunction):
-            result = atan(args[0].asDouble()) * DEGRAD;
+            result = atan(args[0].asDouble());
             break;
         case (CosFunction):
-            result = cos(args[0].asDouble() / DEGRAD);
+            result = cos(args[0].asDouble());
             break;
         case (ExpFunction):
             result = exp(args[0].asDouble());
@@ -93,7 +95,7 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
             result = log10(args[0].asDouble());
             break;
         case (SinFunction):
-            result = sin(args[0].asDouble() / DEGRAD);
+            result = sin(args[0].asDouble());
             break;
         case (SqrtFunction):
             result = sqrt(args[0].asDouble());
@@ -102,7 +104,13 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
             result = M_PI;
             break;
         case (TanFunction):
-            result = tan(args[0].asDouble() / DEGRAD);
+            result = tan(args[0].asDouble());
+            break;
+        case (ToDegreesFunction):
+            result = args[0].asDouble() * DEGRAD;
+            break;
+        case (ToRadiansFunction):
+            result = args[0].asDouble() / DEGRAD;
             break;
         case (TwoPiFunction):
             result = 2.0 * M_PI;

--- a/src/expression/function.cpp
+++ b/src/expression/function.cpp
@@ -17,7 +17,9 @@ EnumOptions<ExpressionFunctionNode::InternalFunction> ExpressionFunctionNode::in
                                                                                       {LogFunction, "log", 1},
                                                                                       {SinFunction, "sin", 1},
                                                                                       {SqrtFunction, "sqrt", 1},
-                                                                                      {TanFunction, "tan", 1}});
+                                                                                      {PiFunction, "pi"},
+                                                                                      {TanFunction, "tan", 1},
+                                                                                      {TwoPiFunction, "twopi"}});
 }
 
 ExpressionFunctionNode::ExpressionFunctionNode(InternalFunction func) : ExpressionNode(), function_(func) {}
@@ -46,7 +48,7 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
 {
     // Number of required child nodes depends on the function
     const auto nArgs = internalFunctions().minArgs(function_);
-    if (children_.size() != nArgs)
+    if (children_.size() != nArgs.value_or(0))
         return std::nullopt;
 
     // Evaluate the arguments
@@ -96,8 +98,14 @@ std::optional<ExpressionValue> ExpressionFunctionNode::evaluate() const
         case (SqrtFunction):
             result = sqrt(args[0].asDouble());
             break;
+        case (PiFunction):
+            result = M_PI;
+            break;
         case (TanFunction):
             result = tan(args[0].asDouble() / DEGRAD);
+            break;
+        case (TwoPiFunction):
+            result = 2.0 * M_PI;
             break;
     }
 
@@ -109,8 +117,11 @@ std::string ExpressionFunctionNode::asString() const
 {
     // Number of required child nodes depends on the function
     const auto nArgs = internalFunctions().minArgs(function_);
-    if (children_.size() != nArgs)
+    if (children_.size() != nArgs.value_or(0))
         return "";
+
+    if (!nArgs)
+        return fmt::format("{}()", internalFunctions().keyword(function_));
 
     // Evaluate the arguments
     std::vector<std::string> args;

--- a/src/expression/function.h
+++ b/src/expression/function.h
@@ -20,9 +20,11 @@ class ExpressionFunctionNode : public ExpressionNode
         ExpFunction,
         LnFunction,
         LogFunction,
+        PiFunction,
         SinFunction,
         SqrtFunction,
-        TanFunction
+        TanFunction,
+        TwoPiFunction
     };
     // Return enum options for NodeTypes
     static EnumOptions<ExpressionFunctionNode::InternalFunction> internalFunctions();

--- a/src/expression/function.h
+++ b/src/expression/function.h
@@ -24,6 +24,8 @@ class ExpressionFunctionNode : public ExpressionNode
         SinFunction,
         SqrtFunction,
         TanFunction,
+        ToDegreesFunction,
+        ToRadiansFunction,
         TwoPiFunction
     };
     // Return enum options for NodeTypes

--- a/src/gui/icons/nodes_customregion.svg
+++ b/src/gui/icons/nodes_customregion.svg
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="100"
+   height="100"
+   id="svg2"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="nodes_customregion.svg">
+  <metadata
+     id="metadata3050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="1531"
+     id="namedview3048"
+     showgrid="false"
+     inkscape:zoom="5.6568544"
+     inkscape:cx="26.593041"
+     inkscape:cy="71.678073"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="false"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs4" />
+  <path
+     id="rect837-6"
+     style="opacity:1;fill:#dcdcdc;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 106.15212,4.3887193 c -0.0469,-0.9876087 -1.24679,-2.049492 -4.94538,-3.2532885 H 27.188852 c 0.01843,0.1000143 0.03739,0.1991765 0.0551,0.2993072 1.014521,5.7343585 -0.446556,-0.51696111 1.568107,4.850337 0.72348,1.9274364 -0.06439,2.0603399 1.186986,4.146742 1.522187,2.537905 4.882936,7.138981 8.570639,9.214859 1.430204,0.805091 3.192219,1.456046 4.846667,2.152107 4.331631,1.82241 2.916254,1.357639 7.677529,2.277192 0.84984,0.164127 1.652579,0.410782 2.553053,0.488045 1.029136,0.0883 2.091194,0 3.136216,0 5.960386,0 -1.171641,0.04986 5.108403,-0.164171 0.716863,-0.02441 1.459899,0.08709 2.155864,0 4.833179,-0.604763 9.393673,-1.949924 13.688223,-3.114803 4.673252,-1.267599 9.819381,-2.14685 14.030309,-3.78601 5.284521,-2.057065 6.341241,-4.176047 9.162982,-7.097373 1.26311,-1.3076901 2.72415,-2.5679037 3.98341,-3.8764726 0.66462,-0.6906477 1.27509,-1.3928599 1.23978,-2.1364711 z" />
+  <g
+     id="g863"
+     transform="matrix(0.99008362,0,0,0.99008362,-30.603055,0.49581899)"
+     style="fill:#d9d9d9;fill-opacity:1;stroke:#eaeae9;stroke-opacity:1">
+    <circle
+       style="fill:#d9d9d9;fill-opacity:1;stroke:#eaeae9;stroke-width:2.55631;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path812"
+       cx="50"
+       cy="50"
+       r="17.812279" />
+    <path
+       id="rect818-3"
+       style="fill:#d9d9d9;fill-opacity:1;stroke:#eaeae9;stroke-width:1.00157;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 44.740234,2.8749996e-8 V 29.769531 A 20.903845,20.903845 0 0 1 50,29.095703 20.903845,20.903845 0 0 1 55.259766,29.769531 V 2.8749996e-8 Z M 44.740234,70.230469 V 100 H 55.259766 V 70.230469 A 20.903845,20.903845 0 0 1 50,70.904297 20.903845,20.903845 0 0 1 44.740234,70.230469 Z" />
+  </g>
+  <g
+     id="g1021"
+     transform="matrix(0.53889026,0,0,0.53889026,87.709003,19.682188)">
+    <text
+       xml:space="preserve"
+       style="font-size:80.4577px;line-height:1.25;font-family:sans-serif;fill:#004b00;fill-opacity:1;stroke:#003800;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       x="-118.46147"
+       y="78.44191"
+       id="text922-3"><tspan
+         sodipodi:role="line"
+         id="tspan920-9"
+         x="-118.46147"
+         y="78.44191"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif Italic';fill:#004b00;fill-opacity:1;stroke:#003800;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">f(x)</tspan></text>
+    <g
+       id="g1014">
+      <text
+         xml:space="preserve"
+         style="font-size:80.4577px;line-height:1.25;font-family:sans-serif;fill:#004b00;fill-opacity:1;stroke:none;stroke-width:4.31024;stroke-opacity:1"
+         x="-118.46147"
+         y="78.44191"
+         id="text922"><tspan
+           sodipodi:role="line"
+           id="tspan920"
+           x="-118.46147"
+           y="78.44191"
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:'DejaVu Serif';-inkscape-font-specification:'DejaVu Serif Italic';fill:#004b00;fill-opacity:1;stroke:none;stroke-width:4.31024;stroke-opacity:1">f(x)</tspan></text>
+    </g>
+  </g>
+  <rect
+     style="fill:#dcdcdc;fill-opacity:1;stroke:#000000;stroke-width:1.99999;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1439"
+     width="22.978289"
+     height="22.246689"
+     x="35.093445"
+     y="77.0634"
+     rx="0"
+     ry="0" />
+  <rect
+     style="fill:#dcdcdc;fill-opacity:1;stroke:#000000;stroke-width:1.99999;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect1439-3"
+     width="22.978289"
+     height="22.246689"
+     x="70.018013"
+     y="76.557899"
+     rx="11.489144"
+     ry="11.123344" />
+</svg>

--- a/src/gui/main.qrc
+++ b/src/gui/main.qrc
@@ -19,6 +19,7 @@
     <file>icons/nodes_calculatedistance.svg</file>
     <file>icons/nodes_calculatevector.svg</file>
     <file>icons/nodes_collect1d.svg</file>
+    <file>icons/nodes_customregion.svg</file>
     <file>icons/nodes_collect2d.svg</file>
     <file>icons/nodes_collect3d.svg</file>
     <file>icons/nodes_context.svg</file>

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -5,10 +5,7 @@
 #include "base/lineparser.h"
 #include "expression/expression.h"
 
-ExpressionKeyword::ExpressionKeyword(Expression &data, const std::vector<std::shared_ptr<ExpressionVariable>> &variables)
-    : KeywordBase(typeid(this)), data_(data), variables_(variables)
-{
-}
+ExpressionKeyword::ExpressionKeyword(Expression &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Data
@@ -18,13 +15,7 @@ ExpressionKeyword::ExpressionKeyword(Expression &data, const std::vector<std::sh
 const Expression &ExpressionKeyword::data() const { return data_; }
 
 // Set data
-bool ExpressionKeyword::setData(std::string_view expressionText)
-{
-    if (!data_.create(expressionText, variables_))
-        return false;
-
-    return true;
-}
+bool ExpressionKeyword::setData(std::string_view expressionText) { return data_.create(expressionText); }
 
 /*
  * Arguments

--- a/src/keywords/expression.h
+++ b/src/keywords/expression.h
@@ -13,7 +13,7 @@ class ExpressionVariable;
 class ExpressionKeyword : public KeywordBase
 {
     public:
-    ExpressionKeyword(Expression &data, const std::vector<std::shared_ptr<ExpressionVariable>> &variables);
+    ExpressionKeyword(Expression &data);
     ~ExpressionKeyword() override = default;
 
     /*
@@ -22,8 +22,6 @@ class ExpressionKeyword : public KeywordBase
     private:
     // Reference to data
     Expression &data_;
-    // Vector of variables available to the expression
-    const std::vector<std::shared_ptr<ExpressionVariable>> &variables_;
 
     public:
     // Return reference to data

--- a/src/modules/dangle/dangle.cpp
+++ b/src/modules/dangle/dangle.cpp
@@ -72,7 +72,7 @@ DAngleModule::DAngleModule() : Module(ModuleTypes::DAngle), analyser_(ProcedureN
     processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
     processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &angleNormalisation = processAngle_->branch()->get();
-    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(toRad(x))");
     angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
 
     // Process2D: 'DAngle'

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
   context.cpp
   coordinatesets.cpp
   copy.cpp
+  customregion.cpp
   cylindricalregion.cpp
   generalregion.cpp
   integrate1d.cpp
@@ -61,6 +62,7 @@ add_library(
   context.h
   coordinatesets.h
   copy.h
+  customregion.h
   cylindricalregion.h
   generalregion.h
   integrate1d.h

--- a/src/procedure/nodes/customregion.cpp
+++ b/src/procedure/nodes/customregion.cpp
@@ -41,8 +41,5 @@ bool CustomRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec
     // Assess expression
     auto x = expression_.asDouble();
 
-    if (x < minimumValue_ || x > maximumValue_)
-        return false;
-
-    return true;
+    return (x >= minimumValue_ && x <= maximumValue_);
 }

--- a/src/procedure/nodes/customregion.cpp
+++ b/src/procedure/nodes/customregion.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/customregion.h"
+#include "classes/configuration.h"
+#include "expression/variable.h"
+#include "keywords/double.h"
+#include "keywords/nodevalue.h"
+
+CustomRegionProcedureNode::CustomRegionProcedureNode() : RegionProcedureNodeBase(ProcedureNode::NodeType::CustomRegion)
+{
+    keywords_.setOrganisation("Options", "Definition");
+    keywords_.add<NodeValueKeyword>("Expression", "Expression describing region", expression_, this);
+    keywords_.add<DoubleKeyword>("Minimum", "Minimum value for descriptive function defining region", minimumValue_);
+    keywords_.add<DoubleKeyword>("Maximum", "Maximum value for descriptive function defining region", maximumValue_);
+
+    x_ = expression_.addLocalVariable("x");
+    y_ = expression_.addLocalVariable("y");
+    z_ = expression_.addLocalVariable("z");
+    xFrac_ = expression_.addLocalVariable("xFrac");
+    yFrac_ = expression_.addLocalVariable("yFrac");
+    zFrac_ = expression_.addLocalVariable("zFrac");
+}
+
+/*
+ * Region Data
+ */
+
+// Return whether voxel centred at supplied real coordinates is valid
+bool CustomRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
+{
+    // Poke values into our variables
+    x_->setValue(r.x);
+    y_->setValue(r.y);
+    z_->setValue(r.z);
+    auto rFrac = cfg->box()->getFractional(r);
+    xFrac_->setValue(rFrac.x);
+    yFrac_->setValue(rFrac.y);
+    zFrac_->setValue(rFrac.z);
+
+    // Assess expression
+    auto x = expression_.asDouble();
+
+    if (x < minimumValue_ || x > maximumValue_)
+        return false;
+
+    return true;
+}

--- a/src/procedure/nodes/customregion.h
+++ b/src/procedure/nodes/customregion.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/regionbase.h"
+#include "procedure/nodevalue.h"
+
+// Custom Region
+class CustomRegionProcedureNode : public RegionProcedureNodeBase
+{
+    public:
+    CustomRegionProcedureNode();
+    ~CustomRegionProcedureNode() override = default;
+
+    /*
+     * Control
+     */
+    private:
+    // Local variables, set when checking voxels
+    std::shared_ptr<ExpressionVariable> x_, y_, z_, xFrac_, yFrac_, zFrac_;
+    // Expression describing region
+    NodeValue expression_;
+    // Minimum threshold value for function
+    double minimumValue_{0.0};
+    // Maximum threshold value for function
+    double maximumValue_{1.0};
+
+    /*
+     * Region Data
+     */
+    public:
+    // Return whether voxel centred at supplied real coordinates is valid
+    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
+};

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -40,6 +40,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Collect3D, "Collect3D"},
                      {ProcedureNode::NodeType::CoordinateSets, "CoordinateSets"},
                      {ProcedureNode::NodeType::Copy, "Copy"},
+                     {ProcedureNode::NodeType::CustomRegion, "CustomRegion"},
                      {ProcedureNode::NodeType::CylindricalRegion, "CylindricalRegion"},
                      {ProcedureNode::NodeType::DynamicSite, "DynamicSite"},
                      {ProcedureNode::NodeType::GeneralRegion, "GeneralRegion"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -51,6 +51,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
         Collect3D,
         CoordinateSets,
         Copy,
+        CustomRegion,
         CylindricalRegion,
         DynamicSite,
         GeneralRegion,

--- a/src/procedure/nodes/operateexpression.cpp
+++ b/src/procedure/nodes/operateexpression.cpp
@@ -13,38 +13,36 @@ OperateExpressionProcedureNode::OperateExpressionProcedureNode(std::string_view 
     : OperateProcedureNodeBase(ProcedureNode::NodeType::OperateExpression)
 {
     // Create variables, and add them to the vector
-    x_ = std::make_shared<ExpressionVariable>("x");
-    variables_.emplace_back(x_);
-    y_ = std::make_shared<ExpressionVariable>("y");
-    variables_.emplace_back(y_);
-    z_ = std::make_shared<ExpressionVariable>("z");
-    variables_.emplace_back(z_);
-    xDelta_ = std::make_shared<ExpressionVariable>("xDelta");
-    variables_.emplace_back(xDelta_);
-    yDelta_ = std::make_shared<ExpressionVariable>("yDelta");
-    variables_.emplace_back(yDelta_);
-    zDelta_ = std::make_shared<ExpressionVariable>("zDelta");
-    variables_.emplace_back(zDelta_);
-    value_ = std::make_shared<ExpressionVariable>("value");
-    variables_.emplace_back(value_);
+    x_ = expression_.addLocalVariable("x");
+    y_ = expression_.addLocalVariable("y");
+    z_ = expression_.addLocalVariable("z");
+    xDelta_ = expression_.addLocalVariable("xDelta");
+    yDelta_ = expression_.addLocalVariable("yDelta");
+    zDelta_ = expression_.addLocalVariable("zDelta");
+    value_ = expression_.addLocalVariable("value");
 
-    expression_.create(expressionText, variables_);
+    expression_.create(expressionText);
 
     keywords_.setOrganisation("Options", "Inputs");
-    keywords_.add<ExpressionKeyword>("Expression", "Expression to apply to values", expression_, variables_);
+    keywords_.add<ExpressionKeyword>("Expression", "Expression to apply to values", expression_);
 }
 
 // Set the expression
 bool OperateExpressionProcedureNode::setExpression(std::string_view expressionText)
 {
-    return expression_.create(expressionText, variables_);
+    return expression_.create(expressionText);
 }
 
 // Zero all variables
 void OperateExpressionProcedureNode::zeroVariables()
 {
-    for (auto &v : variables_)
-        v->setValue(0.0);
+    x_->setValue(0.0);
+    y_->setValue(0.0);
+    z_->setValue(0.0);
+    xDelta_->setValue(0.0);
+    yDelta_->setValue(0.0);
+    zDelta_->setValue(0.0);
+    value_->setValue(0.0);
 }
 
 /*

--- a/src/procedure/nodes/operateexpression.h
+++ b/src/procedure/nodes/operateexpression.h
@@ -19,9 +19,7 @@ class OperateExpressionProcedureNode : public OperateProcedureNodeBase
     private:
     // Expression
     Expression expression_;
-    // Vector of variables accessible by the transform equation
-    std::vector<std::shared_ptr<ExpressionVariable>> variables_;
-    // Variables accessible by the transform equation
+    // Local variables for the transform equation
     std::shared_ptr<ExpressionVariable> x_, y_, z_, xDelta_, yDelta_, zDelta_, value_;
 
     private:

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -14,6 +14,7 @@
 #include "procedure/nodes/collect3d.h"
 #include "procedure/nodes/coordinatesets.h"
 #include "procedure/nodes/copy.h"
+#include "procedure/nodes/customregion.h"
 #include "procedure/nodes/cylindricalregion.h"
 #include "procedure/nodes/generalregion.h"
 #include "procedure/nodes/integrate1d.h"
@@ -80,6 +81,8 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
                                               "General");
 
     // Regions
+    registerProducer<CustomRegionProcedureNode>(ProcedureNode::NodeType::CustomRegion,
+                                                "Generate a custom region based on an expression", "Regions");
     registerProducer<CylindricalRegionProcedureNode>(ProcedureNode::NodeType::CylindricalRegion,
                                                      "Define a cylindrical region in a configuration", "Regions");
     registerProducer<GeneralRegionProcedureNode>(ProcedureNode::NodeType::GeneralRegion,

--- a/src/procedure/nodevalue.cpp
+++ b/src/procedure/nodevalue.cpp
@@ -46,6 +46,12 @@ NodeValue::operator double() { return asDouble(); }
  * Data
  */
 
+// Add local variable to expression
+std::shared_ptr<ExpressionVariable> NodeValue::addLocalVariable(std::string_view name)
+{
+    return expression_.addLocalVariable(name);
+}
+
 // Set integer value
 bool NodeValue::set(int value)
 {

--- a/src/procedure/nodevalue.cpp
+++ b/src/procedure/nodevalue.cpp
@@ -101,7 +101,7 @@ bool NodeValue::isValid() const { return (type_ == ExpressionNodeValue ? express
  */
 
 // Return contained value as integer
-int NodeValue::asInteger()
+int NodeValue::asInteger() const
 {
     if (type_ == IntegerNodeValue)
         return valueI_;
@@ -112,7 +112,7 @@ int NodeValue::asInteger()
 }
 
 // Return contained value as double
-double NodeValue::asDouble()
+double NodeValue::asDouble() const
 {
     if (type_ == IntegerNodeValue)
         return (double)valueI_;

--- a/src/procedure/nodevalue.h
+++ b/src/procedure/nodevalue.h
@@ -58,9 +58,9 @@ class NodeValue
      */
     public:
     // Return contained value as integer
-    int asInteger();
+    int asInteger() const;
     // Return contained value as double
-    double asDouble();
+    double asDouble() const;
     // Return value represented as a string
     std::string asString(bool addQuotesIfRequired = false) const;
 };

--- a/src/procedure/nodevalue.h
+++ b/src/procedure/nodevalue.h
@@ -41,6 +41,8 @@ class NodeValue
     Expression expression_;
 
     public:
+    // Add local variable to expression
+    std::shared_ptr<ExpressionVariable> addLocalVariable(std::string_view name);
     // Set integer value
     bool set(int value);
     // Set double value

--- a/tests/dangle/dangle.txt
+++ b/tests/dangle/dangle.txt
@@ -200,7 +200,7 @@ Module  Analyse  'DAngle(X-H...O)-Analyser'
       SourceData  'ANGLE(ABC)'
       Normalisation
         OperateExpression
-          Expression  "value/sin(x)"
+          Expression  "value/sin(toRad(x))"
         EndOperateExpression
         OperateNormalise
           Value  1.0

--- a/unit/math/expression.cpp
+++ b/unit/math/expression.cpp
@@ -84,9 +84,9 @@ TEST_F(ExpressionTest, BasicFloatMath)
     exprTest("1+24*3.4", 1.0 + 24 * 3.4, false);
     exprTest("(9.231-4*89.4)/76.92+7", (9.231 - 4 * 89.4) / 76.92 + 7, false);
     exprTest("-3^3", DissolveMath::power(-3, 3), false);
-    exprTest("cos(45)", cos(M_PI_4), false);
-    exprTest("exp(cos(45))", exp(cos(M_PI_4)), false);
-    exprTest("sqrt(sin(78.9)*cos(45))", sqrt(sin(78.9 * M_PI / 180.0) * cos(M_PI_4)), false);
+    exprTest("cos(toRad(45))", cos(M_PI_4), false);
+    exprTest("exp(cos(toRad(45)))", exp(cos(M_PI_4)), false);
+    exprTest("sqrt(sin(toRad(78.9))*cos(toRad(45)))", sqrt(sin(78.9 * M_PI / 180.0) * cos(M_PI_4)), false);
     exprTest("atan()", 0, true);
     exprTest("ln(0.0, 1.0)", 0, true);
 }

--- a/unit/procedure/calculateexpression.cpp
+++ b/unit/procedure/calculateexpression.cpp
@@ -27,7 +27,7 @@ TEST(CalculateExpressionTest, Basic)
     // Expressions
     expressionNode->keywords().set("Expression", NodeValue("3.8 * sin(1.2)"));
     expressionNode->execute(ProcedureContext(ProcessPool()));
-    EXPECT_DOUBLE_EQ(expressionNode->value(0), 3.8 * sin(1 / DEGRAD * 1.2));
+    EXPECT_DOUBLE_EQ(expressionNode->value(0), 3.8 * sin(1.2));
 }
 
 TEST(CalculateExpressionTest, NodeParameters)


### PR DESCRIPTION
This PR set out to implement the ability to generate a custom region from a provided mathematical expression. This is indeed the final result, but several other enhancements and modifications were made along the way, namely:

- Build on #1413 and allow `Expression`s to have their own local set of variables as well as access to `Procedure`-wide parameters / variables from other nodes.
- Make all trigonometric functions work in radians rather than auto-convert to/from degrees for consistency with C++ rather than user expectation.
- Add several new functions to the `Expression` lexer - `pi()`, `twopi()`, `toRad(x)`, and `toDeg(x)`.

The new `CustomRegion` node makes use of all of the above.

Closes #1419.
Closes #1063.