### PR TITLE
Messages Hyperlink

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -206,7 +206,7 @@ class DissolveWindow : public QMainWindow
     // Thread controller
     DissolveThreadController threadController_;
     // Whether the GUI is currently running a simulation
-    bool dissolveIterating_;
+    bool dissolveIterating_t;
     // Whether any data has been modified
     bool modified_;
     // Whether window is currently refreshing
@@ -220,6 +220,8 @@ class DissolveWindow : public QMainWindow
 
     private slots:
     void on_MainTabs_currentChanged(int index);
+    void statusLabelLinkClicked(const QString& link);
+    void openMessages();
 
     public:
     // Return whether the GUI is currently running a simulation

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -206,7 +206,7 @@ class DissolveWindow : public QMainWindow
     // Thread controller
     DissolveThreadController threadController_;
     // Whether the GUI is currently running a simulation
-    bool dissolveIterating_t;
+    bool dissolveIterating_;
     // Whether any data has been modified
     bool modified_;
     // Whether window is currently refreshing
@@ -221,7 +221,6 @@ class DissolveWindow : public QMainWindow
     private slots:
     void on_MainTabs_currentChanged(int index);
     void statusLabelLinkClicked(const QString& link);
-    void openMessages();
 
     public:
     // Return whether the GUI is currently running a simulation

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -220,7 +220,7 @@ class DissolveWindow : public QMainWindow
 
     private slots:
     void on_MainTabs_currentChanged(int index);
-    void statusLabelLinkClicked(const QString& link);
+    void statusLabelLinkClicked(const QString &link);
 
     public:
     // Return whether the GUI is currently running a simulation

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -432,7 +432,6 @@ void DissolveWindow::clearMessages()
     Messenger::clearErrorCounts();
 }
 
-// Open the messages window
 void DissolveWindow::statusLabelLinkClicked(const QString &link)
 {
     if (DissolveSys::sameString(link.toStdString(), "Messages"))

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -54,6 +54,8 @@ DissolveWindow::DissolveWindow(Dissolve &dissolve)
     restartFileIndicator_ = addStatusBarIcon(":/general/icons/general_restartfile.svg");
     statusIndicator_ = addStatusBarIcon(":/general/icons/general_true.svg", false);
     statusLabel_ = addStatusBarLabel("Unknown", false);
+    statusLabel_->setOpenExternalLinks(false);
+    connect(statusLabel_, SIGNAL(linkActivated(const QString)), this, SLOT(openMessages()));
 
     // Create recent files menu
     setUpRecentFileMenu();
@@ -296,7 +298,7 @@ void DissolveWindow::updateStatusBar()
     // Set status
     if (Messenger::nErrors() > 0)
     {
-        statusLabel_->setText(QString("%1 %2 (see Messages)")
+        statusLabel_->setText(QString("%1 %2 (see <a href='Messages'>Messages</a>)")
                                   .arg(QString::number(Messenger::nErrors()), Messenger::nErrors() == 1 ? "Error" : "Errors"));
         statusIndicator_->setPixmap(QPixmap(":/general/icons/general_false.svg"));
     }
@@ -428,4 +430,10 @@ void DissolveWindow::clearMessages()
 {
     ui_.MainTabs->messagesTab()->clearMessages();
     Messenger::clearErrorCounts();
+}
+
+// Open the messages window
+void DissolveWindow::openMessages()
+{
+    ui_.MainTabs->setCurrentIndex(0);
 }

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -433,7 +433,7 @@ void DissolveWindow::clearMessages()
 }
 
 // Open the messages window
-void DissolveWindow::statusLabelLinkClicked(const QString& link)
+void DissolveWindow::statusLabelLinkClicked(const QString &link)
 {
     if (DissolveSys::sameString(link.toStdString(), "Messages"))
         ui_.MainTabs->setCurrentIndex(0);

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -55,7 +55,7 @@ DissolveWindow::DissolveWindow(Dissolve &dissolve)
     statusIndicator_ = addStatusBarIcon(":/general/icons/general_true.svg", false);
     statusLabel_ = addStatusBarLabel("Unknown", false);
     statusLabel_->setOpenExternalLinks(false);
-    connect(statusLabel_, SIGNAL(linkActivated(const QString)), this, SLOT(openMessages()));
+    connect(statusLabel_, SIGNAL(linkActivated(const QString)), this, SLOT(statusLabelLinkClicked(const QString)));
 
     // Create recent files menu
     setUpRecentFileMenu();
@@ -433,7 +433,8 @@ void DissolveWindow::clearMessages()
 }
 
 // Open the messages window
-void DissolveWindow::openMessages()
+void DissolveWindow::statusLabelLinkClicked(const QString& link)
 {
-    ui_.MainTabs->setCurrentIndex(0);
+    if (DissolveSys::sameString(link.toStdString(), "Messages"))
+        ui_.MainTabs->setCurrentIndex(0);
 }


### PR DESCRIPTION
Small PR which adds a hyperlink to the `Messages` tab in the status label, when it suggests that it should be viewed. Closes #1266.

Currently you can right click on the hyperlink and `Copy link`, which could be deceiving to users - if necessary, we can install a simple `eventFilter` that ignores right clicking on the link.