### PR TITLE
refactor: Categorical `NodeRegistry` and updated QML Graph menu

### DIFF
--- a/src/gui2/models/enumOptionsModel.cpp
+++ b/src/gui2/models/enumOptionsModel.cpp
@@ -16,14 +16,6 @@ void EnumOptionsModel::setData(std::shared_ptr<const EnumOptionsBase> options)
 /*
  * QAbstractItemModel overrides
  */
-
-QHash<int, QByteArray> EnumOptionsModel::roleNames() const
-{
-    QHash<int, QByteArray> roles;
-    roles[Qt::DisplayRole] = "option";
-    return roles;
-}
-
 int EnumOptionsModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);

--- a/src/gui2/models/enumOptionsModel.cpp
+++ b/src/gui2/models/enumOptionsModel.cpp
@@ -17,6 +17,13 @@ void EnumOptionsModel::setData(std::shared_ptr<const EnumOptionsBase> options)
  * QAbstractItemModel overrides
  */
 
+QHash<int, QByteArray> EnumOptionsModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[Qt::DisplayRole] = "option";
+    return roles;
+}
+
 int EnumOptionsModel::rowCount(const QModelIndex &parent) const
 {
     Q_UNUSED(parent);

--- a/src/gui2/models/enumOptionsModel.h
+++ b/src/gui2/models/enumOptionsModel.h
@@ -27,7 +27,6 @@ class EnumOptionsModel : public QAbstractListModel
      * QAbstractItemModel overrides
      */
     public:
-    QHash<int, QByteArray> roleNames() const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;

--- a/src/gui2/models/enumOptionsModel.h
+++ b/src/gui2/models/enumOptionsModel.h
@@ -27,6 +27,7 @@ class EnumOptionsModel : public QAbstractListModel
      * QAbstractItemModel overrides
      */
     public:
+    QHash<int, QByteArray> roleNames() const override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;

--- a/src/gui2/models/enumRegistry.cpp
+++ b/src/gui2/models/enumRegistry.cpp
@@ -7,6 +7,7 @@
 #include "math/windowFunction.h"
 #include "nodes/gr.h"
 #include "nodes/md.h"
+#include "nodes/registry.h"
 
 std::map<std::type_index, std::shared_ptr<EnumOptionsModel>> EnumRegistry::options_;
 
@@ -35,6 +36,7 @@ void EnumRegistry::instantiateOptions()
     };
 
     options_ = {{typeid(StructureFactors::NormalisationType), wrap(StructureFactors::normalisationTypes())},
+                {typeid(NodeRegistry::Category), wrap(NodeRegistry::category())},
                 {typeid(GRNode::PartialsMethod), wrap(GRNode::partialsMethods())},
                 {typeid(MDNode::TimestepType), wrap(MDNode::timestepType())},
                 {typeid(WindowFunction::Form), wrap(WindowFunction::forms())}};

--- a/src/gui2/models/graphModel.cpp
+++ b/src/gui2/models/graphModel.cpp
@@ -115,21 +115,21 @@ void GraphModel::setCanvasDimensions(const QSizeF &canvasDimensions)
     Q_EMIT canvasDimensionsChanged();
 }
 
-void GraphModel::emplace_back(int x, int y, QVariant type, std::string name, bool avoidSamePosition)
+void GraphModel::emplace_back(int x, int y, QVariant type, QString name, bool avoidSamePosition)
 {
     if (!graph_)
         Messenger::exception(
             "GraphModel has no graph.  This should have been impossible.  Please let the Dissolve developers know about this.");
     nodes_.beginInsertRows({}, graph_->nodes().size(), graph_->nodes().size() + 1);
     auto nodeType = type.toString().toStdString();
-    auto node = graph_->createNode(nodeType, name);
+    auto node = graph_->createNode(nodeType, name.toStdString());
     auto dX = 0, dY = 0;
     if (avoidSamePosition)
         findUniqueXY(x, y, dX, dY);
     node->x = x + dX;
     node->y = y + dY;
     auto &item = wrapped_.emplace_back(*node);
-    item.rawValue().setName(name);
+    item.rawValue().setName(name.toStdString());
     nodes_.endInsertRows();
     graphChanged();
 }

--- a/src/gui2/models/graphModel.h
+++ b/src/gui2/models/graphModel.h
@@ -168,7 +168,7 @@ class GraphModel : public QObject
     void addOutput(int nodeIndex, QString paramName, double x, double y);
 
     // Add a new node at a specific position
-    void emplace_back(int x, int y, QVariant type, std::string name, bool avoidSamePosition = false);
+    void emplace_back(int x, int y, QVariant type, QString name, bool avoidSamePosition = false);
 
     // Switch to parent graph
     void upLevel();

--- a/src/gui2/models/legacy/simpleForcefieldModel.cpp
+++ b/src/gui2/models/legacy/simpleForcefieldModel.cpp
@@ -33,7 +33,7 @@ QStringList SimpleForcefieldModel::library()
 void SimpleForcefieldModel::create(int x, int y)
 {
     auto name = ff_->name();
-    graphModel_->emplace_back(x, y, "Forcefield", std::string(name));
+    graphModel_->emplace_back(x, y, "Forcefield", QString::fromStdString(std::string(name)));
     auto ff = dynamic_cast<ForcefieldNode *>(graphModel_->graph()->findNode(name));
     // if (ff)
     // ff->forcefield() = ff_;

--- a/src/gui2/models/nodeRegistryModel.cpp
+++ b/src/gui2/models/nodeRegistryModel.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "gui2/models/nodeRegistryModel.h"
+#include "enumRegistry.h"
 #include "nodes/dissolve.h"
 
 NodeRegistryModel::NodeRegistryModel(QObject *parent)
@@ -42,14 +43,50 @@ int &NodeRegistryModel::tally(QString nodeType)
     return std::get<int>(entries_[idx]);
 }
 
