### PR TITLE
Node Contexts Tidy

### DIFF
--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -3,11 +3,10 @@
 
 #pragma once
 
-#include "procedure/nodes/node.h"
+#include "procedure/procedure.h"
 #include "templates/optionalref.h"
 #include <QAbstractItemModel>
 #include <QModelIndex>
-
 #include <vector>
 
 class ProcedureModel : public QAbstractItemModel

--- a/src/keywords/nodebranch.cpp
+++ b/src/keywords/nodebranch.cpp
@@ -6,11 +6,7 @@
 #include "procedure/nodes/node.h"
 #include "procedure/nodes/sequence.h"
 
-NodeBranchKeyword::NodeBranchKeyword(ProcedureNodeSequence &data, ProcedureNode *parentNode,
-                                     ProcedureNode::NodeContext branchContext)
-    : KeywordBase(typeid(this)), data_(data), parentNode_(parentNode), branchContext_(branchContext)
-{
-}
+NodeBranchKeyword::NodeBranchKeyword(ProcedureNodeSequence &data) : KeywordBase(typeid(this)), data_(data) {}
 
 /*
  * Arguments

--- a/src/keywords/nodebranch.h
+++ b/src/keywords/nodebranch.h
@@ -14,7 +14,7 @@ class NodeValue;
 class NodeBranchKeyword : public KeywordBase
 {
     public:
-    NodeBranchKeyword(ProcedureNodeSequence &data, ProcedureNode *parentNode, ProcedureNode::NodeContext branchContext);
+    NodeBranchKeyword(ProcedureNodeSequence &data);
     ~NodeBranchKeyword() override = default;
 
     /*
@@ -23,10 +23,6 @@ class NodeBranchKeyword : public KeywordBase
     private:
     // Reference to data
     ProcedureNodeSequence &data_;
-    // Parent ProcedureNode
-    NodeRef parentNode_;
-    // Context for the target branch
-    ProcedureNode::NodeContext branchContext_;
 
     /*
      * Arguments

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -17,15 +17,16 @@
 
 AddProcedureNode::AddProcedureNode(const Species *sp, const NodeValue &population, const NodeValue &density,
                                    Units::DensityUnits densityUnits)
-    : ProcedureNode(ProcedureNode::NodeType::Add), density_{density, densityUnits}, population_(population), species_(sp)
+    : ProcedureNode(ProcedureNode::NodeType::Add, {ProcedureNode::GenerationContext}), density_{density, densityUnits},
+      population_(population), species_(sp)
 {
     setUpKeywords();
 }
 
 AddProcedureNode::AddProcedureNode(std::shared_ptr<const CoordinateSetsProcedureNode> sets, const NodeValue &population,
                                    const NodeValue &density, Units::DensityUnits densityUnits)
-    : ProcedureNode(ProcedureNode::NodeType::Add), coordinateSets_(std::move(sets)), density_{density, densityUnits},
-      population_(population)
+    : ProcedureNode(ProcedureNode::NodeType::Add, {ProcedureNode::GenerationContext}),
+      coordinateSets_(std::move(sets)), density_{density, densityUnits}, population_(population)
 {
     setUpKeywords();
 }
@@ -59,12 +60,6 @@ void AddProcedureNode::setUpKeywords()
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool AddProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool AddProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/add.h
+++ b/src/procedure/nodes/add.h
@@ -30,8 +30,6 @@ class AddProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/addpair.cpp
+++ b/src/procedure/nodes/addpair.cpp
@@ -16,8 +16,8 @@
 
 AddPairProcedureNode::AddPairProcedureNode(const Species *spA, const Species *spB, const NodeValue &population,
                                            const NodeValue &density, Units::DensityUnits densityUnits)
-    : ProcedureNode(ProcedureNode::NodeType::AddPair), density_{density, densityUnits}, population_(population), speciesA_(spA),
-      speciesB_(spB)
+    : ProcedureNode(ProcedureNode::NodeType::AddPair, {ProcedureNode::GenerationContext}), density_{density, densityUnits},
+      population_(population), speciesA_(spA), speciesB_(spB)
 {
     setUpKeywords();
 }
@@ -50,12 +50,6 @@ void AddPairProcedureNode::setUpKeywords()
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool AddPairProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool AddPairProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/addpair.h
+++ b/src/procedure/nodes/addpair.h
@@ -28,8 +28,6 @@ class AddPairProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/box.cpp
+++ b/src/procedure/nodes/box.cpp
@@ -10,8 +10,8 @@
 #include "keywords/vec3nodevalue.h"
 
 BoxProcedureNode::BoxProcedureNode(Vec3<NodeValue> lengths, Vec3<NodeValue> angles, bool nonPeriodic)
-    : ProcedureNode(ProcedureNode::NodeType::Box), angles_(std::move(angles)), lengths_(std::move(lengths)),
-      nonPeriodic_(nonPeriodic)
+    : ProcedureNode(ProcedureNode::NodeType::Box, {ProcedureNode::GenerationContext}), angles_(std::move(angles)),
+      lengths_(std::move(lengths)), nonPeriodic_(nonPeriodic)
 {
     keywords_.setOrganisation("Options", "Definition");
     keywords_.add<Vec3NodeValueKeyword>("Lengths", "Box lengths", lengths_, this, Vec3Labels::ABCLabels);
@@ -22,12 +22,6 @@ BoxProcedureNode::BoxProcedureNode(Vec3<NodeValue> lengths, Vec3<NodeValue> angl
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool BoxProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool BoxProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/box.h
+++ b/src/procedure/nodes/box.h
@@ -18,8 +18,6 @@ class BoxProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/calculatebase.cpp
+++ b/src/procedure/nodes/calculatebase.cpp
@@ -11,18 +11,9 @@ CalculateProcedureNodeBase::CalculateProcedureNodeBase(ProcedureNode::NodeType n
                                                        std::shared_ptr<SelectProcedureNode> site1,
                                                        std::shared_ptr<SelectProcedureNode> site2,
                                                        std::shared_ptr<SelectProcedureNode> site3)
-    : ProcedureNode(nodeType, ProcedureNode::NodeClass::Calculate), sites_{site0, site1, site2, site3}, value_{0.0, 0.0, 0.0}
+    : ProcedureNode(nodeType, {ProcedureNode::AnalysisContext}, ProcedureNode::NodeClass::Calculate),
+      sites_{site0, site1, site2, site3}, value_{0.0, 0.0, 0.0}
 {
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool CalculateProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/calculatebase.h
+++ b/src/procedure/nodes/calculatebase.h
@@ -21,13 +21,6 @@ class CalculateProcedureNodeBase : public ProcedureNode
     ~CalculateProcedureNodeBase() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Observable Target
      */
     protected:

