### PR TITLE
1515 Missing Restart File Error

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,16 @@ int main(int args, char **argv)
             }
         }
         else
-            Messenger::print("Restart file '{}' does not exist.\n", restartFile);
+        {
+            // If a restart file was specifically provided, raise an error. Otherwise just print a message
+            if (options.restartFilename())
+            {
+                Messenger::error("Specified restart file '{}' does not exist.\n", restartFile);
+                return 1;
+            }
+
+            Messenger::print("Default restart file '{}' does not exist.\n", restartFile);
+        }
     }
 
     // If we're just checking the input and restart files, exit now

--- a/tests/epsr/CMakeLists.txt
+++ b/tests/epsr/CMakeLists.txt
@@ -1,4 +1,4 @@
 dissolve_system_test(estimatedsq benzene.txt 1)
 dissolve_system_test(read-pcof pcof.txt 0)
 dissolve_system_test(neutron-xray water-neutron-xray.txt 1)
-dissolve_system_test(poisson water-poisson.txt 1 --restart=water-poisson_coefficients.restart)
+dissolve_system_test(poisson water-poisson.txt 1)


### PR DESCRIPTION
A nice quick PR to help keep our users sane.

Interestingly, once implemented this caught a system test which was trying to reference a restart file which didn't exist!

Closes #1514.