### PR TITLE
Node Selection

### DIFF
--- a/src/gui/procedurewidget.h
+++ b/src/gui/procedurewidget.h
@@ -51,7 +51,7 @@ class ProcedureWidget : public QWidget
     void removeControlWidget(ConstNodeRef node);
 
     private slots:
-    void selectedNodeChanged(const QModelIndex &, const QModelIndex &);
+    void selectedNodeChanged(const QModelIndex &);
     void on_ExpandAllButton_clicked(bool checked);
     void on_CollapseAllButton_clicked(bool checked);
     void on_ShowContextButton_clicked(bool checked);

--- a/src/gui/procedurewidget.h
+++ b/src/gui/procedurewidget.h
@@ -6,6 +6,7 @@
 #include "gui/models/nodePaletteModel.h"
 #include "gui/models/procedureModel.h"
 #include "gui/ui_procedurewidget.h"
+#include <qabstractitemmodel.h>
 
 // Forward Declarations
 class DissolveWindow;
@@ -50,7 +51,7 @@ class ProcedureWidget : public QWidget
     void removeControlWidget(ConstNodeRef node);
 
     private slots:
-    void selectedNodeChanged(const QModelIndex &);
+    void selectedNodeChanged(const QModelIndex &, const QModelIndex &);
     void on_ExpandAllButton_clicked(bool checked);
     void on_CollapseAllButton_clicked(bool checked);
     void on_ShowContextButton_clicked(bool checked);

--- a/src/gui/procedurewidget.h
+++ b/src/gui/procedurewidget.h
@@ -6,7 +6,6 @@
 #include "gui/models/nodePaletteModel.h"
 #include "gui/models/procedureModel.h"
 #include "gui/ui_procedurewidget.h"
-#include <qabstractitemmodel.h>
 
 // Forward Declarations
 class DissolveWindow;

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -7,7 +7,6 @@
 #include "gui/procedurewidget.h"
 #include "main/dissolve.h"
 #include <QMessageBox>
-#include <qfiledialog.h>
 
 ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
 {

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -15,10 +15,7 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
 
     // Set up the procedure model
     ui_.NodesTree->setModel(&procedureModel_);
-    //connect(ui_.NodesTree, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
-    connect(ui_.NodesTree->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this, SLOT(selectedNodeChanged(const QModelIndex &, const QModelIndex&))); 
-
-    //connect(ui_.NodesTree, SIGNAL(currentChanged(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
+    connect(ui_.NodesTree->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this, SLOT(selectedNodeChanged(const QModelIndex &))); 
     connect(&procedureModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
             SLOT(procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
     // Set up the available nodes tree
@@ -77,7 +74,7 @@ void ProcedureWidget::removeControlWidget(ConstNodeRef node)
     }
 }
 
-void ProcedureWidget::selectedNodeChanged(const QModelIndex &index, const QModelIndex& prev)
+void ProcedureWidget::selectedNodeChanged(const QModelIndex &index)
 {
     // Get the selected node
     auto node = procedureModel_.data(index, Qt::UserRole).value<std::shared_ptr<ProcedureNode>>();

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -7,6 +7,7 @@
 #include "gui/procedurewidget.h"
 #include "main/dissolve.h"
 #include <QMessageBox>
+#include <qfiledialog.h>
 
 ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
 {
@@ -14,10 +15,12 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
 
     // Set up the procedure model
     ui_.NodesTree->setModel(&procedureModel_);
-    connect(ui_.NodesTree, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
+    //connect(ui_.NodesTree, SIGNAL(clicked(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
+    connect(ui_.NodesTree->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this, SLOT(selectedNodeChanged(const QModelIndex &, const QModelIndex&))); 
+
+    //connect(ui_.NodesTree, SIGNAL(currentChanged(const QModelIndex &)), this, SLOT(selectedNodeChanged(const QModelIndex &)));
     connect(&procedureModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
             SLOT(procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
-
     // Set up the available nodes tree
     ui_.AvailableNodesTree->setModel(&nodePaletteModel_);
     ui_.AvailableNodesTree->expandAll();
@@ -74,7 +77,7 @@ void ProcedureWidget::removeControlWidget(ConstNodeRef node)
     }
 }
 
-void ProcedureWidget::selectedNodeChanged(const QModelIndex &index)
+void ProcedureWidget::selectedNodeChanged(const QModelIndex &index, const QModelIndex& prev)
 {
     // Get the selected node
     auto node = procedureModel_.data(index, Qt::UserRole).value<std::shared_ptr<ProcedureNode>>();

--- a/src/gui/procedurewidget_funcs.cpp
+++ b/src/gui/procedurewidget_funcs.cpp
@@ -15,7 +15,8 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
 
     // Set up the procedure model
     ui_.NodesTree->setModel(&procedureModel_);
-    connect(ui_.NodesTree->selectionModel(), SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this, SLOT(selectedNodeChanged(const QModelIndex &))); 
+    connect(ui_.NodesTree->selectionModel(), SIGNAL(currentChanged(const QModelIndex &, const QModelIndex &)), this,
+            SLOT(selectedNodeChanged(const QModelIndex &)));
     connect(&procedureModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
             SLOT(procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
     // Set up the available nodes tree


### PR DESCRIPTION
This minute PR ensures that relevant node options are displayed invariant to how the node was selected (either by clicking, or by using cursor keys).

Closes #1360.