--- a/src/procedure/nodes/collect1d.cpp
+++ b/src/procedure/nodes/collect1d.cpp
@@ -25,7 +25,7 @@ Collect1DProcedureNode::Collect1DProcedureNode(std::shared_ptr<CalculateProcedur
                                      Vec3<double>(0.0, 0.0, 1.0e-5), std::nullopt, Vec3Labels::MinMaxBinwidthlabels);
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantity was binned successfully",
-                                           subCollectBranch_, this, ProcedureNode::AnalysisContext);
+                                           subCollectBranch_);
 }
 
 /*

--- a/src/procedure/nodes/collect1d.cpp
+++ b/src/procedure/nodes/collect1d.cpp
@@ -15,8 +15,8 @@
 Collect1DProcedureNode::Collect1DProcedureNode(std::shared_ptr<CalculateProcedureNodeBase> observable,
                                                ProcedureNode::NodeContext subCollectContext, double rMin, double rMax,
                                                double binWidth)
-    : ProcedureNode(ProcedureNode::NodeType::Collect1D), xObservable_{observable, 0}, rangeX_{rMin, rMax, binWidth},
-      subCollectBranch_(subCollectContext, *this, "SubCollect")
+    : ProcedureNode(ProcedureNode::NodeType::Collect1D, {ProcedureNode::AnalysisContext}),
+      xObservable_{observable, 0}, rangeX_{rMin, rMax, binWidth}, subCollectBranch_(subCollectContext, *this, "SubCollect")
 {
     keywords_.setOrganisation("Options", "Quantity / Range");
     keywords_.add<NodeAndIntegerKeyword<CalculateProcedureNodeBase>>(
@@ -26,16 +26,6 @@ Collect1DProcedureNode::Collect1DProcedureNode(std::shared_ptr<CalculateProcedur
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantity was binned successfully",
                                            subCollectBranch_);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Collect1DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/collect1d.h
+++ b/src/procedure/nodes/collect1d.h
@@ -21,13 +21,6 @@ class Collect1DProcedureNode : public ProcedureNode
     ~Collect1DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/collect2d.cpp
+++ b/src/procedure/nodes/collect2d.cpp
@@ -14,7 +14,7 @@ Collect2DProcedureNode::Collect2DProcedureNode(std::shared_ptr<CalculateProcedur
                                                std::shared_ptr<CalculateProcedureNodeBase> yObservable,
                                                ProcedureNode::NodeContext subCollectContext, double xMin, double xMax,
                                                double xBinWidth, double yMin, double yMax, double yBinWidth)
-    : ProcedureNode(ProcedureNode::NodeType::Collect2D), xObservable_{xObservable, 0},
+    : ProcedureNode(ProcedureNode::NodeType::Collect2D, {ProcedureNode::AnalysisContext}), xObservable_{xObservable, 0},
       yObservable_{yObservable, 0}, rangeX_{xMin, xMax, xBinWidth}, rangeY_{yMin, yMax, yBinWidth},
       subCollectBranch_(subCollectContext, *this, "SubCollect")
 {
@@ -32,16 +32,6 @@ Collect2DProcedureNode::Collect2DProcedureNode(std::shared_ptr<CalculateProcedur
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantities were binned successfully",
                                            subCollectBranch_);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Collect2DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/collect2d.cpp
+++ b/src/procedure/nodes/collect2d.cpp
@@ -31,7 +31,7 @@ Collect2DProcedureNode::Collect2DProcedureNode(std::shared_ptr<CalculateProcedur
                                      Vec3<double>(0.0, 0.0, 1.0e-5), std::nullopt, Vec3Labels::MinMaxBinwidthlabels);
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantities were binned successfully",
-                                           subCollectBranch_, this, ProcedureNode::AnalysisContext);
+                                           subCollectBranch_);
 }
 
 /*

--- a/src/procedure/nodes/collect2d.h
+++ b/src/procedure/nodes/collect2d.h
@@ -23,13 +23,6 @@ class Collect2DProcedureNode : public ProcedureNode
     ~Collect2DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/collect3d.cpp
+++ b/src/procedure/nodes/collect3d.cpp
@@ -18,10 +18,9 @@ Collect3DProcedureNode::Collect3DProcedureNode(std::shared_ptr<CalculateProcedur
                                                ProcedureNode::NodeContext subCollectContext, double xMin, double xMax,
                                                double xBinWidth, double yMin, double yMax, double yBinWidth, double zMin,
                                                double zMax, double zBinWidth)
-    : ProcedureNode(ProcedureNode::NodeType::Collect3D), xObservable_{xObservable, 0}, yObservable_{yObservable, 0},
-      zObservable_{zObservable, 0}, rangeX_{xMin, xMax, xBinWidth}, rangeY_{yMin, yMax, yBinWidth}, rangeZ_{zMin, zMax,
-                                                                                                            zBinWidth},
-      subCollectBranch_(subCollectContext, *this, "SubCollect")
+    : ProcedureNode(ProcedureNode::NodeType::Collect3D, {ProcedureNode::AnalysisContext}), xObservable_{xObservable, 0},
+      yObservable_{yObservable, 0}, zObservable_{zObservable, 0}, rangeX_{xMin, xMax, xBinWidth},
+      rangeY_{yMin, yMax, yBinWidth}, rangeZ_{zMin, zMax, zBinWidth}, subCollectBranch_(subCollectContext, *this, "SubCollect")
 {
     keywords_.setOrganisation("Options", "Quantities / Ranges");
     keywords_.add<NodeAndIntegerKeyword<CalculateProcedureNodeBase>>("QuantityX", "Calculated observable to collect for x axis",
@@ -47,10 +46,9 @@ Collect3DProcedureNode::Collect3DProcedureNode(std::shared_ptr<CalculateProcedur
                                                ProcedureNode::NodeContext subCollectContext, double xMin, double xMax,
                                                double xBinWidth, double yMin, double yMax, double yBinWidth, double zMin,
                                                double zMax, double zBinWidth)
-    : ProcedureNode(ProcedureNode::NodeType::Collect3D), xObservable_{xyzObservable, 0}, yObservable_{xyzObservable, 1},
-      zObservable_{xyzObservable, 2}, rangeX_{xMin, xMax, xBinWidth}, rangeY_{yMin, yMax, yBinWidth}, rangeZ_{zMin, zMax,
-                                                                                                              zBinWidth},
-      subCollectBranch_(subCollectContext, *this, "SubCollect")
+    : ProcedureNode(ProcedureNode::NodeType::Collect3D, {ProcedureNode::AnalysisContext}), xObservable_{xyzObservable, 0},
+      yObservable_{xyzObservable, 1}, zObservable_{xyzObservable, 2}, rangeX_{xMin, xMax, xBinWidth},
+      rangeY_{yMin, yMax, yBinWidth}, rangeZ_{zMin, zMax, zBinWidth}, subCollectBranch_(subCollectContext, *this, "SubCollect")
 {
     keywords_.setOrganisation("Options", "Quantities / Ranges");
     keywords_.add<NodeAndIntegerKeyword<CalculateProcedureNodeBase>>("QuantityX", "Calculated observable to collect for x axis",
@@ -71,16 +69,6 @@ Collect3DProcedureNode::Collect3DProcedureNode(std::shared_ptr<CalculateProcedur
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantities were binned successfully",
                                            subCollectBranch_);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Collect3DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/collect3d.cpp
+++ b/src/procedure/nodes/collect3d.cpp
@@ -41,7 +41,7 @@ Collect3DProcedureNode::Collect3DProcedureNode(std::shared_ptr<CalculateProcedur
                                      Vec3<double>(-1.0e6, -1.0e6, 1.0e-5), std::nullopt, Vec3Labels::MinMaxBinwidthlabels);
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantities were binned successfully",
-                                           subCollectBranch_, this, ProcedureNode::AnalysisContext);
+                                           subCollectBranch_);
 }
 Collect3DProcedureNode::Collect3DProcedureNode(std::shared_ptr<CalculateProcedureNodeBase> xyzObservable,
                                                ProcedureNode::NodeContext subCollectContext, double xMin, double xMax,
@@ -70,7 +70,7 @@ Collect3DProcedureNode::Collect3DProcedureNode(std::shared_ptr<CalculateProcedur
                                      Vec3<double>(-1.0e6, -1.0e6, 1.0e-5), std::nullopt, Vec3Labels::MinMaxBinwidthlabels);
 
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantities were binned successfully",
-                                           subCollectBranch_, this, ProcedureNode::AnalysisContext);
+                                           subCollectBranch_);
 }
 
 /*

--- a/src/procedure/nodes/collect3d.h
+++ b/src/procedure/nodes/collect3d.h
@@ -30,13 +30,6 @@ class Collect3DProcedureNode : public ProcedureNode
     ~Collect3DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/coordinatesets.cpp
+++ b/src/procedure/nodes/coordinatesets.cpp
@@ -15,7 +15,7 @@
 #include "modules/md/md.h"
 
 CoordinateSetsProcedureNode::CoordinateSetsProcedureNode(const Species *sp)
-    : ProcedureNode(ProcedureNode::NodeType::CoordinateSets), species_(sp)
+    : ProcedureNode(ProcedureNode::NodeType::CoordinateSets, {ProcedureNode::GenerationContext}), species_(sp)
 {
     keywords_.setOrganisation("Options", "Target");
     keywords_.add<SpeciesKeyword>("Species", "Target species", species_);
@@ -35,12 +35,6 @@ CoordinateSetsProcedureNode::CoordinateSetsProcedureNode(const Species *sp)
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool CoordinateSetsProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool CoordinateSetsProcedureNode::mustBeNamed() const { return true; }

--- a/src/procedure/nodes/coordinatesets.h
+++ b/src/procedure/nodes/coordinatesets.h
@@ -22,8 +22,6 @@ class CoordinateSetsProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/copy.cpp
+++ b/src/procedure/nodes/copy.cpp
@@ -9,7 +9,8 @@
 #include "keywords/speciesvector.h"
 #include <algorithm>
 
-CopyProcedureNode::CopyProcedureNode(Configuration *cfg) : ProcedureNode(ProcedureNode::NodeType::Copy), source_(cfg)
+CopyProcedureNode::CopyProcedureNode(Configuration *cfg)
+    : ProcedureNode(ProcedureNode::NodeType::Copy, {ProcedureNode::GenerationContext}), source_(cfg)
 {
     keywords_.setOrganisation("Options", "Configuration");
     keywords_.add<ConfigurationKeyword>("Source", "Source configuration to copy", source_);
@@ -19,12 +20,6 @@ CopyProcedureNode::CopyProcedureNode(Configuration *cfg) : ProcedureNode(Procedu
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool CopyProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool CopyProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/copy.h
+++ b/src/procedure/nodes/copy.h
@@ -24,8 +24,6 @@ class CopyProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/integrate1d.cpp
+++ b/src/procedure/nodes/integrate1d.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/process1d.h"
 
 Integrate1DProcedureNode::Integrate1DProcedureNode(std::shared_ptr<Process1DProcedureNode> target)
-    : ProcedureNode(ProcedureNode::NodeType::Integrate1D), sourceData_(target)
+    : ProcedureNode(ProcedureNode::NodeType::Integrate1D, {ProcedureNode::AnalysisContext}), sourceData_(target)
 {
     keywords_.setOrganisation("Options", "Target");
     keywords_.add<NodeKeyword<Process1DProcedureNode>>("SourceData", "Process1D node containing the data to integrate",
@@ -22,16 +22,6 @@ Integrate1DProcedureNode::Integrate1DProcedureNode(std::shared_ptr<Process1DProc
     keywords_.add<RangeKeyword>("RangeA", "X range for first integration region", range_[0], Vec3Labels::MinMaxDeltaLabels);
     keywords_.add<RangeKeyword>("RangeB", "X range for second integration region", range_[1], Vec3Labels::MinMaxDeltaLabels);
     keywords_.add<RangeKeyword>("RangeC", "X range for third integration region", range_[2], Vec3Labels::MinMaxDeltaLabels);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Integrate1DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/integrate1d.h
+++ b/src/procedure/nodes/integrate1d.h
@@ -19,13 +19,6 @@ class Integrate1DProcedureNode : public ProcedureNode
     ~Integrate1DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -80,7 +80,7 @@ EnumOptions<ProcedureNode::NodeContext> ProcedureNode::nodeContexts()
 
 ProcedureNode::ProcedureNode(ProcedureNode::NodeType nodeType, std::vector<NodeContext> relevantContexts,
                              ProcedureNode::NodeClass classType)
-    : class_(classType), type_(nodeType), relevantContexts_(std::move(relevantContexts))
+    : type_(nodeType), relevantContexts_(std::move(relevantContexts)), class_(classType)
 {
 }
 

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -9,7 +9,6 @@
 #include "classes/site.h"
 #include "expression/variable.h"
 #include "procedure/nodes/sequence.h"
-#include "procedure/procedure.h"
 #include <algorithm>
 #include <memory>
 #include <utility>

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -91,9 +91,6 @@ ProcedureNode::ProcedureNode(ProcedureNode::NodeType nodeType, std::vector<NodeC
 // Return node type
 ProcedureNode::NodeType ProcedureNode::type() const { return type_; }
 
-// Return whether the node is of the specified class
-ProcedureNode::NodeClass ProcedureNode::nodeClass() const { return class_; }
-
 // Return whether the supplied context is relevant for the current node
 bool ProcedureNode::isContextRelevant(NodeContext targetContext) const
 {
@@ -117,6 +114,9 @@ bool ProcedureNode::isContextRelevant(NodeContext targetContext) const
     else
         return std::find(relevantContexts_.begin(), relevantContexts_.end(), targetContext) != relevantContexts_.end();
 }
+
+// Return whether the node is of the specified class
+ProcedureNode::NodeClass ProcedureNode::nodeClass() const { return class_; }
 
 // Return whether a name for the node must be provided
 bool ProcedureNode::mustBeNamed() const { return true; }

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -15,7 +15,6 @@ class CoreData;
 class ExpressionVariable;
 class GenericList;
 class LineParser;
-class Procedure;
 class ProcedureNodeSequence;
 class ProcessPool;
 class Site;

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -98,22 +98,22 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
      * Identity
      */
     protected:
