### PR TITLE
1528 Input File Error Handling

### DIFF
--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -548,7 +548,11 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!keywords().isValid(parser.argsv(0)))
-            return keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
+            continue;
+        }
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -538,7 +538,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
 {
     Messenger::printVerbose("\nReading information for Site '{}'...\n", name());
 
-    auto blockDone = false, error = false;
+    auto blockDone = false, errorsEncountered = false;
 
     while (!parser.eofOrBlank())
     {
@@ -552,7 +552,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {
-            error = true;
+            errorsEncountered = true;
             continue;
         }
 
@@ -566,7 +566,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                     if (!at || !addDynamicAtomType(at))
                     {
                         Messenger::error("Failed to add target atom type for site '{}'.\n", name());
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                 }
@@ -578,7 +578,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                 {
                     Messenger::error(
                         "Can't set '{}' to be dynamic as origin, x-axis, or y-axis atoms have already been defined.\n", name());
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (SpeciesSite::ElementKeyword):
@@ -588,7 +588,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                     if (el == Elements::Unknown || !addDynamicElement(el))
                     {
                         Messenger::error("Failed to add target element for site '{}'.\n", name());
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                 }
@@ -600,7 +600,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                 if (!fragment_.create(parser.args(1)))
                 {
                     Messenger::error("Failed to parse NETA description for site '{}'.\n", name());
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (SpeciesSite::EndSiteKeyword):
@@ -609,7 +609,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                     if (!generateUniqueSites())
                     {
                         Messenger::error("Failed to generate unique sites for site '{}'.\n", name());
-                        error = true;
+                        errorsEncountered = true;
                     }
                 }
                 Messenger::print("Found end of Site '{}'.\n", name());
@@ -621,7 +621,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                     if (!addStaticOriginAtom(parser.argi(n) - 1))
                     {
                         Messenger::error("Failed to add origin atom for site '{}'.\n", name());
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                 }
@@ -635,7 +635,7 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                     if (!addStaticXAxisAtom(parser.argi(n) - 1))
                     {
                         Messenger::error("Failed to add x-axis atom for site '{}'.\n", name());
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                 }
@@ -646,19 +646,19 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
                     if (!addStaticYAxisAtom(parser.argi(n) - 1))
                     {
                         Messenger::error("Failed to add y-axis atom for site '{}'.\n", name());
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                 }
                 break;
             default:
                 Messenger::error("Site block keyword '{}' not accounted for.\n", keywords().keyword(kwd));
-                error = true;
+                errorsEncountered = true;
                 break;
         }
 
         // Error encountered?
-        if (error)
+        if (errorsEncountered)
             break;
 
         // End of block?
@@ -666,14 +666,14 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
             break;
     }
 
-    // If there's no error and the blockDone flag isn't set, return an error
-    if (!error && !blockDone)
+    // If there's no errorsEncountered and the blockDone flag isn't set, return an errorsEncountered
+    if (!errorsEncountered && !blockDone)
     {
         Messenger::error("Unterminated Site block found.\n");
-        error = true;
+        errorsEncountered = true;
     }
 
-    return (!error);
+    return (!errorsEncountered);
 }
 
 // Write site definition to specified LineParser

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -551,7 +551,10 @@ bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
             return keywords().errorAndPrintValid(parser.argsv(0));
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-            return false;
+        {
+            error = true;
+            continue;
+        }
 
         // All OK, so process the keyword
         switch (kwd)

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -539,10 +539,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 break;
         }
 
-        // Error encountered?
-        if (error)
-            break;
-
         // End of block?
         if (blockDone)
             break;

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -96,11 +96,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 }
                 else
                     a = addAngle(parser.argi(1) - 1, parser.argi(2) - 1, parser.argi(3) - 1);
