### PR TITLE
Node-ify Temperature

### DIFF
--- a/src/gui/addConfigurationDialogFuncs.cpp
+++ b/src/gui/addConfigurationDialogFuncs.cpp
@@ -182,7 +182,7 @@ void AddConfigurationDialog::finalise()
     auto &generator = newConfiguration->generator();
 
     // Add Temperature node, by default
-    generator.createRootNode<TemperatureProcedureNode>("Temperature");
+    generator.createRootNode<TemperatureProcedureNode>({});
 
     std::shared_ptr<GeneralRegionProcedureNode> regionNode;
 

--- a/src/gui/addConfigurationDialogFuncs.cpp
+++ b/src/gui/addConfigurationDialogFuncs.cpp
@@ -180,7 +180,10 @@ void AddConfigurationDialog::finalise()
     // Create the Configuration and a suitable generator
     auto *newConfiguration = dissolve_.addConfiguration();
     auto &generator = newConfiguration->generator();
+
+    // Add Temperature node, by default
     generator.createRootNode<TemperatureProcedureNode>("Temperature");
+
     std::shared_ptr<GeneralRegionProcedureNode> regionNode;
 
     // Add the framework species if present

--- a/src/gui/addConfigurationDialogFuncs.cpp
+++ b/src/gui/addConfigurationDialogFuncs.cpp
@@ -10,6 +10,7 @@
 #include "procedure/nodes/coordinateSets.h"
 #include "procedure/nodes/generalRegion.h"
 #include "procedure/nodes/parameters.h"
+#include "procedure/nodes/temperature.h"
 #include <QInputDialog>
 #include <QMessageBox>
 
@@ -179,6 +180,7 @@ void AddConfigurationDialog::finalise()
     // Create the Configuration and a suitable generator
     auto *newConfiguration = dissolve_.addConfiguration();
     auto &generator = newConfiguration->generator();
+    generator.createRootNode<TemperatureProcedureNode>("Temperature");
     std::shared_ptr<GeneralRegionProcedureNode> regionNode;
 
     // Add the framework species if present

--- a/src/gui/configurationTab.h
+++ b/src/gui/configurationTab.h
@@ -80,8 +80,6 @@ class ConfigurationTab : public QWidget, public MainTab
     private slots:
     // Content
     void on_GenerateButton_clicked(bool checked);
-    // Definition
-    void on_TemperatureSpin_valueChanged(double value);
     // Current Box
     void on_DensityUnitsCombo_currentIndexChanged(int index);
     // Initial Coordinates

--- a/src/gui/configurationTab.ui
+++ b/src/gui/configurationTab.ui
@@ -40,53 +40,6 @@
       <number>4</number>
      </property>
      <item>
-      <widget class="QGroupBox" name="TemperatureGroup">
-       <property name="title">
-        <string>Temperature</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="spacing">
-         <number>4</number>
-        </property>
-        <property name="leftMargin">
-         <number>4</number>
-        </property>
-        <property name="topMargin">
-         <number>4</number>
-        </property>
-        <property name="rightMargin">
-         <number>4</number>
-        </property>
-        <property name="bottomMargin">
-         <number>4</number>
-        </property>
-        <item>
-         <widget class="ExponentialSpin" name="TemperatureSpin">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="TemperatureLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>K</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
       <widget class="QGroupBox" name="CurrentBoxGroup">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -131,6 +84,7 @@
           <property name="font">
            <font>
             <pointsize>10</pointsize>
+            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -144,6 +98,7 @@
           <property name="font">
            <font>
             <pointsize>10</pointsize>
+            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -157,6 +112,7 @@
           <property name="font">
            <font>
             <pointsize>10</pointsize>
+            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -198,6 +154,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -220,6 +177,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -239,6 +197,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -261,6 +220,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -296,6 +256,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -318,6 +279,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>50</weight>
               <bold>false</bold>
              </font>
             </property>
@@ -366,6 +328,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -385,6 +348,7 @@
             <property name="font">
              <font>
               <pointsize>10</pointsize>
+              <weight>75</weight>
               <bold>true</bold>
              </font>
             </property>
@@ -435,6 +399,7 @@
           <property name="font">
            <font>
             <pointsize>10</pointsize>
+            <weight>50</weight>
             <bold>false</bold>
            </font>
           </property>

