### PR TITLE
fix: Return cubic shape to edges

### DIFF
--- a/src/gui2/qml/nodeGraph/GraphView.qml
+++ b/src/gui2/qml/nodeGraph/GraphView.qml
@@ -186,22 +186,15 @@ Pane {
                 strokeColor: "black"
                 strokeWidth: 4
 
-                PathLine {
-                    //id: edgeLine
+                PathCubic {
+                    id: edgeLine
+                    control1X: edgeShape.sourcePos.x + curveOffset
+                    control1Y: edgeShape.sourcePos.y
+                    control2X: edgeShape.targetPos.x - graphRoot.curveOffset
+                    control2Y: edgeShape.targetPos.y
                     x: edgeShape.targetPos.x
                     y: edgeShape.targetPos.y
                 }
-
-                /*
-                PathCubic {
-                    control1X: sourceX + curveOffset
-                    control1Y: sourceY
-                    control2X: x - graphRoot.curveOffset
-                    control2Y: y
-                    x: targetX
-                    y: targetY
-                }
-                */
             }
         }
     }


### PR DESCRIPTION
This should make the edge connections cubic curves again.  Unfortunately, since I currently don't have a good way of adding nodes and connections, I haven't been able to test this code, so it might be worth trying out before merging.