### PR TITLE
Fix Add/AddPair

### DIFF
--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -337,5 +337,8 @@ bool AddProcedureNode::execute(const ProcedureContext &procedureContext)
     Messenger::print("[Add] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", cfg->atomicDensity().value_or(0.0),
                      cfg->chemicalDensity().value_or(0.0));
 
+    // We've added new content to the box, so Need to update our object relationships
+    cfg->updateObjectRelationships();
+
     return true;
 }

--- a/src/procedure/nodes/addpair.cpp
+++ b/src/procedure/nodes/addpair.cpp
@@ -301,5 +301,8 @@ bool AddPairProcedureNode::execute(const ProcedureContext &procedureContext)
     Messenger::print("[AddPair] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n", cfg->atomicDensity().value_or(0.0),
                      cfg->chemicalDensity().value_or(0.0));
 
+    // We've added new content to the box, so Need to update our object relationships
+    cfg->updateObjectRelationships();
+
     return true;
 }


### PR DESCRIPTION
This very short PR addresses an issue with both the `Add` and `AddPair` nodes, which did not call `Configuration::updateObjectRelationships()` after the new molecules had been added.  This had not caused an observable problem until now, when a user experienced crashes trying to create a four component system. Quite how this went unnoticed is a bit of a mystery, but there you go! 