### PR TITLE
Nix - LLVM v13

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,7 @@
           buildInputs = base_libs pkgs ++ gui_libs system pkgs ++ check_libs pkgs
             ++ (with pkgs; [
               (pkgs.clang-tools.override {
-                llvmPackages = pkgs.llvmPackages_7;
+                llvmPackages = pkgs.llvmPackages_13;
               })
               ccache
               ccls


### PR DESCRIPTION
Quick PR to update the version of LLVM installed by nix to 13 so we have a  `clang-format` version consistent with the CI.