-// Instantiate node from registry
-void NodeRegistryModel::instantiateNode(int x, int y, QVariant type)
+// Return node names by category
+QList<QVariantMap> NodeRegistryModel::nodeNames(QString category)
+{
+    QList<QVariantMap> names;
+    auto categoryEnum = NodeRegistry::category().enumeration(category.toStdString());
+    for (const auto &[name, _] : NodeRegistry::categoricalProducers_[categoryEnum])
+    {
+        auto nodeName = QString::fromStdString(std::string(name));
+        auto descriptionIt = std::find_if(entries_.begin(), entries_.end(),
+                                          [&nodeName](const auto &entry) { return std::get<0>(entry) == nodeName; });
+        auto descriptionIdx = std::distance(entries_.begin(), descriptionIt);
+        auto nodeDescription = std::get<1>(entries_[descriptionIdx]);
+        QVariantMap nodeInfo;
+        nodeInfo[QString::fromStdString("name")] = nodeName;
+        nodeInfo[QString::fromStdString("description")] = nodeDescription;
+        names.push_back(nodeInfo);
+    }
+    return names;
+}
+
+// Return the enum options for the node categories
+EnumOptionsModel *NodeRegistryModel::categories() { return EnumRegistry::options(typeid(NodeRegistry::Category)).get(); }
+
+// Return a unique default node name for a given node type
+QString NodeRegistryModel::uniqueNodeName(QVariant type)
 {
     increment(type.toString());
     const auto count = tally(type.toString());
     std::string prefix = type.toString().toStdString() + "_";
     auto name = prefix + std::format("{}", count);
-    graphModel_->emplace_back(x, y, type, name, true);
+    return QString::fromStdString(name);
+}
+
+// Instantiate node from registry
+void NodeRegistryModel::instantiateNode(int x, int y, QVariant type)
+{
+    /*
+    increment(type.toString());
+    const auto count = tally(type.toString());
+    std::string prefix = type.toString().toStdString() + "_";
+    auto name = prefix + std::format("{}", count);
+    */
+    // graphModel_->emplace_back(x, y, type, QString::fromStdString(name), true);
+    graphModel_->emplace_back(x, y, type, uniqueNodeName(type), true);
 }
 
 // Set the graph model

