### PR TITLE
feat: Node test fixtures

### DIFF
--- a/src/base/serialiser.cpp
+++ b/src/base/serialiser.cpp
@@ -7,6 +7,7 @@ namespace Serialisable
 {
 void serialiseOnto(int a, std::string tag, SerialisedValue &target) { target[tag] = a; }
 void serialiseOnto(double a, std::string tag, SerialisedValue &target) { target[tag] = a; }
+void serialiseOnto(std::string_view a, std::string tag, SerialisedValue &target) { target[tag] = std::string(a); }
 void serialiseOnto(std::string a, std::string tag, SerialisedValue &target) { target[tag] = a; }
 } // namespace Serialisable
 

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -41,9 +41,10 @@ namespace Serialisable
 using array = toml::array;
 using table = toml::table;
 
-void serialiseOnto(const int a, std::string tag, SerialisedValue &target);
-void serialiseOnto(const double a, std::string tag, SerialisedValue &target);
-void serialiseOnto(const std::string a, std::string tag, SerialisedValue &target);
+void serialiseOnto(int a, std::string tag, SerialisedValue &target);
+void serialiseOnto(double a, std::string tag, SerialisedValue &target);
+void serialiseOnto(std::string_view a, std::string tag, SerialisedValue &target);
+void serialiseOnto(std::string a, std::string tag, SerialisedValue &target);
 } // namespace Serialisable
 
 namespace Deserialisable

--- a/src/base/serialiserLibrary.h
+++ b/src/base/serialiserLibrary.h
@@ -47,7 +47,21 @@ template <typename K, typename V> void map(const std::map<K, V> &map, std::strin
         serialiseOnto(value, std::format("{}", key), result);
     node[name] = result;
 }
