### PR TITLE
refactor: Graph & IterableGraph TOML roundtrip (#2559)

### DIFF
--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -3,6 +3,7 @@
 
 #include "nodes/edge.h"
 #include "nodes/graph.h"
+#include "nodes/inputs.h"
 #include "nodes/loopBack.h"
 #include "nodes/outputs.h"
 
@@ -31,29 +32,7 @@ class EdgeConstructor : public Edge
 // Create an edge from the supplied definition
 std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definition)
 {
-    // Get source node and output
-    auto sourceNode = parent->findNode(definition.sourceNode);
-    if (!sourceNode)
-    {
-        Messenger::error("Source node '{}' does not exist in the graph.\n", definition.sourceNode);
-        return {};
-    }
-    auto sourceOutput = sourceNode->findOutput(definition.sourceOutput);
-    if (!sourceOutput)
-    {
-        Messenger::error("Source node '{}' has no output parameter '{}'.\n", definition.sourceNode, definition.sourceOutput);
-        return {};
-    }
-
-    // Confirm that the source is actually an output
-    if (!sourceOutput->flags().isSet(ParameterBase::ParameterFlags::Output))
-    {
-        Messenger::error("Source node '{}' has parameter '{}' but it is not an output.\n", definition.sourceNode,
-                         definition.sourceOutput);
-        return {};
-    }
-
-    // Get target node and input
+    // Get target node
     auto targetNode = parent->findNode(definition.targetNode);
     if (!targetNode)
     {
@@ -68,6 +47,44 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
         return {};
     }
 
+    // Get source node and output
+    auto sourceNode = parent->findNode(definition.sourceNode);
+    if (!sourceNode)
+    {
+        Messenger::error("Source node '{}' does not exist in the graph.\n", definition.sourceNode);
+        return {};
+    }
+
+    auto sourceOutput = sourceNode->findOutput(definition.sourceOutput);
+    if (!sourceOutput)
+    {
+        // If the source node is a Graph's own Inputs node, we will create an edge on the fly - else, throw an error
+        if (!dynamic_cast<InputsNode *>(sourceNode))
+        {
+            Messenger::error("Source node '{}' has no output parameter '{}'.\n", definition.sourceNode,
+                             definition.sourceOutput);
+            return {};
+        }
+
+        // The target node is the parent Graph's own Inputs node, so create a parameter link from the mapped input to the
+        // targetInput
+        auto link = targetNode->findInput(definition.targetInput)->createParameterLink(definition.sourceOutput);
+        if (!parent->addProxyInput(link.inputParameter, link.outputParameter))
+        {
+            Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
+            return {};
+        }
+        sourceOutput = parent->proxyInputs().findOutput(definition.sourceOutput);
+    }
+
+    // Confirm that the source is actually an output
+    if (!sourceOutput->flags().isSet(ParameterBase::ParameterFlags::Output))
+    {
+        Messenger::error("Source node '{}' has parameter '{}' but it is not an output.\n", definition.sourceNode,
+                         definition.sourceOutput);
+        return {};
+    }
+
     // We need to check carefully the target node, since we need to permit outside connections to the Graph object itself as
     // well as its Outputs node explicitly.
     std::shared_ptr<ParameterBase> targetInput{nullptr};
@@ -75,13 +92,19 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     {
         // The target node is a Graph: create a parameter link from the sourceOutput and from it a mapped input
         auto graphNode = dynamic_cast<Graph *>(targetNode);
-        auto link = sourceOutput->createParameterLink(definition.targetInput);
-        if (!graphNode->addProxyInput(link.inputParameter, link.outputParameter))
+        auto existingTargetInput = graphNode->findInput(definition.targetInput);
+        if (!existingTargetInput.get())
         {
-            Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
-            return {};
+            auto link = sourceOutput->createParameterLink(definition.targetInput);
+            if (!graphNode->addProxyInput(link.inputParameter, link.outputParameter))
+            {
+                Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
+                return {};
+            }
+            targetInput = link.inputParameter;
         }
-        targetInput = link.inputParameter;
+        else
+            targetInput = existingTargetInput;
     }
     else if (dynamic_cast<OutputsNode *>(targetNode))
     {
@@ -288,3 +311,14 @@ void Edge::deserialise(const SerialisedValue &node)
     throw std::runtime_error("Cannot directly deserialise edges.  Please contact the Dissolve development team if you are "
                              "seeing this error - this is a bug and NOT your fault.\n");
 }
+
+// Express as a serialisable value
+void LoopEdge::serialise(std::string tag, SerialisedValue &target) const
+{
+    definition().serialise(tag, target);
+    target[tag]["targetNode"] = "LoopBacks";
+    target[tag]["analogue"] = analogue_;
+}
+
+// Read values from a serialisable value
+void LoopEdge::deserialise(const SerialisedValue &node) { Edge::deserialise(node); }

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -121,7 +121,7 @@ class LoopEdge : public Edge
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node) override;
+    void deserialise(const SerialisedValue &node);
 };

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -115,4 +115,13 @@ class LoopEdge : public Edge
      *
      */
     ParameterBase *analogue_;
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -115,7 +115,7 @@ class Graph : public Node
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -212,9 +212,9 @@ void IterableGraph::deserialise(const SerialisedValue &node)
     Deserialisable::vector(node, "loopEdges",
                            [this](const auto &value)
                            {
-                               auto edge = Edge::create(
-                                   this, {value.at("sourceNode").as_string(), value.at("sourceOutput").as_string(),
-                                          value.at("targetNode").as_string(), value.at("targetInput").as_string()});
+                               auto edgeDefinition = Deserialisable::deser<EdgeDefinition>(value);
+                               auto edge = Edge::create(this, {edgeDefinition.sourceNode, edgeDefinition.sourceOutput,
+                                                               edgeDefinition.targetNode, edgeDefinition.targetInput});
                                if (!edge)
                                    return false;
 

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -202,22 +202,22 @@ void IterableGraph::serialise(std::string tag, SerialisedValue &target) const
 {
     Graph::serialise(tag, target);
     auto &result = target[tag];
-    fromVector(loopEdges_, "loopEdges", result);
+    Serialisable::vector(loopEdges_, "loopEdges", result);
 }
 
 // Read values from a serialisable value
 void IterableGraph::deserialise(const SerialisedValue &node)
 {
     Graph::deserialise(node);
-    toVector(node, "loopEdges",
-             [this](const auto &value)
-             {
-                 auto definition = toml::get<EdgeDefinition>(value);
-                 auto edge = Edge::create(
-                     this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
-                 if (!edge)
-                     return false;
+    Deserialisable::vector(node, "loopEdges",
+                           [this](const auto &value)
+                           {
+                               auto edge = Edge::create(
+                                   this, {value.at("sourceNode").as_string(), value.at("sourceOutput").as_string(),
+                                          value.at("targetNode").as_string(), value.at("targetInput").as_string()});
+                               if (!edge)
+                                   return false;
 
-                 return addLoopEdge(std::move(edge), definition.sourceOutput);
-             });
+                               return addLoopEdge(std::move(edge), value.at("sourceOutput").as_string());
+                           });
 }

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -85,6 +85,12 @@ LoopEdge *IterableGraph::findLoopEdge(const EdgeDefinition &definition) const
     return {};
 }
 
+// Add edge between nodes
+bool IterableGraph::addLoopEdge(std::unique_ptr<Edge> edge, std::string_view source)
+{
+    return addOutputLoopEdge(source, loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs())).get());
+}
+
 // Add edge to node map
 Edge *IterableGraph::addOutputLoopEdge(std::string_view sourceOutput, Edge *edge)
 {
@@ -128,23 +134,26 @@ Edge *IterableGraph::removeOutputLoopEdge(std::string_view sourceOutput, Edge *e
 // Add edge between nodes
 bool IterableGraph::addEdge(const EdgeDefinition &definition)
 {
-    if (dynamic_cast<InputsNode *>(parentGraph()->findNode(definition.sourceNode)))
-        setLoopBacks();
-    else if (loopBacks_->findInput(definition.targetInput))
-    {
-        auto edge =
-            Edge::create(this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
-        if (!edge)
-            return false;
+    // Refresh the graph loopbacks
+    setLoopBacks();
 
-        loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
+    // Check if the connection is invertible.
+    // Invertibility is satisfied when the source node (internal to the graph) can output to an existing loopback,
+    // which discounts any edge for which no loopbacks correspond to the target input, as well as the graphs own InputsNode.
+    auto nonInvertible = dynamic_cast<InputsNode *>(parentGraph()->findNode(definition.sourceNode)) ||
+                         !loopBacks_->findInput(definition.targetInput);
 
-        addOutputLoopEdge(definition.sourceOutput, loopEdges_.back().get());
+    // If not invertible, create and return a standard edge
+    if (nonInvertible)
+        return Graph::addEdge(definition);
 
-        return true;
-    }
+    // Create loop edge
+    auto edge =
+        Edge::create(this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
+    if (!edge)
+        return false;
 
-    return Graph::addEdge(definition);
+    return addLoopEdge(std::move(edge), definition.sourceOutput);
 }
 
 // Remove edge between nodes
@@ -182,4 +191,33 @@ NodeConstants::ProcessResult IterableGraph::process()
     }
 
     return NodeConstants::ProcessResult::Success;
+}
+
+/*
+ * Serialisation
+ */
+
+// Express as a serialisable value
+void IterableGraph::serialise(std::string tag, SerialisedValue &target) const
+{
+    Graph::serialise(tag, target);
+    auto &result = target[tag];
+    fromVector(loopEdges_, "loopEdges", result);
+}
+
+// Read values from a serialisable value
+void IterableGraph::deserialise(const SerialisedValue &node)
+{
+    Graph::deserialise(node);
+    toVector(node, "loopEdges",
+             [this](const auto &value)
+             {
+                 auto definition = toml::get<EdgeDefinition>(value);
+                 auto edge = Edge::create(
+                     this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
+                 if (!edge)
+                     return false;
+
+                 return addLoopEdge(std::move(edge), definition.sourceOutput);
+             });
 }

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -214,7 +214,7 @@ void IterableGraph::deserialise(const SerialisedValue &node)
                            {
                                auto edgeDefinition = Deserialisable::deser<EdgeDefinition>(value);
                                auto edge = Edge::create(this, {edgeDefinition.sourceNode, edgeDefinition.sourceOutput,
-                                                               edgeDefinition.targetNode, edgeDefinition.targetInput});
+                                                               "LoopBacks", edgeDefinition.targetInput});
                                if (!edge)
                                    return false;
 

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -46,6 +46,8 @@ class IterableGraph : public Graph
     void releaseLoopBack(const std::string &name);
 
     private:
+    // Add edge between nodes
+    bool addLoopEdge(std::unique_ptr<Edge> edge, std::string_view source);
     // Add edge to node map
     Edge *addOutputLoopEdge(std::string_view sourceOutput, Edge *edge);
     // Remove edge from node map
@@ -80,4 +82,13 @@ class IterableGraph : public Graph
     protected:
     // Perform processing
     NodeConstants::ProcessResult process() override;
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -88,7 +88,7 @@ class IterableGraph : public Graph
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node) override;
+    void deserialise(const SerialisedValue &node);
 };

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -88,7 +88,7 @@ class IterableGraph : public Graph
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -367,9 +367,9 @@ class Node
         serialisables_[std::string(key)] = std::make_shared<SerialisableClass<DataClass>>(key, data);
     }
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const;
+    virtual void serialise(std::string tag, SerialisedValue &target) const;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    virtual void deserialise(const SerialisedValue &node);
     // Express persistent data as a serialisable value
     SerialisedValue serialiseData() const;
     // Read persistent data from a serialisable value

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -79,6 +79,14 @@ TEST_F(IterableGraphTest, RoundTrip)
     SerialisedValue graphTOML;
     ASSERT_NO_THROW(root_.serialise("graph", graphTOML));
 
