### PR TITLE
1451 Cache Updating

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -33,7 +33,7 @@ runs:
     id: nix-cache
     with:
       path: /tmp/nixcache
-      key: ${{ runner.os }}-nix-cache
+      key: ${{ runner.os }}-${{ env.nixHash }}-nix-cache
 
   - name: Import Nix Store Cache
     if: "steps.nix-cache.outputs.cache-hit == 'true'"

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -65,7 +65,7 @@ runs:
     id: cache-conan
     uses: actions/cache@v3
     with:
-      key: osx-conan
+      key: osx-conan-${{ env.conanHash }}
       path: |
         ~/.conan
         ~/.conancache

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -131,7 +131,7 @@ runs:
     id: cache-conan
     uses: actions/cache@v3
     with:
-      key: windows-conan
+      key: windows-conan-${{ env.conanHash }}
       path: |
         ~\.conan
         ~\.conancache

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -2,6 +2,12 @@ name: Generate Caches
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+    - 'develop'
+    paths:
+    - 'flake.lock'
+    - 'flake.nix'
 
 jobs:
 

--- a/.github/workflows/cacheConan.yml
+++ b/.github/workflows/cacheConan.yml
@@ -1,4 +1,4 @@
-name: Generate Caches
+name: Generate Conan Caches
 
 on:
   workflow_dispatch:
@@ -6,16 +6,15 @@ on:
     branches:
     - 'develop'
     paths:
-    - 'flake.lock'
-    - 'flake.nix'
+    - 'conanfile.txt'
 
 jobs:
 
-  Cache:
+  CacheConan:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
         target: [dissolve-gui]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cacheNix.yml
+++ b/.github/workflows/cacheNix.yml
@@ -1,0 +1,26 @@
+name: Generate Nix Caches
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - 'develop'
+    paths:
+    - 'flake.lock'
+    - 'flake.nix'
+
+jobs:
+
+  CacheNix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup
+        uses: "./.github/workflows/setup"
+      - name: "Build (Cache Only) (ubuntu-latest)"
+        uses: "./.github/workflows/build"
+        with:
+          target: dissolve-gui
+          cacheOnly: true
+

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup
+      uses: "./.github/workflows/setup"
     - name: Quality Control
       uses: "./.github/workflows/qc"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup
+      uses: "./.github/workflows/setup"
     - name: Quality Control
       uses: "./.github/workflows/qc"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup
+      uses: "./.github/workflows/setup"
     - name: Quality Control
       uses: "./.github/workflows/qc"
 

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -42,3 +42,11 @@ runs:
         echo "dissolveMajorVersion=${DISSOLVE_MAJOR}" >> ${GITHUB_ENV}
         echo "dissolveMinorVersion=${DISSOLVE_MINOR}" >> ${GITHUB_ENV}
         echo "dissolvePatchVersion=${DISSOLVE_PATCH}" >> ${GITHUB_ENV}
+
+    - name: Get nix hash
+      shell: bash
+      run: |
+        set -ex
+        NIX_HASH=`cat flake.lock flake.nix | sha256sum | sed "s/\(.*\)  -/\1/g"`
+        echo "Hash of nix files (flake.lock and flake.nix) is ${NIX_HASH}"
+        echo "nixHash=${NIX_HASH}" >> ${GITHUB_ENV}

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -52,7 +52,7 @@ runs:
       shell: bash
       run: |
         set -ex
-        NIX_HASH=`cat flake.lock flake.nix | sha256sum | sed "s/\(.*\)  -/\1/g"`
+        NIX_HASH=`sha256sum flake.lock | sed "s/\(.*\)  -/\1/g"`
         echo "Hash of nix files (flake.lock and flake.nix) is ${NIX_HASH}"
         echo "nixHash=${NIX_HASH}" >> ${GITHUB_ENV}
 

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Install sha256sum (OSX)
       if: ${{ runner.os == 'macos' }}
       shell: bash
-      run: sudo brew install coreutils
+      run: brew install coreutils
 
     - name: Get nix hash
       shell: bash

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -50,3 +50,11 @@ runs:
         NIX_HASH=`cat flake.lock flake.nix | sha256sum | sed "s/\(.*\)  -/\1/g"`
         echo "Hash of nix files (flake.lock and flake.nix) is ${NIX_HASH}"
         echo "nixHash=${NIX_HASH}" >> ${GITHUB_ENV}
+
+    - name: Get conan hash
+      shell: bash
+      run: |
+        set -ex
+        CONAN_HASH=`sha256sum conanfile.txt | sed "s/\(.*\)  -/\1/g"`
+        echo "Hash of conanfile.txt is ${CONAN_HASH}"
+        echo "conanHash=${CONAN_HASH}" >> ${GITHUB_ENV}

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -43,6 +43,11 @@ runs:
         echo "dissolveMinorVersion=${DISSOLVE_MINOR}" >> ${GITHUB_ENV}
         echo "dissolvePatchVersion=${DISSOLVE_PATCH}" >> ${GITHUB_ENV}
 
+    - name: Install sha256sum (OSX)
+      if: runner.os == "macos"
+      shell: bash
+      run: sudo brew install coreutils
+
     - name: Get nix hash
       shell: bash
       run: |

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -44,7 +44,7 @@ runs:
         echo "dissolvePatchVersion=${DISSOLVE_PATCH}" >> ${GITHUB_ENV}
 
     - name: Install sha256sum (OSX)
-      if: runner.os == "macos"
+      if: ${{ runner.os == 'macos' }}
       shell: bash
       run: sudo brew install coreutils
 


### PR DESCRIPTION
This PR adds the hash of key file(s) to the cache artifacts with the intention of autogenerating new caches when these files change (and our cache becomes, presumably, out-of-date).

The cache workflow has been split into two to give the necessary separation between Linux cache contents (Nix) and Windows/OSX cache contents (Conan). The `cacheNix.yml` action runs on every commit to `develop` which modifies either `flake.lock` or `flake.nix`, and the `cacheConan.yml` action runs on every commit to `develop` which modifies `conanfile.txt`.