--- a/src/gui/configurationTabFuncs.cpp
+++ b/src/gui/configurationTabFuncs.cpp
@@ -112,9 +112,6 @@ void ConfigurationTab::updateControls()
 {
     Locker refreshLocker(refreshLock_);
 
-    // Temperature
-    ui_.TemperatureSpin->setValue(configuration_->temperature());
-
     // Populations
     ui_.AtomPopulation->setText(QString::number(configuration_->nAtoms()));
     ui_.MolPopulation->setText(QString::number(configuration_->nMolecules()));
@@ -146,7 +143,6 @@ void ConfigurationTab::updateControls()
 void ConfigurationTab::preventEditing()
 {
     ui_.GeneratorGroup->setEnabled(false);
-    ui_.TemperatureGroup->setEnabled(false);
     ui_.SizeFactorGroup->setEnabled(false);
 }
 
@@ -154,7 +150,6 @@ void ConfigurationTab::preventEditing()
 void ConfigurationTab::allowEditing()
 {
     ui_.GeneratorGroup->setEnabled(true);
-    ui_.TemperatureGroup->setEnabled(true);
     ui_.SizeFactorGroup->setEnabled(true);
 }
 
@@ -193,16 +188,6 @@ void ConfigurationTab::on_GenerateButton_clicked(bool checked)
     // Update
     updateControls();
     dissolveWindow_->updateStatusBar();
-}
-
-void ConfigurationTab::on_TemperatureSpin_valueChanged(double value)
-{
-    if (refreshLock_.isLocked())
-        return;
-
-    configuration_->setTemperature(value);
-
-    dissolveWindow_->setModified();
 }
 
 // Current Box

--- a/src/gui/configurationTabFuncs.cpp
+++ b/src/gui/configurationTabFuncs.cpp
@@ -128,16 +128,10 @@ void ConfigurationTab::updateControls()
 }
 
 // Prevent editing within tab
-void ConfigurationTab::preventEditing()
-{
-    ui_.GeneratorGroup->setEnabled(false);
-}
+void ConfigurationTab::preventEditing() { ui_.GeneratorGroup->setEnabled(false); }
 
 // Allow editing within tab