+    // count how many loop edges were made
+    auto loop = dynamic_cast<IterableGraph *>(root_.findNode("Iterator"));
+    ASSERT_TRUE(loop);
+    auto correctEdges = loop->loopEdges().size();
+
+    // Confirm that loop edges were rebuilt
+    ASSERT_EQ(loop->loopEdges().size(), 1);
+
     // Deserialise from the stored TOML
     auto deserialisedGraph = std::make_unique<DissolveGraph>();
     ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML["graph"]));
@@ -87,6 +95,11 @@ TEST_F(IterableGraphTest, RoundTrip)
     SerialisedValue compareTOML;
     ASSERT_NO_THROW(deserialisedGraph->serialise("graph", compareTOML));
     ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
+
+    // Confirm that loop edges were rebuilt
+    loop = dynamic_cast<IterableGraph *>(deserialisedGraph->findNode("Iterator"));
+    ASSERT_TRUE(loop);
+    ASSERT_EQ(loop->loopEdges().size(), correctEdges);
 }
 
 TEST_F(IterableGraphTest, BasicNonLoopingSeries)

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -7,6 +7,7 @@
 #include "nodes/numberNode.h"
 #include "nodes/outputs.h"
 #include "nodes/registry.h"
+#include "tests/testGraphFixture.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -37,38 +38,56 @@ class IterableGraphTest : public ::testing::Test
 
         // Create nodes
         i_ = dynamic_cast<NumberNode *>(root_.createNode("Number", "i"));