--- a/src/gui2/models/nodeRegistryModel.cpp
+++ b/src/gui2/models/nodeRegistryModel.cpp
@@ -48,7 +48,8 @@ QList<QVariantMap> NodeRegistryModel::nodeNames(QString category)
 {
     QList<QVariantMap> names;
     auto categoryEnum = NodeRegistry::category().enumeration(category.toStdString());
-    for (const auto &[name, _] : NodeRegistry::categoricalProducers_[categoryEnum])
+    auto nodes = NodeRegistry::categoricalProducers_;
+    for (const auto &[name, _] : nodes[categoryEnum])
     {
         auto nodeName = QString::fromStdString(std::string(name));
         auto descriptionIt = std::find_if(entries_.begin(), entries_.end(),

--- a/src/gui2/models/nodeRegistryModel.cpp
+++ b/src/gui2/models/nodeRegistryModel.cpp
@@ -77,17 +77,7 @@ QString NodeRegistryModel::uniqueNodeName(QVariant type)
 }
 
 // Instantiate node from registry
-void NodeRegistryModel::instantiateNode(int x, int y, QVariant type)
-{
-    /*
-    increment(type.toString());
-    const auto count = tally(type.toString());
-    std::string prefix = type.toString().toStdString() + "_";
-    auto name = prefix + std::format("{}", count);
-    */
-    // graphModel_->emplace_back(x, y, type, QString::fromStdString(name), true);
-    graphModel_->emplace_back(x, y, type, uniqueNodeName(type), true);
-}
+void NodeRegistryModel::instantiateNode(int x, int y, QVariant type) { graphModel_->emplace_back(x, y, type, uniqueNodeName(type), true); }
 
 // Set the graph model
 void NodeRegistryModel::setGraphModel(GraphModel *graphModel)

--- a/src/gui2/models/nodeRegistryModel.h
+++ b/src/gui2/models/nodeRegistryModel.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "enumOptionsModel.h"
 #include "gui2/models/graphModel.h"
 #include "nodes/registry.h"
 #include <QAbstractListModel>
@@ -51,6 +52,12 @@ class NodeRegistryModel : public QAbstractListModel
     GraphModel *graphModel_{nullptr};
 
     public:
+    // Return a unique default node name for a given node type
+    Q_INVOKABLE QString uniqueNodeName(QVariant type);
+    // Return node names by category
+    Q_INVOKABLE QList<QVariantMap> nodeNames(QString category);
+    // Return the enum options for the node categories
+    Q_INVOKABLE EnumOptionsModel *categories();
     // Instantiate node from registry
     Q_INVOKABLE void instantiateNode(int x, int y, QVariant type);
     // Set the graph model

--- a/src/gui2/qml/nodeGraph/GraphView.qml
+++ b/src/gui2/qml/nodeGraph/GraphView.qml
@@ -28,41 +28,42 @@ Pane {
         Menu {
             id: contextMenu
 
-            Instantiator {
+            Repeater {
                 model: nodeRegistry.categories()
 
-                delegate: Menu {
-                    id: nodeCategoryMenu
+                delegate: Item {
+                        id: menuDelegateItem
+                        required property var option
+                        property Menu innerMenu: innerMenuComponent.createObject(parent)
 
-                    required property var option
-                    title: option
+                        Component {
+                            id: innerMenuComponent
 
-                    Instantiator {
-                        model: nodeRegistry.nodeNames(option)
+                            Menu {
+                                id: nodeCategoryMenu
 
-                        delegate: MenuItem {
-                            required property var modelData
-                            text: modelData.name
-                            onClicked: graphRoot.rootGraphModel.emplace_back(ctxMenuCatcher.mousePos.x, ctxMenuCatcher.mousePos.y, modelData.name, nodeRegistry.uniqueNodeName(modelData.name), false)
-                            ToolTip.text: modelData.description
-                            ToolTip.visible: hovered
-                            ToolTip.delay: 500
+                                title: menuDelegateItem.option
+
+                                Repeater {
+                                    model: nodeRegistry.nodeNames(menuDelegateItem.option)
+
+                                    delegate: MenuItem {
+                                        required property var modelData
+                                        text: modelData.name
+                                        onClicked: graphRoot.rootGraphModel.emplace_back(ctxMenuCatcher.mousePos.x, ctxMenuCatcher.mousePos.y, modelData.name, nodeRegistry.uniqueNodeName(modelData.name), false)
+                                        ToolTip.text: modelData.description
+                                        ToolTip.visible: hovered
+                                        ToolTip.delay: 500
+                                    }
+                                }
+                            }
                         }
-
-                        onObjectAdded: (index, object) => {
-                            nodeCategoryMenu.addItem(object)
-                        }
-                        onObjectRemoved: (index, object) => {
-                            nodeCategoryMenu.removeItem(object)
-                        }
-                    }
                 }
-
-                onObjectAdded: (index, object) => {
-                    contextMenu.addMenu(object)
+                onItemAdded: (index, item) => {
+                    contextMenu.addMenu(item.innerMenu)
                 }
-                onObjectRemoved: (index, object) => {
-                    contextMenu.removeMenu(object)
+                onItemRemoved: (index, item) => {
+                    contextMenu.removeMenu(item.innerMenu)
                 }
             }
         }

--- a/src/gui2/qml/nodeGraph/GraphView.qml
+++ b/src/gui2/qml/nodeGraph/GraphView.qml
@@ -15,7 +15,6 @@ Pane {
 
     Component.onCompleted: nodeRegistry.setGraphModel(rootGraphModel);
 
-    /*
     MouseArea {
         id: ctxMenuCatcher
 
@@ -24,133 +23,51 @@ Pane {
 
         onClicked: contextMenu.popup()
 
+        property point mousePos: Qt.point(ctxMenuCatcher.mouseX, ctxMenuCatcher.mouseY)
+
         Menu {
             id: contextMenu
 
-            Menu {
-                title: "Math"
+            Instantiator {
+                model: nodeRegistry.categories()
 
-                MenuItem {
-                    text: "Add"
+                delegate: Menu {
+                    id: nodeCategoryMenu
 
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Add", "New Node")
-                }
-                MenuItem {
-                    text: "Derivative"
+                    required property var option
+                    title: option
 
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Derivative", "New Node")
-                }
-                MenuItem {
-                    text: "Dot Product"
+                    Instantiator {
+                        model: nodeRegistry.nodeNames(option)
 
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "DotProduct", "New Node")
-                }
-                MenuItem {
-                    text: "Integrator"
+                        delegate: MenuItem {
+                            required property var modelData
+                            text: modelData.name
+                            onClicked: graphRoot.rootGraphModel.emplace_back(ctxMenuCatcher.mousePos.x, ctxMenuCatcher.mousePos.y, modelData.name, nodeRegistry.uniqueNodeName(modelData.name), false)
+                            ToolTip.text: modelData.description
+                            ToolTip.visible: hovered
+                            ToolTip.delay: 500
+                        }
 
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Integrator", "New Node")
-                }
-                MenuItem {
-                    text: "Multiply"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Multiply", "New Node")
-                }
-                MenuItem {
-                    text: "Number"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Number", "New Number")
-                }
-                MenuItem {
-                    text: "Subtract"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Subtract", "New Node")
-                }
-                MenuItem {
-                    text: "Vec3Assembly"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Vec3Assembly", "New Node")
-                }
-                MenuItem {
-                    text: "Vec3Decompostion"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Vec3Decomposition", "New Node")
-                }
-            }
-            Menu {
-                title: "Action"
-
-                MenuItem {
-                    text: "Atomic MC"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "AtomicMC", "New Node")
-                }
-                MenuItem {
-                    text: "G(r)"
-
-                    onClicked: rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "GR", "New Node")
-                }
-                MenuItem {
-                    text: "Insert"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Insert", "New Node")
-                }
-                MenuItem {
-                    text: "Molecular Dynamics"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "MD", "New Node")
-                }
-                MenuItem {
-                    text: "S(q)"
-
-                    onClicked: rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "SQ", "New Node")
-                }
-            }
-            Menu {
-                title: "Data"
-
-                MenuItem {
-                    text: "Atomic Species"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "AtomicSpecies", "New Node")
-                }
-                MenuItem {
-                    text: "Configuration"
-
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Configuration", "New Node")
-                }
-                MenuItem {
-                    text: "Forcefield"
-
-                    onClicked: forcefieldDialog.open()
-
-                    ForcefieldDialog {
-                        id: forcefieldDialog
-
-                        graphModel: graphRoot.rootGraphModel
-                        posx: Math.round(ctxMenuCatcher.mouseX)
-                        posy: Math.round(ctxMenuCatcher.mouseY)
+                        onObjectAdded: (index, object) => {
+                            nodeCategoryMenu.addItem(object)
+                        }
+                        onObjectRemoved: (index, object) => {
+                            nodeCategoryMenu.removeItem(object)
+                        }
                     }
                 }
-                MenuItem {
-                    text: "Graph"
 
-                    onClicked: graphRoot.rootGraphModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Graph", "New Graph")
+                onObjectAdded: (index, object) => {
+                    contextMenu.addMenu(object)
                 }
-                MenuItem {
-                    text: "Species"
-
-                    onClicked: speciesDialog.open()
-
-                    SpeciesDialog {
-                        id: speciesDialog
-
-                        graphModel: graphRoot.rootGraphModel
-                    }
+                onObjectRemoved: (index, object) => {
+                    contextMenu.removeMenu(object)
                 }
             }
         }
     }
-    */
+
     // Edge connections
     Repeater {
         model: graphRoot.parameterEndPointsModel

--- a/src/gui2/qml/nodeGraph/GraphView.qml
+++ b/src/gui2/qml/nodeGraph/GraphView.qml
@@ -33,7 +33,7 @@ Pane {
 
                 delegate: Item {
                         id: menuDelegateItem
-                        required property var option
+                        required property var display
                         property Menu innerMenu: innerMenuComponent.createObject(parent)
 
                         Component {
@@ -42,10 +42,10 @@ Pane {
                             Menu {
                                 id: nodeCategoryMenu
 
-                                title: menuDelegateItem.option
+                                title: menuDelegateItem.display
 
                                 Repeater {
-                                    model: nodeRegistry.nodeNames(menuDelegateItem.option)
+                                    model: nodeRegistry.nodeNames(menuDelegateItem.display)
 
                                     delegate: MenuItem {
                                         required property var modelData

--- a/src/nodes/dotProduct.cpp
+++ b/src/nodes/dotProduct.cpp
@@ -15,7 +15,7 @@ DotProductNode::DotProductNode(Graph *parentGraph) : Node(parentGraph)
  */
 
 // Return type of the node
-std::string_view DotProductNode::type() const { return "Dot Product"; }
+std::string_view DotProductNode::type() const { return "DotProduct"; }
 
 // Return short summary of the node's purpose
 std::string_view DotProductNode::summary() const { return "Compute the dot product of vectors u and v"; }

--- a/src/nodes/exportDLPUtilsPDensData.cpp
+++ b/src/nodes/exportDLPUtilsPDensData.cpp
@@ -17,7 +17,7 @@ ExportDLPUtilsPDensDataNode::ExportDLPUtilsPDensDataNode(Graph *parentGraph) : N
  */
 
 // Return type of the node
-std::string_view ExportDLPUtilsPDensDataNode::type() const { return "ExportPDensData"; }
+std::string_view ExportDLPUtilsPDensDataNode::type() const { return "ExportDLPUtilsPDensData"; }
 
 // Return short summary of the node's purpose
 std::string_view ExportDLPUtilsPDensDataNode::summary() const { return "Export 3D data in DLPUtils PDens format"; }

--- a/src/nodes/exportXYZTrajectory.cpp
+++ b/src/nodes/exportXYZTrajectory.cpp
@@ -21,7 +21,7 @@ ExportXYZTrajectoryNode::ExportXYZTrajectoryNode(Graph *parentGraph) : Node(pare
  */
 
 // Return type of the node
-std::string_view ExportXYZTrajectoryNode::type() const { return "ExportTrajectory"; }
+std::string_view ExportXYZTrajectoryNode::type() const { return "ExportXYZTrajectory"; }
 
 // Return short summary of the node's purpose
 std::string_view ExportXYZTrajectoryNode::summary() const

--- a/src/nodes/importXYData.cpp
+++ b/src/nodes/importXYData.cpp
@@ -30,10 +30,10 @@ ImportXYDataNode::ImportXYDataNode(Graph *parentGraph) : Node(parentGraph)
  */
 
 // Return type of the node
-std::string_view ImportXYDataNode::type() const { return "Data1DImport"; }
+std::string_view ImportXYDataNode::type() const { return "ImportXYData"; }
 
 // Return short summary of the node's purpose
-std::string_view ImportXYDataNode::summary() const { return "Import 1D data"; }
+std::string_view ImportXYDataNode::summary() const { return "Import 1D (XY) data"; }
 
 /*
  * Processing

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -68,7 +68,23 @@
 #include <ranges>
 
 // Static Singletons
-std::map<std::string_view, NodeProducer> NodeRegistry::producers_;
+std::map<NodeRegistry::Category, ProducerMap> NodeRegistry::categoricalProducers_;
+ProducerMap NodeRegistry::producers_;
+
+// Return enum option info for Category
+EnumOptions<NodeRegistry::Category> NodeRegistry::category()
+{
+    return EnumOptions<NodeRegistry::Category>("Category", {
+                                                               {Category::Action, "Action"},
+                                                               {Category::Data, "Data"},
+                                                               {Category::Export, "Export"},
+                                                               {Category::Graphs, "Graphs"},
+                                                               {Category::Import, "Import"},
+                                                               {Category::Math, "Math"},
+                                                               {Category::Other, "Other (TODO: finish categories)"},
+                                                           });
+}
+EnumOptions<NodeRegistry::Category> getEnumOptions(NodeRegistry::Category) { return NodeRegistry::category(); }
 
 // Makes unique pointer to derived node instance
 template <typename T> NodeProducer makeDerivedNode()
@@ -76,75 +92,94 @@ template <typename T> NodeProducer makeDerivedNode()
     return [=](Graph *parent) -> std::unique_ptr<Node> { return std::make_unique<T>(parent); };
 }
 
+// Remove categories from categorial node producer map, returning a 'flat' producer map
+ProducerMap NodeRegistry::decategoriseProducers()
+{
+    ProducerMap producers;
+    for (const auto &[_, map] : categoricalProducers_)
+        producers.insert(map.begin(), map.end());
+
+    return producers;
+}
+
 // Instantiate Node Producers
 void NodeRegistry::instantiateNodeProducers()
 {
     // Only need to do this once
-    if (!producers_.empty())
+    if (!categoricalProducers_.empty())
         return;
 
-    producers_ = {{"Add", makeDerivedNode<AddNode>()},
-                  {"Angle", makeDerivedNode<AngleNode>()},
-                  {"AxisAngle", makeDerivedNode<AxisAngleNode>()},
-                  {"AtomicMC", makeDerivedNode<AtomicMCNode>()},
-                  {"AverageMolecule", makeDerivedNode<AverageMoleculeNode>()},
-                  {"Bragg", makeDerivedNode<BraggNode>()},
-                  {"CalculateBonding", makeDerivedNode<CalculateBondingNode>()},
-                  {"ClearBonding", makeDerivedNode<ClearBondingNode>()},
-                  {"Configuration", makeDerivedNode<ConfigurationNode>()},
-                  {"ImportCIFStructure", makeDerivedNode<ImportCIFStructureNode>()},
-                  {"DAngle", makeDerivedNode<DAngleNode>()},
-                  {"Derivative", makeDerivedNode<DerivativeNode>()},
-                  {"DetectMolecules", makeDerivedNode<DetectMoleculesNode>()},
-                  {"DotProduct", makeDerivedNode<DotProductNode>()},
-                  {"Energy", makeDerivedNode<EnergyNode>()},
-                  {"EPSR", makeDerivedNode<EPSRNode>()},
-                  {"ExportBlockData", makeDerivedNode<ExportBlockDataNode>()},
-                  {"ExportData", makeDerivedNode<ExportDataNode>()},
-                  {"ExportDLPUtilsPDensData", makeDerivedNode<ExportDLPUtilsPDensDataNode>()},
-                  {"ExportDLPOLYConfiguration", makeDerivedNode<ExportDLPOLYConfigurationNode>()},
-                  {"ExportXYZTrajectory", makeDerivedNode<ExportXYZTrajectoryNode>()},
-                  {"ExportXYZConfiguration", makeDerivedNode<ExportXYZConfigurationNode>()},
-                  {"Forcefield", makeDerivedNode<ForcefieldNode>()},
-                  {"Graph", makeDerivedNode<Graph>()},
-                  {"GR", makeDerivedNode<GRNode>()},
-                  {"HistogramCN", makeDerivedNode<HistogramCNNode>()},
-                  {"ImportDLPOLYStructure", makeDerivedNode<ImportDLPOLYStructureNode>()},
-                  {"ImportDLPOLYTrajectory", makeDerivedNode<ImportDLPOLYTrajectoryNode>()},
-                  {"ImportDLPUtilsPDens", makeDerivedNode<ImportDLPUtilsPDensNode>()},
-                  {"ImportDLPUtilsSurface", makeDerivedNode<ImportDLPUtilsSurfaceNode>()},
-                  {"ImportEPSRAtoStructure", makeDerivedNode<ImportEPSRAtoStructureNode>()},
-                  {"ImportMoscitoStructure", makeDerivedNode<ImportMoscitoStructureNode>()},
-                  {"ImportXYData", makeDerivedNode<ImportXYDataNode>()},
-                  {"ImportXYZStructure", makeDerivedNode<ImportXYZStructureNode>()},
-                  {"ImportXYZTrajectory", makeDerivedNode<ImportXYZTrajectoryNode>()},
-                  {"Insert", makeDerivedNode<InsertNode>()},
-                  {"Integrator", makeDerivedNode<Integrator1DNode>()},
-                  {"IntraAngle", makeDerivedNode<IntraAngleNode>()},
-                  {"IntraDistance", makeDerivedNode<IntraDistanceNode>()},
-                  {"IntraMC", makeDerivedNode<IntraMCNode>()},
-                  {"Iterator", makeDerivedNode<IterableGraph>()},
-                  {"MC", makeDerivedNode<MCNode>()},
-                  {"MD", makeDerivedNode<MDNode>()},
-                  {"ModifierOSites", makeDerivedNode<ModifierOSitesNode>()},
-                  {"MoleculeTorsion", makeDerivedNode<MoleculeTorsionNode>()},
-                  {"Multiply", makeDerivedNode<MultiplyNode>()},
-                  {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
-                  {"Number", makeDerivedNode<NumberNode>()},
-                  {"OrientedSDF", makeDerivedNode<OrientedSDFNode>()},
-                  {"QSpecies", makeDerivedNode<QSpeciesNode>()},
-                  {"SDF", makeDerivedNode<SDFNode>()},
-                  {"SetBox", makeDerivedNode<SetBoxNode>()},
-                  {"SetCoordinates", makeDerivedNode<SetCoordinatesNode>()},
-                  {"SiteRDF", makeDerivedNode<SiteRDFNode>()},
-                  {"SQ", makeDerivedNode<SQNode>()},
-                  {"Species", makeDerivedNode<SpeciesNode>()},
-                  {"Subtract", makeDerivedNode<SubtractNode>()},
-                  {"SupercellConfiguration", makeDerivedNode<SupercellConfigurationNode>()},
-                  {"Vector3Assemble", makeDerivedNode<Vector3AssembleNode>()},
-                  {"Vector3Decompose", makeDerivedNode<Vector3DecomposeNode>()},
-                  {"XRaySQ", makeDerivedNode<XRaySQNode>()},
-                  {"VoxelDensity", makeDerivedNode<VoxelDensityNode>()}};
+    categoricalProducers_ = {{Action,
+                              {
+                                  {"AtomicMC", makeDerivedNode<AtomicMCNode>()},
+                                  {"GR", makeDerivedNode<GRNode>()},
+                                  {"Insert", makeDerivedNode<InsertNode>()},
+                                  {"MD", makeDerivedNode<MDNode>()},
+                                  {"SQ", makeDerivedNode<SQNode>()},
+                              }},
+                             {Data,
+                              {{"Configuration", makeDerivedNode<ConfigurationNode>()},
+                               {"Forcefield", makeDerivedNode<ForcefieldNode>()},
+                               {"Species", makeDerivedNode<SpeciesNode>()}}},
+                             {Export,
+                              {{"ExportBlockData", makeDerivedNode<ExportBlockDataNode>()},
+                               {"ExportData", makeDerivedNode<ExportDataNode>()},
+                               {"ExportDLPUtilsPDensData", makeDerivedNode<ExportDLPUtilsPDensDataNode>()},
+                               {"ExportDLPOLYConfiguration", makeDerivedNode<ExportDLPOLYConfigurationNode>()},
+                               {"ExportXYZTrajectory", makeDerivedNode<ExportXYZTrajectoryNode>()},
+                               {"ExportXYZConfiguration", makeDerivedNode<ExportXYZConfigurationNode>()}}},
+                             {Graphs, {{"Iterator", makeDerivedNode<IterableGraph>()}, {"Graph", makeDerivedNode<Graph>()}}},
+                             {Import,
+                              {{"ImportCIFStructure", makeDerivedNode<ImportCIFStructureNode>()},
+                               {"ImportDLPOLYStructure", makeDerivedNode<ImportDLPOLYStructureNode>()},
+                               {"ImportDLPOLYTrajectory", makeDerivedNode<ImportDLPOLYTrajectoryNode>()},
+                               {"ImportDLPUtilsPDens", makeDerivedNode<ImportDLPUtilsPDensNode>()},
+                               {"ImportDLPUtilsSurface", makeDerivedNode<ImportDLPUtilsSurfaceNode>()},
+                               {"ImportEPSRAtoStructure", makeDerivedNode<ImportEPSRAtoStructureNode>()},
+                               {"ImportMoscitoStructure", makeDerivedNode<ImportMoscitoStructureNode>()},
+                               {"ImportXYData", makeDerivedNode<ImportXYDataNode>()},
+                               {"ImportXYZStructure", makeDerivedNode<ImportXYZStructureNode>()},
+                               {"ImportXYZTrajectory", makeDerivedNode<ImportXYZTrajectoryNode>()}}},
+                             {Math,
+                              {{"Add", makeDerivedNode<AddNode>()},
+                               {"Derivative", makeDerivedNode<DerivativeNode>()},
+                               {"DotProduct", makeDerivedNode<DotProductNode>()},
+                               {"Integrator", makeDerivedNode<Integrator1DNode>()},
+                               {"Multiply", makeDerivedNode<MultiplyNode>()},
+                               {"Number", makeDerivedNode<NumberNode>()},
+                               {"Subtract", makeDerivedNode<SubtractNode>()},
+                               {"Vector3Assemble", makeDerivedNode<Vector3AssembleNode>()},
+                               {"Vector3Decompose", makeDerivedNode<Vector3DecomposeNode>()}}},
+                             {Other,
+                              {{"Angle", makeDerivedNode<AngleNode>()},
+                               {"AxisAngle", makeDerivedNode<AxisAngleNode>()},
+                               {"AverageMolecule", makeDerivedNode<AverageMoleculeNode>()},
+                               {"Bragg", makeDerivedNode<BraggNode>()},
+                               {"CalculateBonding", makeDerivedNode<CalculateBondingNode>()},
+                               {"ClearBonding", makeDerivedNode<ClearBondingNode>()},
+                               {"DAngle", makeDerivedNode<DAngleNode>()},
+                               {"DetectMolecules", makeDerivedNode<DetectMoleculesNode>()},
+                               {"Energy", makeDerivedNode<EnergyNode>()},
+                               {"EPSR", makeDerivedNode<EPSRNode>()},
+                               {"HistogramCN", makeDerivedNode<HistogramCNNode>()},
+                               {"IntraAngle", makeDerivedNode<IntraAngleNode>()},
+                               {"IntraDistance", makeDerivedNode<IntraDistanceNode>()},
+                               {"IntraMC", makeDerivedNode<IntraMCNode>()},
+                               {"MC", makeDerivedNode<MCNode>()},
+                               {"ModifierOSites", makeDerivedNode<ModifierOSitesNode>()},
+                               {"MoleculeTorsion", makeDerivedNode<MoleculeTorsionNode>()},
+                               {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
+                               {"OrientedSDF", makeDerivedNode<OrientedSDFNode>()},
+                               {"QSpecies", makeDerivedNode<QSpeciesNode>()},
+                               {"SDF", makeDerivedNode<SDFNode>()},
+                               {"SetBox", makeDerivedNode<SetBoxNode>()},
+                               {"SetCoordinates", makeDerivedNode<SetCoordinatesNode>()},
+                               {"SiteRDF", makeDerivedNode<SiteRDFNode>()},
+                               {"SupercellConfiguration", makeDerivedNode<SupercellConfigurationNode>()},
+                               {"XRaySQ", makeDerivedNode<XRaySQNode>()},
+                               {"VoxelDensity", makeDerivedNode<VoxelDensityNode>()}}}};
+
+    producers_ = decategoriseProducers();
 }
 
 // Check whether the supplied node type is known

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -67,8 +67,84 @@
 #include <memory>
 #include <ranges>
 
+// Makes unique pointer to derived node instance
+template <typename T> NodeProducer makeDerivedNode()
+{
+    return [=](Graph *parent) -> std::unique_ptr<Node> { return std::make_unique<T>(parent); };
+}
+
 // Static Singletons
-std::map<NodeRegistry::Category, ProducerMap> NodeRegistry::categoricalProducers_;
+const std::map<NodeRegistry::Category, ProducerMap> NodeRegistry::categoricalProducers_{
+    {Action,
+     {
+         {"AtomicMC", makeDerivedNode<AtomicMCNode>()},
+         {"GR", makeDerivedNode<GRNode>()},
+         {"Insert", makeDerivedNode<InsertNode>()},
+         {"MD", makeDerivedNode<MDNode>()},
+         {"SQ", makeDerivedNode<SQNode>()},
+     }},
+    {Data,
+     {{"Configuration", makeDerivedNode<ConfigurationNode>()},
+      {"Forcefield", makeDerivedNode<ForcefieldNode>()},
+      {"Species", makeDerivedNode<SpeciesNode>()}}},
+    {Export,
+     {{"ExportBlockData", makeDerivedNode<ExportBlockDataNode>()},
+      {"ExportData", makeDerivedNode<ExportDataNode>()},
+      {"ExportDLPUtilsPDensData", makeDerivedNode<ExportDLPUtilsPDensDataNode>()},
+      {"ExportDLPOLYConfiguration", makeDerivedNode<ExportDLPOLYConfigurationNode>()},
+      {"ExportXYZTrajectory", makeDerivedNode<ExportXYZTrajectoryNode>()},
+      {"ExportXYZConfiguration", makeDerivedNode<ExportXYZConfigurationNode>()}}},
+    {Graphs, {{"Iterator", makeDerivedNode<IterableGraph>()}, {"Graph", makeDerivedNode<Graph>()}}},
+    {Import,
+     {{"ImportCIFStructure", makeDerivedNode<ImportCIFStructureNode>()},
+      {"ImportDLPOLYStructure", makeDerivedNode<ImportDLPOLYStructureNode>()},
+      {"ImportDLPOLYTrajectory", makeDerivedNode<ImportDLPOLYTrajectoryNode>()},
+      {"ImportDLPUtilsPDens", makeDerivedNode<ImportDLPUtilsPDensNode>()},
+      {"ImportDLPUtilsSurface", makeDerivedNode<ImportDLPUtilsSurfaceNode>()},
+      {"ImportEPSRAtoStructure", makeDerivedNode<ImportEPSRAtoStructureNode>()},
+      {"ImportMoscitoStructure", makeDerivedNode<ImportMoscitoStructureNode>()},
+      {"ImportXYData", makeDerivedNode<ImportXYDataNode>()},
+      {"ImportXYZStructure", makeDerivedNode<ImportXYZStructureNode>()},
+      {"ImportXYZTrajectory", makeDerivedNode<ImportXYZTrajectoryNode>()}}},
+    {Math,
+     {{"Add", makeDerivedNode<AddNode>()},
+      {"Derivative", makeDerivedNode<DerivativeNode>()},
+      {"DotProduct", makeDerivedNode<DotProductNode>()},
+      {"Integrator", makeDerivedNode<Integrator1DNode>()},
+      {"Multiply", makeDerivedNode<MultiplyNode>()},
+      {"Number", makeDerivedNode<NumberNode>()},
+      {"Subtract", makeDerivedNode<SubtractNode>()},
+      {"Vector3Assemble", makeDerivedNode<Vector3AssembleNode>()},
+      {"Vector3Decompose", makeDerivedNode<Vector3DecomposeNode>()}}},
+    {Other,
+     {{"Angle", makeDerivedNode<AngleNode>()},
+      {"AxisAngle", makeDerivedNode<AxisAngleNode>()},
+      {"AverageMolecule", makeDerivedNode<AverageMoleculeNode>()},
+      {"Bragg", makeDerivedNode<BraggNode>()},
+      {"CalculateBonding", makeDerivedNode<CalculateBondingNode>()},
+      {"ClearBonding", makeDerivedNode<ClearBondingNode>()},
+      {"DAngle", makeDerivedNode<DAngleNode>()},
+      {"DetectMolecules", makeDerivedNode<DetectMoleculesNode>()},
+      {"Energy", makeDerivedNode<EnergyNode>()},
+      {"EPSR", makeDerivedNode<EPSRNode>()},
+      {"HistogramCN", makeDerivedNode<HistogramCNNode>()},
+      {"IntraAngle", makeDerivedNode<IntraAngleNode>()},
+      {"IntraDistance", makeDerivedNode<IntraDistanceNode>()},
+      {"IntraMC", makeDerivedNode<IntraMCNode>()},
+      {"MC", makeDerivedNode<MCNode>()},
+      {"ModifierOSites", makeDerivedNode<ModifierOSitesNode>()},
+      {"MoleculeTorsion", makeDerivedNode<MoleculeTorsionNode>()},
+      {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
+      {"OrientedSDF", makeDerivedNode<OrientedSDFNode>()},
+      {"QSpecies", makeDerivedNode<QSpeciesNode>()},
+      {"SDF", makeDerivedNode<SDFNode>()},
+      {"SetBox", makeDerivedNode<SetBoxNode>()},
+      {"SetCoordinates", makeDerivedNode<SetCoordinatesNode>()},
+      {"SiteRDF", makeDerivedNode<SiteRDFNode>()},
+      {"SupercellConfiguration", makeDerivedNode<SupercellConfigurationNode>()},
+      {"XRaySQ", makeDerivedNode<XRaySQNode>()},
+      {"VoxelDensity", makeDerivedNode<VoxelDensityNode>()}}}};
+
 ProducerMap NodeRegistry::producers_;
 
 // Return enum option info for Category
@@ -86,12 +162,6 @@ EnumOptions<NodeRegistry::Category> NodeRegistry::category()
 }
 EnumOptions<NodeRegistry::Category> getEnumOptions(NodeRegistry::Category) { return NodeRegistry::category(); }
 
-// Makes unique pointer to derived node instance
-template <typename T> NodeProducer makeDerivedNode()
-{
-    return [=](Graph *parent) -> std::unique_ptr<Node> { return std::make_unique<T>(parent); };
-}
-
 // Remove categories from categorial node producer map, returning a 'flat' producer map
 ProducerMap NodeRegistry::decategoriseProducers()
 {
@@ -106,78 +176,8 @@ ProducerMap NodeRegistry::decategoriseProducers()
 void NodeRegistry::instantiateNodeProducers()
 {
     // Only need to do this once
-    if (!categoricalProducers_.empty())
+    if (!producers_.empty())
         return;
-
-    categoricalProducers_ = {{Action,
-                              {
-                                  {"AtomicMC", makeDerivedNode<AtomicMCNode>()},
-                                  {"GR", makeDerivedNode<GRNode>()},
-                                  {"Insert", makeDerivedNode<InsertNode>()},
-                                  {"MD", makeDerivedNode<MDNode>()},
-                                  {"SQ", makeDerivedNode<SQNode>()},
-                              }},
-                             {Data,
-                              {{"Configuration", makeDerivedNode<ConfigurationNode>()},
-                               {"Forcefield", makeDerivedNode<ForcefieldNode>()},
-                               {"Species", makeDerivedNode<SpeciesNode>()}}},
-                             {Export,
-                              {{"ExportBlockData", makeDerivedNode<ExportBlockDataNode>()},
-                               {"ExportData", makeDerivedNode<ExportDataNode>()},
-                               {"ExportDLPUtilsPDensData", makeDerivedNode<ExportDLPUtilsPDensDataNode>()},
-                               {"ExportDLPOLYConfiguration", makeDerivedNode<ExportDLPOLYConfigurationNode>()},
-                               {"ExportXYZTrajectory", makeDerivedNode<ExportXYZTrajectoryNode>()},
-                               {"ExportXYZConfiguration", makeDerivedNode<ExportXYZConfigurationNode>()}}},
-                             {Graphs, {{"Iterator", makeDerivedNode<IterableGraph>()}, {"Graph", makeDerivedNode<Graph>()}}},
-                             {Import,
-                              {{"ImportCIFStructure", makeDerivedNode<ImportCIFStructureNode>()},
-                               {"ImportDLPOLYStructure", makeDerivedNode<ImportDLPOLYStructureNode>()},
-                               {"ImportDLPOLYTrajectory", makeDerivedNode<ImportDLPOLYTrajectoryNode>()},
-                               {"ImportDLPUtilsPDens", makeDerivedNode<ImportDLPUtilsPDensNode>()},
-                               {"ImportDLPUtilsSurface", makeDerivedNode<ImportDLPUtilsSurfaceNode>()},
-                               {"ImportEPSRAtoStructure", makeDerivedNode<ImportEPSRAtoStructureNode>()},
-                               {"ImportMoscitoStructure", makeDerivedNode<ImportMoscitoStructureNode>()},
-                               {"ImportXYData", makeDerivedNode<ImportXYDataNode>()},
-                               {"ImportXYZStructure", makeDerivedNode<ImportXYZStructureNode>()},
-                               {"ImportXYZTrajectory", makeDerivedNode<ImportXYZTrajectoryNode>()}}},
-                             {Math,
-                              {{"Add", makeDerivedNode<AddNode>()},
-                               {"Derivative", makeDerivedNode<DerivativeNode>()},
-                               {"DotProduct", makeDerivedNode<DotProductNode>()},
-                               {"Integrator", makeDerivedNode<Integrator1DNode>()},
-                               {"Multiply", makeDerivedNode<MultiplyNode>()},
-                               {"Number", makeDerivedNode<NumberNode>()},
-                               {"Subtract", makeDerivedNode<SubtractNode>()},
-                               {"Vector3Assemble", makeDerivedNode<Vector3AssembleNode>()},
-                               {"Vector3Decompose", makeDerivedNode<Vector3DecomposeNode>()}}},
-                             {Other,
-                              {{"Angle", makeDerivedNode<AngleNode>()},
-                               {"AxisAngle", makeDerivedNode<AxisAngleNode>()},
-                               {"AverageMolecule", makeDerivedNode<AverageMoleculeNode>()},
-                               {"Bragg", makeDerivedNode<BraggNode>()},
-                               {"CalculateBonding", makeDerivedNode<CalculateBondingNode>()},
-                               {"ClearBonding", makeDerivedNode<ClearBondingNode>()},
-                               {"DAngle", makeDerivedNode<DAngleNode>()},
-                               {"DetectMolecules", makeDerivedNode<DetectMoleculesNode>()},
-                               {"Energy", makeDerivedNode<EnergyNode>()},
-                               {"EPSR", makeDerivedNode<EPSRNode>()},
-                               {"HistogramCN", makeDerivedNode<HistogramCNNode>()},
-                               {"IntraAngle", makeDerivedNode<IntraAngleNode>()},
-                               {"IntraDistance", makeDerivedNode<IntraDistanceNode>()},
-                               {"IntraMC", makeDerivedNode<IntraMCNode>()},
-                               {"MC", makeDerivedNode<MCNode>()},
-                               {"ModifierOSites", makeDerivedNode<ModifierOSitesNode>()},
-                               {"MoleculeTorsion", makeDerivedNode<MoleculeTorsionNode>()},
-                               {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
-                               {"OrientedSDF", makeDerivedNode<OrientedSDFNode>()},
-                               {"QSpecies", makeDerivedNode<QSpeciesNode>()},
-                               {"SDF", makeDerivedNode<SDFNode>()},
-                               {"SetBox", makeDerivedNode<SetBoxNode>()},
-                               {"SetCoordinates", makeDerivedNode<SetCoordinatesNode>()},
-                               {"SiteRDF", makeDerivedNode<SiteRDFNode>()},
-                               {"SupercellConfiguration", makeDerivedNode<SupercellConfigurationNode>()},
-                               {"XRaySQ", makeDerivedNode<XRaySQNode>()},
-                               {"VoxelDensity", makeDerivedNode<VoxelDensityNode>()}}}};
 
     producers_ = decategoriseProducers();
 }

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -7,15 +7,35 @@
 #include <vector>
 
 using NodeProducer = std::function<std::unique_ptr<Node>(Graph *parent)>;
+using ProducerMap = std::map<std::string_view, NodeProducer>;
 
 // Registry of all Producible Node Types
 class NodeRegistry
 {
-    private:
-    // Available Node producers
-    static std::map<std::string_view, NodeProducer> producers_;
+    public:
+    enum Category
+    {
+        Action,
+        Data,
+        Export,
+        Graphs,
+        Import,
+        Math,
+        Other
+    };
+    // Return enum option info for Category
+    static EnumOptions<Category> category();
+
+    public:
+    static std::map<Category, ProducerMap> categoricalProducers_;
 
     private:
+    // Available Node producers
+    static ProducerMap producers_;
+
+    private:
+    // Remove categories from categorial node producer map, returning a 'flat' producer map
+    static ProducerMap decategoriseProducers();
     // Instantiate Node Producers
     static void instantiateNodeProducers();
 

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -27,7 +27,7 @@ class NodeRegistry
     static EnumOptions<Category> category();
 
     public:
-    static std::map<Category, ProducerMap> categoricalProducers_;
+    static const std::map<Category, ProducerMap> categoricalProducers_;
 
     private:
     // Available Node producers


### PR DESCRIPTION
This PR puts the responsibility on the C++ `NodeRegistry` to store Node categories (which had previously been hardcoded into a QML menu) by an enum type. This `categoricalProducers_` map is then flattened for more general use throughout the application, for retrieving any node. The categories are used to generate the context menu that appears when right-clicking in the Graph, and nodes can be created in that way.