### PR TITLE
Species Charge Handling Part 2

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -149,6 +149,7 @@ class DissolveWindow : public QMainWindow
     void on_SimulationDataManagerAction_triggered(bool checked);
     void on_SimulationClearAdditionalPotentialsAction_triggered(bool checked);
     void on_SimulationClearModuleDataAction_triggered(bool checked);
+    void on_SimulationReduceChargesSigFigsAction_triggered(bool checked);
     // Species
     void on_SpeciesCreateAtomicAction_triggered(bool checked);
     void on_SpeciesCreateDrawAction_triggered(bool checked);

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -169,6 +169,7 @@ class DissolveWindow : public QMainWindow
     void on_SpeciesCopyChargesFromAtomTypesAction_triggered(bool checked);
     void on_SpeciesSetAtomTypeChargesFromSpeciesAction_triggered(bool checked);
     void on_SpeciesScaleChargesAction_triggered(bool checked);
+    void on_SpeciesSmoothChargesAction_triggered(bool checked);
     void on_SpeciesReduceChargesSigFigsAction_triggered(bool checked);
     // Configuration
     void on_ConfigurationCreateAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -236,6 +236,7 @@
     <addaction name="SpeciesSetAtomTypesInSelectionAction"/>
     <addaction name="SpeciesSetChargesInSelectionAction"/>
     <addaction name="SpeciesScaleChargesAction"/>
+    <addaction name="SpeciesSmoothChargesAction"/>
     <addaction name="SpeciesReduceChargesSigFigsAction"/>
     <addaction name="SpeciesCopyChargesFromAtomTypesAction"/>
     <addaction name="SpeciesSetAtomTypeChargesFromSpeciesAction"/>
@@ -773,6 +774,11 @@
   <action name="SpeciesScaleChargesAction">
    <property name="text">
     <string>Sc&amp;ale Charges...</string>
+   </property>
+  </action>
+  <action name="SpeciesSmoothChargesAction">
+   <property name="text">
+    <string>S&amp;mooth Charges...</string>
    </property>
   </action>
   <action name="SpeciesReduceChargesSigFigsAction">

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -159,6 +159,7 @@
     <addaction name="separator"/>
     <addaction name="SimulationClearAdditionalPotentialsAction"/>
     <addaction name="SimulationClearModuleDataAction"/>
+    <addaction name="SimulationReduceChargesSigFigsAction"/>
    </widget>
    <widget class="QMenu" name="HelpMenu">
     <property name="font">
@@ -784,6 +785,11 @@
   <action name="SpeciesReduceChargesSigFigsAction">
    <property name="text">
     <string>Reduce Sig. Figs in Charges...</string>
+   </property>
+  </action>
+  <action name="SimulationReduceChargesSigFigsAction">
+   <property name="text">
+    <string>Reduce Sig. Figs in Atom Type Charges...</string>
    </property>
   </action>
   <action name="ConfigurationCreateAction">

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -157,9 +157,10 @@
     <addaction name="separator"/>
     <addaction name="SimulationDataManagerAction"/>
     <addaction name="separator"/>
+    <addaction name="SimulationReduceChargesSigFigsAction"/>
+    <addaction name="separator"/>
     <addaction name="SimulationClearAdditionalPotentialsAction"/>
     <addaction name="SimulationClearModuleDataAction"/>
-    <addaction name="SimulationReduceChargesSigFigsAction"/>
    </widget>
    <widget class="QMenu" name="HelpMenu">
     <property name="font">

--- a/src/gui/gui_funcs.cpp
+++ b/src/gui/gui_funcs.cpp
@@ -351,6 +351,7 @@ void DissolveWindow::updateMenus()
     ui_.SpeciesCopyChargesFromAtomTypesAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesSetAtomTypeChargesFromSpeciesAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesScaleChargesAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
+    ui_.SpeciesSmoothChargesAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesReduceChargesSigFigsAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
     ui_.SpeciesRegenerateIntraFromConnectivityAction->setEnabled(activeTab->type() == MainTab::TabType::Species);
 

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -73,3 +73,24 @@ void DissolveWindow::on_SimulationClearAdditionalPotentialsAction_triggered(bool
 }
 
 void DissolveWindow::on_SimulationClearModuleDataAction_triggered(bool checked) { clearModuleData(); }
+
+void DissolveWindow::on_SimulationReduceChargesSigFigsAction_triggered(bool checked)
+{
+    // Get Atom Types
+    auto atomTypes = dissolve().coreData().atomTypes();
+
+    auto ok = false;
+    auto significantFigures =
+        QInputDialog::getInt(this, "Reduce Signficant Figures in Charges",
+                             "Enter the number of significant figures to use for all atom types", 3, 1, 100, 1, &ok);
+    if (!ok)
+        return;
+
+    for (auto &atomType : atomTypes)
+        atomType->setCharge(std::round(atomType->charge() * std::pow(10, significantFigures)) / std::pow(10, significantFigures));
+
+    setModified();
+
+    fullUpdate();
+}
+

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -87,10 +87,10 @@ void DissolveWindow::on_SimulationReduceChargesSigFigsAction_triggered(bool chec
         return;
 
     for (auto &atomType : atomTypes)
-        atomType->setCharge(std::round(atomType->charge() * std::pow(10, significantFigures)) / std::pow(10, significantFigures));
+        atomType->setCharge(std::round(atomType->charge() * std::pow(10, significantFigures)) /
+                            std::pow(10, significantFigures));
 
     setModified();
 
     fullUpdate();
 }