-        loop_ = dynamic_cast<IterableGraph *>(root_.createNode("Iterator", "Iterator"));
-        x_ = dynamic_cast<AddNode *>(loop_->createNode("Add", "x"));
+        loopGraph_ = dynamic_cast<IterableGraph *>(root_.createNode("Iterator", "Iterator"));
+        x_ = dynamic_cast<AddNode *>(loopGraph_->createNode("Add", "x"));
         y_ = dynamic_cast<AddNode *>(root_.createNode("Add", "y"));
 
         ASSERT_TRUE(i_);
         ASSERT_TRUE(x_);
         ASSERT_TRUE(y_);
-        ASSERT_TRUE(loop_);
+        ASSERT_TRUE(loopGraph_);
 
         ASSERT_EQ(i_->name(), "i");
         ASSERT_EQ(x_->name(), "x");
         ASSERT_EQ(y_->name(), "y");
-        ASSERT_EQ(loop_->name(), "Iterator");
+        ASSERT_EQ(loopGraph_->name(), "Iterator");
 
         // Create edge connections
         // - Number 'i' is a dynamic input to the IterableGraph - we'll call the input "I"
         EXPECT_TRUE(root_.addEdge({"i", "X", "Iterator", "I"}));
         // - Add 'x' takes the IterableGraph input "I" as its parameter "X"
