### PR TITLE
Fix Expression Normalisations

### DIFF
--- a/src/modules/angle/angle.cpp
+++ b/src/modules/angle/angle.cpp
@@ -98,7 +98,7 @@ AngleModule::AngleModule() : Module(ModuleTypes::Angle), analyser_(ProcedureNode
     processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
     processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &angleNormalisation = processAngle_->branch()->get();
-    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(toRad(x))");
     angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
 
     // Process2D: 'DAngle (A-B)-C'
@@ -108,7 +108,7 @@ AngleModule::AngleModule() : Module(ModuleTypes::Angle), analyser_(ProcedureNode
     processDAngleAB_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &dAngleABNormalisation = processDAngleAB_->branch()->get();
     dAngleABNormalisationExpression_ = dAngleABNormalisation.create<OperateExpressionProcedureNode>(
-        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+        {}, fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     dAngleABNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
         {}, ConstNodeVector<SelectProcedureNode>({selectA_, selectC_}));
     dAngleABNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},
@@ -122,7 +122,7 @@ AngleModule::AngleModule() : Module(ModuleTypes::Angle), analyser_(ProcedureNode
     processDAngleBC_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &dAngleBCNormalisation = processDAngleBC_->branch()->get();
     dAngleBCNormalisationExpression_ = dAngleBCNormalisation.create<OperateExpressionProcedureNode>(
-        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+        {}, fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     dAngleBCNormalisation.create<OperateSitePopulationNormaliseProcedureNode>(
         {}, ConstNodeVector<SelectProcedureNode>({selectB_, selectA_}));
     dAngleBCNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({},

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -24,8 +24,10 @@ bool AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     selectC_->setDistanceReferenceSite(selectB_);
     selectC_->setInclusiveDistanceRange({rangeBC_.x, rangeBC_.y});
     calculateAngle_->keywords().set("Symmetric", symmetric_);
-    dAngleABNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
-    dAngleBCNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleABNormalisationExpression_->setExpression(
+        fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
+    dAngleBCNormalisationExpression_->setExpression(
+        fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     collectDDA_->keywords().set("RangeX", rangeAB_);
     collectDDA_->keywords().set("RangeY", rangeBC_);
     collectDDA_->keywords().set("RangeZ", angleRange_);

--- a/src/modules/axisAngle/axisAngle.cpp
+++ b/src/modules/axisAngle/axisAngle.cpp
@@ -71,7 +71,7 @@ AxisAngleModule::AxisAngleModule() : Module(ModuleTypes::AxisAngle), analyser_(P
     processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
     processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &angleNormalisation = processAngle_->branch()->get();
-    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(toRad(x))");
     angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
 
     // Process2D: 'DAngle'
@@ -81,7 +81,7 @@ AxisAngleModule::AxisAngleModule() : Module(ModuleTypes::AxisAngle), analyser_(P
     processDAngle_->keywords().set("LabelValue", std::string("g(r)"));
     auto &dAngleNormalisation = processDAngle_->branch()->get();
     dAngleNormalisationExpression_ = dAngleNormalisation.create<OperateExpressionProcedureNode>(
-        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+        {}, fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     dAngleNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({},
                                                                             ConstNodeVector<SelectProcedureNode>({selectA_}));
     dAngleNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>{selectB_});

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -19,7 +19,8 @@ bool AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Ensure any parameters in our nodes are set correctly
     calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
-    dAngleNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleNormalisationExpression_->setExpression(
+        fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     collectDistance_->keywords().set("RangeX", distanceRange_);
     collectAngle_->keywords().set("RangeX", angleRange_);
     collectDAngle_->keywords().set("RangeX", distanceRange_);

--- a/src/modules/dAngle/dAngle.cpp
+++ b/src/modules/dAngle/dAngle.cpp
@@ -82,7 +82,7 @@ DAngleModule::DAngleModule() : Module(ModuleTypes::DAngle), analyser_(ProcedureN
     processDAngle_->keywords().set("LabelY", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &dAngleNormalisation = processDAngle_->branch()->get();
     dAngleNormalisationExpression_ = dAngleNormalisation.create<OperateExpressionProcedureNode>(
-        {}, fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+        {}, fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     dAngleNormalisation.create<OperateSitePopulationNormaliseProcedureNode>({},
                                                                             ConstNodeVector<SelectProcedureNode>({selectA_}));
     dAngleNormalisation.create<OperateNumberDensityNormaliseProcedureNode>({}, ConstNodeVector<SelectProcedureNode>{selectB_});

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -19,7 +19,8 @@ bool DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Ensure any parameters in our nodes are set correctly
     calculateAngle_->keywords().set("Symmetric", symmetric_);
-    dAngleNormalisationExpression_->setExpression(fmt::format("{} * value/sin(y)/sin(yDelta)", symmetric_ ? 1.0 : 2.0));
+    dAngleNormalisationExpression_->setExpression(
+        fmt::format("{} * value/sin(toRad(y))/sin(toRad(yDelta))", symmetric_ ? 1.0 : 2.0));
     collectDistance_->keywords().set("RangeX", distanceRange_);
     collectAngle_->keywords().set("RangeX", angleRange_);
     collectDAngle_->keywords().set("RangeX", distanceRange_);

--- a/src/modules/intraAngle/intraAngle.cpp
+++ b/src/modules/intraAngle/intraAngle.cpp
@@ -50,7 +50,7 @@ IntraAngleModule::IntraAngleModule() : Module(ModuleTypes::IntraAngle), analyser
     processAngle_->keywords().set("LabelValue", std::string("Normalised Frequency"));
     processAngle_->keywords().set("LabelX", std::string("\\symbol{theta}, \\symbol{degrees}"));
     auto &angleNormalisation = processAngle_->branch()->get();
-    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(x)");
+    angleNormalisation.create<OperateExpressionProcedureNode>({}, "value/sin(toRad(x))");
     angleNormalisation.create<OperateNormaliseProcedureNode>({}, 1.0);
 
     /*


### PR DESCRIPTION
This PR addresses a fairly critical bug affecting the `Angle`, `IntraAngle`, `DAngle`, and `AxisAngle` modules (see the theme here?) whereby the normalisation of the calculated data was wrong. This became broken in #1440 when the trigonometric functions implemented in `Expression` were modified to take an argument in radians rather than user-friendly degrees.

Closes #1521, which is not an overflow issue as suggested, but is related to this.