### PR TITLE
GHA Ubuntu runner disk space

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -14,6 +14,15 @@ runs:
   using: "composite"
   steps:
 
+  - name: Free Space
+    shell: bash
+    run: |
+      set -ex
+      df -mh .
+      sudo rm -rf /usr/share/dotnet
+      sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      df -mh .
+
   - name: Install nix
     uses: "./.github/workflows/get-nix"
     with:


### PR DESCRIPTION
Bit of a mystery this one. It was noticed that the Linux `dissolve-gui` CI build was failing due to running out of disk space. This PR removes some "GitHub detritus" from the runner before attempting the build, giving it an extra 10 Gb, but that amounts to 39 Gb free space in total, so its hard to rationalise why the build failed. The success of this PR run may be a fluke, of course!

There is a commit disabling everything but the `dissolve-gui` Linux build, and which will be removed before merge if the PR is approved.