### PR TITLE
Finite range directional global potentials

### DIFF
--- a/src/kernels/potentials/CMakeLists.txt
+++ b/src/kernels/potentials/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(
   potentials
   base.cpp
+  directional.cpp
   producer.cpp
   simple.cpp
   types.cpp
   base.h
+  directional.h
   producer.h
   simple.h
   types.h

--- a/src/kernels/potentials/directional.cpp
+++ b/src/kernels/potentials/directional.cpp
@@ -91,10 +91,8 @@ double DirectionalPotential::energy(const Atom &i, const Box *box) const
     v.y = vector_.z * yzzy - vector_.x * xyyx;
     v.z = -vector_.x * xzzx - vector_.y * yzzy;
 
-    auto vecji = box->minimumImage(v, Vec3<double>{0., 0., 0.});
-
     // Minimum distance between the atom and a point on the line
-    auto r = vecji.magnitude();
+    auto r = v.magnitude();
 
     switch (interactionPotential_.form())
     {

--- a/src/kernels/potentials/directional.cpp
+++ b/src/kernels/potentials/directional.cpp
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "kernels/potentials/directional.h"
+#include "classes/atom.h"
+#include "classes/box.h"
+#include "keywords/interactionpotential.h"
+#include "keywords/vec3double.h"
+#include "keywords/vec3labels.h"
+#include "types.h"
+
+// Return enum options for DirectionalPotentialFunctions
+EnumOptions<DirectionalPotentialFunctions::Form> DirectionalPotentialFunctions::forms()
+{
+    return EnumOptions<DirectionalPotentialFunctions::Form>("DirectionalPotentialFunction",
+                                                       {{DirectionalPotentialFunctions::Form::LJCylinder, "LJCylinder", 2}});
+}
+
+// Return parameters for specified form
+const std::vector<std::string> &DirectionalPotentialFunctions::parameters(Form form)
+{
+    static std::map<DirectionalPotentialFunctions::Form, std::vector<std::string>> params_ = {
+        {DirectionalPotentialFunctions::Form::LJCylinder, {"epsilon", "sigma"}}};
+    return params_[form];
+}
+
+// Return nth parameter for the given form
+std::string DirectionalPotentialFunctions::parameter(Form form, int n)
+{
+    return (n < 0 || n >= parameters(form).size()) ? "" : parameters(form)[n];
+}
+
+// Return index of parameter in the given form
+std::optional<int> DirectionalPotentialFunctions::parameterIndex(Form form, std::string_view name)
+{
+    auto it = std::find_if(parameters(form).begin(), parameters(form).end(),
+                           [name](const auto &param) { return DissolveSys::sameString(name, param); });
+    if (it == parameters(form).end())
+        return {};
+
+    return it - parameters(form).begin();
+}
+
+DirectionalPotential::DirectionalPotential()
+    : interactionPotential_(DirectionalPotentialFunctions::Form::LJCylinder),
+      ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Cylindrical)
+{
+    keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
+    keywords_.add<InteractionPotentialKeyword<DirectionalPotentialFunctions>>(
+        "Form", "Functional form and parameters for the potential", interactionPotential_);
+    keywords_.add<Vec3DoubleKeyword>("Vector", "Direction vector", vector_, Vec3Labels::LabelType::XYZLabels);
+}
+
+/*
+ * Definition
+ */
+
+// Set potential form
+void DirectionalPotential::setPotential(const InteractionPotential<DirectionalPotentialFunctions> &potential)
+{
+    interactionPotential_ = potential;
+}
+
+// Set coordinate origin of potential
+void DirectionalPotential::setOrigin(Vec3<double> origin) { origin_ = origin; }
+
+// Set vector of potential
+void DirectionalPotential::setVector(Vec3<double> vector) { vector_ = vector; }
+
+/*
+ * Potential Calculation
+ */
+
+// Calculate energy on specified atom
+double DirectionalPotential::energy(const Atom &i, const Box *box) const
+{
+    switch (interactionPotential_.form())
+    {
+        case (DirectionalPotentialFunctions::Form::LJCylinder):
+            return 0.0;
+        default:
+            throw(std::runtime_error(fmt::format("Requested functional form of DirectionalPotential has not been implemented.\n")));
+    }
+}
+
+// Calculate force on specified atom, summing in to supplied vector
+void DirectionalPotential::force(const Atom &i, const Box *box, Vec3<double> &f) const
+{
+    // Get normalised vector and distance
+    auto vecji = box->minimumVector(i.r(), origin_);
+    auto r = vecji.magAndNormalise();
+
+    // Calculate final force multiplier
+    auto forceMultiplier = 0.0;
+    switch (interactionPotential_.form())
+    {
+        case (DirectionalPotentialFunctions::Form::LJCylinder):
+            forceMultiplier = 1.0;
+            break;
+        default:
+            throw(std::runtime_error(fmt::format("Requested functional form of DirectionalPotential has not been implemented.\n")));
+    }
+    
+    // Sum in forces on the atom
+    f -= vecji * forceMultiplier;
+}
+

--- a/src/kernels/potentials/directional.cpp
+++ b/src/kernels/potentials/directional.cpp
@@ -129,10 +129,8 @@ void DirectionalPotential::force(const Atom &i, const Box *box, Vec3<double> &f)
     v.y = vector_.z * yzzy - vector_.x * xyyx;
     v.z = -vector_.x * xzzx - vector_.y * yzzy;
 
-    auto vecji = box->minimumImage(v, Vec3<double>{0., 0., 0.});
-
     // Minimum distance between the atom and a point on the line
-    auto r = vecji.magnitude();
+    auto r = v.magnitude();
 
     // Calculate final force multiplier
     auto forceMultiplier = 0.0;
@@ -151,5 +149,5 @@ void DirectionalPotential::force(const Atom &i, const Box *box, Vec3<double> &f)
     }
 
     // Sum in forces on the atom
