### PR TITLE
refactor: Use comparison operator in comparison overloads

### DIFF
--- a/src/classes/array3DIterator.cpp
+++ b/src/classes/array3DIterator.cpp
@@ -22,23 +22,15 @@ void Array3DIterator::fromIndex(int index)
 
 int Array3DIterator::toIndex() const { return x_ + sizeX_ * y_ + sizeX_ * sizeY_ * z_; }
 
-bool Array3DIterator::operator<(const Array3DIterator &other) const
+std::strong_ordering Array3DIterator::operator<=>(const Array3DIterator &other) const
 {
     if (z_ != other.z_)
-        return z_ < other.z_;
+        return z_ <=> other.z_;
     if (y_ != other.y_)
-        return y_ < other.y_;
-    return x_ < other.x_;
-}
-bool Array3DIterator::operator==(const Array3DIterator &other) const
-{
-    return x_ == other.x_ && y_ == other.y_ && z_ == other.z_;
+        return y_ <=> other.y_;
+    return x_ <=> other.x_;
 }
 
-bool Array3DIterator::operator!=(const Array3DIterator &other) const
-{
-    return x_ != other.x_ || y_ != other.y_ || z_ != other.z_;
-}
 Array3DIterator::value_type Array3DIterator::operator*() { return {x_, y_, z_}; }
 
 Array3DIterator &Array3DIterator::operator++()

--- a/src/classes/array3DIterator.h
+++ b/src/classes/array3DIterator.h
@@ -52,10 +52,6 @@ class Array3DIterator
 
     // Operators : comparison
     bool operator==(const Array3DIterator &other) const = default;
-    bool operator!=(const Array3DIterator &other) const = default;
     bool operator<(const Array3DIterator &other) const = default;
-    bool operator>(const Array3DIterator &other) const = default;
-    bool operator<=(const Array3DIterator &other) const = default;
-    bool operator>=(const Array3DIterator &other) const = default;
     std::strong_ordering operator<=>(const Array3DIterator &value) const;
 };

--- a/src/classes/array3DIterator.h
+++ b/src/classes/array3DIterator.h
@@ -51,10 +51,11 @@ class Array3DIterator
     Array3DIterator operator-(difference_type backward) const;
 
     // Operators : comparison
-    bool operator==(const Array3DIterator &other) const;
-    bool operator!=(const Array3DIterator &other) const;
-    bool operator<(const Array3DIterator &other) const;
-    bool operator>(const Array3DIterator &other) const;
-    bool operator<=(const Array3DIterator &other) const;
-    bool operator>=(const Array3DIterator &other) const;
+    bool operator==(const Array3DIterator &other) const = default;
+    bool operator!=(const Array3DIterator &other) const = default;
+    bool operator<(const Array3DIterator &other) const = default;
+    bool operator>(const Array3DIterator &other) const = default;
+    bool operator<=(const Array3DIterator &other) const = default;
+    bool operator>=(const Array3DIterator &other) const = default;
+    std::strong_ordering operator<=>(const Array3DIterator &value) const;
 };

--- a/src/classes/fullPairIterator.cpp
+++ b/src/classes/fullPairIterator.cpp
@@ -20,16 +20,12 @@ void FullPairIterator::fromIndex(int index)
 
 int FullPairIterator::toIndex() const { return x_ * size_ + y_; }
 
-bool FullPairIterator::operator<(const FullPairIterator &other) const
+std::strong_ordering FullPairIterator::operator<=>(const FullPairIterator &other) const
 {
     if (x_ != other.x_)
-        return x_ < other.x_;
-    return y_ < other.y_;
+        return x_ <=> other.x_;
+    return y_ <=> other.y_;
 }
-
-bool FullPairIterator::operator==(const FullPairIterator &other) const { return x_ == other.x_ && y_ == other.y_; }
-
-bool FullPairIterator::operator!=(const FullPairIterator &other) const { return x_ != other.x_ || y_ != other.y_; }
 
 FullPairIterator::value_type FullPairIterator::operator*() { return {x_, y_}; }
 

--- a/src/classes/fullPairIterator.h
+++ b/src/classes/fullPairIterator.h
@@ -49,10 +49,11 @@ class FullPairIterator
     FullPairIterator operator-(difference_type backward) const;
 
     // Operators : comparison
-    bool operator==(const FullPairIterator &other) const;
-    bool operator!=(const FullPairIterator &other) const;
-    bool operator<(const FullPairIterator &other) const;
-    bool operator>(const FullPairIterator &other) const;
-    bool operator<=(const FullPairIterator &other) const;
-    bool operator>=(const FullPairIterator &other) const;
+    bool operator==(const FullPairIterator &other) const = default;
+    bool operator!=(const FullPairIterator &other) const = default;
+    bool operator<(const FullPairIterator &other) const = default;
+    bool operator>(const FullPairIterator &other) const = default;
+    bool operator<=(const FullPairIterator &other) const = default;
+    bool operator>=(const FullPairIterator &other) const = default;
+    std::strong_ordering operator<=>(const FullPairIterator &value) const;
 };