-        EXPECT_TRUE(loop_->addEdge({"Inputs", "I", "x", "X"}));
+        EXPECT_TRUE(loopGraph_->addEdge({"Inputs", "I", "x", "X"}));
         // - Result from Add 'x' goes to graph output (which we will call "C") as well as loopback to "I"
-        EXPECT_TRUE(loop_->addEdge({"x", "Result", "Outputs", "C"}));
-        EXPECT_TRUE(loop_->addEdge({"x", "Result", "LoopBacks", "I"}));
+        EXPECT_TRUE(loopGraph_->addEdge({"x", "Result", "Outputs", "C"}));
+        EXPECT_TRUE(loopGraph_->addEdge({"x", "Result", "LoopBacks", "I"}));
         // - The output "C" of the loop graph then goes to input "X" of Add 'y'
         EXPECT_TRUE(root_.addEdge({"Iterator", "C", "y", "X"}));
     }
 
     protected:
-    DissolveGraph root_;
+    TestGraph root_;
     NumberNode *i_{nullptr};
     AddNode *x_{nullptr}, *y_{nullptr};
-    IterableGraph *loop_{nullptr};
+    IterableGraph *loopGraph_{nullptr};
 };
+
+TEST_F(IterableGraphTest, RoundTrip)
+{
+    createGraph();
+
+    // Serialised graph TOML
+    SerialisedValue graphTOML;
+    ASSERT_NO_THROW(root_.serialise("graph", graphTOML));
+
+    // Deserialise from the stored TOML
+    auto deserialisedGraph = std::make_unique<DissolveGraph>();
+    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML["graph"]));
+
+    // Complete round trip - re-serialise the result and compare it to the original TOML
+    SerialisedValue compareTOML;
+    ASSERT_NO_THROW(deserialisedGraph->serialise("graph", compareTOML));
+    ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
+}
 
 TEST_F(IterableGraphTest, BasicNonLoopingSeries)
 {
@@ -183,7 +202,7 @@ TEST_F(IterableGraphTest, NoRun)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     nLoops->set<Number>(0);
@@ -193,13 +212,13 @@ TEST_F(IterableGraphTest, NoRun)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(x_->versionIndex(), NodeConstants::InvalidVersion);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 0
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
 }
 
 TEST_F(IterableGraphTest, NoFeedback)