-    f -= vecji * forceMultiplier;
+    f -= v * forceMultiplier;
 }

--- a/src/kernels/potentials/directional.cpp
+++ b/src/kernels/potentials/directional.cpp
@@ -43,7 +43,7 @@ std::optional<int> DirectionalPotentialFunctions::parameterIndex(Form form, std:
 
 DirectionalPotential::DirectionalPotential()
     : interactionPotential_(DirectionalPotentialFunctions::Form::LJCylinder),
-      ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Cylindrical)
+      ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Directional)
 {
     keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
     keywords_.add<InteractionPotentialKeyword<DirectionalPotentialFunctions>>(

--- a/src/kernels/potentials/directional.h
+++ b/src/kernels/potentials/directional.h
@@ -41,7 +41,7 @@ class DirectionalPotential : public ExternalPotential
     // Coordinate origin of potential
     Vec3<double> origin_;
     // Direction of potential
-    Vec3<double> vector_{0.0,0.0,1.0};
+    Vec3<double> vector_{0.0, 0.0, 1.0};
 
     public:
     // Set potential form

--- a/src/kernels/potentials/directional.h
+++ b/src/kernels/potentials/directional.h
@@ -41,7 +41,7 @@ class DirectionalPotential : public ExternalPotential
     // Coordinate origin of potential
     Vec3<double> origin_;
     // Direction of potential
-    Vec3<double> vector_;
+    Vec3<double> vector_{0.0,0.0,1.0};
 
     public:
     // Set potential form

--- a/src/kernels/potentials/directional.h
+++ b/src/kernels/potentials/directional.h
@@ -60,4 +60,3 @@ class DirectionalPotential : public ExternalPotential
     // Calculate force on specified atom, summing in to supplied vector
     void force(const Atom &i, const Box *box, Vec3<double> &f) const override;
 };
-

--- a/src/kernels/potentials/directional.h
+++ b/src/kernels/potentials/directional.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/interactionpotential.h"
+#include "kernels/potentials/base.h"
+
+// DirectionalPotential functional forms
+class DirectionalPotentialFunctions
+{
+    public:
+    enum class Form
+    {
+        LJCylinder /* Lennard-Jones cylindrical potential */
+    };
+    // Return enum options for form
+    static EnumOptions<Form> forms();
+    // Return parameters for specified form
+    static const std::vector<std::string> &parameters(Form form);
+    // Return nth parameter for the given form
+    static std::string parameter(Form form, int n);
+    // Return index of parameter in the given form
+    static std::optional<int> parameterIndex(Form form, std::string_view name);
+};
+
+// Directional Potential
+class DirectionalPotential : public ExternalPotential
+{
+    public:
+    DirectionalPotential();
+    ~DirectionalPotential() = default;
+
+    /*
+     * Definition
+     */
+
+    private:
+    // Potential form
+    InteractionPotential<DirectionalPotentialFunctions> interactionPotential_;
+    // Coordinate origin of potential
+    Vec3<double> origin_;
+    // Direction of potential
+    Vec3<double> vector_;
+
+    public:
+    // Set potential form
+    void setPotential(const InteractionPotential<DirectionalPotentialFunctions> &potential);
+    // Set coordinate origin of potential
+    void setOrigin(Vec3<double> origin);
+    // Set vector of potential
+    void setVector(Vec3<double> vector);
+
+    /*
+     * Potential Calculation
+     */
+    public:
+    // Calculate energy on specified atom
+    double energy(const Atom &i, const Box *box) const override;
+    // Calculate force on specified atom, summing in to supplied vector
+    void force(const Atom &i, const Box *box, Vec3<double> &f) const override;
+};
+

--- a/src/kernels/potentials/producer.cpp
+++ b/src/kernels/potentials/producer.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "kernels/potentials/producer.h"
+#include "kernels/potentials/directional.h"
 #include "kernels/potentials/simple.h"
 
 // External Potential Producer
@@ -12,10 +13,12 @@ std::unique_ptr<ExternalPotential> create(ExternalPotentialTypes::ExternalPotent
 {
     switch (type)
     {
-        case (ExternalPotentialTypes::ExternalPotentialType::Spherical):
+        case (ExternalPotentialTypes::ExternalPotentialType::Simple):
             return std::make_unique<SimplePotential>();
+        case (ExternalPotentialTypes::ExternalPotentialType::Directional):
+            return std::make_unique<DirectionalPotential>();
         default:
-            throw(std::runtime_error(fmt::format("Creation of external potential type '%s' not implemented.\n",
+            throw(std::runtime_error(fmt::format("Creation of external potential type '{}' not implemented.\n",
                                                  ExternalPotentialTypes::keyword(type))));
     }
 }

--- a/src/kernels/potentials/simple.cpp
+++ b/src/kernels/potentials/simple.cpp
@@ -41,7 +41,7 @@ std::optional<int> SimplePotentialFunctions::parameterIndex(Form form, std::stri
 
 SimplePotential::SimplePotential()
     : interactionPotential_(SimplePotentialFunctions::Form::Harmonic),
-      ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Spherical)
+      ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Simple)
 {
     keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
     keywords_.add<InteractionPotentialKeyword<SimplePotentialFunctions>>(

--- a/src/kernels/potentials/types.cpp
+++ b/src/kernels/potentials/types.cpp
@@ -7,7 +7,7 @@
 namespace ExternalPotentialTypes
 {
 // External Potential Types
-EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Spherical, "Spherical"}});
+EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Spherical, "Spherical"}, {ExternalPotentialType::Cylindrical, "Cylindrical"}});
 
 // Return whether the supplied external potential type is valid
 std::optional<ExternalPotentialType> isType(std::string_view name)

--- a/src/kernels/potentials/types.cpp
+++ b/src/kernels/potentials/types.cpp
@@ -7,7 +7,8 @@
 namespace ExternalPotentialTypes
 {
 // External Potential Types
-EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Spherical, "Spherical"}, {ExternalPotentialType::Cylindrical, "Cylindrical"}});
+EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Spherical, "Spherical"},
+                                                                {ExternalPotentialType::Cylindrical, "Cylindrical"}});
 
 // Return whether the supplied external potential type is valid
 std::optional<ExternalPotentialType> isType(std::string_view name)