-

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -465,9 +465,7 @@ void DissolveWindow::on_SpeciesSmoothChargesAction_triggered(bool checked)
     if (!ok)
         return;
 
-    double sum = 0.0, shiftVal = 0.0;
-    for (auto &atom : species->atoms())
-        sum += atom.charge();
+auto sum = species->totalCharge(false), shiftVal = 0.0;
     shiftVal = (sum - targetSum) / species->nAtoms();
     for (auto &atom : species->atoms())
         atom.setCharge(atom.charge() - shiftVal);

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -460,7 +460,7 @@ void DissolveWindow::on_SpeciesSmoothChargesAction_triggered(bool checked)
 
     auto ok = false;
     auto targetSum = QInputDialog::getDouble(this, "Smooth atom charges", "Enter the target sum to smooth atom charges to.",
-                                            0.0, -100.0, 100.0, 5, &ok);
+                                             0.0, -100.0, 100.0, 5, &ok);
 
     if (!ok)
         return;

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -465,7 +465,7 @@ void DissolveWindow::on_SpeciesSmoothChargesAction_triggered(bool checked)
     if (!ok)
         return;
 
-auto sum = species->totalCharge(false), shiftVal = 0.0;
+    auto sum = species->totalCharge(false), shiftVal = 0.0;
     shiftVal = (sum - targetSum) / species->nAtoms();
     for (auto &atom : species->atoms())
         atom.setCharge(atom.charge() - shiftVal);

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -24,6 +24,7 @@
 #include <qinputdialog.h>
 #include <qmessagebox.h>
 #include <qpushbutton.h>
+#include <valarray>
 
 void DissolveWindow::on_SpeciesCreateAtomicAction_triggered(bool checked)
 {
@@ -448,6 +449,31 @@ void DissolveWindow::on_SpeciesScaleChargesAction_triggered(bool checked)
         setModified();
         fullUpdate();
     }
+}
+
+void DissolveWindow::on_SpeciesSmoothChargesAction_triggered(bool checked)
+{
+    // Get the current Species (if a SpeciesTab is selected)
+    auto species = ui_.MainTabs->currentSpecies();
+    if (!species)
+        return;
+
+    auto ok = false;
+    auto targetSum = QInputDialog::getDouble(this, "Smooth atom charges", "Enter the target sum to smooth atom charges to.", 0.0,
+                                     -100.0, 100.0, 5, &ok);
+    
+    if (!ok)
+        return;
+
+    double sum = 0.0, shiftVal = 0.0;
+    for (auto &atom : species->atoms())
+        sum += atom.charge();
+    shiftVal = std::abs(targetSum - sum) / species->nAtoms();
+    for (auto &atom : species->atoms())
+        atom.setCharge(atom.charge() - shiftVal);
+
+    setModified();
+    fullUpdate();
 }
 
 void DissolveWindow::on_SpeciesReduceChargesSigFigsAction_triggered(bool checked)

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -459,9 +459,9 @@ void DissolveWindow::on_SpeciesSmoothChargesAction_triggered(bool checked)
         return;
 
     auto ok = false;
-    auto targetSum = QInputDialog::getDouble(this, "Smooth atom charges", "Enter the target sum to smooth atom charges to.", 0.0,
-                                     -100.0, 100.0, 5, &ok);
-    
+    auto targetSum = QInputDialog::getDouble(this, "Smooth atom charges", "Enter the target sum to smooth atom charges to.",
+                                            0.0, -100.0, 100.0, 5, &ok);
+
     if (!ok)
         return;
 

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -468,7 +468,7 @@ void DissolveWindow::on_SpeciesSmoothChargesAction_triggered(bool checked)
     double sum = 0.0, shiftVal = 0.0;
     for (auto &atom : species->atoms())
         sum += atom.charge();
-    shiftVal = std::abs(targetSum - sum) / species->nAtoms();
+    shiftVal = (sum - targetSum) / species->nAtoms();
     for (auto &atom : species->atoms())
         atom.setCharge(atom.charge() - shiftVal);
 


### PR DESCRIPTION
This PR should finish of the Species Charge Handling Epic (#1449).
- Similarly to the functionality available in the `Species` menu, the option to reduce the number of significant figures in the charges in the `Atom Types` has been added to the `Simulation` menu. Closes #1453.
- The option to "smooth" the sum of the charges in a `Species` to a given value has been added to the `Species` menu. Closes #1454.

Side note: while #1454 names the latter functionality as "trimming", I felt like "smoothing" was more suiting (and we also haven't used that terminology yet). Although I'm happy to change it, if you don't agree.