### PR TITLE
fix: Properly deserialise loopback edges

### DIFF
--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -214,7 +214,7 @@ void IterableGraph::deserialise(const SerialisedValue &node)
                            {
                                auto edgeDefinition = Deserialisable::deser<EdgeDefinition>(value);
                                auto edge = Edge::create(this, {edgeDefinition.sourceNode, edgeDefinition.sourceOutput,
-                                                               edgeDefinition.targetNode, edgeDefinition.targetInput});
+                                                               "LoopBacks", edgeDefinition.targetInput});
                                if (!edge)
                                    return false;
 

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -79,6 +79,14 @@ TEST_F(IterableGraphTest, RoundTrip)
     SerialisedValue graphTOML;
     ASSERT_NO_THROW(root_.serialise("graph", graphTOML));
 
+    // count how many loop edges were made
+    auto loop = dynamic_cast<IterableGraph *>(root_.findNode("Iterator"));
+    ASSERT_TRUE(loop);
+    auto correctEdges = loop->loopEdges().size();
+
+    // Confirm that loop edges were rebuilt
+    ASSERT_EQ(loop->loopEdges().size(), 1);
+
     // Deserialise from the stored TOML
     auto deserialisedGraph = std::make_unique<DissolveGraph>();
     ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML["graph"]));
@@ -87,6 +95,11 @@ TEST_F(IterableGraphTest, RoundTrip)
     SerialisedValue compareTOML;
     ASSERT_NO_THROW(deserialisedGraph->serialise("graph", compareTOML));
     ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
+
+    // Confirm that loop edges were rebuilt
+    loop = dynamic_cast<IterableGraph *>(deserialisedGraph->findNode("Iterator"));
+    ASSERT_TRUE(loop);
+    ASSERT_EQ(loop->loopEdges().size(), correctEdges);
 }
 
 TEST_F(IterableGraphTest, BasicNonLoopingSeries)


### PR DESCRIPTION
This fixes the issue with deserialising the loopback edges.  I've also added a small test to confirm that the number of loopback edges are correct after the roundtrip.

The extra test is because I briefly thought that I had solved the problem, but found that I had merely prevented loopbacks from exporting, so both the original and the roundtrip showed no loopbacks and the test passed, despite the roundtrip not actually reconstructing the same graph.