--- a/src/kernels/potentials/types.cpp
+++ b/src/kernels/potentials/types.cpp
@@ -7,8 +7,8 @@
 namespace ExternalPotentialTypes
 {
 // External Potential Types
-EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Spherical, "Spherical"},
-                                                                {ExternalPotentialType::Cylindrical, "Cylindrical"}});
+EnumOptions<ExternalPotentialType> types_("ExternalPotential", {{ExternalPotentialType::Simple, "Simple"},
+                                                                {ExternalPotentialType::Directional, "Directional"}});
 
 // Return whether the supplied external potential type is valid
 std::optional<ExternalPotentialType> isType(std::string_view name)

--- a/src/kernels/potentials/types.h
+++ b/src/kernels/potentials/types.h
@@ -12,7 +12,8 @@ namespace ExternalPotentialTypes
 // External Potential Types
 enum class ExternalPotentialType
 {
-    Spherical
+    Spherical,
+    Cylindrical
 };
 // Return whether the supplied external potential type is valid
 std::optional<ExternalPotentialType> isType(std::string_view name);

--- a/src/kernels/potentials/types.h
+++ b/src/kernels/potentials/types.h
@@ -12,8 +12,8 @@ namespace ExternalPotentialTypes
 // External Potential Types
 enum class ExternalPotentialType
 {
-    Spherical,
-    Cylindrical
+    Simple,
+    Directional
 };
 // Return whether the supplied external potential type is valid
 std::optional<ExternalPotentialType> isType(std::string_view name);

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   copy.cpp
   customregion.cpp
   cylindricalregion.cpp