-void ConfigurationTab::allowEditing()
-{
-    ui_.GeneratorGroup->setEnabled(true);
-}
+void ConfigurationTab::allowEditing() { ui_.GeneratorGroup->setEnabled(true); }
 
 /*
  * Signals / Slots

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -177,6 +177,7 @@ class DissolveWindow : public QMainWindow
     void on_ConfigurationRenameAction_triggered(bool checked);
     void on_ConfigurationDeleteAction_triggered(bool checked);
     void on_ConfigurationExportToXYZAction_triggered(bool checked);
+    void on_ConfigurationAdjustTemperatureAction_triggered(bool checked);
     // Layer
     void on_LayerCreateEmptyAction_triggered(bool checked);
     void on_LayerCreateEvolveBasicAtomicAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -806,7 +806,7 @@
   </action>
   <action name="ConfigurationAdjustTemperatureAction">
    <property name="text">
-    <string>Adjust Temperature...</string>
+    <string>Adjust &amp;Temperature...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -270,6 +270,8 @@
     <addaction name="ConfigurationDeleteAction"/>
     <addaction name="separator"/>
     <addaction name="ConfigurationExportToMenu"/>
+    <addaction name="separator"/>
+    <addaction name="ConfigurationAdjustTemperatureAction"/>
    </widget>
    <widget class="QMenu" name="LayerMenu">
     <property name="font">
@@ -800,6 +802,11 @@
    </property>
    <property name="text">
     <string>Create...</string>
+   </property>
+  </action>
+  <action name="ConfigurationAdjustTemperatureAction">
+   <property name="text">
+    <string>Adjust Temperature...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -359,6 +359,7 @@ void DissolveWindow::updateMenus()
     ui_.ConfigurationRenameAction->setEnabled(activeTab->type() == MainTab::TabType::Configuration);
     ui_.ConfigurationDeleteAction->setEnabled(activeTab->type() == MainTab::TabType::Configuration);
     ui_.ConfigurationExportToMenu->setEnabled(activeTab->type() == MainTab::TabType::Configuration);
+    ui_.ConfigurationAdjustTemperatureAction->setEnabled(activeTab->type() == MainTab::TabType::Configuration);
 
     // Layer Menu
     ui_.LayerRenameAction->setEnabled(activeTab->type() == MainTab::TabType::Layer);

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -146,8 +146,9 @@ void DissolveWindow::on_ConfigurationAdjustTemperatureAction_triggered(bool chec
         return;
 
     auto ok = false;
-    auto temperature = QInputDialog::getDouble(this, "Set temperature for configuration", "Enter the temperature (K) to apply to this configuration", cfg->temperature(),
-                                     -10000.0, 10000.0, 3, &ok);
+    auto temperature = QInputDialog::getDouble(this, "Set temperature for configuration",
+                                               "Enter the temperature (K) to apply to this configuration", cfg->temperature(),
+                                               -10000.0, 10000.0, 3, &ok);
     if (!ok)
         return;
 

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -13,6 +13,7 @@
 #include "procedure/nodes/generalRegion.h"
 #include "procedure/nodes/parameters.h"
 #include <QFileDialog>
+#include <QInputDialog>
 #include <QMessageBox>
 
 /*
@@ -135,4 +136,24 @@ void DissolveWindow::on_ConfigurationExportToXYZAction_triggered(bool checked)
                              QMessageBox::Ok, QMessageBox::Ok);
     else
         Messenger::print("Successfully exported configuration '{}' to '{}'.\n", cfg->name(), fileAndFormat.filename());
+}
+
+void DissolveWindow::on_ConfigurationAdjustTemperatureAction_triggered(bool checked)
+{
+    // Get the currently-displayed Configuration
+    auto *cfg = ui_.MainTabs->currentConfiguration();
+    if (!cfg)
+        return;
+
+    auto ok = false;
+    auto temperature = QInputDialog::getDouble(this, "Set temperature for configuration", "Enter the temperature (K) to apply to this configuration", cfg->temperature(),
+                                     -10000.0, 10000.0, 3, &ok);
+    if (!ok)
+        return;
+
+    cfg->setTemperature(temperature);
+
+    setModified();
+
+    fullUpdate();
 }

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -148,7 +148,7 @@ void DissolveWindow::on_ConfigurationAdjustTemperatureAction_triggered(bool chec
     auto ok = false;
     auto temperature = QInputDialog::getDouble(this, "Set temperature for configuration",
                                                "Enter the temperature (K) to apply to this configuration", cfg->temperature(),
-                                               -10000.0, 10000.0, 3, &ok);
+                                               0.0, 1000000.0, 3, &ok);
     if (!ok)
         return;
 

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -77,6 +77,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 cfg->setRequestedSizeFactor(parser.argd(1));
                 break;
             case (ConfigurationBlock::TemperatureKeyword):
+                Messenger::warn("The TemperatureKeyword will be deprecated in future versions.\n");
                 cfg->setTemperature(parser.argd(1));
                 break;
             default:

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -77,7 +77,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 cfg->setRequestedSizeFactor(parser.argd(1));
                 break;
             case (ConfigurationBlock::TemperatureKeyword):
-                Messenger::warn("The TemperatureKeyword will be deprecated in future versions.\n");
+                Messenger::warn("The 'Temperature' keyword will be deprecated in a future version.\n");
                 cfg->setTemperature(parser.argd(1));
                 break;
             default:

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(
   sequence.cpp
   simpleGlobalPotential.cpp
   sum1D.cpp
+  temperature.cpp
   transmute.cpp
   add.h
   addPair.h
@@ -95,11 +96,12 @@ add_library(
   remove.h
   rotateFragment.h
   restraintPotential.h
-  transmute.h
   select.h
   sequence.h
   simpleGlobalPotential.h
   sum1D.h
+  temperature.h
+  transmute.h
 )
 
 target_include_directories(procedureNodes PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -68,6 +68,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Sequence, "Sequence"},
                      {ProcedureNode::NodeType::SimpleGlobalPotential, "SimpleGlobalPotential"},
                      {ProcedureNode::NodeType::Sum1D, "Sum1D"},
+                     {ProcedureNode::NodeType::Temperature, "Temperature"},
                      {ProcedureNode::NodeType::Transmute, "Transmute"}});
 }
 

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -80,6 +80,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         Sequence,
         SimpleGlobalPotential,
         Sum1D,
+        Temperature,
         Transmute
     };
     // Return enum option info for NodeType

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -41,6 +41,7 @@
 #include "procedure/nodes/select.h"
 #include "procedure/nodes/simpleGlobalPotential.h"
 #include "procedure/nodes/sum1D.h"
+#include "procedure/nodes/temperature.h"
 #include "procedure/nodes/transmute.h"
 
 ProcedureNodeRegistry::ProcedureNodeRegistry()
@@ -54,6 +55,7 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
                                                   "Generate coordinate sets for a species", "Build");
     registerProducer<CopyProcedureNode>(ProcedureNode::NodeType::Copy, "Copy the contents of a configuration", "Build");
     registerProducer<RemoveProcedureNode>(ProcedureNode::NodeType::Remove, "Remove molecules from a configuration", "Build");
+    registerProducer<TemperatureProcedureNode>(ProcedureNode::NodeType::Temperature, "Set temperature for configuration", "Build"); 
     registerProducer<TransmuteProcedureNode>(ProcedureNode::NodeType::Transmute,
                                              "Turn molecules from one species type into another", "Build");
 

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -55,7 +55,8 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
                                                   "Generate coordinate sets for a species", "Build");
     registerProducer<CopyProcedureNode>(ProcedureNode::NodeType::Copy, "Copy the contents of a configuration", "Build");
     registerProducer<RemoveProcedureNode>(ProcedureNode::NodeType::Remove, "Remove molecules from a configuration", "Build");
-    registerProducer<TemperatureProcedureNode>(ProcedureNode::NodeType::Temperature, "Set temperature for configuration", "Build"); 
+    registerProducer<TemperatureProcedureNode>(ProcedureNode::NodeType::Temperature, "Set temperature for configuration",
+                                               "Build");
     registerProducer<TransmuteProcedureNode>(ProcedureNode::NodeType::Transmute,
                                              "Turn molecules from one species type into another", "Build");
 

--- a/src/procedure/nodes/temperature.cpp
+++ b/src/procedure/nodes/temperature.cpp
@@ -8,7 +8,7 @@
 TemperatureProcedureNode::TemperatureProcedureNode()
     : ProcedureNode(ProcedureNode::NodeType::Temperature, {ProcedureNode::GenerationContext})
 {
-    keywords_.add<NodeValueKeyword>("Temperature", "Temperature in K", temperature_, this);
+    keywords_.add<NodeValueKeyword>("Temperature", "Temperature (K)", temperature_, this);
 }
 
 /*

--- a/src/procedure/nodes/temperature.cpp
+++ b/src/procedure/nodes/temperature.cpp
@@ -5,6 +5,7 @@
 #include "classes/configuration.h"
 #include "keywords/nodeValue.h"
 #include "procedure/nodes/node.h"
+
 TemperatureProcedureNode::TemperatureProcedureNode()
     : ProcedureNode(ProcedureNode::NodeType::Temperature, {ProcedureNode::GenerationContext})
 {
@@ -15,6 +16,7 @@ TemperatureProcedureNode::TemperatureProcedureNode()
  * Identity
  */
 