--- a/src/classes/fullPairIterator.h
+++ b/src/classes/fullPairIterator.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 #pragma once
 
+#include <compare>
 #include <iterator>
 #include <tuple>
 
@@ -50,10 +51,6 @@ class FullPairIterator
 
     // Operators : comparison
     bool operator==(const FullPairIterator &other) const = default;
-    bool operator!=(const FullPairIterator &other) const = default;
     bool operator<(const FullPairIterator &other) const = default;
-    bool operator>(const FullPairIterator &other) const = default;
-    bool operator<=(const FullPairIterator &other) const = default;
-    bool operator>=(const FullPairIterator &other) const = default;
     std::strong_ordering operator<=>(const FullPairIterator &value) const;
 };

--- a/src/classes/pairIterator.cpp
+++ b/src/classes/pairIterator.cpp
@@ -26,16 +26,12 @@ int PairIterator::toIndex() const
     return front + y_ - x_;
 }
 
-bool PairIterator::operator<(const PairIterator &other) const
+std::strong_ordering PairIterator::operator<=>(const PairIterator &other) const
 {
     if (x_ != other.x_)
-        return x_ < other.x_;
-    return y_ < other.y_;
+        return x_ <=> other.x_;
+    return y_ <=> other.y_;
 }
-
-bool PairIterator::operator==(const PairIterator &other) const { return x_ == other.x_ && y_ == other.y_; }
-
-bool PairIterator::operator!=(const PairIterator &other) const { return x_ != other.x_ || y_ != other.y_; }
 
 PairIterator::value_type PairIterator::operator*() { return {x_, y_}; }
 

--- a/src/classes/pairIterator.h
+++ b/src/classes/pairIterator.h
@@ -50,10 +50,6 @@ class PairIterator
 
     // Operators : comparison
     bool operator==(const PairIterator &other) const = default;
-    bool operator!=(const PairIterator &other) const = default;
     bool operator<(const PairIterator &other) const = default;
-    bool operator>(const PairIterator &other) const = default;
-    bool operator<=(const PairIterator &other) const = default;
-    bool operator>=(const PairIterator &other) const = default;
     std::strong_ordering operator<=>(const PairIterator &value) const;
 };

--- a/src/classes/pairIterator.h
+++ b/src/classes/pairIterator.h
@@ -49,10 +49,11 @@ class PairIterator
     PairIterator operator-(difference_type backward) const;
 
     // Operators : comparison
-    bool operator==(const PairIterator &other) const;
-    bool operator!=(const PairIterator &other) const;
-    bool operator<(const PairIterator &other) const;
-    bool operator>(const PairIterator &other) const;
-    bool operator<=(const PairIterator &other) const;
-    bool operator>=(const PairIterator &other) const;
+    bool operator==(const PairIterator &other) const = default;
+    bool operator!=(const PairIterator &other) const = default;
+    bool operator<(const PairIterator &other) const = default;
+    bool operator>(const PairIterator &other) const = default;
+    bool operator<=(const PairIterator &other) const = default;
+    bool operator>=(const PairIterator &other) const = default;
+    std::strong_ordering operator<=>(const PairIterator &value) const;
 };

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "nodes/number.h"
+#include <compare>
 #include <string>
+#include <type_traits>
 
 Number::Number(const std::variant<int, double> &value) : value_(value) {}
 
@@ -60,28 +62,30 @@ Number &Number::operator/=(const Number &other)
     return *this;
 }
 