+  directionalglobalpotential.cpp
   generalregion.cpp
   integrate1d.cpp
   node.cpp
@@ -64,6 +65,7 @@ add_library(
   copy.h
   customregion.h
   cylindricalregion.h
+  directionalglobalpotential.h
   generalregion.h
   integrate1d.h
   node.h

--- a/src/procedure/nodes/directionalglobalpotential.cpp
+++ b/src/procedure/nodes/directionalglobalpotential.cpp
@@ -12,8 +12,8 @@ DirectionalGlobalPotentialProcedureNode::DirectionalGlobalPotentialProcedureNode
       potential_(DirectionalPotentialFunctions::Form::LJCylinder)
 {
     keywords_.setOrganisation("Options", "Definition");
-    keywords_.add<InteractionPotentialKeyword<DirectionalPotentialFunctions>>("Potential", "Form of directional global potential to apply ",
-                                                                         potential_);
+    keywords_.add<InteractionPotentialKeyword<DirectionalPotentialFunctions>>(
+        "Potential", "Form of directional global potential to apply ", potential_);
     keywords_.add<Vec3NodeValueKeyword>("Origin", "Origin of global potential", origin_, this);
     keywords_.add<Vec3NodeValueKeyword>("Vector", "Vector of global potential", vector_, this);
 }
@@ -36,4 +36,3 @@ bool DirectionalGlobalPotentialProcedureNode::execute(const ProcedureContext &pr
 
     return true;
 }
-

--- a/src/procedure/nodes/directionalglobalpotential.cpp
+++ b/src/procedure/nodes/directionalglobalpotential.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/directionalglobalpotential.h"
+#include "classes/configuration.h"
+#include "kernels/potentials/directional.h"
+#include "keywords/interactionpotential.h"
+#include "keywords/vec3nodevalue.h"
+
+DirectionalGlobalPotentialProcedureNode::DirectionalGlobalPotentialProcedureNode()
+    : ProcedureNode(ProcedureNode::NodeType::DirectionalGlobalPotential, {ProcedureNode::GenerationContext}),
+      potential_(DirectionalPotentialFunctions::Form::LJCylinder)
+{
+    keywords_.setOrganisation("Options", "Definition");
+    keywords_.add<InteractionPotentialKeyword<DirectionalPotentialFunctions>>("Potential", "Form of directional global potential to apply ",
+                                                                         potential_);
+    keywords_.add<Vec3NodeValueKeyword>("Origin", "Origin of global potential", origin_, this);
+    keywords_.add<Vec3NodeValueKeyword>("Vector", "Vector of global potential", vector_, this);
+}
+
+/*
+ * Execute
+ */
+
+// Execute node
+bool DirectionalGlobalPotentialProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    auto *cfg = procedureContext.configuration();
+
+    auto pot = std::make_unique<DirectionalPotential>();
+    pot->setPotential(potential_);
+    pot->setOrigin({origin_.x.asDouble(), origin_.y.asDouble(), origin_.z.asDouble()});
+    pot->setVector({vector_.x.asDouble(), vector_.y.asDouble(), vector_.z.asDouble()});
+
+    cfg->addGlobalPotential(std::unique_ptr<ExternalPotential>(std::move(pot)));
+
+    return true;
+}
+