-    // Node class
-    NodeClass class_;
     // Node type
     NodeType type_;
-    // Node name
-    std::string name_;
     // Relevant contexts for node
     std::vector<NodeContext> relevantContexts_;
+    // Node class
+    NodeClass class_;
+    // Node name
+    std::string name_;
 
     public:
-    // Return node class
-    NodeClass nodeClass() const;
     // Return node type
     NodeType type() const;
     // Return whether the supplied context is relevant for the current node
     bool isContextRelevant(NodeContext targetContext) const;
+    // Return node class
+    NodeClass nodeClass() const;
     // Return whether a name for the node must be provided
     virtual bool mustBeNamed() const;
     // Set node name

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -85,11 +85,13 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
         NoContext = 0,
         AnalysisContext = 1,
         GenerationContext = 2,
-        OperateContext = 4
+        OperateContext = 4,
+        AnyContext = 8,
+        ParentProcedureContext = 16
     };
     // Return enum option info for NodeContext
     static EnumOptions<NodeContext> nodeContexts();
-    ProcedureNode(NodeType nodeType, NodeClass nodeClass = NodeClass::None);
+    ProcedureNode(NodeType nodeType, std::vector<NodeContext> relevantContexts, NodeClass nodeClass = NodeClass::None);
     virtual ~ProcedureNode() = default;
 
     /*
@@ -102,14 +104,16 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
     NodeType type_;
     // Node name
     std::string name_;
+    // Relevant contexts for node
+    std::vector<NodeContext> relevantContexts_;
 
     public:
     // Return node class
     NodeClass nodeClass() const;
     // Return node type
     NodeType type() const;
-    // Return whether specified context is relevant for this node type
-    virtual bool isContextRelevant(NodeContext context);
+    // Return whether the supplied context is relevant for the current node
+    bool isContextRelevant(NodeContext targetContext) const;
     // Return whether a name for the node must be provided
     virtual bool mustBeNamed() const;
     // Set node name

--- a/src/procedure/nodes/nodereference.h
+++ b/src/procedure/nodes/nodereference.h
@@ -6,8 +6,9 @@
 #include "procedure/nodes/node.h"
 
 // Forward Declarations
-class CoreData;
 class AnalyseModule;
+class CoreData;
+class Procedure;
 
 // Procedure Node Reference
 class ProcedureNodeReference

--- a/src/procedure/nodes/operatebase.cpp
+++ b/src/procedure/nodes/operatebase.cpp
@@ -6,7 +6,7 @@
 #include "base/sysfunc.h"
 
 OperateProcedureNodeBase::OperateProcedureNodeBase(ProcedureNode::NodeType nodeType)
-    : ProcedureNode(nodeType, ProcedureNode::NodeClass::Operate)
+    : ProcedureNode(nodeType, {ProcedureNode::OperateContext}, ProcedureNode::NodeClass::Operate)
 {
     targetData1D_ = nullptr;
     targetData2D_ = nullptr;
@@ -16,12 +16,6 @@ OperateProcedureNodeBase::OperateProcedureNodeBase(ProcedureNode::NodeType nodeT
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool OperateProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::OperateContext);
-}
 
 // Return whether a name for the node must be provided
 bool OperateProcedureNodeBase::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/operatebase.h
+++ b/src/procedure/nodes/operatebase.h
@@ -22,8 +22,6 @@ class OperateProcedureNodeBase : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/parameters.cpp
+++ b/src/procedure/nodes/parameters.cpp
@@ -5,7 +5,8 @@
 #include "expression/variable.h"
 #include "keywords/expressionvariablevector.h"
 
-ParametersProcedureNode::ParametersProcedureNode() : ProcedureNode(ProcedureNode::NodeType::Parameters)
+ParametersProcedureNode::ParametersProcedureNode()
+    : ProcedureNode(ProcedureNode::NodeType::Parameters, {ProcedureNode::AnyContext})
 {
     keywords_.setOrganisation("Options", "Data");
     keywords_.add<ExpressionVariableVectorKeyword>("Parameter", "Defined parameters", parameters_, this);
@@ -14,12 +15,6 @@ ParametersProcedureNode::ParametersProcedureNode() : ProcedureNode(ProcedureNode
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool ParametersProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context != ProcedureNode::NoContext);
-}
 
 // Return whether a name for the node must be provided
 bool ParametersProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/parameters.h
+++ b/src/procedure/nodes/parameters.h
@@ -20,8 +20,6 @@ class ParametersProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/pickbase.cpp
+++ b/src/procedure/nodes/pickbase.cpp
@@ -6,21 +6,11 @@
 #include "keywords/node.h"
 
 PickProcedureNodeBase::PickProcedureNodeBase(ProcedureNode::NodeType nodeType)
-    : ProcedureNode(nodeType, ProcedureNode::NodeClass::Pick), selection_(nullptr)
+    : ProcedureNode(nodeType, {ProcedureNode::GenerationContext}, ProcedureNode::NodeClass::Pick), selection_(nullptr)
 {
     keywords_.setOrganisation("Options", "Restrictions");
     keywords_.add<NodeKeyword<PickProcedureNodeBase>>("From", "Existing picked selection of molecules from which to pick",
                                                       selection_, this, ProcedureNode::NodeClass::Pick, true);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool PickProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return context == ProcedureNode::GenerationContext;
 }
 
 /*

--- a/src/procedure/nodes/pickbase.h
+++ b/src/procedure/nodes/pickbase.h
@@ -18,13 +18,6 @@ class PickProcedureNodeBase : public ProcedureNode
     ~PickProcedureNodeBase() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Picked Molecules
      */
     protected:

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -15,7 +15,7 @@
 
 Process1DProcedureNode::Process1DProcedureNode(std::shared_ptr<Collect1DProcedureNode> target,
                                                ProcedureNode::NodeContext normalisationContext)
