### PR TITLE
Toml fixes

### DIFF
--- a/src/classes/data3DStore.cpp
+++ b/src/classes/data3DStore.cpp
@@ -44,7 +44,6 @@ OptionalReferenceWrapper<const Data3D> Data3DStore::data(std::string_view name) 
 // Return vector of all data
 const std::vector<std::shared_ptr<std::pair<Data3D, Data3DImportFileFormat>>> &Data3DStore::data() const { return data_; }
 
-
 // Express as a serialisable value
 SerialisedValue Data3DStore::serialise() const
 {

--- a/src/classes/data3DStore.cpp
+++ b/src/classes/data3DStore.cpp
@@ -47,7 +47,6 @@ const std::vector<std::shared_ptr<std::pair<Data3D, Data3DImportFileFormat>>> &D
 // Express as a serialisable value
 SerialisedValue Data3DStore::serialise() const
 {
-
     if (data_.empty())
         return {};
     return fromVectorToMap(

--- a/src/classes/data3DStore.cpp
+++ b/src/classes/data3DStore.cpp
@@ -43,3 +43,28 @@ OptionalReferenceWrapper<const Data3D> Data3DStore::data(std::string_view name) 
 
 // Return vector of all data
 const std::vector<std::shared_ptr<std::pair<Data3D, Data3DImportFileFormat>>> &Data3DStore::data() const { return data_; }
+
+
+// Express as a serialisable value
+SerialisedValue Data3DStore::serialise() const
+{
+
+    if (data_.empty())
+        return {};
+    return fromVectorToMap(
+        data_, [](const auto &item) { return std::string(item->first.tag()); }, [](const auto &item) { return item->second; });
+}
+
+// Read values from a serialisable value
+void Data3DStore::deserialise(const SerialisedValue &node, const CoreData &coreData)
+{
+    toMap(node,
+          [this, &coreData](const auto key, const auto value)
+          {
+              auto pair = std::make_shared<std::pair<Data3D, Data3DImportFileFormat>>();
+              pair->first.setTag(key);
+              pair->second.deserialise(value, coreData);
+              pair->second.importData(pair->first);
+              data_.push_back(pair);
+          });
+}

--- a/src/classes/data3DStore.h
+++ b/src/classes/data3DStore.h
@@ -9,7 +9,7 @@
 #include <list>
 
 // Data3D Store
-class Data3DStore
+class Data3DStore : public Serialisable<const CoreData &>
 {
     public:
     Data3DStore() = default;
@@ -32,4 +32,8 @@ class Data3DStore
     OptionalReferenceWrapper<const Data3D> data(std::string_view name) const;
     // Return vector of all data
     const std::vector<std::shared_ptr<std::pair<Data3D, Data3DImportFileFormat>>> &data() const;
+    // Express as a serialisable value
+    SerialisedValue serialise() const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/data3DStore.cpp
+++ b/src/keywords/data3DStore.cpp
@@ -55,6 +55,4 @@ bool Data3DStoreKeyword::serialise(LineParser &parser, std::string_view keywordN
 }
 
 // Express as a serialisable value
-SerialisedValue Data3DStoreKeyword::serialise() const {
-  return data_;
-}
+SerialisedValue Data3DStoreKeyword::serialise() const { return data_; }

--- a/src/keywords/data3DStore.cpp
+++ b/src/keywords/data3DStore.cpp
@@ -55,4 +55,6 @@ bool Data3DStoreKeyword::serialise(LineParser &parser, std::string_view keywordN
 }
 
 // Express as a serialisable value
-SerialisedValue Data3DStoreKeyword::serialise() const { throw std::runtime_error("Cannot serialise Data3DStoreKeyword"); }
+SerialisedValue Data3DStoreKeyword::serialise() const {
+  return data_;
+}

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -99,9 +99,11 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase
     }
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override {
-      if (data_) return data_->name();
-      return {};
+    SerialisedValue serialise() const override
+    {
+        if (data_)
+            return data_->name();
+        return {};
     }
 
     // Read values from a serialisable value

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -99,7 +99,10 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase
     }
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override { return data_->name(); }
+    SerialisedValue serialise() const override {
+      if (data_) return data_->name();
+      return {};
+    }
 
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -296,7 +296,7 @@ SerialisedValue KeywordStore::serialiseOnto(SerialisedValue node) const
         if (!k.keyword()->isDefault())
         {
             auto value = k.keyword()->serialise();
-            if (!value.is_uninitialized())
+            if (k.type() != KeywordStoreData::KeywordType::Deprecated && !value.is_uninitialized())
                 node[toml_format(k.keyword()->name())] = value;
         }
     return node;


### PR DESCRIPTION
Fixes a couple of issues in the TOML serialisation

1) Replace the serialisation stub for Data3DStore with actual methods
2) Don't export null modules
3) Don't serialise deprecate keywords

We're still at 35 failing tests, but two tests now fail at runtime instead of crashing during parsing.