+// Return whether a name for the node must be provided
 bool TemperatureProcedureNode::mustBeNamed() const { return false; }
 
 /*

--- a/src/procedure/nodes/temperature.cpp
+++ b/src/procedure/nodes/temperature.cpp
@@ -19,6 +19,7 @@ bool TemperatureProcedureNode::mustBeNamed() const { return false; }
 /*
  * Execute
  */
+
 // Execute node
 bool TemperatureProcedureNode::execute(const ProcedureContext &procedureContext)
 {

--- a/src/procedure/nodes/temperature.cpp
+++ b/src/procedure/nodes/temperature.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/temperature.h"
+#include "classes/configuration.h"
+#include "keywords/nodeValue.h"
+#include "procedure/nodes/node.h"
+TemperatureProcedureNode::TemperatureProcedureNode()
+    : ProcedureNode(ProcedureNode::NodeType::Temperature, {ProcedureNode::GenerationContext})
+{
+    keywords_.add<NodeValueKeyword>("Temperature", "Temperature in K", temperature_, this);
+}
+
+/*
+ * Identity
+ */
+bool TemperatureProcedureNode::mustBeNamed() const { return false; }
+
+/*
+ * Execute
+ */
+// Execute node
+bool TemperatureProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    auto *cfg = procedureContext.configuration();
+    cfg->setTemperature(temperature_.asDouble());
+    return true;
+}

--- a/src/procedure/nodes/temperature.cpp
+++ b/src/procedure/nodes/temperature.cpp
@@ -14,6 +14,7 @@ TemperatureProcedureNode::TemperatureProcedureNode()
 /*
  * Identity
  */
+
 bool TemperatureProcedureNode::mustBeNamed() const { return false; }
 
 /*

--- a/src/procedure/nodes/temperature.h
+++ b/src/procedure/nodes/temperature.h
@@ -5,6 +5,7 @@
 
 #include "keywords/nodeValue.h"
 #include "procedure/nodes/node.h"
+
 class TemperatureProcedureNode : public ProcedureNode
 {
     public:

--- a/src/procedure/nodes/temperature.h
+++ b/src/procedure/nodes/temperature.h
@@ -25,7 +25,6 @@ class TemperatureProcedureNode : public ProcedureNode
     // Temperature for configuration
     NodeValue temperature_{300.0};
 
-
     /*
      * Execute
      */

--- a/src/procedure/nodes/temperature.h
+++ b/src/procedure/nodes/temperature.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "keywords/nodeValue.h"
+#include "procedure/nodes/node.h"
+class TemperatureProcedureNode : public ProcedureNode
+{
+    public:
+    TemperatureProcedureNode();
+    ~TemperatureProcedureNode() override = default;
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Node Data
+     */
+    private:
+    // Temperature for configuration
+    NodeValue temperature_{300.0};
+
+
+    /*
+     * Execute
+     */
+    public:
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+};


### PR DESCRIPTION
This PR moves the Temperature for configurations from being a GUI control to a node: `Temperature`. For now, we still read `TemperatureKeywords`, but with a deprecation warning. Closes #146.