-    : ProcedureNode(ProcedureNode::NodeType::Process1D), sourceData_(target),
+    : ProcedureNode(ProcedureNode::NodeType::Process1D, {ProcedureNode::AnalysisContext}), sourceData_(target),
       normalisationBranch_(normalisationContext, *this, "Normalisation")
 {
     keywords_.setOrganisation("Options", "Source");
@@ -38,16 +38,6 @@ Process1DProcedureNode::Process1DProcedureNode(std::shared_ptr<Collect1DProcedur
 
     // Initialise data pointer
     processedData_ = nullptr;
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Process1DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/process1d.cpp
+++ b/src/procedure/nodes/process1d.cpp
@@ -34,7 +34,7 @@ Process1DProcedureNode::Process1DProcedureNode(std::shared_ptr<Collect1DProcedur
                                         exportFileAndFormat_, "EndExport");
 
     keywords_.addHidden<NodeBranchKeyword>("Normalisation", "Branch providing normalisation operations for the data",
-                                           normalisationBranch_, this, ProcedureNode::OperateContext);
+                                           normalisationBranch_);
 
     // Initialise data pointer
     processedData_ = nullptr;

--- a/src/procedure/nodes/process1d.h
+++ b/src/procedure/nodes/process1d.h
@@ -21,13 +21,6 @@ class Process1DProcedureNode : public ProcedureNode
     ~Process1DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/process2d.cpp
+++ b/src/procedure/nodes/process2d.cpp
@@ -29,7 +29,7 @@ Process2DProcedureNode::Process2DProcedureNode(std::shared_ptr<Collect2DProcedur
                                         exportFileAndFormat_, "EndExport");
 
     keywords_.addHidden<NodeBranchKeyword>("Normalisation", "Branch providing normalisation operations for the data",
-                                           normalisationBranch_, this, ProcedureNode::OperateContext);
+                                           normalisationBranch_);
 
     // Initialise data pointer
     processedData_ = nullptr;