-                if (!a)
-                {
-                    error = true;
-                    break;
-                }
 
                 /*
                  * If only the indices were given, create an angle without a specified functional form (a
@@ -191,11 +186,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 }
                 else
                     b = addBond(parser.argi(1) - 1, parser.argi(2) - 1);
-                if (!b)
-                {
-                    error = true;
-                    break;
-                }
 
                 /*
                  * If only the indices were given, create a bond without a specified functional form (a
@@ -328,11 +318,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 }
                 else
                     imp = addImproper(parser.argi(1) - 1, parser.argi(2) - 1, parser.argi(3) - 1, parser.argi(4) - 1);
-                if (!imp)
-                {
-                    error = true;
-                    break;
-                }
 
                 // Check the functional form specified - if it starts with '@' it is a reference to master
                 // parameters
@@ -496,11 +481,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 }
                 else
                     torsion = addTorsion(parser.argi(1) - 1, parser.argi(2) - 1, parser.argi(3) - 1, parser.argi(4) - 1);
-                if (!torsion)
-                {
-                    error = true;
-                    break;
-                }
 
                 /*
                  * If only the indices were given, create an angle without a specified functional form (a

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -73,7 +73,10 @@ bool Species::read(LineParser &parser, CoreData &coreData)
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!keywords().isValid(parser.argsv(0)))
-            return keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            keywords().errorAndPrintValid(parser.argsv(0));
+            continue;
+        }
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -75,6 +75,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
         if (!keywords().isValid(parser.argsv(0)))
         {
             keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
             continue;
         }
         auto kwd = keywords().enumeration(parser.argsv(0));

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -76,7 +76,10 @@ bool Species::read(LineParser &parser, CoreData &coreData)
             return keywords().errorAndPrintValid(parser.argsv(0));
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-            return false;
+        {
+            error = true;
+            continue;
+        }
 
         // All OK, so process the keyword
         switch (kwd)

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -34,6 +34,7 @@ bool Dissolve::loadInput(LineParser &parser)
         if (!BlockKeywords::keywords().isValid(parser.argsv(0)))
         {
             BlockKeywords::keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
             continue;
         }
         auto kwd = BlockKeywords::keywords().enumeration(parser.argsv(0));

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -32,7 +32,10 @@ bool Dissolve::loadInput(LineParser &parser)
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!BlockKeywords::keywords().isValid(parser.argsv(0)))
-            return BlockKeywords::keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            BlockKeywords::keywords().errorAndPrintValid(parser.argsv(0));
+            continue;
+        }
         auto kwd = BlockKeywords::keywords().enumeration(parser.argsv(0));
 
         // All OK, so process the keyword

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -22,7 +22,7 @@ bool Dissolve::loadInput(LineParser &parser)
     Configuration *cfg;
     ModuleLayer *layer = nullptr;
     Species *sp;
-    auto error = false;
+    auto errorsEncountered = false;
 
     while (!parser.eofOrBlank())
     {
@@ -41,55 +41,43 @@ bool Dissolve::loadInput(LineParser &parser)
             case (BlockKeywords::ConfigurationBlockKeyword):
                 // Check to see if a Configuration with this name already exists...
                 if (findConfiguration(parser.argsv(1)))
-                {
-                    Messenger::error("Redefinition of Configuration '{}'.\n", parser.argsv(1));
-                    error = true;
-                    break;
-                }
+                    return Messenger::error("Redefinition of Configuration '{}'.\n", parser.argsv(1));
+
                 cfg = addConfiguration();
                 cfg->setName(parser.argsv(1));
                 Messenger::print("\n--> Created Configuration '{}'\n", cfg->name());
                 if (!ConfigurationBlock::parse(parser, this, cfg))
-                {
-                    error = true;
-                    break;
-                }
+                    errorsEncountered = true;
                 break;
             case (BlockKeywords::LayerBlockKeyword):
                 // Check to see if a processing layer with this name already exists...
                 if (findProcessingLayer(parser.argsv(1)))
-                {
                     Messenger::error("Redefinition of processing layer '{}'.\n", parser.argsv(1));
-                    error = true;
-                    break;
-                }
+
                 layer = addProcessingLayer();
                 layer->setName(parser.argsv(1));
                 Messenger::print("\n--> Created processing layer '{}'\n", layer->name());
                 if (!LayerBlock::parse(parser, this, layer))
-                    error = true;
+                    errorsEncountered = true;
                 break;
             case (BlockKeywords::MasterBlockKeyword):
                 if (!MasterBlock::parse(parser, coreData_))
-                    error = true;
+                    errorsEncountered = true;
                 break;
             case (BlockKeywords::PairPotentialsBlockKeyword):
                 if (!PairPotentialsBlock::parse(parser, this))
-                    error = true;
+                    errorsEncountered = true;
                 break;
             case (BlockKeywords::SpeciesBlockKeyword):
                 // Check to see if a Species with this name already exists...
                 if (findSpecies(parser.argsv(1)))
-                {
-                    Messenger::error("Redefinition of species '{}'.\n", parser.argsv(1));
-                    error = true;
-                    break;
-                }
+                    return Messenger::error("Redefinition of species '{}'.\n", parser.argsv(1));
+
                 sp = addSpecies();
                 sp->setName(parser.argsv(1));
                 Messenger::print("\n--> Created Species '{}'\n", sp->name());
                 if (!sp->read(parser, coreData_))
-                    error = true;
+                    errorsEncountered = true;
                 else if (Messenger::isVerbose())
                 {
                     Messenger::print("\n--- Species '{}'...\n", sp->name());
@@ -99,23 +87,19 @@ bool Dissolve::loadInput(LineParser &parser)
             default:
                 Messenger::error("Block keyword '{}' is not relevant in this context.\n",
                                  BlockKeywords::keywords().keyword(kwd));
-                error = true;
+                errorsEncountered = true;
                 break;
         }
-
-        // Error encountered?
-        if (error)
-            break;
     }
 
     // Error encountered?
-    if (error)
+    if (errorsEncountered)
         Messenger::error("Errors encountered while parsing input.");
 
     // Done
     parser.closeFiles();
 
-    return (!error);
+    return (!errorsEncountered);
 }
 
 // Load input from supplied string

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -81,10 +81,6 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 break;
         }
 
-        // Error encountered?
-        if (errorsEncountered)
-            break;
-
         // End of block?
         if (blockDone)
             break;

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -36,7 +36,10 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!keywords().isValid(parser.argsv(0)))
-            return keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            keywords().errorAndPrintValid(parser.argsv(0));
+            continue;
+        }
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -26,7 +26,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                      BlockKeywords::keywords().keyword(BlockKeywords::ConfigurationBlockKeyword), cfg->name());
 
     std::string niceName;
-    auto blockDone = false, error = false;
+    auto blockDone = false, errorsEncountered = false;
 
     while (!parser.eofOrBlank())
     {
@@ -40,7 +40,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {
-            error = true;
+            errorsEncountered = true;
             continue;
         }
 
@@ -59,7 +59,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 if (!cfg->generator().deserialise(parser, dissolve->coreData()))
                 {
                     Messenger::error("Failed to read generator procedure for Configuration.\n");
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (ConfigurationBlock::SizeFactorKeyword):
@@ -74,12 +74,12 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
                 Messenger::error("{} block keyword '{}' not accounted for.\n",
                                  BlockKeywords::keywords().keyword(BlockKeywords::ConfigurationBlockKeyword),
                                  keywords().keyword(kwd));
-                error = true;
+                errorsEncountered = true;
                 break;
         }
 
         // Error encountered?
-        if (error)
+        if (errorsEncountered)
             break;
 
         // End of block?
@@ -87,13 +87,13 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
             break;
     }
 
-    // If there's no error and the blockDone flag isn't set, return an error
-    if (!error && !blockDone)
+    // If there's no errorsEncountered and the blockDone flag isn't set, return an errorsEncountered
+    if (!errorsEncountered && !blockDone)
     {
         Messenger::error("Unterminated {} block found.\n",
                          BlockKeywords::keywords().keyword(BlockKeywords::ConfigurationBlockKeyword));
-        error = true;
+        errorsEncountered = true;
     }
 
-    return (!error);
+    return (!errorsEncountered);
 }

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -61,7 +61,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
             case (ConfigurationBlock::GeneratorKeyword):
                 if (!cfg->generator().deserialise(parser, dissolve->coreData()))
                 {
-                    Messenger::error("Failed to read generator procedure for Configuration.\n");
+                    Messenger::error("Errors while reading generator procedure for Configuration.\n");
                     errorsEncountered = true;
                 }
                 break;

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -38,6 +38,7 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
         if (!keywords().isValid(parser.argsv(0)))
         {
             keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
             continue;
         }
         auto kwd = keywords().enumeration(parser.argsv(0));

--- a/src/main/keywords_configuration.cpp
+++ b/src/main/keywords_configuration.cpp
@@ -39,7 +39,10 @@ bool ConfigurationBlock::parse(LineParser &parser, Dissolve *dissolve, Configura
             return keywords().errorAndPrintValid(parser.argsv(0));
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-            return false;
+        {
+            error = true;
+            continue;
+        }
 
         // All OK, so process the keyword
         switch (kwd)

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -137,10 +137,6 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                 break;
         }
 
-        // Error encountered?
-        if (error)
-            break;
-
         // End of block?
         if (blockDone)
             break;

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -38,7 +38,10 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!keywords().isValid(parser.argsv(0)))
-            return keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            keywords().errorAndPrintValid(parser.argsv(0));
+            continue;
+        }
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -95,7 +95,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                 {
                     Messenger::error("Module type '{}' does not exist.\n", parser.argsv(1));
                     errorsEncountered = true;
-                    break;
+                    continue;
                 }
 
                 // Set unique name, if it was provided - need to check if it has been used elsewhere

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -26,7 +26,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
     Messenger::print("\nParsing {} block '{}'...\n", BlockKeywords::keywords().keyword(BlockKeywords::LayerBlockKeyword),
                      layer->name());
 
-    auto blockDone = false, error = false;
+    auto blockDone = false, errorsEncountered = false;
     Module *module = nullptr;
     std::string niceName;
 
@@ -42,7 +42,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {
-            error = true;
+            errorsEncountered = true;
             continue;
         }
 
@@ -91,7 +91,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                 if (!module)
                 {
                     Messenger::error("Module type '{}' does not exist.\n", parser.argsv(1));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
 
@@ -103,7 +103,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                     if (existingModule && (existingModule != module))
                     {
                         Messenger::error("A Module with the unique name '{}' already exists.\n", niceName);
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                     else if (dissolve->findConfigurationByNiceName(niceName))
@@ -111,7 +111,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
                         Messenger::error("A Configuration with the unique name '{}' already exist, and so "
                                          "cannot be used as a Module name.\n",
                                          niceName);
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
                     else
@@ -120,8 +120,8 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
 
                 // Parse rest of Module block
                 if (!ModuleBlock::parse(parser, dissolve, module, dissolve->processingModuleData(), false))
-                    error = true;
-                if (error)
+                    errorsEncountered = true;
+                if (errorsEncountered)
                     break;
                 break;
             case (LayerBlock::RequireEnergyStabilityKeyword):
@@ -133,7 +133,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
             default:
                 Messenger::error("{} block keyword '{}' not accounted for.\n",
                                  BlockKeywords::keywords().keyword(BlockKeywords::LayerBlockKeyword), keywords().keyword(kwd));
-                error = true;
+                errorsEncountered = true;
                 break;
         }
 
@@ -142,12 +142,12 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
             break;
     }
 
-    // If there's no error and the blockDone flag isn't set, return an error
-    if (!error && !blockDone)
+    // If there's no errorsEncountered and the blockDone flag isn't set, return an errorsEncountered
+    if (!errorsEncountered && !blockDone)
     {
         Messenger::error("Unterminated {} block found.\n", BlockKeywords::keywords().keyword(BlockKeywords::LayerBlockKeyword));
-        error = true;
+        errorsEncountered = true;
     }
 
-    return (!error);
+    return (!errorsEncountered);
 }

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -41,7 +41,10 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
             return keywords().errorAndPrintValid(parser.argsv(0));
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-            return false;
+        {
+            error = true;
+            continue;
+        }
 
         // All OK, so process the keyword
         switch (kwd)

--- a/src/main/keywords_layer.cpp
+++ b/src/main/keywords_layer.cpp
@@ -40,6 +40,7 @@ bool LayerBlock::parse(LineParser &parser, Dissolve *dissolve, ModuleLayer *laye
         if (!keywords().isValid(parser.argsv(0)))
         {
             keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
             continue;
         }
         auto kwd = keywords().enumeration(parser.argsv(0));

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -41,7 +41,10 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
             return keywords().errorAndPrintValid(parser.argsv(0));
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-            return false;
+        {
+            error = true;
+            continue;
+        }
 
         // All OK, so process the keyword
         switch (kwd)

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -40,6 +40,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
         if (!keywords().isValid(parser.argsv(0)))
         {
             keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
             continue;
         }
         auto kwd = keywords().enumeration(parser.argsv(0));

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -227,10 +227,6 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 break;
         }
 
-        // Error encountered?
-        if (error)
-            break;
-
         // End of block?
         if (blockDone)
             break;

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -28,7 +28,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
     AngleFunctions::Form af;
     TorsionFunctions::Form tf;
     auto elec14Scaling = 0.5, vdw14Scaling = 0.5;
-    auto blockDone = false, error = false;
+    auto blockDone = false, errorsEncountered = false;
 
     while (!parser.eofOrBlank())
     {
@@ -42,7 +42,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {
-            error = true;
+            errorsEncountered = true;
             continue;
         }
 
@@ -54,7 +54,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 if (!AngleFunctions::forms().isValid(parser.argsv(2)))
                 {
                     Messenger::error("Functional form of angle ({}) not recognised.\n", parser.argsv(2));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
                 af = AngleFunctions::forms().enumeration(parser.argsv(2));
@@ -68,14 +68,14 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     // Check number of args provided
                     if (!AngleFunctions::forms().validNArgs(af, parser.nArgs() - 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
                     // Set parameters
                     if (!masterAngle.setInteractionParameters(parser, 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
@@ -86,7 +86,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 catch (const std::runtime_error &e)
                 {
                     Messenger::error(e.what());
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (MasterBlock::BondKeyword):
@@ -94,7 +94,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 if (!BondFunctions::forms().isValid(parser.argsv(2)))
                 {
                     Messenger::error("Functional form of bond ({}) not recognised.\n", parser.argsv(2));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
                 bf = BondFunctions::forms().enumeration(parser.argsv(2));
@@ -108,14 +108,14 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     // Check number of args provided
                     if (!BondFunctions::forms().validNArgs(bf, parser.nArgs() - 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
                     // Set parameters
                     if (!masterBond.setInteractionParameters(parser, 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
@@ -126,7 +126,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 catch (const std::runtime_error &e)
                 {
                     Messenger::error(e.what());
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (MasterBlock::EndMasterKeyword):
@@ -138,7 +138,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 if (!TorsionFunctions::forms().isValid(parser.argsv(2)))
                 {
                     Messenger::error("Functional form of improper ({}) not recognised.\n", parser.argsv(2));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
                 tf = TorsionFunctions::forms().enumeration(parser.argsv(2));
@@ -152,14 +152,14 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     // Check number of args provided
                     if (!TorsionFunctions::forms().validNArgs(tf, parser.nArgs() - 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
                     // Set parameters
                     if (!masterImproper.setInteractionParameters(parser, 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
@@ -170,7 +170,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 catch (const std::runtime_error &e)
                 {
                     Messenger::error(e.what());
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (MasterBlock::Scaling14Keyword):
@@ -182,7 +182,7 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 if (!TorsionFunctions::forms().isValid(parser.argsv(2)))
                 {
                     Messenger::error("Functional form of torsion ({}) not recognised.\n", parser.argsv(2));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
                 tf = TorsionFunctions::forms().enumeration(parser.argsv(2));
@@ -196,14 +196,14 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                     // Check number of args provided
                     if (!TorsionFunctions::forms().validNArgs(tf, parser.nArgs() - 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
                     // Set parameters
                     if (!masterTorsion.setInteractionParameters(parser, 3))
                     {
-                        error = true;
+                        errorsEncountered = true;
                         break;
                     }
 
@@ -217,13 +217,13 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
                 catch (const std::runtime_error &e)
                 {
                     Messenger::error(e.what());
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             default:
                 Messenger::error("{} block keyword '{}' not accounted for.\n",
                                  BlockKeywords::keywords().keyword(BlockKeywords::MasterBlockKeyword), keywords().keyword(kwd));
-                error = true;
+                errorsEncountered = true;
                 break;
         }
 
@@ -232,13 +232,13 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
             break;
     }
 
-    // If there's no error and the blockDone flag isn't set, return an error
-    if (!error && !blockDone)
+    // If there's no errorsEncountered and the blockDone flag isn't set, return an errorsEncountered
+    if (!errorsEncountered && !blockDone)
     {
         Messenger::error("Unterminated {} block found.\n",
                          BlockKeywords::keywords().keyword(BlockKeywords::MasterBlockKeyword));
-        error = true;
+        errorsEncountered = true;
     }
 
-    return (!error);
+    return (!errorsEncountered);
 }

--- a/src/main/keywords_master.cpp
+++ b/src/main/keywords_master.cpp
@@ -38,7 +38,10 @@ bool MasterBlock::parse(LineParser &parser, CoreData &coreData)
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!keywords().isValid(parser.argsv(0)))
-            return keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            keywords().errorAndPrintValid(parser.argsv(0));
+            continue;
+        }
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -82,10 +82,6 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
                 error = true;
         }
 
-        // Error encountered?
-        if (error)
-            break;
-
         // End of block?
         if (blockDone)
             break;

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -35,7 +35,10 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
         {
             auto kwd = keywords().enumeration(parser.argsv(0));
             if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-                return false;
+            {
+                error = true;
+                continue;
+            }
 
             // All OK, so process the keyword
             switch (kwd)

--- a/src/main/keywords_module.cpp
+++ b/src/main/keywords_module.cpp
@@ -22,7 +22,7 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
     Messenger::print("\nParsing {} block '{}' ({})...\n", BlockKeywords::keywords().keyword(BlockKeywords::ModuleBlockKeyword),
                      module->name(), ModuleTypes::moduleType(module->type()));
 
-    auto blockDone = false, error = false;
+    auto blockDone = false, errorsEncountered = false;
 
     while (!parser.eofOrBlank())
     {
@@ -36,7 +36,7 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
             auto kwd = keywords().enumeration(parser.argsv(0));
             if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
             {
-                error = true;
+                errorsEncountered = true;
                 continue;
             }
 
@@ -58,7 +58,7 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
                     Messenger::error("{} block keyword '{}' not accounted for.\n",
                                      BlockKeywords::keywords().keyword(BlockKeywords::ModuleBlockKeyword),
                                      keywords().keyword(kwd));
-                    error = true;
+                    errorsEncountered = true;
                     break;
             }
         }
@@ -74,12 +74,12 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
                                  ModuleTypes::moduleType(module->type()));
                 keywords().errorAndPrintValid(parser.argsv(0));
                 module->printValidKeywords();
-                error = true;
+                errorsEncountered = true;
             }
             else if (result == KeywordBase::ParseResult::Deprecated)
                 Messenger::warn("The '{}' keyword is deprecated and will be removed in a future version.\n", parser.argsv(0));
             else if (result == KeywordBase::ParseResult::Failed)
-                error = true;
+                errorsEncountered = true;
         }
 
         // End of block?
@@ -87,13 +87,13 @@ bool ModuleBlock::parse(LineParser &parser, Dissolve *dissolve, Module *module, 
             break;
     }
 
-    // If there's no error and the blockDone flag isn't set, return an error
-    if (!error && !blockDone)
+    // If there's no errorsEncountered and the blockDone flag isn't set, return an errorsEncountered
+    if (!errorsEncountered && !blockDone)
     {
         Messenger::error("Unterminated {} block found.\n",
                          BlockKeywords::keywords().keyword(BlockKeywords::ModuleBlockKeyword));
-        error = true;
+        errorsEncountered = true;
     }
 
-    return (!error);
+    return (!errorsEncountered);
 }

--- a/src/main/keywords_pairPotentials.cpp
+++ b/src/main/keywords_pairPotentials.cpp
@@ -43,7 +43,10 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
             return keywords().errorAndPrintValid(parser.argsv(0));
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
-            return false;
+        {
+            error = true;
+            continue;
+        }
 
         // All OK, so process the keyword
         switch (kwd)

--- a/src/main/keywords_pairPotentials.cpp
+++ b/src/main/keywords_pairPotentials.cpp
@@ -42,6 +42,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
         if (!keywords().isValid(parser.argsv(0)))
         {
             keywords().errorAndPrintValid(parser.argsv(0));
+            errorsEncountered = true;
             continue;
         }
         auto kwd = keywords().enumeration(parser.argsv(0));

--- a/src/main/keywords_pairPotentials.cpp
+++ b/src/main/keywords_pairPotentials.cpp
@@ -149,10 +149,6 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 break;
         }
 
-        // Error encountered?
-        if (error)
-            break;
-
         // End of block?
         if (blockDone)
             break;

--- a/src/main/keywords_pairPotentials.cpp
+++ b/src/main/keywords_pairPotentials.cpp
@@ -29,7 +29,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
     Messenger::print("\nParsing {} block...\n", BlockKeywords::keywords().keyword(BlockKeywords::PairPotentialsBlockKeyword));
 
     std::shared_ptr<AtomType> at1;
-    auto blockDone = false, error = false;
+    auto blockDone = false, errorsEncountered = false;
     Elements::Element Z;
 
     while (!parser.eofOrBlank())
@@ -44,7 +44,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {
-            error = true;
+            errorsEncountered = true;
             continue;
         }
 
@@ -58,7 +58,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 else
                 {
                     PairPotential::coulombTruncationSchemes().errorAndPrintValid(parser.argsv(1));
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (PairPotentialsBlock::DeltaKeyword):
@@ -85,7 +85,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 {
                     Messenger::error("Unknown element '{}' given for atom type '{}' in PairPotentials block.\n",
                                      parser.argsv(2), parser.argsv(1));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
 
@@ -104,7 +104,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                     Messenger::error("Element '{}' does not match that for the existing atom type '{}' in "
                                      "PairPotentials block.\n",
                                      parser.argsv(2), parser.argsv(1));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
 
@@ -115,13 +115,13 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 if (!ShortRangeFunctions::forms().isValid(parser.argsv(4)))
                 {
                     ShortRangeFunctions::forms().errorAndPrintValid(parser.argsv(4));
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
                 at1->interactionPotential().setForm(ShortRangeFunctions::forms().enumeration(parser.argsv(4)));
                 if (!at1->interactionPotential().parseParameters(parser, 5))
                 {
-                    error = true;
+                    errorsEncountered = true;
                     break;
                 }
                 break;
@@ -135,7 +135,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 else
                 {
                     PairPotential::shortRangeTruncationSchemes().errorAndPrintValid(parser.argsv(1));
-                    error = true;
+                    errorsEncountered = true;
                 }
                 break;
             case (PairPotentialsBlock::ShortRangeTruncationWidthKeyword):
@@ -145,7 +145,7 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 Messenger::error("{} block keyword '{}' not accounted for.\n",
                                  BlockKeywords::keywords().keyword(BlockKeywords::PairPotentialsBlockKeyword),
                                  keywords().keyword(kwd));
-                error = true;
+                errorsEncountered = true;
                 break;
         }
 
@@ -155,12 +155,12 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
     }
 
     // If there's no error and the blockDone flag isn't set, return an error
-    if (!error && !blockDone)
+    if (!errorsEncountered && !blockDone)
     {
         Messenger::error("Unterminated {} block found.\n",
                          BlockKeywords::keywords().keyword(BlockKeywords::PairPotentialsBlockKeyword));
-        error = true;
+        errorsEncountered = true;
     }
 
-    return (!error);
+    return (!errorsEncountered);
 }

--- a/src/main/keywords_pairPotentials.cpp
+++ b/src/main/keywords_pairPotentials.cpp
@@ -40,7 +40,10 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
 
         // Do we recognise this keyword and, if so, do we have an appropriate number of arguments?
         if (!keywords().isValid(parser.argsv(0)))
-            return keywords().errorAndPrintValid(parser.argsv(0));
+        {
+            keywords().errorAndPrintValid(parser.argsv(0));
+            continue;
+        }
         auto kwd = keywords().enumeration(parser.argsv(0));
         if (!keywords().validNArgs(kwd, parser.nArgs() - 1))
         {

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -278,6 +278,7 @@ bool ProcedureNode::finalise(const ProcedureContext &procedureContext) { return 
 bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
 {
     // Read until we encounter the ending keyword (derived from the node type), or we fail for some reason
+    auto errorsEncountered = false;
     while (!parser.eofOrBlank())
     {
         // Read and parse the next line
@@ -286,7 +287,7 @@ bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
 
         // Is this the end of the node block?
         if (DissolveSys::sameString(parser.argsv(0), fmt::format("End{}", nodeTypes().keyword(type_))))
-            return true;
+            return !errorsEncountered;
 
         // Try to parse this line as a keyword
         KeywordBase::ParseResult result = keywords_.deserialise(parser, coreData);
@@ -296,10 +297,10 @@ bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
         else if (result == KeywordBase::ParseResult::Deprecated)
             Messenger::warn("The '{}' keyword is deprecated and will be removed in a future version.\n", parser.argsv(0));
         else if (result == KeywordBase::ParseResult::Failed)
-            return Messenger::error("Failed to parse keyword '{}'.\n", parser.argsv(0));
+            errorsEncountered = true;
     }
 
-    return true;
+    return !errorsEncountered;
 }
 
 // Write node data to specified LineParser

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -300,7 +300,7 @@ bool ProcedureNode::deserialise(LineParser &parser, const CoreData &coreData)
             errorsEncountered = true;
     }
 
-    return !errorsEncountered;
+    return (!errorsEncountered);
 }
 
 // Write node data to specified LineParser

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -525,7 +525,7 @@ bool ProcedureNodeSequence::deserialise(LineParser &parser, const CoreData &core
         }
     }
 
-    return !errorsEncountered;
+    return (!errorsEncountered);
 }
 
 // Write structure to specified LineParser

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -486,7 +486,10 @@ bool ProcedureNodeSequence::deserialise(LineParser &parser, const CoreData &core
 
         // Not a control keyword, so must be a node type
         if (!ProcedureNode::nodeTypes().isValid(parser.argsv(0)))
-            return Messenger::error("Unrecognised node type '{}' found.\n", parser.argsv(0));
+        {
+            Messenger::error("Unrecognised node type '{}' found.\n", parser.argsv(0));
+            continue;
+        }
 
         // Create a new node of the specified type
         auto newNode = ProcedureNodeRegistry::create(ProcedureNode::nodeTypes().enumeration(parser.argsv(0)));
@@ -511,7 +514,7 @@ bool ProcedureNodeSequence::deserialise(LineParser &parser, const CoreData &core
 
         // Read the new node
         if (!newNode->deserialise(parser, coreData))
-            return Messenger::error("Failed to read node sequence.\n");
+            Messenger::error("Failed to read node sequence.\n");
     }
 
     return true;


### PR DESCRIPTION
This PR significantly "softens" the assumed severity of errors encountered while reading our (current) input file format. Wherever possible errors are simply reported, but parsing continues, and should greatly reduce the amount of bad UX when loading in a slightly older input file.

Closes #1528.