-bool Number::operator==(const Number &other) const { return value_ == other.value_; }
-
-bool Number::operator!=(const Number &other) const { return value_ != other.value_; }
-
-bool Number::operator<(const Number &other) const
+std::strong_ordering Number::operator<=>(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return a < b; }, value_, other.value_);
-}
-
-bool Number::operator<=(const Number &other) const
-{
-    return std::visit([](auto a, auto b) -> bool { return a <= b; }, value_, other.value_);
-}
-
-bool Number::operator>(const Number &other) const
-{
-    return std::visit([](auto a, auto b) -> bool { return a > b; }, value_, other.value_);
-}
-
-bool Number::operator>=(const Number &other) const
-{
-    return std::visit([](auto a, auto b) -> bool { return a >= b; }, value_, other.value_);
+    return std::visit(
+        [](auto a, auto b) -> std::strong_ordering
+        {
+            using T = std::decay_t<decltype(a)>;
+            using U = std::decay_t<decltype(b)>;
+            if constexpr (std::is_floating_point_v<T> || std::is_floating_point_v<U>)
+            {
+                auto cmp = a <=> b;
+                if (cmp == std::partial_ordering::less)
+                    return std::strong_ordering::less;
+                else if (cmp == std::partial_ordering::equivalent)
+                    return std::strong_ordering::equivalent;
+                else if (cmp == std::partial_ordering::greater)
+                    return std::strong_ordering::greater;
+                else
+                    // Just need a dummy ordering for NaN on floating point
+                    return std::strong_ordering::less;
+            }
+            else
+                return a <=> b;
+        },
+        value_, other.value_);
 }
 
 /*

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "base/serialiser.h"
+#include <compare>
 #include <optional>
 #include <variant>
 
@@ -27,12 +28,13 @@ class Number
     Number &operator/=(const Number &other);
     Number &operator++();
     Number &operator--();
-    bool operator==(const Number &value) const;
-    bool operator!=(const Number &value) const;
-    bool operator<(const Number &other) const;
-    bool operator<=(const Number &other) const;
-    bool operator>(const Number &other) const;
-    bool operator>=(const Number &other) const;
+    bool operator==(const Number &value) const = default;
+    bool operator!=(const Number &value) const = default;
+    bool operator<(const Number &other) const = default;
+    bool operator<=(const Number &other) const = default;
+    bool operator>(const Number &other) const = default;
+    bool operator>=(const Number &other) const = default;
+    std::strong_ordering operator<=>(const Number &value) const;
 
     /*
      * Data

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -29,11 +29,7 @@ class Number
     Number &operator++();
     Number &operator--();
     bool operator==(const Number &value) const = default;
-    bool operator!=(const Number &value) const = default;
     bool operator<(const Number &other) const = default;
-    bool operator<=(const Number &other) const = default;
-    bool operator>(const Number &other) const = default;
-    bool operator>=(const Number &other) const = default;
     std::strong_ordering operator<=>(const Number &value) const;
 
     /*

--- a/src/templates/tbbFallbacks.h
+++ b/src/templates/tbbFallbacks.h
@@ -61,11 +61,7 @@ template <typename IntType> class counting_iterator
     // Operators : comparison
     std::strong_ordering operator<=>(const counting_iterator &other) const { return this->counter_ <=> other.counter_; };
     bool operator==(const counting_iterator &other) const = default;
-    bool operator!=(const counting_iterator &other) const = default;
     bool operator<(const counting_iterator &other) const = default;
-    bool operator>(const counting_iterator &other) const = default;
-    bool operator<=(const counting_iterator &other) const = default;
-    bool operator>=(const counting_iterator &other) const = default;
 
     private:
     IntType counter_;

--- a/src/templates/tbbFallbacks.h
+++ b/src/templates/tbbFallbacks.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 #pragma once
 #include <cassert>
+#include <compare>
 #include <iterator>
 #include <type_traits>
 
@@ -58,12 +59,13 @@ template <typename IntType> class counting_iterator
     counting_iterator operator-(difference_type backward) const { return counting_iterator(counter_ - backward); };
 
     // Operators : comparison
-    bool operator==(const counting_iterator &other) const { return this->counter_ == other.counter_; };
-    bool operator!=(const counting_iterator &other) const { return !(*this == other); };
-    bool operator<(const counting_iterator &other) const { return *this - other < 0; };
-    bool operator>(const counting_iterator &other) const { return other < *this; };
-    bool operator<=(const counting_iterator &other) const { return !(*this > other); };
-    bool operator>=(const counting_iterator &other) const { return !(*this < other); };
+    std::strong_ordering operator<=>(const counting_iterator &other) const { return this->counter_ <=> other.counter_; };
+    bool operator==(const counting_iterator &other) const = default;
+    bool operator!=(const counting_iterator &other) const = default;
+    bool operator<(const counting_iterator &other) const = default;
+    bool operator>(const counting_iterator &other) const = default;
+    bool operator<=(const counting_iterator &other) const = default;
+    bool operator>=(const counting_iterator &other) const = default;
 
     private:
     IntType counter_;


### PR DESCRIPTION
C++20 added the comparison operator (sometimes referred to as the spaceship operator), from which all of the other comparison operators can be derived.  I've used this to cut down on a bunch of the boiler plate in our iterator overloads and for our `Number` type.

There's one change in the handling of NaN for the Number class. For any floating point value *x*, the following statements are *always* true under the new setup, but were *always* false under the old setup:

```
a < NaN
Nan < a
```

This was done to allow strong ordering of Number, despite floating point values only having weak ordering.  This convention was chosen to preserve the the following three relations, which I considered more fundamental:

```
a != NaN
NaN != a
NaN != Nan
```