--- a/src/procedure/nodes/process2d.cpp
+++ b/src/procedure/nodes/process2d.cpp
@@ -13,7 +13,7 @@
 
 Process2DProcedureNode::Process2DProcedureNode(std::shared_ptr<Collect2DProcedureNode> target,
                                                ProcedureNode::NodeContext normalisationContext)
-    : ProcedureNode(ProcedureNode::NodeType::Process2D), sourceData_(target),
+    : ProcedureNode(ProcedureNode::NodeType::Process2D, {ProcedureNode::AnalysisContext}), sourceData_(target),
       normalisationBranch_(normalisationContext, *this, "Normalisation")
 {
     keywords_.setOrganisation("Options", "Control");
@@ -33,16 +33,6 @@ Process2DProcedureNode::Process2DProcedureNode(std::shared_ptr<Collect2DProcedur
 
     // Initialise data pointer
     processedData_ = nullptr;
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Process2DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/process2d.h
+++ b/src/procedure/nodes/process2d.h
@@ -21,13 +21,6 @@ class Process2DProcedureNode : public ProcedureNode
     ~Process2DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -31,7 +31,7 @@ Process3DProcedureNode::Process3DProcedureNode(std::shared_ptr<Collect3DProcedur
                                         exportFileAndFormat_, "EndExport");
 
     keywords_.addHidden<NodeBranchKeyword>("Normalisation", "Branch providing normalisation operations for the data",
-                                           normalisationBranch_, this, ProcedureNode::OperateContext);
+                                           normalisationBranch_);
 
     // Initialise data pointer
     processedData_ = nullptr;

--- a/src/procedure/nodes/process3d.cpp
+++ b/src/procedure/nodes/process3d.cpp
@@ -13,7 +13,7 @@
 
 Process3DProcedureNode::Process3DProcedureNode(std::shared_ptr<Collect3DProcedureNode> target,
                                                ProcedureNode::NodeContext normalisationContext)
-    : ProcedureNode(ProcedureNode::NodeType::Process3D), sourceData_(target),
+    : ProcedureNode(ProcedureNode::NodeType::Process3D, {ProcedureNode::AnalysisContext}), sourceData_(target),
       normalisationBranch_(normalisationContext, *this, "Normalisation")
 {
     keywords_.setOrganisation("Options", "Control");
@@ -35,16 +35,6 @@ Process3DProcedureNode::Process3DProcedureNode(std::shared_ptr<Collect3DProcedur
 
     // Initialise data pointer
     processedData_ = nullptr;
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Process3DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/process3d.h
+++ b/src/procedure/nodes/process3d.h
@@ -22,13 +22,6 @@ class Process3DProcedureNode : public ProcedureNode
     ~Process3DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/regionbase.cpp
+++ b/src/procedure/nodes/regionbase.cpp
@@ -6,7 +6,7 @@
 #include "keywords/double.h"
 
 RegionProcedureNodeBase::RegionProcedureNodeBase(ProcedureNode::NodeType nodeType)
-    : ProcedureNode(nodeType, ProcedureNode::NodeClass::Region)
+    : ProcedureNode(nodeType, {ProcedureNode::GenerationContext}, ProcedureNode::NodeClass::Region)
 {
     keywords_.setOrganisation("Options", "Grid");
     keywords_.add<DoubleKeyword>("VoxelSize", "Voxel size (length) guiding the coarseness / detail of the region", voxelSize_,
@@ -17,12 +17,6 @@ RegionProcedureNodeBase::RegionProcedureNodeBase(ProcedureNode::NodeType nodeTyp
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool RegionProcedureNodeBase::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool RegionProcedureNodeBase::mustBeNamed() const { return true; }

--- a/src/procedure/nodes/regionbase.h
+++ b/src/procedure/nodes/regionbase.h
@@ -24,8 +24,6 @@ class RegionProcedureNodeBase : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/remove.cpp
+++ b/src/procedure/nodes/remove.cpp
@@ -9,7 +9,7 @@
 #include "keywords/speciesvector.h"
 #include "procedure/nodes/pick.h"
 
-RemoveProcedureNode::RemoveProcedureNode() : ProcedureNode(ProcedureNode::NodeType::Remove)
+RemoveProcedureNode::RemoveProcedureNode() : ProcedureNode(ProcedureNode::NodeType::Remove, {ProcedureNode::GenerationContext})
 {
     keywords_.setOrganisation("Options", "Targets");
     keywords_.add<SpeciesVectorKeyword>("Species", "Target species to remove", speciesToRemove_);
@@ -20,12 +20,6 @@ RemoveProcedureNode::RemoveProcedureNode() : ProcedureNode(ProcedureNode::NodeTy
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool RemoveProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool RemoveProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/remove.h
+++ b/src/procedure/nodes/remove.h
@@ -22,8 +22,6 @@ class RemoveProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -17,8 +17,8 @@
 
 SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites, ProcedureNode::NodeContext forEachContext,
                                          bool axesRequired)
-    : ProcedureNode(ProcedureNode::NodeType::Select), speciesSites_(std::move(sites)), axesRequired_(axesRequired),
-      forEachBranch_(forEachContext, *this, "ForEach")
+    : ProcedureNode(ProcedureNode::NodeType::Select, {ProcedureNode::AnalysisContext}), speciesSites_(std::move(sites)),
+      axesRequired_(axesRequired), forEachBranch_(forEachContext, *this, "ForEach")
 {
     inclusiveDistanceRange_.set(0.0, 5.0);
 
@@ -61,12 +61,6 @@ SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites,
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool SelectProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
-}
 
 // Set node name
 void SelectProcedureNode::setName(std::string_view name)

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -47,8 +47,7 @@ SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites,
         "Distance range (from reference site) within which sites are selected (only if ReferenceSite is defined)",
         inclusiveDistanceRange_, Vec3Labels::MinMaxBinwidthlabels);
 
-    keywords_.addHidden<NodeBranchKeyword>("ForEach", "Branch to run on each site selected", forEachBranch_, this,
-                                           ProcedureNode::AnalysisContext);
+    keywords_.addHidden<NodeBranchKeyword>("ForEach", "Branch to run on each site selected", forEachBranch_);
 
     currentSiteIndex_ = -1;
     nCumulativeSites_ = 0;

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -28,8 +28,6 @@ class SelectProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Set node name
     void setName(std::string_view name) override;
 

--- a/src/procedure/nodes/simpleglobalpotential.cpp
+++ b/src/procedure/nodes/simpleglobalpotential.cpp
@@ -7,22 +7,13 @@
 #include "keywords/vec3nodevalue.h"
 
 SimpleGlobalPotentialProcedureNode::SimpleGlobalPotentialProcedureNode()
-    : ProcedureNode(ProcedureNode::NodeType::SimpleGlobalPotential), potential_(SimplePotentialFunctions::Form::Harmonic)
+    : ProcedureNode(ProcedureNode::NodeType::SimpleGlobalPotential, {ProcedureNode::GenerationContext}),
+      potential_(SimplePotentialFunctions::Form::Harmonic)
 {
     keywords_.setOrganisation("Options", "Definition");
     keywords_.add<InteractionPotentialKeyword<SimplePotentialFunctions>>("Potential", "Form of global potential to apply ",
                                                                          potential_);
     keywords_.add<Vec3NodeValueKeyword>("Origin", "Origin of global potential", origin_, this);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool SimpleGlobalPotentialProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
 }
 
 /*

--- a/src/procedure/nodes/simpleglobalpotential.h
+++ b/src/procedure/nodes/simpleglobalpotential.h
@@ -14,13 +14,6 @@ class SimpleGlobalPotentialProcedureNode : public ProcedureNode
     ~SimpleGlobalPotentialProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Potential Function
      */
     private:

--- a/src/procedure/nodes/simplerestraintpotential.cpp
+++ b/src/procedure/nodes/simplerestraintpotential.cpp
@@ -8,7 +8,8 @@
 #include "keywords/speciesvector.h"
 
 SimpleRestraintPotentialProcedureNode::SimpleRestraintPotentialProcedureNode()
-    : ProcedureNode(ProcedureNode::NodeType::SimpleRestraintPotential), potential_(SimplePotentialFunctions::Form::Harmonic)
+    : ProcedureNode(ProcedureNode::NodeType::SimpleRestraintPotential, {ProcedureNode::GenerationContext}),
+      potential_(SimplePotentialFunctions::Form::Harmonic)
 {
     keywords_.setOrganisation("Options", "Definition");
     keywords_.add<InteractionPotentialKeyword<SimplePotentialFunctions>>("Potential", "Potential to apply to individual atoms",
@@ -19,16 +20,6 @@ SimpleRestraintPotentialProcedureNode::SimpleRestraintPotentialProcedureNode()
     keywords_.add<NodeKeyword<PickProcedureNodeBase>>("Selection",
                                                       "Picked selection of molecules to apply atomic restraints to",
                                                       selectionToRestrain_, this, ProcedureNode::NodeClass::Pick, true);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool SimpleRestraintPotentialProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
 }
 
 /*

--- a/src/procedure/nodes/simplerestraintpotential.h
+++ b/src/procedure/nodes/simplerestraintpotential.h
@@ -15,13 +15,6 @@ class SimpleRestraintPotentialProcedureNode : public ProcedureNode
     ~SimpleRestraintPotentialProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/sum1d.cpp
+++ b/src/procedure/nodes/sum1d.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/process1d.h"
 
 Sum1DProcedureNode::Sum1DProcedureNode(std::shared_ptr<Process1DProcedureNode> target)
-    : ProcedureNode(ProcedureNode::NodeType::Sum1D), sourceData_(target)
+    : ProcedureNode(ProcedureNode::NodeType::Sum1D, {ProcedureNode::AnalysisContext}), sourceData_(target)
 {
     keywords_.setOrganisation("Options", "Source");
     keywords_.add<NodeKeyword<Process1DProcedureNode>>("SourceData", "Process1D node containing the data to sum", sourceData_,
@@ -25,16 +25,6 @@ Sum1DProcedureNode::Sum1DProcedureNode(std::shared_ptr<Process1DProcedureNode> t
     keywords_.add<RangeKeyword>("RangeB", "X range for second summation region", range_[1], Vec3Labels::MinMaxDeltaLabels);
     keywords_.add<BoolKeyword>("RangeCEnabled", "Whether the second summation region is enabled", rangeEnabled_[2]);
     keywords_.add<RangeKeyword>("RangeC", "X range for third summation region", range_[2], Vec3Labels::MinMaxDeltaLabels);
-}
-
-/*
- * Identity
- */
-
-// Return whether specified context is relevant for this node type
-bool Sum1DProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::AnalysisContext);
 }
 
 /*

--- a/src/procedure/nodes/sum1d.h
+++ b/src/procedure/nodes/sum1d.h
@@ -19,13 +19,6 @@ class Sum1DProcedureNode : public ProcedureNode
     ~Sum1DProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/transmute.cpp
+++ b/src/procedure/nodes/transmute.cpp
@@ -10,7 +10,8 @@
 #include "keywords/speciesvector.h"
 #include "procedure/nodes/pick.h"
 
-TransmuteProcedureNode::TransmuteProcedureNode() : ProcedureNode(ProcedureNode::NodeType::Transmute)
+TransmuteProcedureNode::TransmuteProcedureNode()
+    : ProcedureNode(ProcedureNode::NodeType::Transmute, {ProcedureNode::GenerationContext})
 {
     keywords_.setOrganisation("Options", "Source");
     keywords_.add<SpeciesVectorKeyword>("Species", "Species types to transmute into the target species", speciesToTransmute_);
@@ -24,12 +25,6 @@ TransmuteProcedureNode::TransmuteProcedureNode() : ProcedureNode(ProcedureNode::
 /*
  * Identity
  */
-
-// Return whether specified context is relevant for this node type
-bool TransmuteProcedureNode::isContextRelevant(ProcedureNode::NodeContext context)
-{
-    return (context == ProcedureNode::GenerationContext);
-}
 
 // Return whether a name for the node must be provided
 bool TransmuteProcedureNode::mustBeNamed() const { return false; }

--- a/src/procedure/nodes/transmute.h
+++ b/src/procedure/nodes/transmute.h
@@ -22,8 +22,6 @@ class TransmuteProcedureNode : public ProcedureNode
      * Identity
      */
     public:
-    // Return whether specified context is relevant for this node type
-    bool isContextRelevant(ProcedureNode::NodeContext context) override;
     // Return whether a name for the node must be provided
     bool mustBeNamed() const override;
 


### PR DESCRIPTION
As part of work towards #1455 this PR tidies up "context handling" of procedure nodes.  Essentially, #1455 requires some new functionality to be introduced to the complement of `ProcedureNode`s in the form of `if`-style nodes, which are essentially usable in any context. Introducing that, and handling the checks in a nice way, warranted a bit of a refactor. 