--- a/src/procedure/nodes/directionalglobalpotential.h
+++ b/src/procedure/nodes/directionalglobalpotential.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "kernels/potentials/directional.h"
+#include "procedure/nodes/node.h"
+
+// Directional Global Potential Procedure Node
+class DirectionalGlobalPotentialProcedureNode : public ProcedureNode
+{
+    public:
+    DirectionalGlobalPotentialProcedureNode();
+    ~DirectionalGlobalPotentialProcedureNode() override = default;
+
+    /*
+     * Potential Function
+     */
+    private:
+    // Potential form, origin and directional vector
+    InteractionPotential<DirectionalPotentialFunctions> potential_;
+    Vec3<NodeValue> origin_;
+    Vec3<NodeValue> vector_;
+
+
+    /*
+     * Execute
+     */
+    public:
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+};
+

--- a/src/procedure/nodes/directionalglobalpotential.h
+++ b/src/procedure/nodes/directionalglobalpotential.h
@@ -22,7 +22,6 @@ class DirectionalGlobalPotentialProcedureNode : public ProcedureNode
     Vec3<NodeValue> origin_;
     Vec3<NodeValue> vector_;
 
-
     /*
      * Execute
      */
@@ -30,4 +29,3 @@ class DirectionalGlobalPotentialProcedureNode : public ProcedureNode
     // Execute node
     bool execute(const ProcedureContext &procedureContext) override;
 };
-

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -41,6 +41,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Copy, "Copy"},
                      {ProcedureNode::NodeType::CustomRegion, "CustomRegion"},
                      {ProcedureNode::NodeType::CylindricalRegion, "CylindricalRegion"},
+                     {ProcedureNode::NodeType::DirectionalGlobalPotential, "DirectionalGlobalPotential"},
                      {ProcedureNode::NodeType::DynamicSite, "DynamicSite"},
                      {ProcedureNode::NodeType::GeneralRegion, "GeneralRegion"},
                      {ProcedureNode::NodeType::Integrate1D, "Integrate1D"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -52,6 +52,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>
         Copy,
         CustomRegion,
         CylindricalRegion,
+        DirectionalGlobalPotential,
         DynamicSite,
         GeneralRegion,
         Integrate1D,

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -118,7 +118,8 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
     registerProducer<SimpleGlobalPotentialProcedureNode>(ProcedureNode::NodeType::SimpleGlobalPotential,
                                                          "Add a global potential affecting all atoms", "Potentials");
     registerProducer<DirectionalGlobalPotentialProcedureNode>(ProcedureNode::NodeType::DirectionalGlobalPotential,
-                                                              "Add a directional global potential affecting all atoms", "Potentials");
+                                                              "Add a directional global potential affecting all atoms",
+                                                              "Potentials");
     registerProducer<SimpleRestraintPotentialProcedureNode>(ProcedureNode::NodeType::SimpleRestraintPotential,
                                                             "Restraint atoms of molecules to their current positions",
                                                             "Potentials");

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -16,6 +16,7 @@
 #include "procedure/nodes/copy.h"
 #include "procedure/nodes/customregion.h"
 #include "procedure/nodes/cylindricalregion.h"
+#include "procedure/nodes/directionalglobalpotential.h"
 #include "procedure/nodes/generalregion.h"
 #include "procedure/nodes/integrate1d.h"
 #include "procedure/nodes/operatedivide.h"
@@ -116,6 +117,8 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
     // Potentials
     registerProducer<SimpleGlobalPotentialProcedureNode>(ProcedureNode::NodeType::SimpleGlobalPotential,
                                                          "Add a global potential affecting all atoms", "Potentials");
+    registerProducer<DirectionalGlobalPotentialProcedureNode>(ProcedureNode::NodeType::DirectionalGlobalPotential,
+                                                              "Add a directional global potential affecting all atoms", "Potentials");
     registerProducer<SimpleRestraintPotentialProcedureNode>(ProcedureNode::NodeType::SimpleRestraintPotential,
                                                             "Restraint atoms of molecules to their current positions",
                                                             "Potentials");


### PR DESCRIPTION
This PR adds a new category of global potentials: Directional Global Potentials. Moreover, it adds a Directional Global Potential form, `LJCylinder` - which produces a cylindrical Lennard-Jones Potential defined by an origin point and a vector describing the "direction" of the cylinder. Directional Global Potentials are interfaced with through a new node of the same name.