+template <typename K, typename V, typename Lambda>
+void map(const std::map<K, V> &map, std::string name, SerialisedValue &node, Lambda shouldSerialise)
+{
+    auto hasData = false;
+    SerialisedValue result;
+    for (auto &[key, value] : map)
+        if (shouldSerialise(value))
+        {
+            serialiseOnto(value, std::format("{}", key), result);
+            hasData = true;
+        }
 
+    if (hasData)
+        node[name] = result;
+}
 // A helper function to add elements of a vector to a node under the named heading
 template <SerialisablePointer T> void fromVectorToTable(const std::vector<T> &vec, std::string name, SerialisedValue &node)
 {

--- a/src/base/serialiserLibrary.h
+++ b/src/base/serialiserLibrary.h
@@ -20,15 +20,12 @@ concept SerialisablePointer = requires(T a, std::string tag, SerialisedValue tar
 template <typename T>
 concept SerialisableClass = requires(T a, std::string tag, SerialisedValue &target) { a.serialise(tag, target); };
 
-template <SerialisablePointer T> void serialiseOnto(const T &a, std::string tag, SerialisedValue &target)
+template <SerialisablePointer T> void serialiseOnto(T &a, std::string tag, SerialisedValue &target)
 {
     a->serialise(tag, target);
 }
 
-template <SerialisableClass T> void serialiseOnto(const T &a, std::string tag, SerialisedValue &target)
-{
-    a.serialise(tag, target);
-}
+template <SerialisableClass T> void serialiseOnto(T &a, std::string tag, SerialisedValue &target) { a.serialise(tag, target); }
 
 template <typename T>
 concept Serialisable = requires(const T a, std::string tag, SerialisedValue &target) { serialiseOnto(a, tag, target); };

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -140,13 +140,14 @@ bool AtomBase::isGeometry(AtomGeometry geom) const { return geometry() == geom; 
 // Express as a serialisable value
 void AtomBase::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = Serialisable::table{{"index", index_}, {"z", Serialisable::ser(Z_)}, {"r", Serialisable::ser(r_)}, {"q", q_}};
+    target[tag] = Serialisable::table{
+        {"index", index_}, {"z", Serialisable::ser(Elements::symbol(Z_))}, {"r", Serialisable::ser(r_)}, {"q", q_}};
 }
 // Read values from a serialisable value
 void AtomBase::deserialise(const SerialisedValue &node)
 {
     index_ = Deserialisable::deser<int>(node.at("index"));
 
-    set(Deserialisable::deser<Elements::Element>(node.at("z")), Deserialisable::deser<Vector3>(node.at("r")),
+    set(Elements::element(Deserialisable::deser<std::string>(node.at("z"))), Deserialisable::deser<Vector3>(node.at("r")),
         Deserialisable::deser_or<double>(node, "q", 0));
 }

--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -69,7 +69,7 @@ void AtomType::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &atomType = target[tag];
 
-    atomType["z"] = Serialisable::ser(Z_);
+    atomType["z"] = Serialisable::ser(Elements::symbol(Z_));
     atomType["charge"] = charge_;
     atomType["form"] = ShortRangeFunctions::forms().keyword(interactionPotential_.form());
     atomType["exchangeable"] = exchangeable_;
@@ -88,7 +88,7 @@ void AtomType::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void AtomType::deserialise(SerialisedValue node)
 {
-    Z_ = Deserialisable::deser<Elements::Element>(node.at("z"));
+    Z_ = Elements::element(Deserialisable::deser<std::string>(node.at("z")));
     charge_ = Deserialisable::deser_or<double>(node, "charge", 0.0);
     exchangeable_ = Deserialisable::deser_or<bool>(node, "exchangeable", false);
 

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -168,7 +168,8 @@ SpeciesAtom::ScaledInteractionDefinition SpeciesAtom::scaling(const SpeciesAtom 
 // Express as a serialisable value
 void SpeciesAtom::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = Serialisable::table{{"index", index_}, {"z", Serialisable::ser(Z_)}, {"r", Serialisable::ser(r_)}, {"q", q_}};
+    target[tag] = Serialisable::table{
+        {"index", index_}, {"z", Serialisable::ser(Elements::symbol(Z_))}, {"r", Serialisable::ser(r_)}, {"q", q_}};
     if (atomType_)
         target[tag]["type"] = atomType_->name().data();
 }
@@ -178,7 +179,7 @@ void SpeciesAtom::deserialise(const SerialisedValue &node)
 {
     index_ = Deserialisable::deser<int>(node.at("index"));
 
-    set(Deserialisable::deser<Elements::Element>(node.at("z")), Deserialisable::deser<Vector3>(node.at("r")),
+    set(Elements::element(Deserialisable::deser<std::string>(node.at("z"))), Deserialisable::deser<Vector3>(node.at("r")),
         Deserialisable::deser_or<double>(node, "q", 0));
 
     Deserialisable::optionalOn(node, "type",

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -514,7 +514,7 @@ void SpeciesSite::serialise(std::string tag, SerialisedValue &target) const
     switch (type_)
     {
         case SiteType::Dynamic:
-            Serialisable::vector(dynamicElements_, "element", site);
+            Serialisable::vector(dynamicElements_, "element", site, [&](const auto Z) { return Elements::symbol(Z); });
             break;
         case SiteType::Fragment:
             site["description"] = fragment_.definitionString();
@@ -554,7 +554,7 @@ void SpeciesSite::deserialise(const SerialisedValue &node)
             break;
         case SiteType::Dynamic:
             Deserialisable::vector(node, "element", [this](const auto &element)
-                                   { addDynamicElement(Deserialisable::deser<Elements::Element>(element)); });
+                                   { addDynamicElement(Elements::element(Deserialisable::deser<std::string>(element))); });
             break;
     }
 

--- a/src/classes/speciesSites.cpp
+++ b/src/classes/speciesSites.cpp
@@ -82,7 +82,7 @@ void SpeciesSites::deserialise(const SerialisedValue &node)
 {
     clear();
 
-    Deserialisable::map(node, "set",
+    Deserialisable::map(node, "sites",
                         [&](const std::string &speciesName, const SerialisedValue &sites)
                         {
                             auto &set = sites_[speciesName];

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -283,7 +283,7 @@ void Graph::deserialise(const SerialisedValue &node)
 }
 
 /*
- *Mermaid processing code
+ * Mermaid processing code
  */
 
 // Node types that represent data sources

--- a/src/nodes/insertRandom.cpp
+++ b/src/nodes/insertRandom.cpp
@@ -15,8 +15,8 @@ InsertRandomNode::InsertRandomNode(Graph *parentGraph) : Node(parentGraph)
     // Inputs
     addInput("Species", "Source species to add", species_);
     addInput("Configuration", "Target configuration to insert into", configuration_);
-    addInput("Population", "Population of the target to add", population_);
-    addInput("Density", "Density at which to add the target", density_);
+    addSerialisableInput("Population", "Population of the target to add", population_);
+    addSerialisableInput("Density", "Density at which to add the target", density_);
 
     // Options
     addOption("DensityUnits", "Units of target density", densityUnits_);

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -144,7 +144,7 @@ bool IterableGraph::addEdge(const EdgeDefinition &definition)
                          !loopBacks_->findInput(definition.targetInput);
 
     // If not invertible, create and return a standard edge
-    if (nonInvertible)
+    if (nonInvertible || definition.targetNode != "LoopBacks")
         return Graph::addEdge(definition);
 
     // Create loop edge

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -357,14 +357,14 @@ void Node::deserialise(const SerialisedValue &node)
                         [this](const auto &k, const auto &v)
                         {
                             if (inputs_.contains(k))
-                            try
-                            {
-                                inputs_[k]->deserialise(v);
-                            }
-                  catch (std::exception &ex)
-                  {
-                      Messenger::exception("Error reading input {} in node {} ({}).", k, name(), ex.what());
-                  }
+                                try
+                                {
+                                    inputs_[k]->deserialise(v);
+                                }
+                                catch (std::exception &ex)
+                                {
+                                    Messenger::exception("Error reading input {} in node {} ({}).", k, name(), ex.what());
+                                }
                             else
                                 Messenger::exception("Node {} does not contain a parameter {}", name(), k);
                         });
@@ -372,14 +372,14 @@ void Node::deserialise(const SerialisedValue &node)
                         [this](const auto &k, const auto &v)
                         {
                             if (options_.contains(k))
-                            try
-                            {
-                                options_[k]->deserialise(v);
-                            }
-                  catch (std::exception &ex)
-                  {
-                      Messenger::exception("Error reading option {} in node {} ({}).", k, name(), ex.what());
-                  }
+                                try
+                                {
+                                    options_[k]->deserialise(v);
+                                }
+                                catch (std::exception &ex)
+                                {
+                                    Messenger::exception("Error reading option {} in node {} ({}).", k, name(), ex.what());
+                                }
                             else
                                 Messenger::exception("Node {} does not contain an option {}", name(), k);
                         });

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -357,7 +357,14 @@ void Node::deserialise(const SerialisedValue &node)
                         [this](const auto &k, const auto &v)
                         {
                             if (inputs_.contains(k))
+                            try
+                            {
                                 inputs_[k]->deserialise(v);
+                            }
+                  catch (std::exception &ex)
+                  {
+                      Messenger::exception("Error reading input {} in node {} ({}).", k, name(), ex.what());
+                  }
                             else
                                 Messenger::exception("Node {} does not contain a parameter {}", name(), k);
                         });
@@ -365,7 +372,14 @@ void Node::deserialise(const SerialisedValue &node)
                         [this](const auto &k, const auto &v)
                         {
                             if (options_.contains(k))
+                            try
+                            {
                                 options_[k]->deserialise(v);
+                            }
+                  catch (std::exception &ex)
+                  {
+                      Messenger::exception("Error reading option {} in node {} ({}).", k, name(), ex.what());
+                  }
                             else
                                 Messenger::exception("Node {} does not contain an option {}", name(), k);
                         });

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -342,6 +342,8 @@ void Node::serialise(std::string tag, SerialisedValue &target) const
     result["y"] = y;
 
     Serialisable::map(options_, "options", result);
+    Serialisable::map(inputs_, "inputs", result,
+                      [](const auto &parameter) { return parameter->flags().isSet(ParameterBase::ParameterFlags::Serialise); });
 
     serialiseInternal(result);
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -356,7 +356,14 @@ void Node::deserialise(const SerialisedValue &node)
           [this](const auto &k, const auto &v)
           {
               if (inputs_.contains(k))
-                  inputs_[k]->deserialise(v);
+                  try
+                  {
+                      inputs_[k]->deserialise(v);
+                  }
+                  catch (std::exception &ex)
+                  {
+                      Messenger::exception("Error reading input {} in node {} ({}).", k, name(), ex.what());
+                  }
               else
                   Messenger::exception("Node {} does not contain a parameter {}", name(), k);
           });
@@ -364,7 +371,14 @@ void Node::deserialise(const SerialisedValue &node)
           [this](const auto &k, const auto &v)
           {
               if (options_.contains(k))
-                  options_[k]->deserialise(v);
+                  try
+                  {
+                      options_[k]->deserialise(v);
+                  }
+                  catch (std::exception &ex)
+                  {
+                      Messenger::exception("Error reading option {} in node {} ({}).", k, name(), ex.what());
+                  }
               else
                   Messenger::exception("Node {} does not contain an option {}", name(), k);
           });

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -216,7 +216,7 @@ class Node
         auto param =
             inputs_.emplace(std::make_pair(inputName, ParameterFactory::createSerialisable(this, inputName, description, data)))
                 .first->second;
-        param->setFlags(ParameterBase::ParameterFlags::Input);
+        param->setFlags({ParameterBase::ParameterFlags::Input, ParameterBase::ParameterFlags::Serialise});
         return param;
     }
     // Add output parameter

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -609,23 +609,23 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
         else if constexpr (HasEnumOptions<DataClass>)
         {
             DataClass proxy; // Fake T value to get the correct overload
-            Parameter<DataClass>::data_ = getEnumOptions(proxy).deserialise(node);
+            Parameter<DataClass>::data_ = getEnumOptions(proxy).enumeration(toml::find<std::string>(node, "data"));
         }
-        else if constexpr (std::is_convertible<DataClass, std::optional<double>>::value)
+        else if constexpr (std::is_same_v<DataClass, std::optional<double>>)
         {
             if (node.contains("data"))
                 Parameter<DataClass>::data_ = Deserialisable::deser<double>(node.at("data"));
             else
                 Parameter<DataClass>::data_ = {};
         }
-        else if constexpr (std::is_convertible<DataClass, std::optional<Number>>::value)
+        else if constexpr (std::is_same_v<DataClass, std::optional<Number>>)
         {
             if (node.contains("data"))
                 Parameter<DataClass>::data_ = Deserialisable::deser<Number>(node.at("data"));
             else
                 Parameter<DataClass>::data_ = {};
         }
-        else if constexpr (std::is_convertible<DataClass, std::optional<Data1D>>::value)
+        else if constexpr (std::is_same_v<DataClass, std::optional<Data1D>>)
         {
             if (node.contains("data"))
                 Parameter<DataClass>::data_ = Deserialisable::deser<Data1D>(node.at("data"));

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -54,6 +54,7 @@ class ParameterBase
         ClearData, /* Indicates that any local data should be cleared if the parameter is changed */
         Input,     /* Indicates that the parameter is meant to be a sink for data and not a source */
         Output,    /* Indicates that the parameter is meant to be a source of data and not a sink */
+        Serialise  /* Indicates that the (input) parameter should be serialised */
     };
     // Allowed Edge Count
     enum AllowedEdgeCount

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -578,9 +578,10 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
     {
         SerialisedValue result = {};
 
-        // Serialise non-pointer values
         if constexpr (HasEnumOptions<DataClass>)
             result["data"] = getEnumOptions(Parameter<DataClass>::data_).serialise(Parameter<DataClass>::data_);
+        else if constexpr (std::is_trivial_v<DataClass>)
+            result["data"] = Parameter<DataClass>::data_;
         else if constexpr (std::is_convertible<DataClass, Number>::value)
             result["data"] = Serialisable::ser(Parameter<DataClass>::data_);
         else if constexpr (std::is_convertible<DataClass, std::string>::value)
@@ -601,9 +602,7 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
     void deserialise(const SerialisedValue &node)
     {
         if constexpr (std::is_pointer<DataClass>::value)
-        {
             Parameter<DataClass>::data_ = nullptr;
-        }
         else if constexpr (is_ptr_vector<DataClass>::value)
             Parameter<DataClass>::data_.clear();
         else if constexpr (HasEnumOptions<DataClass>)
@@ -611,6 +610,8 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
             DataClass proxy; // Fake T value to get the correct overload
             Parameter<DataClass>::data_ = getEnumOptions(proxy).enumeration(toml::find<std::string>(node, "data"));
         }
+        else if constexpr (std::is_trivial_v<DataClass>)
+            Parameter<DataClass>::data_ = Deserialisable::deser<DataClass>(node.at("data"));
         else if constexpr (std::is_same_v<DataClass, std::optional<double>>)
         {
             if (node.contains("data"))

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -606,23 +606,23 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
         else if constexpr (HasEnumOptions<DataClass>)
         {
             DataClass proxy; // Fake T value to get the correct overload
-            Parameter<DataClass>::data_ = getEnumOptions(proxy).deserialise(node);
+            Parameter<DataClass>::data_ = getEnumOptions(proxy).enumeration(toml::find<std::string>(node, "data"));
         }
-        else if constexpr (std::is_convertible<DataClass, std::optional<double>>::value)
+        else if constexpr (std::is_same_v<DataClass, std::optional<double>>)
         {
             if (node.contains("data"))
                 Parameter<DataClass>::data_ = toml::find<double>(node, "data");
             else
                 Parameter<DataClass>::data_ = {};
         }
-        else if constexpr (std::is_convertible<DataClass, std::optional<Number>>::value)
+        else if constexpr (std::is_same_v<DataClass, std::optional<Number>>)
         {
             if (node.contains("data"))
                 Parameter<DataClass>::data_ = toml::find<Number>(node, "data");
             else
                 Parameter<DataClass>::data_ = {};
         }
-        else if constexpr (std::is_convertible<DataClass, std::optional<Data1D>>::value)
+        else if constexpr (std::is_same_v<DataClass, std::optional<Data1D>>)
         {
             if (node.contains("data"))
                 Parameter<DataClass>::data_ = toml::find<Data1D>(node, "data");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ function(dissolve_add_test)
 
 endfunction()
 
-add_library(testing testing.cpp testGraph.cpp testing.h testGraph.h)
+add_library(testing testing.cpp testGraph.cpp testing.h testGraph.h testGraphFixture.h)
 target_link_libraries(testing PRIVATE GTest::gtest_main)
 target_include_directories(
   testing PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src ${PROJECT_SOURCE_DIR} ${CONAN_INCLUDE_DIRS_GTEST}

--- a/tests/nodes/atomicMC.cpp
+++ b/tests/nodes/atomicMC.cpp
@@ -29,7 +29,7 @@ TEST(AtomShakeTest, Water)
     ASSERT_TRUE(testGraph.fetchHead()->setOption<Number>("X", 0));
 
     // Set connections
-    EXPECT_TRUE(testGraph.addEdge({"Insert-Water", "Configuration", "Iterator", "Configuration"}));
+    EXPECT_TRUE(testGraph.addEdge({"InsertRandom-Water", "Configuration", "Iterator", "Configuration"}));
     EXPECT_TRUE(iterator->addEdge({"Inputs", "Configuration", "AtomicMC", "Configuration"}));
     // TODO: Output parameter name cannot be the same as loopback (although loopback param CAN match input).
     // May need to enforce this.

--- a/tests/nodes/graphArgon.cpp
+++ b/tests/nodes/graphArgon.cpp
@@ -18,7 +18,7 @@ TEST(GraphArgonTest, InitSimulation)
     testGraph.createConfiguration("Box", {{"Ar", 1000}}, 0.0213);
 
     // Get the Insert node and run the graph
-    auto insertNode = testGraph.findNode("Insert-Ar");
+    auto insertNode = testGraph.findNode("InsertRandom-Ar");
     ASSERT_TRUE(insertNode);
     ASSERT_EQ(insertNode->run(), NodeConstants::ProcessResult::Success);
 

--- a/tests/nodes/sdf.cpp
+++ b/tests/nodes/sdf.cpp
@@ -44,14 +44,14 @@ class SDFNodeWaterTest : public TestGraphFixture
         ASSERT_TRUE(iterator->addEdge({testGraph_.fetchHeadName(), "Configuration", "SDF", "Configuration"}));
     }
     // Run the graph
-    void runGraph()
+    void runGraph() override
     {
         auto *iterator = findNode<IterableGraph>("Iterator");
         ASSERT_TRUE(iterator);
         ASSERT_EQ(iterator->run(), NodeConstants::ProcessResult::Success);
     }
     // Perform tests on generated data
-    void performTests()
+    void performTests() override
     {
         auto *iterator = findNode<IterableGraph>("Iterator");
         ASSERT_TRUE(iterator);

--- a/tests/nodes/sdf.cpp
+++ b/tests/nodes/sdf.cpp
@@ -5,69 +5,122 @@
 #include "nodes/importDLPUtilsPDens.h"
 #include "nodes/iterableGraph.h"
 #include "nodes/species.h"
-#include "tests/testGraph.h"
+#include "tests/testGraphFixture.h"
 
 namespace UnitTest
 {
-TEST(SDFNodeTest, Water)
+class SDFNodeWaterTest : public TestGraphFixture
 {
-    // Set up the test graph
-    TestGraph testGraph;
-    testGraph.createConfiguration("Box", {{"species/water-dlpoly.toml", 267}}, 0.1);
+    private:
+    Data3D referenceData_;
 
-    // Create trajectory iterator
-    auto iterator = testGraph.appendTrajectoryIterator("ImportXYZTrajectory", "dlpoly/water267-analysis/water-267-298K.xyz");
-    EXPECT_TRUE(iterator);
+    protected:
+    // Prepare any necessary test data
+    void prepareTestData() override
+    {
+        ASSERT_TRUE(ImportDLPUtilsPDensNode::read(referenceData_, "dlpoly/water267-analysis/water-267-298K.11.pdens"));
+    }
+    // Perform graph construction
+    void constructGraph() override
+    {
+        testGraph_.createConfiguration("Box", {{"species/water-dlpoly.toml", 267}}, 0.1);
 
-    // Add the analysis module to the iterator
-    auto sdf = dynamic_cast<SDFNode *>(iterator->createNode("SDF"));
-    ASSERT_TRUE(sdf);
-    auto *water = testGraph.findNode("Water")->getOutputValue<const Species *>("Species");
-    ASSERT_TRUE(water);
-    ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteA", {{water->findSite("HMidpoint")}}));
-    ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteB", {{water->findSite("HMidpoint")}}));
-    ASSERT_TRUE(sdf->setOption<Vector3>("RangeX", {-10.25, 10.25, 0.5}));
-    ASSERT_TRUE(sdf->setOption<Vector3>("RangeY", {-10.25, 10.25, 0.5}));
-    ASSERT_TRUE(sdf->setOption<Vector3>("RangeZ", {-10.25, 10.25, 0.5}));
-    ASSERT_TRUE(iterator->addEdge({testGraph.fetchHeadName(), "Configuration", "SDF", "Configuration"}));
+        // Create trajectory iterator
+        auto iterator =
+            testGraph_.appendTrajectoryIterator("ImportXYZTrajectory", "dlpoly/water267-analysis/water-267-298K.xyz");
+        ASSERT_TRUE(iterator);
+        ASSERT_TRUE(iterator->setOption<Number>("N", 95));
 
-    // Run from the iterator node explicitly
-    ASSERT_TRUE(iterator->setOption<Number>("N", 95));
-    ASSERT_EQ(iterator->run(), NodeConstants::ProcessResult::Success);
+        // Add the analysis module to the iterator
+        auto sdf = dynamic_cast<SDFNode *>(iterator->createNode("SDF"));
+        ASSERT_TRUE(sdf);
+        auto *water = testGraph_.findNode("Water")->getOutputValue<const Species *>("Species");
+        ASSERT_TRUE(water);
+        ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteA", {{water->findSite("HMidpoint")}}));
+        ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteB", {{water->findSite("HMidpoint")}}));
+        ASSERT_TRUE(sdf->setOption<Vector3>("RangeX", {-10.25, 10.25, 0.5}));
+        ASSERT_TRUE(sdf->setOption<Vector3>("RangeY", {-10.25, 10.25, 0.5}));
+        ASSERT_TRUE(sdf->setOption<Vector3>("RangeZ", {-10.25, 10.25, 0.5}));
+        ASSERT_TRUE(iterator->addEdge({testGraph_.fetchHeadName(), "Configuration", "SDF", "Configuration"}));
+    }
+    // Run the graph
+    void runGraph()
+    {
+        auto *iterator = findNode<IterableGraph>("Iterator");
+        ASSERT_TRUE(iterator);
+        ASSERT_EQ(iterator->run(), NodeConstants::ProcessResult::Success);
+    }
+    // Perform tests on generated data
+    void performTests()
+    {
+        auto *iterator = findNode<IterableGraph>("Iterator");
+        ASSERT_TRUE(iterator);
+        auto *sdf = dynamic_cast<SDFNode *>(iterator->findNode("SDF"));
+        ASSERT_TRUE(sdf);
+        EXPECT_TRUE(testData3D(sdf->sdf(), "SDF", referenceData_, "dlpoly/water267-analysis/water-267-298K.11.pdens", 0.13));
+    }
+};
 
-    Data3D referenceData;
-    EXPECT_TRUE(ImportDLPUtilsPDensNode::read(referenceData, "dlpoly/water267-analysis/water-267-298K.11.pdens"));
-    EXPECT_TRUE(testData3D(sdf->sdf(), "SDF", referenceData, "dlpoly/water267-analysis/water-267-298K.11.pdens", 0.13));
-}
-
-TEST(SDFNodeTest, Benzene)
-{
-    // Set up the test graph
-    TestGraph testGraph;
-    testGraph.createConfiguration("Box", {{"species/benzene.toml", 181}}, {29.925089931000, 29.925089931000, 29.925089931000});
-
-    // Create trajectory iterator
-    auto iterator = testGraph.appendTrajectoryIterator("ImportXYZTrajectory", "dlpoly/benzene181/benzene181.xyz");
-    EXPECT_TRUE(iterator);
-
-    // Add the analysis module to the iterator
-    auto sdf = dynamic_cast<SDFNode *>(iterator->createNode("SDF"));
-    ASSERT_TRUE(sdf);
-    auto *benzene = testGraph.findNode("Benzene")->getOutputValue<const Species *>("Species");
-    ASSERT_TRUE(benzene);
-    ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteA", {{benzene->findSite("Ring")}}));
-    ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteB", {{benzene->findSite("Ring")}}));
-    ASSERT_TRUE(sdf->setOption<Vector3>("RangeX", {-10.25, 10.25, 0.5}));
-    ASSERT_TRUE(sdf->setOption<Vector3>("RangeY", {-10.25, 10.25, 0.5}));
-    ASSERT_TRUE(sdf->setOption<Vector3>("RangeZ", {-10.25, 10.25, 0.5}));
-    ASSERT_TRUE(iterator->addEdge({testGraph.fetchHeadName(), "Configuration", "SDF", "Configuration"}));
-
-    // Run from the iterator node explicitly
-    ASSERT_TRUE(iterator->setOption<Number>("N", 80));
-    ASSERT_EQ(iterator->run(), NodeConstants::ProcessResult::Success);
-
-    Data3D referenceData;
-    EXPECT_TRUE(ImportDLPUtilsPDensNode::read(referenceData, "dlpoly/benzene181/benzene181.11.pdens"));
-    EXPECT_TRUE(testData3D(sdf->sdf(), "SDF", referenceData, "dlpoly/benzene181/benzene181.11.pdens", 0.3));
-}
+TEST_F(SDFNodeWaterTest, Water) { go(); }
+// {
+//     // Set up the test graph
+//     TestGraph testGraph;
+//     testGraph.createConfiguration("Box", {{"species/water-dlpoly.toml", 267}}, 0.1);
+//
+//     // Create trajectory iterator
+//     auto iterator = testGraph.appendTrajectoryIterator("ImportXYZTrajectory", "dlpoly/water267-analysis/water-267-298K.xyz");
+//     EXPECT_TRUE(iterator);
+//
+//     // Add the analysis module to the iterator
+//     auto sdf = dynamic_cast<SDFNode *>(iterator->createNode("SDF"));
+//     ASSERT_TRUE(sdf);
+//     auto *water = testGraph.findNode("Water")->getOutputValue<const Species *>("Species");
+//     ASSERT_TRUE(water);
+//     ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteA", {{water->findSite("HMidpoint")}}));
+//     ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteB", {{water->findSite("HMidpoint")}}));
+//     ASSERT_TRUE(sdf->setOption<Vector3>("RangeX", {-10.25, 10.25, 0.5}));
+//     ASSERT_TRUE(sdf->setOption<Vector3>("RangeY", {-10.25, 10.25, 0.5}));
+//     ASSERT_TRUE(sdf->setOption<Vector3>("RangeZ", {-10.25, 10.25, 0.5}));
+//     ASSERT_TRUE(iterator->addEdge({testGraph.fetchHeadName(), "Configuration", "SDF", "Configuration"}));
+//
+//     // Run from the iterator node explicitly
+//     ASSERT_TRUE(iterator->setOption<Number>("N", 95));
+//     ASSERT_EQ(iterator->run(), NodeConstants::ProcessResult::Success);
+//
+//     Data3D referenceData;
+//     EXPECT_TRUE(ImportDLPUtilsPDensNode::read(referenceData, "dlpoly/water267-analysis/water-267-298K.11.pdens"));
+//     EXPECT_TRUE(testData3D(sdf->sdf(), "SDF", referenceData, "dlpoly/water267-analysis/water-267-298K.11.pdens", 0.13));
+// }
+//
+// TEST(SDFNodeTest, Benzene)
+// {
+//     // Set up the test graph
+//     TestGraph testGraph;
+//     testGraph.createConfiguration("Box", {{"species/benzene.toml", 181}},
+//     {29.925089931000, 29.925089931000, 29.925089931000});
+//
+//     // Create trajectory iterator
+//     auto iterator = testGraph.appendTrajectoryIterator("ImportXYZTrajectory", "dlpoly/benzene181/benzene181.xyz");
+//     EXPECT_TRUE(iterator);
+//
+//     // Add the analysis module to the iterator
+//     auto sdf = dynamic_cast<SDFNode *>(iterator->createNode("SDF"));
+//     ASSERT_TRUE(sdf);
+//     auto *benzene = testGraph.findNode("Benzene")->getOutputValue<const Species *>("Species");
+//     ASSERT_TRUE(benzene);
+//     ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteA", {{benzene->findSite("Ring")}}));
+//     ASSERT_TRUE(sdf->setOption<SpeciesSites>("SiteB", {{benzene->findSite("Ring")}}));
+//     ASSERT_TRUE(sdf->setOption<Vector3>("RangeX", {-10.25, 10.25, 0.5}));
+//     ASSERT_TRUE(sdf->setOption<Vector3>("RangeY", {-10.25, 10.25, 0.5}));
+//     ASSERT_TRUE(sdf->setOption<Vector3>("RangeZ", {-10.25, 10.25, 0.5}));
+//     ASSERT_TRUE(iterator->addEdge({testGraph.fetchHeadName(), "Configuration", "SDF", "Configuration"}));
+//
+//     // Run from the iterator node explicitly
+//     ASSERT_TRUE(iterator->setOption<Number>("N", 80));
+//     ASSERT_EQ(iterator->run(), NodeConstants::ProcessResult::Success);
+//
+//     Data3D referenceData;
+//     EXPECT_TRUE(ImportDLPUtilsPDensNode::read(referenceData, "dlpoly/benzene181/benzene181.11.pdens"));
+//     EXPECT_TRUE(testData3D(sdf->sdf(), "SDF", referenceData, "dlpoly/benzene181/benzene181.11.pdens", 0.3));
+// }
 } // namespace UnitTest

--- a/tests/nodes/trajectory.cpp
+++ b/tests/nodes/trajectory.cpp
@@ -25,7 +25,7 @@ TEST(TrajectoryNodesTest, RoundTrip)
     ASSERT_TRUE(trajectoryImport);
     ASSERT_TRUE(trajectoryImport->setOption<std::string>("FilePath", importFile));
     ASSERT_TRUE(testGraph_.createNode("SetCoordinates"));
-    ASSERT_TRUE(testGraph_.addEdge({"Insert-Water", "Configuration", "SetCoordinates", "Configuration"}));
+    ASSERT_TRUE(testGraph_.addEdge({"InsertRandom-Water", "Configuration", "SetCoordinates", "Configuration"}));
     ASSERT_TRUE(testGraph_.addEdge({"ImportXYZTrajectory", "Structure", "SetCoordinates", "Structure"}));
 
     // Create an export configuration trajectory node

--- a/tests/testGraph.cpp
+++ b/tests/testGraph.cpp
@@ -83,7 +83,7 @@ Node *TestGraph::createAndInsertSpecies(Node *cfgSourceNode, std::string cfgSour
         // Move the species node into the graph
         currentGraph_->addNode(std::move(speciesUnique), speciesNode.name());
 
-        auto insertNodeName = std::format("Insert-{}", speciesNode.name());
+        auto insertNodeName = std::format("InsertRandom-{}", speciesNode.name());
         EXPECT_TRUE(appendNode("InsertRandom", insertNodeName));
         EXPECT_TRUE(fetchHead()->setInput<Number>("Population", population));
         EXPECT_TRUE(fetchHead()->setInput<Number>("Density", rho));

--- a/tests/testGraph.cpp
+++ b/tests/testGraph.cpp
@@ -216,7 +216,7 @@ IterableGraph *TestGraph::appendTrajectoryIterator(std::string trajectoryImportN
     auto oldGraph = currentGraph_;
 
     // Add iterator node and make it the current graph
-    currentGraph_ = dynamic_cast<IterableGraph *>(appendNode("Iterator", "Iterator"));
+    currentGraph_ = dynamic_cast<IterableGraph *>(appendNode("Iterator"));
     EXPECT_TRUE(currentGraph_);
     head_ = nullptr;
 

--- a/tests/testGraph.cpp
+++ b/tests/testGraph.cpp
@@ -198,7 +198,7 @@ IterableGraph *TestGraph::appendTrajectoryIterator(std::string trajectoryImportN
     auto oldGraph = currentGraph_;
 
     // Add iterator node and make it the current graph
-    currentGraph_ = dynamic_cast<IterableGraph *>(appendNode("Iterator", "Iterator"));
+    currentGraph_ = dynamic_cast<IterableGraph *>(appendNode("Iterator"));
     EXPECT_TRUE(currentGraph_);
     head_ = nullptr;
 

--- a/tests/testGraphFixture.h
+++ b/tests/testGraphFixture.h
@@ -48,6 +48,8 @@ class TestGraphFixture : public testing::Test
     virtual void prepareTestData() = 0;
     // Perform graph construction
     virtual void constructGraph() = 0;
+    // Run graph
+    virtual void runGraph() = 0;
     // Perform tests on generated data
     virtual void performTests() = 0;
     // Find specified node
@@ -62,18 +64,30 @@ class TestGraphFixture : public testing::Test
     // Go
     void go()
     {
+        // Prepare test data
+        ASSERT_NO_THROW(prepareTestData());
+
+        // Set the initial graph target to the test graph
         currentGraph_ = testGraph_;
 
         // Construct the graph
         ASSERT_NO_THROW(constructGraph());
+        // Run the graph
+        ASSERT_NO_THROW(runGraph());
         // Run the tests
         ASSERT_NO_THROW(performTests());
         // Serialise graph to TOML
         ASSERT_TRUE(serialiseGraphToTOML());
 
-        //
+        // Switch to the deserialised graph target
         currentGraph_ = deserialisedGraph_;
+
+        // Deserialise from the stored TOML
+        ASSERT_NO_THROW(deserialisedGraph_.deserialise(graphTOML_["graph"]));
+        // Run the graph
+        ASSERT_NO_THROW(runGraph());
+        // Run the tests
+        ASSERT_NO_THROW(performTests());
     }
-    //
 };
 }; // namespace UnitTest

--- a/tests/testGraphFixture.h
+++ b/tests/testGraphFixture.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "tests/testGraph.h"
+
+namespace UnitTest
+{
+class TestGraphFixture : public testing::Test
+{
+    public:
+    TestGraphFixture() = default;
+    ~TestGraphFixture() override = default;
+
+    private:
+    // Serialised graph TOML
+    SerialisedValue graphTOML_;
+
+    protected:
+    // Test graph
+    TestGraph testGraph_;
+    // Deserialised graph
+    DissolveGraph deserialisedGraph_;
+    // Current graph target
+    OptionalReferenceWrapper<DissolveGraph> currentGraph_;
+
+    private:
+    // Serialise the current graph to a TOML
+    bool serialiseGraphToTOML()
+    {
+        try
+        {
+            testGraph_.serialise("graph", graphTOML_);
+        }
+        catch (std::exception &ex)
+        {
+            std::cout << std::format("Failed to serialise graph TOML for test {}:\n", "TODO");
+            std::cout << ex.what() << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    protected:
+    // Prepare any necessary test data
+    virtual void prepareTestData() = 0;
+    // Perform graph construction
+    virtual void constructGraph() = 0;
+    // Perform tests on generated data
+    virtual void performTests() = 0;
+    // Find specified node
+    template <class NodeClass> NodeClass *findNode(std::string nodeName)
+    {
+        EXPECT_TRUE(currentGraph_.has_value());
+        auto *node = currentGraph_.value().get().findNode(nodeName);
+        EXPECT_TRUE(node);
+        return dynamic_cast<NodeClass *>(node);
+    }
+
+    // Go
+    void go()
+    {
+        currentGraph_ = testGraph_;
+
+        // Construct the graph
+        ASSERT_NO_THROW(constructGraph());
+        // Run the tests
+        ASSERT_NO_THROW(performTests());
+        // Serialise graph to TOML
+        ASSERT_TRUE(serialiseGraphToTOML());
+
+        //
+        currentGraph_ = deserialisedGraph_;
+    }
+    //
+};
+}; // namespace UnitTest


### PR DESCRIPTION
This implements a sort of fixture-based approach to more full-range testing of Graphs, particularly those involving analysis nodes calculating a specific result. The idea is to define the setup, run, and test functions individually, and then let the fixture setup, run, test. This automation then allows serialisation round-trip testing for free, as well as restart-data reading / testing when we are ready.