### PR TITLE
Empty Potential Functions

### DIFF
--- a/src/classes/interactionPotential.h
+++ b/src/classes/interactionPotential.h
@@ -14,7 +14,7 @@
 template <class Functions> class InteractionPotential
 {
     public:
-    explicit InteractionPotential(typename Functions::Form form) { setForm(form); };
+    InteractionPotential(typename Functions::Form form) { setForm(form); };
     virtual ~InteractionPotential() = default;
     InteractionPotential(const InteractionPotential &source) = default;
     InteractionPotential(InteractionPotential &&source) = delete;

--- a/src/classes/interactionPotential.h
+++ b/src/classes/interactionPotential.h
@@ -14,7 +14,7 @@
 template <class Functions> class InteractionPotential
 {
     public:
-    explicit InteractionPotential(typename Functions::Form form) : form_(form){};
+    explicit InteractionPotential(typename Functions::Form form) { setForm(form); };
     virtual ~InteractionPotential() = default;
     InteractionPotential(const InteractionPotential &source) = default;
     InteractionPotential(InteractionPotential &&source) = delete;
@@ -121,8 +121,7 @@ template <class Functions> class InteractionPotential
     std::string parametersAsString() const
     {
         auto id = 0;
-        return joinStrings(Functions::parameters(form()), " ",
-                           [&](const auto &parameter)
-                           { return fmt::format("{}={}", parameter, id < parameters().size() ? parameters().at(id++) : 0.0); });
+        return joinStrings(parameters(), " ",
+                           [&](const auto &value) { return fmt::format("{}={}", Functions::parameter(form(), id++), value); });
     }
 };

--- a/src/classes/interactionPotential.h
+++ b/src/classes/interactionPotential.h
@@ -121,7 +121,8 @@ template <class Functions> class InteractionPotential
     std::string parametersAsString() const
     {
         auto id = 0;
-        return joinStrings(parameters(), " ",
-                           [&](const auto &value) { return fmt::format("{}={}", Functions::parameter(form(), id++), value); });
+        return joinStrings(Functions::parameters(form()), " ",
+                           [&](const auto &parameter)
+                           { return fmt::format("{}={}", parameter, id < parameters().size() ? parameters().at(id++) : 0.0); });
     }
 };

--- a/src/classes/interactionPotential.h
+++ b/src/classes/interactionPotential.h
@@ -14,7 +14,7 @@
 template <class Functions> class InteractionPotential
 {
     public:
-    InteractionPotential(typename Functions::Form form) { setForm(form); };
+    explicit InteractionPotential(typename Functions::Form form) { setForm(form); };
     virtual ~InteractionPotential() = default;
     InteractionPotential(const InteractionPotential &source) = default;
     InteractionPotential(InteractionPotential &&source) = delete;


### PR DESCRIPTION
Simply updates the `InteractionPotential` class to call `setForm` in it's constructor (which constructs the `parameters_` vector), rather than just assigning the form. Closes #1525.