@@ -218,7 +237,7 @@ TEST_F(IterableGraphTest, NoFeedback)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     // Zero iterations: We expect 1 + (xB = 1) = 1 + 1 = 2
@@ -229,13 +248,13 @@ TEST_F(IterableGraphTest, NoFeedback)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 0);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 0);
     EXPECT_EQ(x_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 0);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 0);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 0
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
 }
 
 TEST_F(IterableGraphTest, SingleFeedback)
@@ -254,7 +273,7 @@ TEST_F(IterableGraphTest, SingleFeedback)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     // One iteration: We expect (LB = 2) + (xB = 1) = 2 + 1 = 3
@@ -265,13 +284,13 @@ TEST_F(IterableGraphTest, SingleFeedback)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 1);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 1);
     EXPECT_EQ(x_->versionIndex(), 1);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 1);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 1);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 0
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 0);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 0);
 }
 
 TEST_F(IterableGraphTest, ExtendedFeedback)
@@ -290,7 +309,7 @@ TEST_F(IterableGraphTest, ExtendedFeedback)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     /*
@@ -317,27 +336,27 @@ TEST_F(IterableGraphTest, ExtendedFeedback)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 9);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 9);
     EXPECT_EQ(x_->versionIndex(), 9);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 9);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 9);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 1
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 8);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 8);
 }
 
 TEST_F(IterableGraphTest, ReleaseLoopBack)
 {
     createGraph();
 
-    const auto nEdges = loop_->edges().size();
+    const auto nEdges = loopGraph_->edges().size();
 
-    auto flagged = loop_->proxyInputs().findOutput("I");
+    auto flagged = loopGraph_->proxyInputs().findOutput("I");
 
-    loop_->removeEdge({"x", "Result", "LoopBacks", "I"});
+    loopGraph_->removeEdge({"x", "Result", "LoopBacks", "I"});
 
-    ASSERT_EQ(loop_->loopEdges().size(), 0);
-    ASSERT_EQ(loop_->edges().size(), nEdges);
+    ASSERT_EQ(loopGraph_->loopEdges().size(), 0);
+    ASSERT_EQ(loopGraph_->edges().size(), nEdges);
 }
 
 TEST_F(IterableGraphTest, UpstreamChange)
@@ -356,7 +375,7 @@ TEST_F(IterableGraphTest, UpstreamChange)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     /*
@@ -372,14 +391,14 @@ TEST_F(IterableGraphTest, UpstreamChange)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 99);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 99);
     EXPECT_EQ(x_->versionIndex(), 99);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 99);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 99);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration 0 < i <= nLoops
     // (in 100 runs, loop backs up version 99 times, starting from -1)
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 98);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 98);
 
     /*
      * Alter upstream number node and run for another 100 iterations
@@ -394,14 +413,14 @@ TEST_F(IterableGraphTest, UpstreamChange)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 1);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 199);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 199);
     EXPECT_EQ(x_->versionIndex(), 199);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 199);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 199);
     EXPECT_EQ(y_->versionIndex(), 1);
 
     // Loopbacks node only runs on iteration 0 < i <= nLoops
     // (after another 100 runs, loop backs up version a further 99 times, starting from 98)
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 197);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 197);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -7,7 +7,7 @@
 #include "nodes/numberNode.h"
 #include "nodes/outputs.h"
 #include "nodes/registry.h"
-#include "tests/testGraphFixture.h"
+#include "tests/testing.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -65,7 +65,7 @@ class IterableGraphTest : public ::testing::Test
     }
 
     protected:
-    TestGraph root_;
+    DissolveGraph root_;
     NumberNode *i_{nullptr};
     AddNode *x_{nullptr}, *y_{nullptr};
     IterableGraph *loopGraph_{nullptr};

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -4,6 +4,7 @@
 #include "nodes/add.h"
 #include "nodes/dissolve.h"
 #include "nodes/number.h"
+#include "tests/testing.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -71,6 +72,21 @@ class SubGraphTest : public ::testing::Test
         wB_ = w_->findInput("Y");
         ASSERT_TRUE(wB_);
         wB_->set(Number{5});
+
+        // Create a mapped input on GraphA by creating an edge to it
+        EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
+
+        // Connect the mapped input on GraphA internally to it's "z" node
+        EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
+
+        // Connect y result to z
+        EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
+
+        // Connect z result to graphA output, creating a mapped output
+        EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
+
+        // Connect GraphA mapped output "D" to node "w"
+        EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
     }
 
     protected:
@@ -80,46 +96,53 @@ class SubGraphTest : public ::testing::Test
     std::shared_ptr<ParameterBase> xA_{nullptr}, xB_{nullptr};
     std::shared_ptr<ParameterBase> yA_{nullptr}, yB_{nullptr};
     std::shared_ptr<ParameterBase> wB_{nullptr};
+
+    // Basic sub-graph connection test
+    void connect()
+    {
+        // Create a mapped input on GraphA by creating an edge to it
+        EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
+
+        // Connect the mapped input on GraphA internally to it's "z" node
+        EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
+
+        // Connect y result to z
+        EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
+
+        // Connect z result to graphA output, creating a mapped output
+        EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
+
+        // Connect GraphA mapped output "D" to node "w"
+        EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
+    }
 };
+
+TEST_F(SubGraphTest, RoundTrip)
+{
+    createGraph();
+
+    // Serialised graph TOML
+    SerialisedValue graphTOML;
+    ASSERT_NO_THROW(root_.serialise("graph", graphTOML));
+
+    // Deserialise from the stored TOML
+    auto deserialisedGraph = std::make_unique<DissolveGraph>();
+    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML["graph"]));
+
+    // Complete round trip - re-serialise the result and compare it to the original TOML
+    SerialisedValue compareTOML;
+    ASSERT_NO_THROW(deserialisedGraph->serialise("graph", compareTOML));
+    ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
+}
 
 TEST_F(SubGraphTest, Connections)
 {
     createGraph();
-
-    // Create a mapped input on GraphA by creating an edge to it
-    EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
-
-    // Connect the mapped input on GraphA internally to it's "z" node
-    EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
-
-    // Connect y result to z
-    EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
-
-    // Connect z result to graphA output, creating a mapped output
-    EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
-
-    // Connect GraphA mapped output "D" to node "w"
-    EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
 }
 
 TEST_F(SubGraphTest, Flow)
 {
     createGraph();
-
-    // Create a mapped input on GraphA by creating an edge to it
-    EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
-
-    // Connect the mapped input on GraphA internally to it's "z" node
-    EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
-
-    // Connect y result to z
-    EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
-
-    // Connect z result to graphA output, creating a mapped output
-    EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
-
-    // Connect GraphA mapped output "D" to node "w"
-    EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
 
     // Run w - all nodes should update
     EXPECT_EQ(w_->run(), NodeConstants::ProcessResult::Success);

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -135,10 +135,7 @@ TEST_F(SubGraphTest, RoundTrip)
     ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
 }
 
-TEST_F(SubGraphTest, Connections)
-{
-    createGraph();
-}
+TEST_F(SubGraphTest, Connections) { createGraph(); }
 
 TEST_F(SubGraphTest, Flow)
 {

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -427,9 +427,12 @@ void compareToml(std::string location, SerialisedValue toml, SerialisedValue tom
     if (toml.is_table())
     {
         ASSERT_TRUE(toml2.is_table()) << location;
+        auto tab1 = toml.as_table();
+        auto tab2 = toml2.as_table();
         for (auto &[k, v] : toml.as_table())
         {
-            ASSERT_TRUE(toml2.contains(k)) << location << "." << k << std::endl << "Expected:" << std::endl << toml[k];
+            auto result = toml2.contains(k);
+            ASSERT_TRUE(result) << location << "." << k << std::endl << "Expected:" << std::endl << toml[k];
             compareToml(std::format("{}.{}", location, k), v, toml2.at(k));
         }
     }


### PR DESCRIPTION
Fixes round-trip serialisation of graphs and iterables.