### PR TITLE
Removing advertisement from custom 404 page

### DIFF
--- a/web/layouts/404.html
+++ b/web/layouts/404.html
@@ -3,8 +3,6 @@
       <div>
        <h1 id="title">Not found</h1>
        <p>Oops! This page doesn't exist. Try going back to our <a href="{{ "/" | relURL }}">home page</a>.</p>
-
-       <p>You can learn how to make a 404 page like this in <a href="https://gohugo.io/templates/404/">Custom 404 Pages</a>.</p>      
       </div>
     </main>
 {{ end }}


### PR DESCRIPTION
Removed the "You can learn how to make a 404 page like this in [Custom 404 Pages](https://gohugo.io/templates/404/)." promotion.

![image](https://github.com/disorderedmaterials/dissolve/assets/101950441/bd33205d-925a-4343-b23f-ac75d9c96f87)